### PR TITLE
Drop invalid rows

### DIFF
--- a/crates/table/lib.rs
+++ b/crates/table/lib.rs
@@ -181,6 +181,26 @@ impl Table {
 		&mut self.columns
 	}
 
+	pub fn drop_row(&mut self, idx: usize) {
+		for column in self.columns_mut() {
+			match column {
+				TableColumn::Enum(etc) => {
+					let _ = etc.data_mut().remove(idx);
+				}
+				TableColumn::Number(ntc) => {
+					let _ = ntc.data_mut().remove(idx);
+				}
+				TableColumn::Text(ttc) => {
+					let _ = ttc.data_mut().remove(idx);
+				}
+				TableColumn::Unknown(utc) => {
+					let len = utc.len_mut();
+					*len -= 1;
+				}
+			}
+		}
+	}
+
 	pub fn ncols(&self) -> usize {
 		self.columns.len()
 	}

--- a/crates/table/lib.rs
+++ b/crates/table/lib.rs
@@ -181,9 +181,9 @@ impl Table {
 		&mut self.columns
 	}
 
-	pub fn drop_row(&mut self, idx: usize) {
+	pub fn drop_row(&mut self, index: usize) {
 		for column in self.columns_mut() {
-			column.drop_row(idx);
+			column.drop_row(index);
 		}
 	}
 

--- a/crates/table/lib.rs
+++ b/crates/table/lib.rs
@@ -183,21 +183,7 @@ impl Table {
 
 	pub fn drop_row(&mut self, idx: usize) {
 		for column in self.columns_mut() {
-			match column {
-				TableColumn::Enum(etc) => {
-					let _ = etc.data_mut().remove(idx);
-				}
-				TableColumn::Number(ntc) => {
-					let _ = ntc.data_mut().remove(idx);
-				}
-				TableColumn::Text(ttc) => {
-					let _ = ttc.data_mut().remove(idx);
-				}
-				TableColumn::Unknown(utc) => {
-					let len = utc.len_mut();
-					*len -= 1;
-				}
-			}
+			column.drop_row(idx);
 		}
 	}
 
@@ -289,6 +275,24 @@ impl TableColumn {
 			TableColumn::Number(s) => s.name.as_deref(),
 			TableColumn::Enum(s) => s.name.as_deref(),
 			TableColumn::Text(s) => s.name.as_deref(),
+		}
+	}
+
+	pub fn drop_row(&mut self, idx: usize) {
+		match self {
+			TableColumn::Enum(etc) => {
+				let _ = etc.data_mut().remove(idx);
+			}
+			TableColumn::Number(ntc) => {
+				let _ = ntc.data_mut().remove(idx);
+			}
+			TableColumn::Text(ttc) => {
+				let _ = ttc.data_mut().remove(idx);
+			}
+			TableColumn::Unknown(utc) => {
+				let len = utc.len_mut();
+				*len -= 1;
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR addresses #32.  After loading, rows containing invalid target data are dropped from the dataset prior to shuffling and splitting.  A warning is printed to the console informing the user of which row(s) were dropped..