### PR TITLE
fix(runtime): ensure server temp path exists before creating sandbox

### DIFF
--- a/packages/runtime/src/darwin.rs
+++ b/packages/runtime/src/darwin.rs
@@ -1,4 +1,4 @@
-use crate::util::render;
+use crate::util::{ensure_dir_exists, render};
 use bytes::Bytes;
 use futures::{stream::FuturesOrdered, FutureExt, TryStreamExt};
 use indoc::writedoc;
@@ -30,6 +30,10 @@ pub async fn build(
 
 	// Create a tempdir for the root.
 	let server_directory_tmp_path = server_directory_path.join("tmp");
+
+	// Create the toplevel tempdir if it does not exist.
+	ensure_dir_exists(&server_directory_temp_path).await?;
+
 	let root_directory_tempdir = tempfile::TempDir::new_in(&server_directory_tmp_path)
 		.wrap_err("Failed to create the temporary directory.")?;
 	let root_directory_path = root_directory_tempdir.path().to_owned();

--- a/packages/runtime/src/darwin.rs
+++ b/packages/runtime/src/darwin.rs
@@ -1,4 +1,4 @@
-use crate::util::{ensure_dir_exists, render};
+use crate::util::render;
 use bytes::Bytes;
 use futures::{stream::FuturesOrdered, FutureExt, TryStreamExt};
 use indoc::writedoc;
@@ -32,7 +32,9 @@ pub async fn build(
 	let server_directory_tmp_path = server_directory_path.join("tmp");
 
 	// Create the toplevel tempdir if it does not exist.
-	ensure_dir_exists(&server_directory_temp_path).await?;
+	tokio::fs::create_dir_all(&server_directory_temp_path)
+		.await
+		.wrap_err("Failed to create the server temp directory.")?;
 
 	let root_directory_tempdir = tempfile::TempDir::new_in(&server_directory_tmp_path)
 		.wrap_err("Failed to create the temporary directory.")?;

--- a/packages/runtime/src/linux.rs
+++ b/packages/runtime/src/linux.rs
@@ -1,4 +1,4 @@
-use crate::util::{ensure_dir_exists, render};
+use crate::util::render;
 use bytes::Bytes;
 use futures::{stream::FuturesOrdered, FutureExt, TryStreamExt};
 use indoc::formatdoc;
@@ -70,7 +70,9 @@ pub async fn build(
 	let server_directory_temp_path = server_directory_host_path.join("tmp");
 
 	// Create the toplevel tempdir if it does not exist.
-	ensure_dir_exists(&server_directory_temp_path).await?;
+	tokio::fs::create_dir_all(&server_directory_temp_path)
+		.await
+		.wrap_err("Failed to create the server temp directory.")?;
 
 	let root_directory_tempdir = tempfile::TempDir::new_in(&server_directory_temp_path)
 		.wrap_err("Failed to create temporary directory.")?;

--- a/packages/runtime/src/linux.rs
+++ b/packages/runtime/src/linux.rs
@@ -1,4 +1,4 @@
-use crate::util::render;
+use crate::util::{ensure_dir_exists, render};
 use bytes::Bytes;
 use futures::{stream::FuturesOrdered, FutureExt, TryStreamExt};
 use indoc::formatdoc;
@@ -68,6 +68,10 @@ pub async fn build(
 
 	// Create a tempdir for the root.
 	let server_directory_temp_path = server_directory_host_path.join("tmp");
+
+	// Create the toplevel tempdir if it does not exist.
+	ensure_dir_exists(&server_directory_temp_path).await?;
+
 	let root_directory_tempdir = tempfile::TempDir::new_in(&server_directory_temp_path)
 		.wrap_err("Failed to create temporary directory.")?;
 	let root_directory_host_path = root_directory_tempdir.path().to_owned();

--- a/packages/runtime/src/util.rs
+++ b/packages/runtime/src/util.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use tangram_client as tg;
-use tangram_error::{error, Result, WrapErr};
+use tangram_error::Result;
 
 /// Render a value.
 pub async fn render(
@@ -32,29 +32,4 @@ pub async fn render(
 	} else {
 		Ok("<tangram value>".to_owned())
 	}
-}
-
-/// Ensure a directory exists.
-pub(crate) async fn ensure_dir_exists(path: impl AsRef<Path>) -> Result<()> {
-	let path = path.as_ref();
-	match tokio::fs::symlink_metadata(path).await {
-		Ok(metadata) => {
-			if !metadata.is_dir() {
-				return Err(error!(
-					r#"The path "{}" exists but is not a directory."#,
-					path.display()
-				));
-			}
-		},
-		Err(error) => {
-			if error.kind() != std::io::ErrorKind::NotFound {
-				return Err(error)
-					.wrap_err("Failed to determine the metadata of the server temp path.");
-			}
-			tokio::fs::create_dir_all(path)
-				.await
-				.wrap_err("Failed to create the server temp path.")?;
-		},
-	}
-	Ok(())
 }

--- a/packages/runtime/src/util.rs
+++ b/packages/runtime/src/util.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 use tangram_client as tg;
-use tangram_error::Result;
+use tangram_error::{error, Result, WrapErr};
 
 /// Render a value.
 pub async fn render(
@@ -32,4 +32,29 @@ pub async fn render(
 	} else {
 		Ok("<tangram value>".to_owned())
 	}
+}
+
+/// Ensure a directory exists.
+pub(crate) async fn ensure_dir_exists(path: impl AsRef<Path>) -> Result<()> {
+	let path = path.as_ref();
+	match tokio::fs::symlink_metadata(path).await {
+		Ok(metadata) => {
+			if !metadata.is_dir() {
+				return Err(error!(
+					r#"The path "{}" exists but is not a directory."#,
+					path.display()
+				));
+			}
+		},
+		Err(error) => {
+			if error.kind() != std::io::ErrorKind::NotFound {
+				return Err(error)
+					.wrap_err("Failed to determine the metadata of the server temp path.");
+			}
+			tokio::fs::create_dir_all(path)
+				.await
+				.wrap_err("Failed to create the server temp path.")?;
+		},
+	}
+	Ok(())
 }


### PR DESCRIPTION
This PR updates the Linux and Darwin runtime setup code to handle the case where the `<tangram path>/tmp` directory has been removed since the server was created.