### PR TITLE
fix(server): check if build is at unique depth and add build.max_concurrency config.

### DIFF
--- a/packages/cli/src/commands/server.rs
+++ b/packages/cli/src/commands/server.rs
@@ -135,6 +135,13 @@ impl Cli {
 		};
 		let remote = if args.no_remote { None } else { Some(remote) };
 
+		// Create the build options.
+		let max_concurrency = config
+			.as_ref()
+			.and_then(|config| config.build.as_ref())
+			.and_then(|build| build.max_concurrency);
+		let build = tangram_server::BuildOptions { max_concurrency };
+
 		let version = self.version.clone();
 
 		let vfs = self
@@ -148,6 +155,7 @@ impl Cli {
 		// Create the options.
 		let options = tangram_server::Options {
 			addr,
+			build,
 			path,
 			remote,
 			version,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -72,6 +72,9 @@ struct Config {
 	autoenv: Option<AutoenvConfig>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	build: Option<BuildConfig>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	remote: Option<RemoteConfig>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -82,6 +85,13 @@ struct Config {
 struct AutoenvConfig {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	paths: Vec<PathBuf>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+struct BuildConfig {
+	/// The maximum number of concurrent builds.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	max_concurrency: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -96,12 +106,6 @@ struct RemoteConfig {
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-struct VfsConfig {
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	enable: Option<bool>,
-}
-
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 struct RemoteBuildConfig {
 	/// Enable remote builds.
 	#[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -110,6 +114,12 @@ struct RemoteBuildConfig {
 	/// Limit remote builds to targets with the specified hosts.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	hosts: Option<Vec<tg::System>>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+struct VfsConfig {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	enable: Option<bool>,
 }
 
 fn main() {

--- a/packages/cli/src/tui.rs
+++ b/packages/cli/src/tui.rs
@@ -729,6 +729,7 @@ impl Drop for LogInner {
 
 impl Log {
 	// Create a new log data stream.
+	#[allow(clippy::too_many_lines)]
 	fn new(tg: &dyn tg::Handle, build: &tg::Build, rect: Rect) -> Self {
 		let build = build.clone();
 		let chunks = tokio::sync::Mutex::new(Vec::new());
@@ -1240,6 +1241,7 @@ mod tests {
 		assert_eq!(&lines[3], "d... ");
 	}
 
+	#[allow(clippy::too_many_lines)]
 	#[test]
 	fn tailing() {
 		let chunks = vec![

--- a/packages/server/src/artifact.rs
+++ b/packages/server/src/artifact.rs
@@ -542,7 +542,7 @@ impl Server {
 			let attributes = tg::file::Attributes { references };
 			let attributes =
 				serde_json::to_vec(&attributes).wrap_err("Failed to serialize attributes.")?;
-			xattr::set(&path, tg::file::TANGRAM_FILE_XATTR_NAME, &attributes)
+			xattr::set(path, tg::file::TANGRAM_FILE_XATTR_NAME, &attributes)
 				.wrap_err("Failed to set attributes as an xattr.")?;
 		}
 

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -383,6 +383,7 @@ impl Server {
 		let (outcome, _) = tokio::sync::watch::channel(());
 		let (stop, _) = tokio::sync::watch::channel(false);
 		let context = Arc::new(BuildContext {
+			build: build_id.clone(),
 			children: Some(children),
 			depth: arg.options.depth,
 			log: Some(log),
@@ -511,7 +512,9 @@ impl Server {
 					.read()
 					.unwrap()
 					.values()
+					.filter(|context| context.build != id)
 					.all(|context| context.depth != options.depth);
+
 				let permit = self.inner.build_semaphore.clone().try_acquire_owned();
 				let permit = match (unique, permit) {
 					(_, Ok(permit)) => Some(permit),
@@ -650,6 +653,7 @@ impl Server {
 			// Create the build context.
 			let (stop, _) = tokio::sync::watch::channel(false);
 			let context = Arc::new(BuildContext {
+				build: id.clone(),
 				children: None,
 				depth: options.depth,
 				log: None,

--- a/packages/vfs/src/nfs.rs
+++ b/packages/vfs/src/nfs.rs
@@ -536,7 +536,9 @@ impl Server {
 			NodeKind::Root { .. }
 			| NodeKind::Directory { .. }
 			| NodeKind::NamedAttributeDirectory { .. } => ACCESS4_EXECUTE | ACCESS4_READ | ACCESS4_LOOKUP,
-			NodeKind::Symlink { .. } | NodeKind::NamedAttribute { .. } => ACCESS4_READ,
+			NodeKind::Symlink { .. }
+			| NodeKind::NamedAttribute { .. }
+			| NodeKind::Checkout { .. } => ACCESS4_READ,
 			NodeKind::File { file, .. } => {
 				let is_executable = match file.executable(self.inner.tg.as_ref()).await {
 					Ok(b) => b,
@@ -551,7 +553,6 @@ impl Server {
 					ACCESS4_READ
 				}
 			},
-			NodeKind::Checkout { .. } => ACCESS4_READ,
 		};
 
 		let supported = arg.access & access;
@@ -656,7 +657,7 @@ impl Server {
 					mode,
 				)
 			},
-			NodeKind::Symlink { .. } => {
+			NodeKind::Symlink { .. } | NodeKind::Checkout { .. } => {
 				FileAttrData::new(file_handle, nfs_ftype4::NF4LNK, 1, O_RDONLY)
 			},
 			NodeKind::NamedAttribute { data } => {
@@ -666,9 +667,6 @@ impl Server {
 			NodeKind::NamedAttributeDirectory { children, .. } => {
 				let len = children.read().await.len();
 				FileAttrData::new(file_handle, nfs_ftype4::NF4ATTRDIR, len, O_RX)
-			},
-			NodeKind::Checkout { .. } => {
-				FileAttrData::new(file_handle, nfs_ftype4::NF4LNK, 1, O_RDONLY)
 			},
 		};
 		Some(data)


### PR DESCRIPTION
- Added `build: tg::build::Id` to server's `BuildContext`.
- Filter out builds in the queue that match the build's ID before checking if at a unique depth.
- Added a `build.max_concurrency` configuration option to the server/cli. 

This can be tested by running a recursive build that creates more than `max_concurrent` transitive children. 

```ts
export let outer = tg.target(async () => {
	await inner(100);
});

export let inner = tg.target(async (limit: number) => {
	await innerInner(limit);
});

let innerInner = async (limit: number) => {
	if (limit == 0) {
		return;
	}
	await inner(limit - 1);
};
```
