### PR TITLE
`Into<PredictInputValue>` for integer primitives

### DIFF
--- a/crates/app/pages/repos/_/models/_/production_metrics/class_metrics/server/page.rs
+++ b/crates/app/pages/repos/_/models/_/production_metrics/class_metrics/server/page.rs
@@ -333,7 +333,7 @@ impl Component for PrecisionRecallSection {
 						.title(precision_interval_chart_title)
 						.x_axis_grid_line_interval(GridLineInterval { k: 1.0, p: 0.0 })
 						.y_max(Finite::new(1.0).unwrap())
-						.y_min(Finite::new(0.0).unwrap())
+						.y_min(Finite::new(0.0).unwrap()),
 				)),
 			)
 			.child(
@@ -345,7 +345,7 @@ impl Component for PrecisionRecallSection {
 						.y_min(Finite::new(0.0).unwrap())
 						.labels(chart_labels.clone())
 						.series(recall_chart_series)
-						.title(recall_interval_chart_title)
+						.title(recall_interval_chart_title),
 				)),
 			)
 			.child(
@@ -374,7 +374,7 @@ impl Component for PrecisionRecallSection {
 						.series(f1_score_chart_series)
 						.title(f1_score_interval_chart_title)
 						.y_min(Finite::new(0.0).unwrap())
-						.y_max(Finite::new(1.0).unwrap())
+						.y_max(Finite::new(1.0).unwrap()),
 				)),
 			)
 			.into_node()

--- a/crates/core/predict.rs
+++ b/crates/core/predict.rs
@@ -59,14 +59,20 @@ impl From<f32> for PredictInputValue {
 	}
 }
 
-impl From<i16> for PredictInputValue {
-	fn from(value: i16) -> Self {
+impl From<i32> for PredictInputValue {
+	fn from(value: i32) -> Self {
 		PredictInputValue::Number(f64::from(value))
 	}
 }
 
-impl From<i8> for PredictInputValue {
-	fn from(value: i8) -> Self {
+impl From<u32> for PredictInputValue {
+	fn from(value: u32) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<i16> for PredictInputValue {
+	fn from(value: i16) -> Self {
 		PredictInputValue::Number(f64::from(value))
 	}
 }
@@ -77,20 +83,13 @@ impl From<u16> for PredictInputValue {
 	}
 }
 
+impl From<i8> for PredictInputValue {
+	fn from(value: i8) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
 impl From<u8> for PredictInputValue {
 	fn from(value: u8) -> Self {
-		PredictInputValue::Number(f64::from(value))
-	}
-}
-
-impl From<i32> for PredictInputValue {
-	fn from(value: i32) -> Self {
-		PredictInputValue::Number(f64::from(value))
-	}
-}
-
-impl From<u32> for PredictInputValue {
-	fn from(value: u32) -> Self {
 		PredictInputValue::Number(f64::from(value))
 	}
 }

--- a/crates/core/predict.rs
+++ b/crates/core/predict.rs
@@ -53,6 +53,48 @@ impl From<f64> for PredictInputValue {
 	}
 }
 
+impl From<f32> for PredictInputValue {
+	fn from(value: f32) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<i16> for PredictInputValue {
+	fn from(value: i16) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<i8> for PredictInputValue {
+	fn from(value: i8) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<u16> for PredictInputValue {
+	fn from(value: u16) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<u8> for PredictInputValue {
+	fn from(value: u8) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<i32> for PredictInputValue {
+	fn from(value: i32) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<u32> for PredictInputValue {
+	fn from(value: u32) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
 impl From<String> for PredictInputValue {
 	fn from(value: String) -> Self {
 		PredictInputValue::String(value)

--- a/languages/rust/lib.rs
+++ b/languages/rust/lib.rs
@@ -99,6 +99,41 @@ impl From<f32> for PredictInputValue {
 	}
 }
 
+impl From<i32> for PredictInputValue {
+	fn from(value: i32) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<u32> for PredictInputValue {
+	fn from(value: u32) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<i16> for PredictInputValue {
+	fn from(value: i16) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<u16> for PredictInputValue {
+	fn from(value: u16) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
+impl From<i8> for PredictInputValue {
+	fn from(value: i8) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+impl From<u8> for PredictInputValue {
+	fn from(value: u8) -> Self {
+		PredictInputValue::Number(f64::from(value))
+	}
+}
+
 impl From<String> for PredictInputValue {
 	fn from(value: String) -> Self {
 		PredictInputValue::String(value)


### PR DESCRIPTION
This PR addresses #27 covering the following types:

* u32
* i32
* u16
* i16
* u8
* i8

Each type can safely convert to `f64`.  `u64` and `i64` require a design decision 

I did not locate any tests, doctest or otherwise, for the existing conversions.