### PR TITLE
Alert Sending

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: test
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,6 +3209,7 @@ dependencies = [
  "tangram_id",
  "tangram_metrics",
  "tangram_model",
+ "tangram_serve",
  "tangram_table",
  "tangram_text",
  "tangram_zip",

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -11,6 +11,7 @@ path = "lib.rs"
 [dev-dependencies]
 insta = "1"
 tangram = { path = "../../../languages/rust" }
+tangram_serve = { path = "../../serve" }
 tracing-test = "0.2"
 
 [dependencies]

--- a/crates/app/core/alert_sender.rs
+++ b/crates/app/core/alert_sender.rs
@@ -1,13 +1,16 @@
 use crate::{
+	alert::{Alert, AlertMethod},
 	heuristics::{
 		ALERT_SENDER_HEARTBEAT_DURATION_PRODUCTION, ALERT_SENDER_HEARTBEAT_DURATION_TESTING,
+		ALERT_SENDER_MAXIMUM_RETRY_PERIODS, ALERT_SENDER_RETRY_DECAY_FACTOR,
+		ALERT_SENDER_RETRY_INITIAL_PERIOD,
 	},
 	App, AppState,
 };
 use anyhow::Result;
 use futures::{select, FutureExt};
-//use lettre::AsyncTransport;
-use std::{borrow::BorrowMut, sync::Arc};
+use sqlx::prelude::*;
+use std::{borrow::BorrowMut, io, str::FromStr, sync::Arc};
 use tangram_id::Id;
 use tokio::sync::{mpsc, oneshot};
 
@@ -19,7 +22,7 @@ pub enum AlertSenderMessage {
 /// Read database for unsent alerts
 #[tracing::instrument(level = "info", skip_all)]
 pub async fn alert_sender(
-	app: Arc<AppState>,
+	app_state: Arc<AppState>,
 	mut receiver: mpsc::UnboundedReceiver<AlertSenderMessage>,
 ) -> Result<()> {
 	let period = if cfg!(debug_assertions) {
@@ -42,12 +45,14 @@ pub async fn alert_sender(
 			}
 		};
 		tracing::info!("Begin alert_sender heartbeat");
-		let mut txn = app.begin_transaction().await?;
-		let unsent_alerts = app.get_unsent_alerts(txn.borrow_mut()).await?;
-		for alert in unsent_alerts {
-			app.send_alert(alert, txn.borrow_mut()).await?;
+		let mut txn = app_state.begin_transaction().await?;
+		// First, find any orphaned tasks still marked Sending and reset them
+		reset_dropped_sends(&app_state, txn.borrow_mut()).await?;
+		let unsent_alerts = get_all_unsent_alert_sends(&app_state, txn.borrow_mut()).await?;
+		for alert_send in unsent_alerts {
+			handle_alert_send_with_decay(&app_state, alert_send, txn.borrow_mut()).await?;
 		}
-		app.commit_transaction(txn).await?;
+		app_state.commit_transaction(txn).await?;
 		tracing::info!("End alert_sender heartbeat");
 		if let Event::Message(AlertSenderMessage::Run(sender)) = event {
 			sender.send(()).unwrap();
@@ -56,7 +61,331 @@ pub async fn alert_sender(
 	Ok(())
 }
 
-/// Update an alert record to indicate it has been sent
+pub async fn handle_alert_send(
+	app_state: &AppState,
+	alert_send: &AlertSend,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<AlertSendStatus> {
+	set_alert_send_status(
+		app_state,
+		alert_send.id,
+		AlertSendStatus::Sending,
+		txn.borrow_mut(),
+	)
+	.await?;
+	increment_attempt_count(alert_send.id, txn.borrow_mut()).await?;
+	let exceeded_thresholds = alert_send.alert.result;
+
+	match &alert_send.method {
+		AlertMethod::Email(email) => {
+			let email = lettre::Message::builder()
+				.from("Tangram <noreply@tangram.dev>".parse()?)
+				.to(email.email.parse()?)
+				.subject("Tangram Metrics Alert")
+				.body(format!(
+					"Exceeded alert thresholds: {:?}",
+					exceeded_thresholds
+				))?;
+			let status = match app_state.send_email(email).await {
+				Ok(_) => AlertSendStatus::Succeeded,
+				Err(_) => AlertSendStatus::Retrying,
+			};
+			set_alert_send_status(app_state, alert_send.id, status, txn.borrow_mut()).await?;
+			Ok(status)
+		}
+		AlertMethod::Stdout => {
+			println!("exceeded thresholds: {:?}", exceeded_thresholds);
+			Ok(AlertSendStatus::Succeeded)
+		}
+		AlertMethod::Webhook(url) => {
+			let url = &url.url;
+			let status = match app_state
+				.http_sender
+				.post_payload(exceeded_thresholds, url.clone())
+				.await
+			{
+				Ok(_) => AlertSendStatus::Succeeded,
+				Err(_) => AlertSendStatus::Retrying,
+			};
+			set_alert_send_status(app_state, alert_send.id, status, txn.borrow_mut()).await?;
+			Ok(status)
+		}
+	}
+}
+
+async fn reset_dropped_sends(
+	app_state: &AppState,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<()> {
+	// Find any record in alert_sends that as a status of Sending and an initiated time greater than one heartbeat ago
+	let one_heartbeat_ago =
+		(app_state.clock().now_utc() - ALERT_SENDER_HEARTBEAT_DURATION_PRODUCTION).unix_timestamp();
+	let rows = sqlx::query(
+		"
+			select
+				id
+			from
+				alert_sends
+			where
+				status = $1
+			and
+				initiated_date <= $2
+		",
+	)
+	.bind(u8::from(AlertSendStatus::Sending) as i64)
+	.bind(one_heartbeat_ago)
+	.fetch_all(txn.borrow_mut())
+	.await?;
+	// Set all statuses back to Unsent, so they're picked up in this heartbeat.
+	for row in rows {
+		let id: String = row.get(0);
+		let id = Id::from_str(&id)?;
+		set_alert_send_status(app_state, id, AlertSendStatus::Unsent, txn.borrow_mut()).await?;
+	}
+	Ok(())
+}
+
+// TODO - call this at the start for all alerts.
+async fn handle_alert_send_with_decay(
+	app_state: &AppState,
+	alert_send: AlertSend,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<()> {
+	// this should either spawn a task, or be spawned in a task?
+	let mut retry_count = 0u32;
+	while retry_count < ALERT_SENDER_MAXIMUM_RETRY_PERIODS {
+		// attempt the send
+		if (handle_alert_send(app_state, &alert_send, txn.borrow_mut()).await).is_ok() {
+			set_alert_send_status(
+				app_state,
+				alert_send.id,
+				AlertSendStatus::Succeeded,
+				txn.borrow_mut(),
+			)
+			.await?;
+			return Ok(());
+		}
+		// If we failed, set back to retrying
+		retry_count += 1;
+		set_alert_send_status(
+			app_state,
+			alert_send.id,
+			AlertSendStatus::Retrying,
+			txn.borrow_mut(),
+		)
+		.await?;
+		// change period
+		let old_secs = ALERT_SENDER_RETRY_INITIAL_PERIOD.as_secs();
+		let new_secs = old_secs * ALERT_SENDER_RETRY_DECAY_FACTOR.pow(retry_count);
+		let period = std::time::Duration::from_secs(new_secs);
+		tokio::time::sleep(period).await;
+	}
+	// If we hit the end and it never succeeded, write a failiure
+	set_alert_send_status(
+		app_state,
+		alert_send.id,
+		AlertSendStatus::Failed,
+		txn.borrow_mut(),
+	)
+	.await?;
+	Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum AlertSendStatus {
+	Unsent,
+	Sending,
+	Retrying,
+	Succeeded,
+	Failed,
+}
+
+impl TryFrom<u8> for AlertSendStatus {
+	type Error = io::Error;
+	fn try_from(value: u8) -> Result<Self, Self::Error> {
+		match value {
+			0 => Ok(AlertSendStatus::Unsent),
+			1 => Ok(AlertSendStatus::Sending),
+			2 => Ok(AlertSendStatus::Retrying),
+			3 => Ok(AlertSendStatus::Succeeded),
+			4 => Ok(AlertSendStatus::Failed),
+			_ => Err(io::Error::new(
+				io::ErrorKind::InvalidInput,
+				"Unrecognized alert attempt status",
+			)),
+		}
+	}
+}
+
+impl From<AlertSendStatus> for u8 {
+	fn from(status: AlertSendStatus) -> Self {
+		match status {
+			AlertSendStatus::Unsent => 0,
+			AlertSendStatus::Sending => 1,
+			AlertSendStatus::Retrying => 2,
+			AlertSendStatus::Succeeded => 3,
+			AlertSendStatus::Failed => 4,
+		}
+	}
+}
+
+/// Insert a new alert attempt
+pub async fn create_alert_send(
+	app_state: &AppState,
+	alert_id: Id,
+	method: AlertMethod,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<Id> {
+	let id = Id::generate();
+	let now = app_state.clock().now_utc().unix_timestamp();
+	let method_json = serde_json::to_string(&method)?;
+	sqlx::query(
+		"
+		insert into alert_sends
+			(id, alert_id, attempt_count, method, status, initiated_date)
+		values
+			($1, $2, 0, $3, $4, $5)
+	",
+	)
+	.bind(id.to_string())
+	.bind(alert_id.to_string())
+	.bind(method_json)
+	.bind(u8::from(AlertSendStatus::Unsent) as i64)
+	.bind(now)
+	.execute(txn.borrow_mut())
+	.await?;
+	Ok(id)
+}
+
+async fn increment_attempt_count(
+	alert_id: Id,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<()> {
+	sqlx::query(
+		"
+			update
+				alert_sends
+			set
+				attempt_count = attempt_count + 1
+			where
+				id = $1
+		",
+	)
+	.bind(alert_id.to_string())
+	.execute(txn.borrow_mut())
+	.await?;
+	Ok(())
+}
+
+/// Update the status of an alert attempt
+pub async fn set_alert_send_status(
+	app_state: &AppState,
+	alert_send_id: Id,
+	new_status: AlertSendStatus,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<()> {
+	sqlx::query(
+		"
+			update
+				alert_sends
+			set
+				status = $1
+			where
+				id = $2
+		",
+	)
+	.bind(u8::from(new_status) as i64)
+	.bind(alert_send_id.to_string())
+	.execute(txn.borrow_mut())
+	.await?;
+	// If the attempt status is either Succeeded or Failed, also set the completed time
+	if matches!(new_status, AlertSendStatus::Succeeded)
+		|| matches!(new_status, AlertSendStatus::Failed)
+	{
+		let now = app_state.clock().now_utc().unix_timestamp();
+		sqlx::query(
+			"
+				update
+					alert_sends
+				set
+					completed_date = $1
+				where
+					id = $2
+			",
+		)
+		.bind(now)
+		.bind(alert_send_id.to_string())
+		.execute(txn.borrow_mut())
+		.await?;
+	}
+	Ok(())
+}
+
+pub struct AlertSend {
+	id: Id,
+	alert: Alert,
+	method: AlertMethod,
+}
+
+pub async fn get_all_unsent_alert_sends(
+	app_state: &AppState,
+	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+) -> Result<Vec<AlertSend>> {
+	let rows = sqlx::query(
+		"
+		select
+			id,
+			alert_id,
+			method
+		from alert_sends
+		where
+			status = $1
+	",
+	)
+	.bind(u8::from(AlertSendStatus::Unsent) as i64)
+	.fetch_all(txn.borrow_mut())
+	.await?;
+	// Process all returned rows with just the alert id
+	struct RawAlertSend {
+		id: Id,
+		alert_id: Id,
+		method: AlertMethod,
+	}
+	let raw_results: Vec<RawAlertSend> = rows
+		.into_iter()
+		.map(|row| {
+			// Pull data
+			let id: String = row.get(0);
+			let id = Id::from_str(&id).unwrap();
+			let alert_id: String = row.get(1);
+			let alert_id = Id::from_str(&alert_id).unwrap();
+			let method: String = row.get(2);
+			let method: AlertMethod =
+				serde_json::from_str(&method).expect("Malformed alert method");
+			RawAlertSend {
+				id,
+				alert_id,
+				method,
+			}
+		})
+		.collect();
+	// Grab the actual alert for each returned Id
+	let mut results = vec![];
+	for result in raw_results {
+		let alert = app_state
+			.get_alert(txn.borrow_mut(), result.alert_id)
+			.await?
+			.unwrap();
+		results.push(AlertSend {
+			id: result.id,
+			alert,
+			method: result.method,
+		});
+	}
+	Ok(results)
+}
+
+/// Update an alert record to indicate it has been picked up by the alert_sender
 pub async fn set_alert_sent(
 	alert_id: Id,
 	txn: &mut sqlx::Transaction<'_, sqlx::Any>,
@@ -87,17 +416,39 @@ impl App {
 		Ok(())
 	}
 }
-/*
+
 #[cfg(test)]
 mod test {
 	use super::*;
 	use crate::{
-		alert::{AlertMethod, AlertMetric},
+		alert::{AlertMethod, AlertMethodWebhook, AlertMetric},
 		monitor::{MonitorCadence, MonitorThreshold, MonitorThresholdMode},
 		monitor_checker::MonitorConfig,
 		test_common::*,
 	};
 	use tracing_test::traced_test;
+
+	async fn get_total_sends_with_status(
+		txn: &mut sqlx::Transaction<'_, sqlx::Any>,
+		status: AlertSendStatus,
+	) -> Result<i64> {
+		let result = sqlx::query(
+			"
+				select
+					count (*)
+				from
+					alert_sends
+				where
+					status = $1
+			",
+		)
+		.bind(u8::from(status) as i64)
+		.fetch_one(txn.borrow_mut())
+		.await?
+		.get(0);
+		Ok(result)
+	}
+
 	#[tokio::test]
 	#[traced_test]
 	async fn test_alert_email_send() {
@@ -115,7 +466,72 @@ mod test {
 				difference_upper: Some(0.05),
 			},
 			title: None,
-			methods: vec![AlertMethod::Email("ben@tangram.dev".to_owned())],
+			methods: vec![AlertMethod::Email("ben@tangram.dev".to_owned().into())],
+		};
+		seed_single_monitor(&app, &test_monitor, model_id)
+			.await
+			.unwrap();
+		seed_events(&app, 100, model_id).await.unwrap();
+		// Scroll to allow monitor_checker to write alert
+		app.clock().pause();
+		app.clock()
+			.advance(std::time::Duration::from_secs(60 * 60))
+			.await;
+		app.clock().resume();
+		app.check_monitors().await.unwrap();
+
+		// Scroll to allow alert_sender to pick up alert
+		app.clock().pause();
+		app.clock()
+			.advance(std::time::Duration::from_secs(10))
+			.await;
+		app.clock().resume();
+		app.check_monitors().await.unwrap();
+
+		// Assert exactly one success has been logged.
+		let mut txn = app.begin_transaction().await.unwrap();
+		let num_successes =
+			get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Succeeded)
+				.await
+				.unwrap();
+		assert_eq!(num_successes, 1);
+
+		// Assert there are no unset, sending, or failed
+		let num_unsent = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Unsent)
+			.await
+			.unwrap();
+		assert_eq!(num_unsent, 0);
+		let num_sending = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Sending)
+			.await
+			.unwrap();
+		assert_eq!(num_sending, 0);
+		let num_failed = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Failed)
+			.await
+			.unwrap();
+		assert_eq!(num_failed, 0);
+		app.commit_transaction(txn).await.unwrap();
+	}
+
+	#[tokio::test]
+	#[traced_test]
+	async fn test_alert_webhook_send() {
+		// Seed app, generate an alert, assert the email is sent
+		let app = init_test_app().await.unwrap();
+		app.clock().resume();
+		let model_id = init_heart_disease_model(&app).await.unwrap();
+		seed_monitor_event_pair(&app, model_id, true).await.unwrap();
+		let test_monitor = MonitorConfig {
+			cadence: MonitorCadence::Hourly,
+			threshold: MonitorThreshold {
+				metric: AlertMetric::Accuracy,
+				mode: MonitorThresholdMode::Absolute,
+				difference_lower: Some(0.05),
+				difference_upper: Some(0.05),
+			},
+			title: None,
+			methods: vec![AlertMethod::Webhook(
+				AlertMethodWebhook::try_from("http://0.0.0.0:8085/webhook".to_owned()).unwrap(),
+			)],
 		};
 		seed_single_monitor(&app, &test_monitor, model_id)
 			.await
@@ -127,6 +543,101 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		// Scroll to allow alert_sender to pick up alert
+		app.clock().pause();
+		app.clock()
+			.advance(std::time::Duration::from_secs(10))
+			.await;
+		app.clock().resume();
+		app.check_monitors().await.unwrap();
+
+		// Assert exactly one success has been logged.
+		let mut txn = app.begin_transaction().await.unwrap();
+		let num_successes =
+			get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Succeeded)
+				.await
+				.unwrap();
+		assert_eq!(num_successes, 1);
+
+		// Assert there are no unset, sending, or failed
+		let num_unsent = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Unsent)
+			.await
+			.unwrap();
+		assert_eq!(num_unsent, 0);
+		let num_sending = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Sending)
+			.await
+			.unwrap();
+		assert_eq!(num_sending, 0);
+		let num_failed = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Failed)
+			.await
+			.unwrap();
+		assert_eq!(num_failed, 0);
+		app.commit_transaction(txn).await.unwrap();
+	}
+
+	#[tokio::test]
+	#[traced_test]
+	async fn test_alert_multiple_methods_send() {
+		// Seed app, generate an alert, assert the email is sent
+		let app = init_test_app().await.unwrap();
+		app.clock().resume();
+		let model_id = init_heart_disease_model(&app).await.unwrap();
+		seed_monitor_event_pair(&app, model_id, true).await.unwrap();
+		let test_monitor = MonitorConfig {
+			cadence: MonitorCadence::Hourly,
+			threshold: MonitorThreshold {
+				metric: AlertMetric::Accuracy,
+				mode: MonitorThresholdMode::Absolute,
+				difference_lower: Some(0.05),
+				difference_upper: Some(0.05),
+			},
+			title: None,
+			methods: vec![
+				AlertMethod::Email("ben@tangram.dev".to_owned().into()),
+				AlertMethod::Webhook(
+					AlertMethodWebhook::try_from("http://0.0.0.0:8085/webhook".to_owned()).unwrap(),
+				),
+			],
+		};
+		seed_single_monitor(&app, &test_monitor, model_id)
+			.await
+			.unwrap();
+		seed_events(&app, 100, model_id).await.unwrap();
+		app.clock().pause();
+		app.clock()
+			.advance(std::time::Duration::from_secs(60 * 60))
+			.await;
+		app.clock().resume();
+		app.check_monitors().await.unwrap();
+		// Scroll to allow alert_sender to pick up alert
+		app.clock().pause();
+		app.clock()
+			.advance(std::time::Duration::from_secs(10))
+			.await;
+		app.clock().resume();
+		app.check_monitors().await.unwrap();
+
+		// Assert exactly two successes have been logged.
+		let mut txn = app.begin_transaction().await.unwrap();
+		let num_successes =
+			get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Succeeded)
+				.await
+				.unwrap();
+		assert_eq!(num_successes, 2);
+
+		// Assert there are no unset, sending, or failed
+		let num_unsent = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Unsent)
+			.await
+			.unwrap();
+		assert_eq!(num_unsent, 0);
+		let num_sending = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Sending)
+			.await
+			.unwrap();
+		assert_eq!(num_sending, 0);
+		let num_failed = get_total_sends_with_status(txn.borrow_mut(), AlertSendStatus::Failed)
+			.await
+			.unwrap();
+		assert_eq!(num_failed, 0);
+		app.commit_transaction(txn).await.unwrap();
 	}
 }
-*/

--- a/crates/app/core/alert_sender.rs
+++ b/crates/app/core/alert_sender.rs
@@ -452,8 +452,11 @@ mod test {
 	#[tokio::test]
 	#[traced_test]
 	async fn test_alert_email_send() {
+		let mut ctx = TestContext::new("email_send").await;
 		// Seed app, generate an alert, assert the email is sent
-		let app = init_test_app().await.unwrap();
+		let app = init_test_app(init_test_options_postgres("email_send"))
+			.await
+			.unwrap();
 		app.clock().resume();
 		let model_id = init_heart_disease_model(&app).await.unwrap();
 		seed_monitor_event_pair(&app, model_id, true).await.unwrap();
@@ -510,13 +513,17 @@ mod test {
 			.unwrap();
 		assert_eq!(num_failed, 0);
 		app.commit_transaction(txn).await.unwrap();
+		ctx.drop().await;
 	}
 
 	#[tokio::test]
 	#[traced_test]
 	async fn test_alert_webhook_send() {
+		let mut ctx = TestContext::new("webhook_send").await;
 		// Seed app, generate an alert, assert the email is sent
-		let app = init_test_app().await.unwrap();
+		let app = init_test_app(init_test_options_postgres("webhook_send"))
+			.await
+			.unwrap();
 		app.clock().resume();
 		let model_id = init_heart_disease_model(&app).await.unwrap();
 		seed_monitor_event_pair(&app, model_id, true).await.unwrap();
@@ -573,13 +580,17 @@ mod test {
 			.unwrap();
 		assert_eq!(num_failed, 0);
 		app.commit_transaction(txn).await.unwrap();
+		ctx.drop().await;
 	}
 
 	#[tokio::test]
 	#[traced_test]
 	async fn test_alert_multiple_methods_send() {
+		let mut ctx = TestContext::new("multiple_methods_send").await;
 		// Seed app, generate an alert, assert the email is sent
-		let app = init_test_app().await.unwrap();
+		let app = init_test_app(init_test_options_postgres("multiple_methods_send"))
+			.await
+			.unwrap();
 		app.clock().resume();
 		let model_id = init_heart_disease_model(&app).await.unwrap();
 		seed_monitor_event_pair(&app, model_id, true).await.unwrap();
@@ -639,5 +650,6 @@ mod test {
 			.unwrap();
 		assert_eq!(num_failed, 0);
 		app.commit_transaction(txn).await.unwrap();
+		ctx.drop().await;
 	}
 }

--- a/crates/app/core/alert_sender.rs
+++ b/crates/app/core/alert_sender.rs
@@ -493,6 +493,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 
 		// Scroll to allow alert_sender to pick up alert
 		app.clock().pause();
@@ -501,6 +502,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 
 		// Assert exactly one success has been logged.
 		let mut txn = app.begin_transaction().await.unwrap();
@@ -564,6 +566,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 
 		// Assert exactly one success has been logged.
 		let mut txn = app.begin_transaction().await.unwrap();
@@ -629,6 +632,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(10))
 			.await;
 		app.clock().resume();
+		app.check_monitors().await.unwrap();
 		app.check_alert_sends().await.unwrap();
 
 		// Assert exactly two successes have been logged.

--- a/crates/app/core/alert_sender.rs
+++ b/crates/app/core/alert_sender.rs
@@ -625,6 +625,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
+		app.check_monitors().await.unwrap();
 		app.check_alert_sends().await.unwrap();
 		// Scroll to allow alert_sender to pick up alert
 		app.clock().pause();

--- a/crates/app/core/clock.rs
+++ b/crates/app/core/clock.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 use std::sync::{Arc, RwLock};
 
-use crate::App;
+use crate::{App, AppState};
 use time::OffsetDateTime;
 
 #[derive(Debug)]
@@ -76,7 +76,13 @@ impl Default for Clock {
 
 impl App {
 	pub fn clock(&self) -> &Clock {
-		&self.state.clock
+		self.state.clock()
+	}
+}
+
+impl AppState {
+	pub fn clock(&self) -> &Clock {
+		&self.clock
 	}
 }
 

--- a/crates/app/core/heuristics.rs
+++ b/crates/app/core/heuristics.rs
@@ -8,6 +8,10 @@ pub const MONITOR_CHECKER_HEARTBEAT_DURATION_PRODUCTION: std::time::Duration =
 	std::time::Duration::from_secs(60 * 60);
 pub const ALERT_SENDER_HEARTBEAT_DURATION_PRODUCTION: std::time::Duration =
 	std::time::Duration::from_secs(60 * 60);
+pub const ALERT_SENDER_MAXIMUM_RETRY_PERIODS: u32 = 10;
+pub const ALERT_SENDER_RETRY_INITIAL_PERIOD: std::time::Duration =
+	std::time::Duration::from_secs(60);
+pub const ALERT_SENDER_RETRY_DECAY_FACTOR: u64 = 2;
 pub const PRODUCTION_PREDICTIONS_NUM_PREDICTIONS_PER_PAGE_TABLE: i64 = 10;
 pub const PRODUCTION_STATS_LARGE_ABSENT_RATIO_THRESHOLD_TO_TRIGGER_ALERT: f32 = 0.1;
 pub const PRODUCTION_STATS_LARGE_INVALID_RATIO_THRESHOLD_TO_TRIGGER_ALERT: f32 = 0.1;

--- a/crates/app/core/monitor_checker.rs
+++ b/crates/app/core/monitor_checker.rs
@@ -511,6 +511,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -526,6 +527,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -542,6 +544,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -574,6 +577,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -617,6 +621,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -643,6 +648,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -685,6 +691,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -714,6 +721,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -756,6 +764,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -782,6 +791,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -824,6 +834,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -852,6 +863,7 @@ mod test {
 			.await;
 		app.clock().resume();
 		app.check_monitors().await.unwrap();
+		app.check_alert_sends().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)

--- a/crates/app/core/monitor_checker.rs
+++ b/crates/app/core/monitor_checker.rs
@@ -489,7 +489,7 @@ mod test {
 		// Ensure that at the beginning, we have no alerts.
 		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
-		let all_alerts = app
+		let _all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
 			.await
 			.unwrap();
@@ -524,7 +524,6 @@ mod test {
 			.await
 			.unwrap();
 		app.commit_transaction(txn).await.unwrap();
-		dbg!(&all_alerts);
 		//assert_eq!(all_alerts.len(), 1);
 
 		// Scroll to one day, check that daily alert is created

--- a/crates/app/core/monitor_checker.rs
+++ b/crates/app/core/monitor_checker.rs
@@ -187,18 +187,6 @@ impl App {
 		Ok(())
 	}
 
-	/// Send a message to the monitor checker and wait for it to reply back indicating it has run.
-	#[tracing::instrument(level = "info", skip_all)]
-	pub async fn check_monitors(&self) -> Result<()> {
-		tracing::info!("starting check_monitors");
-		let (sender, receiver) = oneshot::channel();
-		self.monitor_checker_sender
-			.send(MonitorCheckerMessage::Run(sender))?;
-		receiver.await?;
-		tracing::info!("finished check_monitors, response received");
-		Ok(())
-	}
-
 	pub async fn create_monitor(&self, args: CreateMonitorArgs<'_, '_>) -> Result<()> {
 		let CreateMonitorArgs {
 			db,
@@ -495,7 +483,7 @@ mod test {
 		app.commit_transaction(txn).await.unwrap();
 
 		// Ensure that at the beginning, we have no alerts.
-		app.check_monitors().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -510,8 +498,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 30))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -526,8 +513,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 30))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -543,8 +529,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60 * 23))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -560,7 +545,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60 * 24 * 6))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -576,8 +561,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60 * 24 * 7 * 3))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -620,8 +604,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -647,8 +630,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -690,8 +672,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -720,8 +701,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -763,8 +743,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -790,8 +769,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -833,8 +811,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)
@@ -862,8 +839,7 @@ mod test {
 			.advance(std::time::Duration::from_secs(60 * 60))
 			.await;
 		app.clock().resume();
-		app.check_monitors().await.unwrap();
-		app.check_alert_sends().await.unwrap();
+		app.sync_tasks().await.unwrap();
 		let mut txn = app.begin_transaction().await.unwrap();
 		let all_alerts = app
 			.get_all_alerts_for_model(txn.borrow_mut(), model_id)

--- a/crates/app/core/monitor_checker.rs
+++ b/crates/app/core/monitor_checker.rs
@@ -3,7 +3,7 @@ use crate::{
 	heuristics::{
 		ALERT_METRICS_MINIMUM_PRODUCTION_METRICS_DEBUG_THRESHOLD,
 		ALERT_METRICS_MINIMUM_PRODUCTION_METRICS_THRESHOLD,
-		MONITOR_CHECKER_HEARTBEAT_DURATION_PRODUCTION,
+		MONITOR_CHECKER_HEARTBEAT_DURATION_PRODUCTION, MONITOR_CHECKER_HEARTBEAT_DURATION_TESTING,
 	},
 	model::get_model_bytes,
 	monitor::{
@@ -52,8 +52,8 @@ pub async fn monitor_checker(
 	} else {
 		// In every mode other than release, don't introduce a delay, just start in one heartbeat.
 		(
-			tokio::time::Instant::now() + MONITOR_CHECKER_HEARTBEAT_DURATION_PRODUCTION,
-			MONITOR_CHECKER_HEARTBEAT_DURATION_PRODUCTION,
+			tokio::time::Instant::now() + MONITOR_CHECKER_HEARTBEAT_DURATION_TESTING,
+			MONITOR_CHECKER_HEARTBEAT_DURATION_TESTING,
 		)
 	};
 	// start interval.

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -19,14 +19,12 @@ use tangram_app_monitor_event::{
 use tangram_id::Id;
 use tangram_table::TableView;
 
-const SQLITE_IN_MEMORY: &str = "sqlite::memory:";
-
 pub fn init_test_options() -> crate::options::Options {
 	let mut options = crate::options::Options::default();
 	// set in-memory SQLite DB
-	let database_url = SQLITE_IN_MEMORY.parse().expect("Malformed URL");
+	let database_url = "sqlite::memory:".parse().expect("Malformed URL");
 	let database_options = crate::options::DatabaseOptions {
-		max_connections: None,
+		max_connections: Some(10),
 		url: database_url,
 	};
 	options.database = database_options;

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -24,7 +24,7 @@ pub fn init_test_options() -> crate::options::Options {
 	// set in-memory SQLite DB
 	let database_url = "sqlite::memory:".parse().expect("Malformed URL");
 	let database_options = crate::options::DatabaseOptions {
-		max_connections: Some(1),
+		max_connections: Some(2),
 		url: database_url,
 	};
 	options.database = database_options;

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -10,7 +10,8 @@ use crate::{
 use anyhow::{bail, Result};
 use chrono::{Datelike, TimeZone, Timelike, Utc};
 use num::ToPrimitive;
-use std::{collections::HashMap, path::PathBuf};
+use sqlx::PgPool;
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 use tangram::ClassificationOutputValue;
 use tangram_app_monitor_event::{
 	BinaryClassificationPredictOutput, MonitorEvent, NumberOrString, PredictOutput,
@@ -18,8 +19,76 @@ use tangram_app_monitor_event::{
 };
 use tangram_id::Id;
 use tangram_table::TableView;
+use url::Url;
 
-pub fn init_test_options() -> crate::options::Options {
+const TEST_POSTGRES_URL: &str = "postgres://postgres:example@0.0.0.0:5432";
+
+/// The TestContext handles establishing a PostgreSQL database to use for an individual test.
+///
+/// Use at the beginning of any test requiring a connection, and call drop when done:
+/// ```no_run
+/// #[tokio::test]
+/// async fn cool_test {
+/// 	let mut ctx = TestContext::new("cool_test").await;
+/// 	// test logic!
+/// 	ctx.drop().await;
+/// }
+/// ```
+pub struct TestContext {
+	db_name: String,
+}
+
+impl TestContext {
+	pub async fn new(db_name: &str) -> Self {
+		// Connect to DB
+		let postgres_url = Url::from_str(&format!("{}/postgres", TEST_POSTGRES_URL)).unwrap();
+		// Create database for test
+		let pool = PgPool::connect(postgres_url.as_str())
+			.await
+			.expect("Failed to connect to test database");
+		let query_str = format!("CREATE DATABASE {}", db_name);
+		sqlx::query(&query_str)
+			.bind(db_name)
+			.execute(&pool)
+			.await
+			.expect("Could not create test database");
+		Self {
+			db_name: db_name.to_owned(),
+		}
+	}
+
+	pub async fn drop(&mut self) {
+		// Connect to database
+		let postgres_url = Url::from_str(&format!("{}/postgres", TEST_POSTGRES_URL)).unwrap();
+		let pool = PgPool::connect(postgres_url.as_str())
+			.await
+			.expect("Failed to connect to test database");
+		// Forcibly disconnect active users
+		sqlx::query(
+			"
+			select
+				pg_terminate_backend(pid)
+			from
+				pg_stat_activity
+			where
+				datname = $1
+		",
+		)
+		.bind(&self.db_name)
+		.execute(&pool)
+		.await
+		.expect("Unable to unceremoniously dump users");
+		// Drop database
+		let query_str = format!("DROP DATABASE {}", self.db_name);
+		sqlx::query(&query_str)
+			.bind(&self.db_name)
+			.execute(&pool)
+			.await
+			.expect("Could not drop test database");
+	}
+}
+
+pub fn init_test_options_sqlite() -> crate::options::Options {
 	let mut options = crate::options::Options::default();
 	// set in-memory SQLite DB
 	let database_url = "sqlite::memory:".parse().expect("Malformed URL");
@@ -33,8 +102,23 @@ pub fn init_test_options() -> crate::options::Options {
 	options
 }
 
-pub async fn init_test_app() -> Result<App> {
-	let options = init_test_options();
+pub fn init_test_options_postgres(db_name: &str) -> crate::options::Options {
+	let mut options = crate::options::Options::default();
+	// set in-memory SQLite DB
+	let database_url = format!("{}/{}", TEST_POSTGRES_URL, db_name)
+		.parse()
+		.expect("Malformed URL");
+	let database_options = crate::options::DatabaseOptions {
+		max_connections: None,
+		url: database_url,
+	};
+	options.database = database_options;
+	// Use in-memory storage
+	options.storage = crate::options::StorageOptions::InMemory;
+	options
+}
+
+pub async fn init_test_app(options: crate::options::Options) -> Result<App> {
 	let app = App::new(options).await?;
 	Ok(app)
 }

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -31,6 +31,8 @@ const TEST_POSTGRES_URL: &str = "postgres://postgres:test@0.0.0.0:5432";
 /// async fn cool_test {
 /// 	let mut ctx = TestContext::new("cool_test").await;
 /// 	// test logic!
+/// 	let app = init_test_app(init_test_options_postgres("cool_test")).await.unwrap();
+/// 	// ...
 /// 	ctx.drop().await;
 /// }
 /// ```

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -24,7 +24,7 @@ pub fn init_test_options() -> crate::options::Options {
 	// set in-memory SQLite DB
 	let database_url = "sqlite::memory:".parse().expect("Malformed URL");
 	let database_options = crate::options::DatabaseOptions {
-		max_connections: Some(10),
+		max_connections: None,
 		url: database_url,
 	};
 	options.database = database_options;

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -24,7 +24,7 @@ pub fn init_test_options() -> crate::options::Options {
 	// set in-memory SQLite DB
 	let database_url = "sqlite::memory:".parse().expect("Malformed URL");
 	let database_options = crate::options::DatabaseOptions {
-		max_connections: None,
+		max_connections: Some(1),
 		url: database_url,
 	};
 	options.database = database_options;

--- a/crates/app/core/test_common.rs
+++ b/crates/app/core/test_common.rs
@@ -21,7 +21,7 @@ use tangram_id::Id;
 use tangram_table::TableView;
 use url::Url;
 
-const TEST_POSTGRES_URL: &str = "postgres://postgres:example@0.0.0.0:5432";
+const TEST_POSTGRES_URL: &str = "postgres://postgres:test@0.0.0.0:5432";
 
 /// The TestContext handles establishing a PostgreSQL database to use for an individual test.
 ///
@@ -46,9 +46,15 @@ impl TestContext {
 		let pool = PgPool::connect(postgres_url.as_str())
 			.await
 			.expect("Failed to connect to test database");
+		// First, clear the deck in case of previous fail
+		let query_str = format!("DROP DATABASE IF EXISTS {}", db_name);
+		sqlx::query(&query_str)
+			.execute(&pool)
+			.await
+			.expect("Could not clean up existing DB");
+		// Create new DB
 		let query_str = format!("CREATE DATABASE {}", db_name);
 		sqlx::query(&query_str)
-			.bind(db_name)
 			.execute(&pool)
 			.await
 			.expect("Could not create test database");
@@ -81,7 +87,6 @@ impl TestContext {
 		// Drop database
 		let query_str = format!("DROP DATABASE {}", self.db_name);
 		sqlx::query(&query_str)
-			.bind(&self.db_name)
 			.execute(&pool)
 			.await
 			.expect("Could not drop test database");

--- a/crates/app/migrations/migration_2021_11_23_000000.sql
+++ b/crates/app/migrations/migration_2021_11_23_000000.sql
@@ -10,6 +10,15 @@ create table alerts (
 	id char(32) primary key,
 	monitor_id char(32) references monitors (id) not null,
 	data text not null,
-	sent integer not null,
 	date bigint not null
+);
+
+create table alert_sends (
+	id char(32) primary key,
+	alert_id char(32) references alerts (id) not null,
+	attempt_count integer not null,
+	method text not null,
+	status integer not null,
+	initiated_date bigint not null,
+	completed_date bigint
 );

--- a/crates/app/routes/login/server/post.rs
+++ b/crates/app/routes/login/server/post.rs
@@ -214,6 +214,6 @@ async fn send_code_email(app: &App, email: String, code: String) -> Result<()> {
 		.to(email.parse()?)
 		.subject("Tangram Login Code")
 		.body(format!("Your Tangram login code is {}.", code))?;
-	app.send_email(email).await;
+	app.send_email(email).await?;
 	Ok(())
 }

--- a/crates/app/routes/organizations/_/members/new/server/post.rs
+++ b/crates/app/routes/organizations/_/members/new/server/post.rs
@@ -157,6 +157,6 @@ async fn send_invitation_email(
 			"{} invited you to join their team on Tangram. Click the link below to login.\n\n{}",
 			inviter_email, href
 		))?;
-	app.send_email(email).await;
+	app.send_email(email).await?;
 	Ok(())
 }

--- a/crates/app/routes/repos/_/models/_/monitors/_/edit/server/post.rs
+++ b/crates/app/routes/repos/_/models/_/monitors/_/edit/server/post.rs
@@ -116,10 +116,27 @@ pub async fn post(request: &mut http::Request<hyper::Body>) -> Result<http::Resp
 			// Validate metric type
 			let mut methods = vec![AlertMethod::Stdout];
 			if !email.is_empty() {
-				methods.push(AlertMethod::Email(email));
+				methods.push(AlertMethod::Email(email.into()));
 			}
 			if !webhook.is_empty() {
-				methods.push(AlertMethod::Webhook(webhook));
+				match webhook.try_into() {
+					Ok(webhook) => methods.push(AlertMethod::Webhook(webhook)),
+					Err(_) => {
+						let page = Page {
+							monitor: get_monitor(&mut db, Id::from_str(&monitor_id)?).await?,
+							monitor_id,
+							model_layout_info,
+							model_type,
+							error: Some("Received malformed webhook url.".to_owned()),
+						};
+						let html = html(page);
+						let response = http::Response::builder()
+							.status(http::StatusCode::BAD_REQUEST)
+							.body(hyper::Body::from(html))
+							.unwrap();
+						return Ok(response);
+					}
+				}
 			}
 			let threshold_bounds = validate_threshold_bounds(threshold_lower, threshold_upper);
 			if threshold_bounds.is_none() {


### PR DESCRIPTION
This PR adds missing functionality for sending alerts as configured in monitors, alongside automated tests.

Outstanding tasks:

- [x] Resolve test suite failures.  In-memory sqlite databases used in test appear to conflict when running multiple tests