### PR TITLE
fix(vfs): render relative symlinks to existing internal checkouts

### DIFF
--- a/packages/vfs/src/fuse.rs
+++ b/packages/vfs/src/fuse.rs
@@ -6,6 +6,7 @@ use std::{
 	io::SeekFrom,
 	os::{fd::FromRawFd, unix::prelude::OsStrExt},
 	path::{Path, PathBuf},
+	str::FromStr,
 	sync::{Arc, Weak},
 };
 use tangram_client as tg;
@@ -889,8 +890,13 @@ impl Server {
 		let child = match &parent_node.kind {
 			NodeKind::Root { .. } => {
 				let id = name.parse::<tg::artifact::Id>().map_err(|_| libc::ENOENT)?;
-				let checkout_path = self.inner.path.join("../checkouts").join(id.to_string());
-				if matches!(tokio::fs::try_exists(&checkout_path).await, Ok(true)) {
+				let checkout_path = std::path::PathBuf::from_str("../checkouts")
+					.unwrap()
+					.join(id.to_string());
+				if matches!(
+					tokio::fs::try_exists(&self.inner.path.join(&checkout_path)).await,
+					Ok(true)
+				) {
 					Either::Left(checkout_path)
 				} else {
 					Either::Right(tg::Artifact::with_id(id))

--- a/packages/vfs/src/fuse.rs
+++ b/packages/vfs/src/fuse.rs
@@ -893,10 +893,10 @@ impl Server {
 				let checkout_path = std::path::PathBuf::from_str("../checkouts")
 					.unwrap()
 					.join(id.to_string());
-				if matches!(
-					tokio::fs::try_exists(&self.inner.path.join(&checkout_path)).await,
-					Ok(true)
-				) {
+				if tokio::fs::try_exists(&self.inner.path.join(&checkout_path))
+					.await
+					.unwrap_or(false)
+				{
 					Either::Left(checkout_path)
 				} else {
 					Either::Right(tg::Artifact::with_id(id))

--- a/packages/vfs/src/nfs.rs
+++ b/packages/vfs/src/nfs.rs
@@ -852,10 +852,10 @@ impl Server {
 				let path = std::path::PathBuf::from_str("../checkouts")
 					.unwrap()
 					.join(id.to_string());
-				if matches!(
-					tokio::fs::try_exists(&self.inner.path.join(&path)).await,
-					Ok(true)
-				) {
+				if tokio::fs::try_exists(&self.inner.path.join(&path))
+					.await
+					.unwrap_or(false)
+				{
 					Either::Left(Either::Left(path))
 				} else {
 					Either::Left(Either::Right(tg::Artifact::with_id(id)))

--- a/packages/vfs/src/nfs.rs
+++ b/packages/vfs/src/nfs.rs
@@ -33,6 +33,7 @@ use std::{
 	collections::BTreeMap,
 	os::unix::ffi::OsStrExt,
 	path::{Path, PathBuf},
+	str::FromStr,
 	sync::{Arc, Weak},
 };
 use tangram_client as tg;

--- a/packages/vfs/src/nfs.rs
+++ b/packages/vfs/src/nfs.rs
@@ -848,8 +848,13 @@ impl Server {
 					tracing::error!(?e, ?name, "Failed to parse artifact ID.");
 					nfsstat4::NFS4ERR_NOENT
 				})?;
-				let path = self.inner.path.join("../checkouts").join(id.to_string());
-				if matches!(tokio::fs::try_exists(&path).await, Ok(true)) {
+				let path = std::path::PathBuf::from_str("../checkouts")
+					.unwrap()
+					.join(id.to_string());
+				if matches!(
+					tokio::fs::try_exists(&self.inner.path.join(&path)).await,
+					Ok(true)
+				) {
 					Either::Left(Either::Left(path))
 				} else {
 					Either::Left(Either::Right(tg::Artifact::with_id(id)))


### PR DESCRIPTION
This PR updates the VFS implementations to render relative symlinks if an artifact has been found in the checkouts:

Old behavior:
`/path/to/.tangram/artifacts/id -> /path/to/.tangram/artifacts/../checkouts/id`

New behavior:
`/path/to/.tangram/artifacts/id -> ../checkouts/id`