### PR TITLE
Update tangram.gemspec

### DIFF
--- a/languages/ruby/tangram.gemspec
+++ b/languages/ruby/tangram.gemspec
@@ -6,7 +6,10 @@ Gem::Specification.new do |s|
   s.authors = ["Tangram"]
   s.email = "help@tangram.dev"
   s.files = Dir["**/**"].grep_v(/^tangram.gem$/).grep_v(/^examples/)
-  s.homepage = "https://rubygems.org/gems/tangram"
+  s.homepage = "https://www.tangram.dev/"
+  s.metadata = {
+    "source_code_uri" => "https://github.com/tangramdotdev/tangram/tree/main/languages/ruby"
+  }
   s.license = "MIT"
   s.add_dependency "ffi", "~> 1"
 end


### PR DESCRIPTION
Hi. I think it's redundant to have the rubygems page as homepage as most people will see this url on rubygems.org, it would be more helpful to use your official site (btw you won't need to squish it into the description this way). It's also very helpful to have a link to the source code when it's available, easier to make sure that this project is still alive, etc.