### PR TITLE
feat(cli): add name/version options to init and new

### DIFF
--- a/packages/cli/src/commands/init.rs
+++ b/packages/cli/src/commands/init.rs
@@ -9,11 +9,13 @@ use tangram_error::{error, Result, Wrap, WrapErr};
 pub struct Args {
 	/// The directory to initialize the package in.
 	pub path: Option<PathBuf>,
-	/// The name of the package. Will use the directory name if not provided.
+	
+	/// The name of the package. Defaults to the directory name.
 	#[arg(long)]
 	pub name: Option<String>,
-	/// The version of the package. Will use "0.1.0" if not provided.
-	#[arg(long, default_value = "0.1.0")]
+	
+	/// The version of the package. Defaults to "0.0.0".
+	#[arg(long, default_value = "0.0.0")]
 	pub version: String,
 }
 
@@ -41,6 +43,7 @@ impl Cli {
 			Err(error) => return Err(error.wrap("Failed to get the metadata for the path.")),
 		};
 
+		// Get the name and version.
 		let name = if let Some(name) = args.name {
 			name
 		} else {

--- a/packages/cli/src/commands/new.rs
+++ b/packages/cli/src/commands/new.rs
@@ -8,11 +8,13 @@ use tangram_error::{Result, WrapErr};
 pub struct Args {
 	/// The directory to initialize the package in.
 	pub path: Option<PathBuf>,
-	/// The name of the package. Will use the directory name if not provided.
+	
+	/// The name of the package. Defaults to the directory name.
 	#[arg(long)]
 	pub name: Option<String>,
-	/// The version of the package. Will use "0.1.0" if not provided.
-	#[arg(long, default_value = "0.1.0")]
+	
+	/// The version of the package. Defaults to "0.0.0".
+	#[arg(long, default_value = "0.0.0")]
 	pub version: String,
 }
 

--- a/packages/cli/src/commands/new.rs
+++ b/packages/cli/src/commands/new.rs
@@ -6,7 +6,14 @@ use tangram_error::{Result, WrapErr};
 #[derive(Debug, clap::Args)]
 #[command(verbatim_doc_comment)]
 pub struct Args {
+	/// The directory to initialize the package in.
 	pub path: Option<PathBuf>,
+	/// The name of the package. Will use the directory name if not provided.
+	#[arg(long)]
+	pub name: Option<String>,
+	/// The version of the package. Will use "0.1.0" if not provided.
+	#[arg(long, default_value = "0.1.0")]
+	pub version: String,
 }
 
 impl Cli {
@@ -24,8 +31,12 @@ impl Cli {
 		})?;
 
 		// Init.
-		self.command_init(super::init::Args { path: args.path })
-			.await?;
+		self.command_init(super::init::Args {
+			path: args.path,
+			name: args.name,
+			version: args.version,
+		})
+		.await?;
 
 		Ok(())
 	}


### PR DESCRIPTION
This PR comprises the following changes to the packages created by  the `init` and `new` subcommand:

* rename file to `tangram.ts`.
*  add a `metadata` object
* add optional CLI flags to set the name and version
* Add default values - `name` will use the name of the directory, and `version` will use `0.1.0` if not provided.