### PR TITLE
fix(server): clear timestamps in internal checkouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "derive_more 1.0.0-beta.6",
+ "filetime",
  "fnv",
  "futures",
  "http 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ data-encoding = "2"
 data-encoding-macro = "0.1"
 derive_more = { version = "1.0.0-beta.6", features = ["full"] }
 either = { version = "1", features = ["serde"] }
+filetime = "0.2"
 fnv = "1"
 futures = "0.3"
 hex = { version = "0.4", features = ["serde"] }

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -17,6 +17,7 @@ async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true }
+filetime = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }


### PR DESCRIPTION
This PR ensures the file timestamps of internal checkouts are cleared.