### PR TITLE
Autogrid

### DIFF
--- a/crates/cli/main.rs
+++ b/crates/cli/main.rs
@@ -110,7 +110,7 @@ pub struct PredictArgs {
 	)]
 	probabilities: Option<bool>,
 	#[clap(short, long, about = "The threshold value to use for predictions.")]
-	threshold: Option<f32>
+	threshold: Option<f32>,
 }
 
 #[cfg(feature = "tangram_app")]

--- a/crates/core/config.rs
+++ b/crates/core/config.rs
@@ -151,10 +151,26 @@ pub struct BagOfWordsCosineSimilarityFeatureGroup {
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Train {
+	/// Use `autogrid` to control how the default hyperparameter grid is computed.
+	pub autogrid: Option<AutoGridOptions>,
 	/// The `grid` specifies which models should be trained and with which hyperparameters. If you do not specify this option, a reasonable default grid will be used.
 	pub grid: Option<Vec<GridItem>>,
 	/// This is the metric that will be computed on the comparison dataset to choose the best model.
 	pub comparison_metric: Option<ComparisonMetric>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct AutoGridOptions {
+	/// Which types of model to train
+	pub model_types: Option<Vec<ModelType>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub enum ModelType {
+	#[serde(rename = "linear")]
+	Linear,
+	#[serde(rename = "tree")]
+	Tree,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/crates/core/grid.rs
+++ b/crates/core/grid.rs
@@ -318,7 +318,7 @@ const DEFAULT_TREE_MAX_ROUNDS_VALUES: [u64; 1] = [1000];
 const DEFAULT_TREE_MAX_DEPTH: [u64; 1] = [50];
 
 /// Compute the default hyperparameter grid for regression.
-pub fn default_regression_hyperparameter_grid(
+pub fn auto_regression_hyperparameter_grid(
 	target_column_index: usize,
 	column_stats: &[ColumnStatsOutput],
 	config: &config::Config,
@@ -375,64 +375,79 @@ pub fn default_regression_hyperparameter_grid(
 }
 
 /// Compute the default hyperparameter grid for binary classification.
-pub fn default_binary_classification_hyperparameter_grid(
+pub fn auto_binary_classification_hyperparameter_grid(
 	target_column_index: usize,
 	column_stats: &[ColumnStatsOutput],
 	config: &config::Config,
 ) -> Vec<GridItem> {
+	let autogrid = &config.train.autogrid;
+	let (train_linear, train_tree) = match autogrid {
+		Some(ag) => match &ag.model_types {
+			Some(vec) => (
+				vec.contains(&config::ModelType::Linear),
+				vec.contains(&config::ModelType::Tree),
+			),
+			None => (false, false),
+		},
+		None => (false, false),
+	};
 	let mut grid = Vec::new();
-	for (&l2_regularization, &learning_rate, &max_epochs, &n_examples_per_batch) in iproduct!(
-		DEFAULT_LINEAR_L2_REGULARIZATION_VALUES.iter(),
-		DEFAULT_LINEAR_MODEL_LEARNING_RATE_VALUES.iter(),
-		DEFAULT_LINEAR_MAX_EPOCHS_VALUES.iter(),
-		DEFAULT_LINEAR_N_EXAMPLES_PER_BATCH_VALUES.iter()
-	) {
-		grid.push(GridItem::LinearBinaryClassifier {
-			target_column_index,
-			feature_groups: choose_feature_groups_linear(column_stats, config),
-			options: LinearModelTrainOptions {
-				l2_regularization: Some(l2_regularization),
-				learning_rate: Some(learning_rate),
-				max_epochs: Some(max_epochs),
-				n_examples_per_batch: Some(n_examples_per_batch),
-				early_stopping_options: Some(Default::default()),
-			},
-		});
+	if train_linear {
+		for (&l2_regularization, &learning_rate, &max_epochs, &n_examples_per_batch) in iproduct!(
+			DEFAULT_LINEAR_L2_REGULARIZATION_VALUES.iter(),
+			DEFAULT_LINEAR_MODEL_LEARNING_RATE_VALUES.iter(),
+			DEFAULT_LINEAR_MAX_EPOCHS_VALUES.iter(),
+			DEFAULT_LINEAR_N_EXAMPLES_PER_BATCH_VALUES.iter()
+		) {
+			grid.push(GridItem::LinearBinaryClassifier {
+				target_column_index,
+				feature_groups: choose_feature_groups_linear(column_stats, config),
+				options: LinearModelTrainOptions {
+					l2_regularization: Some(l2_regularization),
+					learning_rate: Some(learning_rate),
+					max_epochs: Some(max_epochs),
+					n_examples_per_batch: Some(n_examples_per_batch),
+					early_stopping_options: Some(Default::default()),
+				},
+			});
+		}
 	}
-	for (
-		&max_leaf_nodes,
-		&learning_rate,
-		&l2_regularization_for_continous_splits,
-		&max_rounds,
-		&max_depth,
-	) in iproduct!(
-		DEFAULT_TREE_MAX_LEAF_NODES.iter(),
-		DEFAULT_TREE_LEARNING_RATE_VALUES.iter(),
-		DEFAULT_TREE_L2_REGULARIZATION_VALUES_FOR_CONTINUOUS_SPLITS.iter(),
-		DEFAULT_TREE_MAX_ROUNDS_VALUES.iter(),
-		DEFAULT_TREE_MAX_DEPTH.iter()
-	) {
-		grid.push(GridItem::TreeBinaryClassifier {
-			target_column_index,
-			feature_groups: choose_feature_groups_tree(column_stats, config),
-			options: TreeModelTrainOptions {
-				max_leaf_nodes: Some(max_leaf_nodes),
-				learning_rate: Some(learning_rate),
-				max_rounds: Some(max_rounds),
-				max_depth: Some(max_depth),
-				l2_regularization_for_continuous_splits: Some(
-					l2_regularization_for_continous_splits,
-				),
-				early_stopping_options: Some(Default::default()),
-				..Default::default()
-			},
-		});
+	if train_tree {
+		for (
+			&max_leaf_nodes,
+			&learning_rate,
+			&l2_regularization_for_continous_splits,
+			&max_rounds,
+			&max_depth,
+		) in iproduct!(
+			DEFAULT_TREE_MAX_LEAF_NODES.iter(),
+			DEFAULT_TREE_LEARNING_RATE_VALUES.iter(),
+			DEFAULT_TREE_L2_REGULARIZATION_VALUES_FOR_CONTINUOUS_SPLITS.iter(),
+			DEFAULT_TREE_MAX_ROUNDS_VALUES.iter(),
+			DEFAULT_TREE_MAX_DEPTH.iter()
+		) {
+			grid.push(GridItem::TreeBinaryClassifier {
+				target_column_index,
+				feature_groups: choose_feature_groups_tree(column_stats, config),
+				options: TreeModelTrainOptions {
+					max_leaf_nodes: Some(max_leaf_nodes),
+					learning_rate: Some(learning_rate),
+					max_rounds: Some(max_rounds),
+					max_depth: Some(max_depth),
+					l2_regularization_for_continuous_splits: Some(
+						l2_regularization_for_continous_splits,
+					),
+					early_stopping_options: Some(Default::default()),
+					..Default::default()
+				},
+			});
+		}
 	}
 	grid
 }
 
 /// Compute the default hyperparameter grid for multiclass classification.
-pub fn default_multiclass_classification_hyperparameter_grid(
+pub fn auto_multiclass_classification_hyperparameter_grid(
 	target_column_index: usize,
 	column_stats: &[ColumnStatsOutput],
 	config: &config::Config,

--- a/crates/core/grid.rs
+++ b/crates/core/grid.rs
@@ -323,53 +323,68 @@ pub fn auto_regression_hyperparameter_grid(
 	column_stats: &[ColumnStatsOutput],
 	config: &config::Config,
 ) -> Vec<GridItem> {
+	let autogrid = &config.train.autogrid;
+	let (train_linear, train_tree) = match autogrid {
+		Some(ag) => match &ag.model_types {
+			Some(vec) => (
+				vec.contains(&config::ModelType::Linear),
+				vec.contains(&config::ModelType::Tree),
+			),
+			None => (true, true),
+		},
+		None => (true, true),
+	};
 	let mut grid = Vec::new();
-	for (&l2_regularization, &learning_rate, &max_epochs, &n_examples_per_batch) in iproduct!(
-		DEFAULT_LINEAR_L2_REGULARIZATION_VALUES.iter(),
-		DEFAULT_LINEAR_MODEL_LEARNING_RATE_VALUES.iter(),
-		DEFAULT_LINEAR_MAX_EPOCHS_VALUES.iter(),
-		DEFAULT_LINEAR_N_EXAMPLES_PER_BATCH_VALUES.iter()
-	) {
-		grid.push(GridItem::LinearRegressor {
-			target_column_index,
-			feature_groups: choose_feature_groups_linear(column_stats, config),
-			options: LinearModelTrainOptions {
-				l2_regularization: Some(l2_regularization),
-				learning_rate: Some(learning_rate),
-				max_epochs: Some(max_epochs),
-				n_examples_per_batch: Some(n_examples_per_batch),
-				early_stopping_options: Some(Default::default()),
-			},
-		});
+	if train_linear {
+		for (&l2_regularization, &learning_rate, &max_epochs, &n_examples_per_batch) in iproduct!(
+			DEFAULT_LINEAR_L2_REGULARIZATION_VALUES.iter(),
+			DEFAULT_LINEAR_MODEL_LEARNING_RATE_VALUES.iter(),
+			DEFAULT_LINEAR_MAX_EPOCHS_VALUES.iter(),
+			DEFAULT_LINEAR_N_EXAMPLES_PER_BATCH_VALUES.iter()
+		) {
+			grid.push(GridItem::LinearRegressor {
+				target_column_index,
+				feature_groups: choose_feature_groups_linear(column_stats, config),
+				options: LinearModelTrainOptions {
+					l2_regularization: Some(l2_regularization),
+					learning_rate: Some(learning_rate),
+					max_epochs: Some(max_epochs),
+					n_examples_per_batch: Some(n_examples_per_batch),
+					early_stopping_options: Some(Default::default()),
+				},
+			});
+		}
 	}
-	for (
-		&max_leaf_nodes,
-		&learning_rate,
-		&l2_regularization_for_continuous_splits,
-		&max_rounds,
-		&max_depth,
-	) in iproduct!(
-		DEFAULT_TREE_MAX_LEAF_NODES.iter(),
-		DEFAULT_TREE_LEARNING_RATE_VALUES.iter(),
-		DEFAULT_TREE_L2_REGULARIZATION_VALUES_FOR_CONTINUOUS_SPLITS.iter(),
-		DEFAULT_TREE_MAX_ROUNDS_VALUES.iter(),
-		DEFAULT_TREE_MAX_DEPTH.iter()
-	) {
-		grid.push(GridItem::TreeRegressor {
-			target_column_index,
-			feature_groups: choose_feature_groups_tree(column_stats, config),
-			options: TreeModelTrainOptions {
-				max_leaf_nodes: Some(max_leaf_nodes),
-				learning_rate: Some(learning_rate),
-				max_rounds: Some(max_rounds),
-				max_depth: Some(max_depth),
-				l2_regularization_for_continuous_splits: Some(
-					l2_regularization_for_continuous_splits,
-				),
-				early_stopping_options: Some(Default::default()),
-				..Default::default()
-			},
-		});
+	if train_tree {
+		for (
+			&max_leaf_nodes,
+			&learning_rate,
+			&l2_regularization_for_continuous_splits,
+			&max_rounds,
+			&max_depth,
+		) in iproduct!(
+			DEFAULT_TREE_MAX_LEAF_NODES.iter(),
+			DEFAULT_TREE_LEARNING_RATE_VALUES.iter(),
+			DEFAULT_TREE_L2_REGULARIZATION_VALUES_FOR_CONTINUOUS_SPLITS.iter(),
+			DEFAULT_TREE_MAX_ROUNDS_VALUES.iter(),
+			DEFAULT_TREE_MAX_DEPTH.iter()
+		) {
+			grid.push(GridItem::TreeRegressor {
+				target_column_index,
+				feature_groups: choose_feature_groups_tree(column_stats, config),
+				options: TreeModelTrainOptions {
+					max_leaf_nodes: Some(max_leaf_nodes),
+					learning_rate: Some(learning_rate),
+					max_rounds: Some(max_rounds),
+					max_depth: Some(max_depth),
+					l2_regularization_for_continuous_splits: Some(
+						l2_regularization_for_continuous_splits,
+					),
+					early_stopping_options: Some(Default::default()),
+					..Default::default()
+				},
+			});
+		}
 	}
 	grid
 }
@@ -387,9 +402,9 @@ pub fn auto_binary_classification_hyperparameter_grid(
 				vec.contains(&config::ModelType::Linear),
 				vec.contains(&config::ModelType::Tree),
 			),
-			None => (false, false),
+			None => (true, true),
 		},
-		None => (false, false),
+		None => (true, true),
 	};
 	let mut grid = Vec::new();
 	if train_linear {
@@ -452,53 +467,68 @@ pub fn auto_multiclass_classification_hyperparameter_grid(
 	column_stats: &[ColumnStatsOutput],
 	config: &config::Config,
 ) -> Vec<GridItem> {
+	let autogrid = &config.train.autogrid;
+	let (train_linear, train_tree) = match autogrid {
+		Some(ag) => match &ag.model_types {
+			Some(vec) => (
+				vec.contains(&config::ModelType::Linear),
+				vec.contains(&config::ModelType::Tree),
+			),
+			None => (true, true),
+		},
+		None => (true, true),
+	};
 	let mut grid = Vec::new();
-	for (&l2_regularization, &learning_rate, &max_epochs, &n_examples_per_batch) in iproduct!(
-		DEFAULT_LINEAR_L2_REGULARIZATION_VALUES.iter(),
-		DEFAULT_LINEAR_MODEL_LEARNING_RATE_VALUES.iter(),
-		DEFAULT_LINEAR_MAX_EPOCHS_VALUES.iter(),
-		DEFAULT_LINEAR_N_EXAMPLES_PER_BATCH_VALUES.iter()
-	) {
-		grid.push(GridItem::LinearMulticlassClassifier {
-			target_column_index,
-			feature_groups: choose_feature_groups_linear(column_stats, config),
-			options: LinearModelTrainOptions {
-				l2_regularization: Some(l2_regularization),
-				learning_rate: Some(learning_rate),
-				max_epochs: Some(max_epochs),
-				n_examples_per_batch: Some(n_examples_per_batch),
-				early_stopping_options: Some(Default::default()),
-			},
-		});
+	if train_linear {
+		for (&l2_regularization, &learning_rate, &max_epochs, &n_examples_per_batch) in iproduct!(
+			DEFAULT_LINEAR_L2_REGULARIZATION_VALUES.iter(),
+			DEFAULT_LINEAR_MODEL_LEARNING_RATE_VALUES.iter(),
+			DEFAULT_LINEAR_MAX_EPOCHS_VALUES.iter(),
+			DEFAULT_LINEAR_N_EXAMPLES_PER_BATCH_VALUES.iter()
+		) {
+			grid.push(GridItem::LinearMulticlassClassifier {
+				target_column_index,
+				feature_groups: choose_feature_groups_linear(column_stats, config),
+				options: LinearModelTrainOptions {
+					l2_regularization: Some(l2_regularization),
+					learning_rate: Some(learning_rate),
+					max_epochs: Some(max_epochs),
+					n_examples_per_batch: Some(n_examples_per_batch),
+					early_stopping_options: Some(Default::default()),
+				},
+			});
+		}
 	}
-	for (
-		&max_leaf_nodes,
-		&learning_rate,
-		&l2_regularization_for_continuous_splits,
-		&max_rounds,
-		&max_depth,
-	) in iproduct!(
-		DEFAULT_TREE_MAX_LEAF_NODES.iter(),
-		DEFAULT_TREE_LEARNING_RATE_VALUES.iter(),
-		DEFAULT_TREE_L2_REGULARIZATION_VALUES_FOR_CONTINUOUS_SPLITS.iter(),
-		DEFAULT_TREE_MAX_ROUNDS_VALUES.iter(),
-		DEFAULT_TREE_MAX_DEPTH.iter()
-	) {
-		grid.push(GridItem::TreeMulticlassClassifier {
-			target_column_index,
-			feature_groups: choose_feature_groups_tree(column_stats, config),
-			options: TreeModelTrainOptions {
-				max_leaf_nodes: Some(max_leaf_nodes),
-				learning_rate: Some(learning_rate),
-				max_rounds: Some(max_rounds),
-				max_depth: Some(max_depth),
-				l2_regularization_for_continuous_splits: Some(
-					l2_regularization_for_continuous_splits,
-				),
-				early_stopping_options: Some(Default::default()),
-				..Default::default()
-			},
-		});
+	if train_tree {
+		for (
+			&max_leaf_nodes,
+			&learning_rate,
+			&l2_regularization_for_continuous_splits,
+			&max_rounds,
+			&max_depth,
+		) in iproduct!(
+			DEFAULT_TREE_MAX_LEAF_NODES.iter(),
+			DEFAULT_TREE_LEARNING_RATE_VALUES.iter(),
+			DEFAULT_TREE_L2_REGULARIZATION_VALUES_FOR_CONTINUOUS_SPLITS.iter(),
+			DEFAULT_TREE_MAX_ROUNDS_VALUES.iter(),
+			DEFAULT_TREE_MAX_DEPTH.iter()
+		) {
+			grid.push(GridItem::TreeMulticlassClassifier {
+				target_column_index,
+				feature_groups: choose_feature_groups_tree(column_stats, config),
+				options: TreeModelTrainOptions {
+					max_leaf_nodes: Some(max_leaf_nodes),
+					learning_rate: Some(learning_rate),
+					max_rounds: Some(max_rounds),
+					max_depth: Some(max_depth),
+					l2_regularization_for_continuous_splits: Some(
+						l2_regularization_for_continuous_splits,
+					),
+					early_stopping_options: Some(Default::default()),
+					..Default::default()
+				},
+			});
+		}
 	}
 	grid
 }

--- a/crates/core/train.rs
+++ b/crates/core/train.rs
@@ -902,18 +902,18 @@ fn compute_hyperparameter_grid(
 			}
 		})
 		.unwrap_or_else(|| match &task {
-			Task::Regression => grid::default_regression_hyperparameter_grid(
+			Task::Regression => grid::auto_regression_hyperparameter_grid(
 				target_column_index,
 				train_column_stats,
 				config,
 			),
-			Task::BinaryClassification => grid::default_binary_classification_hyperparameter_grid(
+			Task::BinaryClassification => grid::auto_binary_classification_hyperparameter_grid(
 				target_column_index,
 				train_column_stats,
 				config,
 			),
 			Task::MulticlassClassification { .. } => {
-				grid::default_multiclass_classification_hyperparameter_grid(
+				grid::auto_multiclass_classification_hyperparameter_grid(
 					target_column_index,
 					train_column_stats,
 					config,

--- a/languages/python/build.rs
+++ b/languages/python/build.rs
@@ -2,7 +2,10 @@ fn main() {
 	let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
 	match target_os.as_str() {
 		"windows" => {
-			println!("cargo:rustc-link-search=native={}", std::env::var("CARGO_MANIFEST_DIR").unwrap());
+			println!(
+				"cargo:rustc-link-search=native={}",
+				std::env::var("CARGO_MANIFEST_DIR").unwrap()
+			);
 		}
 		_ => {}
 	};


### PR DESCRIPTION
This PR addresses #46 by adding an `autogrid` option to the config file:

```json
{
  "train": {
    "autogrid": {
      "model_types": ["linear"]
    }
  }
}
```

This code will instruct Tangram to only train linear models.