### PR TITLE
fix(server): implement try_get_build_log, try_get_build_log_local

### DIFF
--- a/packages/cli/src/tui.rs
+++ b/packages/cli/src/tui.rs
@@ -693,17 +693,22 @@ impl Log {
 			async move {
 				let mut file = tokio::fs::File::from_std(tempfile::tempfile().unwrap());
 				let mut scroll: Option<u64> = None;
-				let Ok(stream) = log.inner.build.log(log.inner.tg.as_ref()).await else {
+				let Ok(stream) = log
+					.inner
+					.build
+					.log(log.inner.tg.as_ref(), Some(0), None)
+					.await
+				else {
 					return;
 				};
 				let mut stream = stream.fuse();
 				loop {
 					tokio::select! {
-						Some(bytes) = stream.next(), if !stream.is_terminated() => {
-							let Ok(bytes) = bytes else {
+						Some(entry) = stream.next(), if !stream.is_terminated() => {
+							let Ok(entry) = entry else {
 								return;
 							};
-							let result = log.bytes_impl(&mut file, &mut scroll, &bytes).await;
+							let result = log.bytes_impl(&mut file, &mut scroll, &entry.bytes).await;
 							if result.is_err() {
 								return;
 							}

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -1,5 +1,5 @@
 use crate::{
-	artifact, build, directory, health, lock, object, package, target, user, Dependency, Id,
+	artifact, build, directory, health, lock, log, object, package, target, user, Dependency, Id,
 	System, User,
 };
 use async_trait::async_trait;
@@ -119,9 +119,14 @@ pub trait Handle: Send + Sync + 'static {
 		child_id: &build::Id,
 	) -> Result<()>;
 
-	async fn get_build_log(&self, id: &build::Id) -> Result<BoxStream<'static, Result<Bytes>>> {
+	async fn get_build_log(
+		&self,
+		id: &build::Id,
+		pos: Option<u64>,
+		len: Option<i64>,
+	) -> Result<BoxStream<'static, Result<log::Entry>>> {
 		Ok(self
-			.try_get_build_log(id)
+			.try_get_build_log(id, pos, len)
 			.await?
 			.wrap_err("Failed to get the build.")?)
 	}
@@ -129,7 +134,9 @@ pub trait Handle: Send + Sync + 'static {
 	async fn try_get_build_log(
 		&self,
 		id: &build::Id,
-	) -> Result<Option<BoxStream<'static, Result<Bytes>>>>;
+		pos: Option<u64>,
+		len: Option<i64>,
+	) -> Result<Option<BoxStream<'static, Result<log::Entry>>>>;
 
 	async fn add_build_log(&self, user: Option<&User>, id: &build::Id, bytes: Bytes) -> Result<()>;
 

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -23,6 +23,7 @@ pub mod id;
 pub mod leaf;
 pub mod lock;
 pub mod lockfile;
+pub mod log;
 pub mod mutation;
 pub mod object;
 pub mod package;

--- a/packages/client/src/log.rs
+++ b/packages/client/src/log.rs
@@ -1,0 +1,41 @@
+use bytes::Bytes;
+use num::ToPrimitive;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct Entry {
+	pub pos: u64,
+	pub bytes: Bytes,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Params {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub pos: Option<u64>,
+
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub len: Option<i64>,
+}
+
+impl Entry {
+	pub async fn read<R>(mut reader: R) -> std::io::Result<Self>
+	where
+		R: AsyncRead + Unpin,
+	{
+		let pos = reader.read_u64().await?;
+		let len = reader.read_u64().await?.to_usize().unwrap();
+		let mut bytes = vec![0u8; len];
+		reader.read_exact(&mut bytes).await?;
+		let bytes = bytes.into();
+		Ok(Self { pos, bytes })
+	}
+
+	pub fn to_bytes(&self) -> Bytes {
+		let pos = self.pos.to_be_bytes();
+		let len = self.bytes.len().to_u64().unwrap().to_be_bytes();
+		pos.into_iter()
+			.chain(len.into_iter())
+			.chain(self.bytes.iter().copied())
+			.collect()
+	}
+}

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -1199,12 +1199,9 @@ impl Server {
 			None => {
 				let db = self.inner.database.get().await?;
 				let statement = "
-					select
-						coalesce(max(position) + length(bytes), 0)
-					from
-						logs
-					where
-						build = ?1
+					select coalesce(max(position) + length(bytes), 0)
+					from logs
+					where build = ?1
 				";
 				let params = params![id.to_string()];
 				let mut statement = db
@@ -1253,21 +1250,16 @@ impl Server {
 						.wrap_err("Failed to get build status.")?;
 					let db = server.inner.database.get().await?;
 					let statement = "
-						select
-							position, bytes
-						from
-							logs
+						select position, bytes
+						from logs
 						where
-							build = ?1 and
-							(
-								position >= ?2 or
-								(
+							build = ?1 and (
+								position >= ?2 or (
 									position < ?2 and
 									position + length(bytes) > ?2
 								)
 							)
-						order by
-							position
+						order by position
 						limit 1
 						offset ?3;
 					";

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use tangram_client as tg;
 use tangram_error::{error, return_error, Error, Result, WrapErr};
 use tg::Handle;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_stream::wrappers::WatchStream;
 use tokio_util::either::Either;
 
@@ -35,8 +36,8 @@ impl Server {
 	) -> Result<Option<tg::build::Id>> {
 		let db = self.inner.database.get().await?;
 		let statement = "
-			select build 
-			from assignments 
+			select build
+			from assignments
 			where target = ?1;
 		";
 		let params = params![target_id.to_string()];
@@ -747,6 +748,33 @@ impl Server {
 		}
 	}
 
+	async fn try_get_build_log_data_local(&self, id: &tg::build::Id) -> Result<Option<tg::blob::Id>> {
+		let db = self.inner.database.get().await?;
+		let statement = "
+			select json->>'log' as log
+			from builds
+			where id = ?1;
+		";
+		let params = params![id.to_string()];
+		let mut statement = db
+			.prepare_cached(statement)
+			.wrap_err("Failed to prepare the query.")?;
+		let mut rows = statement
+			.query(params)
+			.wrap_err("Failed to execute the query.")?;
+		let Some(row) = rows.next().wrap_err("Failed to get the row.")? else {
+			return Ok(None);
+		};
+		let Some(log) = row
+			.get::<_, Option<String>>(0)
+			.wrap_err("Failed to deserialize the column.")?
+		else {
+			return Ok(None);
+		};
+		let log = log.parse()?;
+		Ok(Some(log))
+	}
+
 	async fn try_get_build_status_local(
 		&self,
 		id: &tg::build::Id,
@@ -1098,10 +1126,12 @@ impl Server {
 	pub async fn try_get_build_log(
 		&self,
 		id: &tg::build::Id,
-	) -> Result<Option<BoxStream<'static, Result<Bytes>>>> {
-		if let Some(log) = self.try_get_build_log_local(id).await? {
+		pos: Option<u64>,
+		len: Option<i64>,
+	) -> Result<Option<BoxStream<'static, Result<tg::log::Entry>>>> {
+		if let Some(log) = self.try_get_build_log_local(id, pos, len).await? {
 			Ok(Some(log))
-		} else if let Some(log) = self.try_get_build_log_remote(id).await? {
+		} else if let Some(log) = self.try_get_build_log_remote(id, pos, len).await? {
 			Ok(Some(log))
 		} else {
 			Ok(None)
@@ -1111,23 +1141,186 @@ impl Server {
 	async fn try_get_build_log_local(
 		&self,
 		id: &tg::build::Id,
-	) -> Result<Option<BoxStream<'static, Result<Bytes>>>> {
+		pos: Option<u64>,
+		len: Option<i64>,
+	) -> Result<Option<BoxStream<'static, Result<tg::log::Entry>>>> {
 		// Verify the build is local.
 		if !self.build_is_local(id).await? {
 			return Ok(None);
 		}
 
-		return Ok(Some(stream::empty().boxed()));
+		// Check if we have this build's log stored as a blob.
+		if let Some(id) = self.try_get_build_log_data_local(id).await? {
+			let blob = tg::blob::Blob::with_id(id);
+			let mut reader = blob
+				.reader(self)
+				.await
+				.wrap_err("Failed to create blob reader.")?;
+			let pos = pos.unwrap_or(blob.size(self).await?);
+			let (start, end) = match len {
+				Some(len) if len > 0 => (pos, pos.saturating_add(len.to_u64().unwrap())),
+				Some(len) => (pos.saturating_sub(len.abs().to_u64().unwrap()), pos),
+				None => (
+					pos,
+					blob.size(self).await.wrap_err("Failed to get blob size.")?,
+				),
+			};
+			reader
+				.seek(std::io::SeekFrom::Start(start))
+				.await
+				.wrap_err("Failed to seek.")?;
+			let stream = stream::once(async move {
+				let mut bytes = vec![0; (end - start).to_usize().unwrap()];
+				reader
+					.read_exact(&mut bytes)
+					.await
+					.wrap_err("Failed to read blob.")?;
+				let pos = start;
+				let bytes = bytes.into();
+				let mut entry = tg::log::Entry { pos, bytes };
+				if entry.pos < start {
+					let offset = (start - entry.pos).to_usize().unwrap();
+					entry.pos = start;
+					entry.bytes = entry.bytes.slice(offset..);
+				}
+				if (entry.pos + entry.bytes.len().to_u64().unwrap()) > end {
+					let length = (end - entry.pos) as usize;
+					entry.bytes = entry.bytes.slice(0..length);
+				}
+				Ok(entry)
+			})
+			.boxed();
+			return Ok(Some(stream));
+		}
+
+		// Otherwise get the starting position of the log stream. If pos is None, return the end.
+		let start_pos = match pos {
+			Some(pos) => pos,
+			None => {
+				let db = self.inner.database.get().await?;
+				let statement = "
+					select
+						coalesce(max(position) + length(bytes), 0)
+					from
+						logs
+					where
+						build = ?1
+				";
+				let params = params![id.to_string()];
+				let mut statement = db
+					.prepare_cached(statement)
+					.wrap_err("Failed to prepare statement.")?;
+				let mut query = statement
+					.query(params)
+					.wrap_err("Failed to perform query.")?;
+				let row = query
+					.next()
+					.wrap_err("Failed to get row.")?
+					.wrap_err("Expected a row.")?;
+				row.get(0).wrap_err("Expected a position.")?
+			},
+		};
+
+		// Get the start and end positions
+		let (start, end) = match len {
+			None => (start_pos, None),
+			Some(len) if len > 0 => (
+				start_pos,
+				Some(start_pos.saturating_add(len.to_u64().unwrap())),
+			),
+			Some(len) => (start_pos.saturating_sub(len.abs().to_u64().unwrap()), pos), // Note: not Some(start_pos).
+		};
+
+		// Create the stream.
+		let offset = 0;
+		let count = 0;
+		let server = self.clone();
+		let id = id.clone();
+		let stream = stream::try_unfold(
+			(start, end, count, offset, id, server),
+			|(start, end, count, offset, id, server)| async move {
+				// Check if we've reached the end condition.
+				match end {
+					Some(end) if start + count >= end => return Ok(None),
+					_ => (),
+				}
+
+				// Get the next log entry.
+				let mut entry = loop {
+					let build_status = server
+						.get_build_status(&id)
+						.await
+						.wrap_err("Failed to get build status.")?;
+					let db = server.inner.database.get().await?;
+					let statement = "
+						select
+							position, bytes
+						from
+							logs
+						where
+							build = ?1 and
+							(
+								position >= ?2 or
+								(
+									position < ?2 and
+									position + length(bytes) > ?2
+								)
+							)
+						order by
+							position
+						limit 1
+						offset ?3;
+					";
+					let params = params![id.to_string(), start, offset];
+					let mut statement = db
+						.prepare_cached(statement)
+						.wrap_err("Failed to prepare statement.")?;
+					let mut query = statement
+						.query(params)
+						.wrap_err("Failed to perform query.")?;
+					let entry = query.next().wrap_err("Expected a row.")?.map(|row| {
+						let pos = row.get(0).unwrap();
+						let bytes = row.get::<_, Vec<u8>>(1).unwrap().into();
+						tg::log::Entry { pos, bytes }
+					});
+					match (build_status, entry) {
+						(tg::build::Status::Finished, None) => return Ok(None),
+						(_, Some(entry)) => break entry,
+						_ => continue,
+					}
+				};
+
+				// Truncate the entry.
+				if entry.pos < start {
+					let offset = (start - entry.pos).to_usize().unwrap();
+					entry.pos = start;
+					entry.bytes = entry.bytes.slice(offset..);
+				}
+				match end {
+					Some(end) if (entry.pos + entry.bytes.len().to_u64().unwrap()) > end => {
+						let length = (end - entry.pos) as usize;
+						entry.bytes = entry.bytes.slice(0..length);
+					},
+					_ => (),
+				}
+				let offset = offset + 1;
+				let count = count + entry.bytes.len().to_u64().unwrap();
+				Ok(Some((entry, (start, end, count, offset, id, server))))
+			},
+		);
+		Ok(Some(stream.boxed()))
 	}
 
 	async fn try_get_build_log_remote(
 		&self,
 		id: &tg::build::Id,
-	) -> Result<Option<BoxStream<'static, Result<Bytes>>>> {
+		pos: Option<u64>,
+		len: Option<i64>,
+	) -> Result<Option<BoxStream<'static, Result<tg::log::Entry>>>> {
 		let Some(remote) = self.inner.remote.as_ref() else {
 			return Ok(None);
 		};
-		let Some(log) = remote.try_get_build_log(id).await? else {
+		let Some(log) = remote.try_get_build_log(id, pos, len).await? else {
 			return Ok(None);
 		};
 		Ok(Some(log))
@@ -1180,7 +1373,7 @@ impl Server {
 								where build = ?1
 								order by position desc
 								limit 1
-							), 
+							),
 							0
 						)
 					),

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -550,8 +550,10 @@ impl tg::Handle for Server {
 	async fn try_get_build_log(
 		&self,
 		id: &tg::build::Id,
-	) -> Result<Option<BoxStream<'static, Result<Bytes>>>> {
-		self.try_get_build_log(id).await
+		pos: Option<u64>,
+		len: Option<i64>,
+	) -> Result<Option<BoxStream<'static, Result<tg::log::Entry>>>> {
+		self.try_get_build_log(id, pos, len).await
 	}
 
 	async fn add_build_log(


### PR DESCRIPTION
- Added `pos: Option<u64>`, `len: Option<i64>` arguments to try_get_build_log functions.
- Query local database for build logs and convert to stream.
- Add `log: Option<tg::blob::Id>` field to builds in the database.
- If log is available as a blob, try_get_log_local will create a blob stream and truncate it accordingly.
- Revive old TUI behavior.