### PR TITLE
Fix link to Rust lib in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Train a model from a CSV file on the command line. Make predictions from Elixir,
 Tangram makes it easy for programmers to train, deploy, and monitor machine learning models.
 
 - Run `tangram train` to train a model from a CSV file on the command line.
-- Make predictions with libraries for [Elixir](https://hex.pm/packages/tangram), [Go](https://pkg.go.dev/github.com/tangramdotdev/tangram-go), [JavaScript](https://www.npmjs.com/package/@tangramdotdev/tangram), [PHP](https://packagist.org/packages/tangram/tangram), [Python](https://pypi.org/project/tangram), [Ruby](https://rubygems.org/gems/tangram), and [Rust](lib.rs/tangram).
+- Make predictions with libraries for [Elixir](https://hex.pm/packages/tangram), [Go](https://pkg.go.dev/github.com/tangramdotdev/tangram-go), [JavaScript](https://www.npmjs.com/package/@tangramdotdev/tangram), [PHP](https://packagist.org/packages/tangram/tangram), [Python](https://pypi.org/project/tangram), [Ruby](https://rubygems.org/gems/tangram), and [Rust](https://lib.rs/crates/tangram).
 - Run `tangram app` to learn more about your models and monitor them in production.
 
 ### Install


### PR DESCRIPTION
When viewed on Github the link resolved to https://github.com/tangramdotdev/tangram/blob/main/lib.rs/tangram, which 404s.