### PR TITLE
feat(package)!: support nested path dependencies

### DIFF
--- a/packages/client/src/path.rs
+++ b/packages/client/src/path.rs
@@ -68,10 +68,14 @@ impl Path {
 			self.components.clear();
 		}
 
-		// Add the component.
-		if !self.components.is_empty() {
-			self.string.push('/');
+		// Add the separator.
+		match self.components.last() {
+			Some(Component::Root) => (),
+			Some(_) => self.string.push('/'),
+			None => (),
 		}
+
+		// Add the component.
 		match &component {
 			Component::Root => self.string.push('/'),
 			Component::Current => self.string.push('.'),
@@ -90,8 +94,10 @@ impl Path {
 			None => 0,
 		};
 		self.string.truncate(self.string.len() - n);
-		if !self.components.is_empty() {
-			self.string.truncate(self.string.len() - 1);
+		match self.components().last() {
+			Some(Component::Root) => (),
+			Some(_) => self.string.truncate(self.string.len() - 1),
+			None => (),
 		}
 	}
 
@@ -112,12 +118,27 @@ impl Path {
 	pub fn normalize(self) -> Self {
 		let mut path = Self::default();
 		for component in self.into_components() {
-			if component == Component::Parent
-				&& matches!(path.components().last(), Some(Component::Normal(_)))
-			{
-				path.pop();
-			} else {
-				path.push(component);
+			match (component, path.components().last()) {
+				// If any component is root, then the normalized path is root.
+				(Component::Root, _) => {
+					path = Self::with_components(vec![Component::Root]);
+				},
+
+				// Drop any current paths.
+				(Component::Current, _) => (),
+
+				// Flatten any parent paths.
+				(Component::Parent, Some(Component::Normal(_))) => {
+					path.pop();
+				},
+
+				// If the parent is root then skip.
+				(Component::Parent, Some(Component::Root)) => (),
+
+				// Otherwise add the component.
+				(component, _) => {
+					path.push(component);
+				},
 			}
 		}
 		path
@@ -215,8 +236,39 @@ impl TryFrom<PathBuf> for Path {
 	}
 }
 
+impl<'a> TryFrom<&'a std::path::Path> for Path {
+	type Error = Error;
+
+	fn try_from(value: &'a std::path::Path) -> std::prelude::v1::Result<Self, Self::Error> {
+		value
+			.as_os_str()
+			.to_str()
+			.wrap_err("The path must be valid UTF-8.")?
+			.parse()
+	}
+}
+
 impl AsRef<std::path::Path> for Path {
 	fn as_ref(&self) -> &std::path::Path {
 		std::path::Path::new(self.string.as_str())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Path;
+	#[test]
+	fn path_normalization() {
+		let path: Path = "/foo/../bar/baz".parse().unwrap();
+		assert_eq!(path.normalize().to_string(), "/bar/baz");
+
+		let path: Path = "/../bar/baz".parse().unwrap();
+		assert_eq!(path.normalize().to_string(), "/bar/baz");
+
+		let path: Path = "../bar/baz".parse().unwrap();
+		assert_eq!(path.normalize().to_string(), "../bar/baz");
+
+		let path: Path = "./bar/baz".parse().unwrap();
+		assert_eq!(path.normalize().to_string(), "bar/baz");
 	}
 }

--- a/packages/client/src/path.rs
+++ b/packages/client/src/path.rs
@@ -94,9 +94,8 @@ impl Path {
 		};
 		self.string.truncate(self.string.len() - n);
 		match self.components().last() {
-			Some(Component::Root) => (),
+			None | Some(Component::Root) => (),
 			Some(_) => self.string.truncate(self.string.len() - 1),
-			None => (),
 		}
 	}
 

--- a/packages/client/src/path.rs
+++ b/packages/client/src/path.rs
@@ -70,9 +70,8 @@ impl Path {
 
 		// Add the separator.
 		match self.components.last() {
-			Some(Component::Root) => (),
+			Some(Component::Root) | None => (),
 			Some(_) => self.string.push('/'),
-			None => (),
 		}
 
 		// Add the component.
@@ -119,26 +118,9 @@ impl Path {
 		let mut path = Self::default();
 		for component in self.into_components() {
 			match (component, path.components().last()) {
-				// If any component is root, then the normalized path is root.
-				(Component::Root, _) => {
-					path = Self::with_components(vec![Component::Root]);
-				},
-
-				// Drop any current paths.
-				(Component::Current, _) => (),
-
-				// Flatten any parent paths.
-				(Component::Parent, Some(Component::Normal(_))) => {
-					path.pop();
-				},
-
-				// If the parent is root then skip.
+				(Component::Parent, Some(Component::Normal(_))) => path.pop(),
 				(Component::Parent, Some(Component::Root)) => (),
-
-				// Otherwise add the component.
-				(component, _) => {
-					path.push(component);
-				},
+				(component, _) => path.push(component),
 			}
 		}
 		path
@@ -269,6 +251,6 @@ mod tests {
 		assert_eq!(path.normalize().to_string(), "../bar/baz");
 
 		let path: Path = "./bar/baz".parse().unwrap();
-		assert_eq!(path.normalize().to_string(), "bar/baz");
+		assert_eq!(path.normalize().to_string(), "./bar/baz");
 	}
 }

--- a/packages/package/src/lib.rs
+++ b/packages/package/src/lib.rs
@@ -1065,7 +1065,7 @@ impl Solution {
 			.insert(dependant.clone(), Mark::Permanent(complete.clone()));
 
 		// If this is not a path dependency then we add it to the global solution.
-		if context.is_path_dependency(&dependant).unwrap() {
+		if !context.is_path_dependency(&dependant).unwrap() {
 			solution
 				.permanent
 				.insert(dependant.dependency.name.clone().unwrap(), complete);

--- a/packages/runtime/src/js/path.ts
+++ b/packages/runtime/src/js/path.ts
@@ -93,6 +93,12 @@ export class Path {
 				Path.Component.isNormal(lastComponent)
 			) {
 				path.pop();
+			} else if (
+				component === ".." &&
+				lastComponent !== undefined &&
+				Path.Component.isRoot(lastComponent)
+			) {
+				continue;
 			} else {
 				path.push(component);
 			}


### PR DESCRIPTION
This adds support for the following pattern in registry dependencies: 

```ts
// in package "P"
import * as nested from "tg:nested?path=<path>"
```

If the version solving algorithm can find `<path>` within `P`'s directory, it will resolve the dependency on `nested`  to a package at that path within `P`. 

If it cannot find `<path>` within `P`, then it will attempt to resolve `nested` as a registry dependency.

Packages with local path dependencies that refer outside the package's source directory are unaffected.

---

The implementation is a little hairy. Summarized: 

- In `tangram_package::Context`, dependency resolution is now split into two methods, `Context::try_resolve_path_dependency` and `Context::try_resolve_registry_dependency`. 
- In `solve`, the algorithm first makes a call to `context.try_resolve_path_dependency` to check if it can override the dependency with a path: 
  - if a package's dependency has a `path`, look in its corresponding `analysis.path_dependencies` table to see if there is an existing override. 
 
The `analysis.path_dependencies` field is created in two places: 

- Before `solve`, the `analysis` is computed using the `PackageWithPathDependencies` tree that is constructed when the package is recursively checked in.
- Lazily during version solving, when a call to `try_get_analysis` finds that the `context.analysis` cache is missing an entry for a package, it will attempt to resolve any path dependencies using the directory tree of that package's artifact. 

In order for this to work, the package directory must contain any nested package directories. To do this, we need to make sure the nested package's directory gets added during `get_package_with_path_dependencies_for_path_inner`.

