### PR TITLE
fix(server): disable LIFO slot heuristic in the tokio runtime initialization

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -113,6 +113,7 @@ fn main() {
 	// Initialize the tokio runtime and run the main function.
 	let result = tokio::runtime::Builder::new_multi_thread()
 		.enable_all()
+		.disable_lifo_slot()
 		.build()
 		.unwrap()
 		.block_on(main_inner());


### PR DESCRIPTION
This change has two impacts: 

- The SQLite connection pool's reclamation task cannot be starved/deadlock because of badly behaving tasks scheduled on the same worker thread
- Performance is notably better. 

