### PR TITLE
feat(server): use internal checkouts in builds

### DIFF
--- a/packages/cli/src/commands/server.rs
+++ b/packages/cli/src/commands/server.rs
@@ -137,12 +137,21 @@ impl Cli {
 
 		let version = self.version.clone();
 
+		let vfs = self
+			.config()
+			.await?
+			.and_then(|config| config.vfs)
+			.map(|cfg| tangram_server::VfsOptions {
+				enable: cfg.enable.unwrap_or(true),
+			});
+
 		// Create the options.
 		let options = tangram_server::Options {
 			addr,
 			path,
 			remote,
 			version,
+			vfs,
 		};
 
 		// Start the server.

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -73,6 +73,9 @@ struct Config {
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	remote: Option<RemoteConfig>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	vfs: Option<VfsConfig>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -90,6 +93,12 @@ struct RemoteConfig {
 	/// Configure remote builds.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	build: Option<RemoteBuildConfig>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+struct VfsConfig {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	enable: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]

--- a/packages/runtime/src/darwin.rs
+++ b/packages/runtime/src/darwin.rs
@@ -314,7 +314,9 @@ pub async fn build(
 	};
 
 	// Spawn the child.
-	let mut child = command.spawn().wrap_err("Failed to spawn the process.")?;
+	let mut child = command
+		.spawn()
+		.wrap_err_with(|| format!("Failed to spawn the process ({executable})."))?;
 
 	// Create the log task.
 	let mut stdout = child.stdout.take().unwrap();

--- a/packages/runtime/src/js/syscall.rs
+++ b/packages/runtime/src/js/syscall.rs
@@ -132,7 +132,7 @@ async fn syscall_download(state: Rc<State>, args: (Url, tg::Checksum)) -> Result
 		.acquire()
 		.await
 		.unwrap();
-	let response = reqwest::get(url)
+	let response = reqwest::get(url.clone())
 		.await
 		.wrap_err("Failed to perform the request.")?
 		.error_for_status()

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -725,6 +725,22 @@ impl Server {
 			tg::system::Os::Darwin => {
 				#[cfg(target_os = "macos")]
 				{
+					// If there's no VFS, perform an internal checkout on the target.
+					if self.inner.vfs.lock().unwrap().is_none() {
+						target
+							.data(self)
+							.await?
+							.children()
+							.into_iter()
+							.filter_map(|id| id.try_into().ok())
+							.map(|id| async move {
+								let artifact = tg::Artifact::with_id(id);
+								artifact.check_out(self, None).await
+							})
+							.collect::<FuturesUnordered<_>>()
+							.try_collect::<Vec<_>>()
+							.await?;
+					}
 					tangram_runtime::darwin::build(self, &build, &options, stop, self.path()).await
 				}
 				#[cfg(not(target_os = "macos"))]
@@ -735,6 +751,22 @@ impl Server {
 			tg::system::Os::Linux => {
 				#[cfg(target_os = "linux")]
 				{
+					// If there's no VFS, perform an internal checkout on the target.
+					if self.inner.vfs.lock().unwrap().is_none() {
+						target
+							.data(self)
+							.await?
+							.children()
+							.into_iter()
+							.filter_map(|id| id.try_into().ok())
+							.map(|id| async move {
+								let artifact = tg::Artifact::with_id(id);
+								artifact.check_out(self, None).await
+							})
+							.collect::<FuturesUnordered<_>>()
+							.try_collect::<Vec<_>>()
+							.await?;
+					}
 					tangram_runtime::linux::build(self, &build, &options, stop, self.path()).await
 				}
 				#[cfg(not(target_os = "linux"))]

--- a/packages/server/src/clean.rs
+++ b/packages/server/src/clean.rs
@@ -25,6 +25,14 @@ impl Server {
 			.await
 			.wrap_err("Failed to recreate the temporary directory.")?;
 
+		// Clean the checkouts directory.
+		tokio::fs::remove_dir_all(self.checkouts_path())
+			.await
+			.wrap_err("Failed to remove the temporary directory.")?;
+		tokio::fs::create_dir_all(self.checkouts_path())
+			.await
+			.wrap_err("Failed to recreate the temporary directory.")?;
+
 		Ok(())
 	}
 }

--- a/packages/server/src/migrations.rs
+++ b/packages/server/src/migrations.rs
@@ -108,12 +108,6 @@ async fn migration_0000(path: &Path) -> Result<()> {
 	db.execute_batch(sql)
 		.wrap_err("Failed to create the database tables.")?;
 
-	// Create the artifacts directory.
-	let artifacts_path = path.join("artifacts");
-	tokio::fs::create_dir_all(&artifacts_path)
-		.await
-		.wrap_err("Failed to create the artifacts directory.")?;
-
 	// Create the checkouts directory.
 	let checkouts_path = path.join("checkouts");
 	tokio::fs::create_dir_all(&checkouts_path)


### PR DESCRIPTION
- Add vfs.enable option to CLI config and server options.
- Create symlink nodes in FUSE and NFS servers that point to internal checkouts if they exist.
- Create symlink to artifacts during server initialization if vfs.enable is false.
- Make sure tg clean removes checkouts.