### PR TITLE
Add GitHub Action to run tests + run clippy on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: clippy-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-clippy-${{ hashFiles('**/clippy.toml') }}
+
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: test-${{ runner.os }}-cargo-${{ hashfiles('**/cargo.lock') }}
+
+      - name: Build for Tests
+        run: cargo test --no-run
+
+      - name: Run tests
+        run: cargo test

--- a/languages/javascript/wasm/lib.rs
+++ b/languages/javascript/wasm/lib.rs
@@ -1,3 +1,8 @@
+// wasm_bindgen generates some code in their proc macro that contains unused unit expressions.
+// This has been fixed in https://github.com/rustwasm/wasm-bindgen/issues/2774 , but not yet
+// released.
+#![allow(clippy::unused_unit)]
+
 use std::collections::BTreeMap;
 use wasm_bindgen::{prelude::*, JsValue};
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,9 @@
 [toolchain]
-channel = "stable"
+
+# New Rust versions can introduce new Clippy lints, which can spuriously cause
+# the build to fail---so we pin the latest stable version here, and fix any new 
+# lints when we manually upgrade to the latest Rust version.
+channel = "1.58.1"
+
+# Install the wasm target so we can build the web frontend
 targets = [ "wasm32-unknown-unknown" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,5 +5,7 @@
 # lints when we manually upgrade to the latest Rust version.
 channel = "1.58.1"
 
+components = [ "clippy", "rustfmt" ]
+
 # Install the wasm target so we can build the web frontend
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
### This PR:

- Pins the Rust version to the latest stable, because the introduction of new Clippy lints has the potential to break the build
- Silences some warnings related to `wasm_bindgen`, until they're fixed upstream (in https://github.com/rustwasm/wasm-bindgen/issues/2774)
- Adds a GH Actions workflow to run tests
- Adds a GH Actions workflow to run clippy, and attach any clippy warnings to PRs/commits as GitHub annotations

Builds take around ~30min with no cache, and around ~5min with a warm cache, on the default Actions runners.

Using `cargo2nix` here could potentially work, but (at least from my reading of their [docs](https://github.com/cargo2nix/cargo2nix)) it requires another lockfile (`Cargo.nix`) that could fall out of sync with `Cargo.lock`---and would make contributing to this repo more complicated. It's something we can look into down the line, but for now I don't think the extra complexity is really necessary.

### To do:
- [ ] Check that `nix flake check` runs the Cargo tests locally
- [ ] Configure `nix flake check` to run Clippy locally
- [ ] Actually enable Actions on this repo