### PR TITLE
fix(nfs): fix stateid creation and validation

### DIFF
--- a/packages/vfs/src/nfs/types.rs
+++ b/packages/vfs/src/nfs/types.rs
@@ -1452,6 +1452,14 @@ impl stateid4 {
 	pub fn is_lock_set(&self) -> bool {
 		u32::from_be_bytes(self.other[8..12].try_into().unwrap()) == 1
 	}
+
+	pub fn is_valid(&self) -> bool {
+		if [0, u64::MAX].contains(&self.index()) {
+			[0, u32::MAX].contains(&self.seqid.0)
+		} else {
+			true
+		}
+	}
 }
 
 impl seqid4 {


### PR DESCRIPTION
- Added a correction to how stateids are created (forbid 0, u64::MAX).
- Added additional check in read implementation for correct stateids.
- Improved stateid creation on open to account for u64 overflow and duplication.
