### PR TITLE
Fix build errors

### DIFF
--- a/crates/app/core/lib.rs
+++ b/crates/app/core/lib.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Result};
 use lettre::AsyncTransport;
+use lettre::Transport;
 use serde::Serialize;
 use sqlx::postgres::PgPoolOptions;
 use std::{
@@ -117,7 +118,7 @@ impl Mailer {
 				transport.send(email).await?;
 			}
 			Mailer::Testing(transport) => {
-				transport.send(email).await?;
+				transport.send(&email)?;
 			}
 		};
 		Ok(())


### PR DESCRIPTION
Fix the following errors:
```
error[E0599]: no method named `send` found for reference `&StubTransport` in the current scope
   --> crates/app/core/lib.rs:120:15
    |
120 |                 transport.send(email).await?;
    |                           ^^^^ method not found in `&StubTransport`
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
1   | use lettre::Transport;
    |
```
```
error[E0308]: mismatched types
   --> crates/app/core/lib.rs:121:20
    |
121 |                 transport.send(email).await?;
    |                                ^^^^^
    |                                |
    |                                expected `&Message`, found struct `Message`
    |                                help: consider borrowing here: `&email`
```
```
error[E0277]: `Result<(), lettre::transport::stub::Error>` is not a future
   --> crates/app/core/lib.rs:121:26
    |
121 |                 transport.send(email).await?;
    |                                      ^^^^^^ `Result<(), lettre::transport::stub::Error>` is not a future
    |
    = help: the trait `futures::Future` is not implemented for `Result<(), lettre::transport::stub::Error>`
    = note: Result<(), lettre::transport::stub::Error> must be a future or must implement `IntoFuture` to be awaited
    = note: required because of the requirements on the impl of `std::future::IntoFuture` for `Result<(), lettre::transport::stub::Error>`
help: remove the `.await`
    |
121 -                 transport.send(email).await?;
121 +                 transport.send(email)?;
    |
```