### PR TITLE
feat(client-symlink): implement Symlink::resolve_from

### DIFF
--- a/packages/client/src/symlink.rs
+++ b/packages/client/src/symlink.rs
@@ -43,7 +43,7 @@ pub struct Data {
 
 impl Id {
 	pub fn new(bytes: &Bytes) -> Self {
-		Self(crate::Id::new_hashed(id::Kind::Symlink, bytes))
+		Self(crate::Id::new_blake3(id::Kind::Symlink, bytes))
 	}
 }
 

--- a/packages/client/src/symlink.rs
+++ b/packages/client/src/symlink.rs
@@ -189,6 +189,11 @@ impl Symlink {
 			artifact = symlink.resolve(tg).await?;
 		}
 		let path = self.path(tg).await?.clone();
+
+		if artifact.is_some() && from_artifact.is_some() {
+			return_error!("Expected no `from` value when `artifact` is set.");
+		}
+
 		if artifact.is_some() && path.is_none() {
 			return Ok(artifact);
 		} else if artifact.is_none() && path.is_some() {

--- a/packages/runtime/src/js/symlink.ts
+++ b/packages/runtime/src/js/symlink.ts
@@ -170,6 +170,11 @@ export class Symlink {
 			artifact = await artifact.resolve();
 		}
 		let path = await this.path();
+
+		if (artifact !== undefined && fromArtifact !== undefined) {
+			throw new Error("Expected no `from` value when `artifact` is set.");
+		}
+
 		if (artifact !== undefined && !path) {
 			return artifact;
 		} else if (artifact === undefined && path) {


### PR DESCRIPTION
This PR implements the unimplemented `resolve_from` method to match the TS impl in the global.