### PR TITLE
fix(pool): back tangram_util::Pool with tokio::sync::mpsc to avoid deadlock

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -58,12 +58,24 @@ pub struct Build {
 	pub permits: Option<usize>,
 }
 
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Database {
-	#[default]
-	Sqlite,
+	Sqlite(SqliteDatabase),
 	Postgres(PostgresDatabase),
+}
+
+impl Default for Database {
+	fn default() -> Self {
+		Self::Sqlite(SqliteDatabase::default())
+	}
+}
+
+#[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize)]
+pub struct SqliteDatabase {
+	/// The maximum number of connections.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub max_connections: Option<usize>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -80,8 +80,14 @@ fn main() {
 	// Initialize V8. This must happen on the main thread.
 	initialize_v8();
 
+	let worker_threads = std::env::var("TANGRAM_WORKER_THREADS")
+		.ok()
+		.and_then(|n| n.parse().ok())
+		.unwrap_or(std::thread::available_parallelism().unwrap().get());
+
 	// Create the tokio runtime and run the main function.
 	tokio::runtime::Builder::new_multi_thread()
+		.worker_threads(worker_threads)
 		.enable_all()
 		.disable_lifo_slot()
 		.build()

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -165,9 +165,9 @@ impl Server {
 
 		// Create the database.
 		let database = match options.database {
-			self::options::Database::Sqlite => {
+			self::options::Database::Sqlite(sqlite) => {
 				let database_path = path.join("database");
-				Database::new_sqlite(database_path).await?
+				Database::new_sqlite(database_path, sqlite.max_connections).await?
 			},
 			self::options::Database::Postgres(postgres) => {
 				Database::new_postgres(postgres.url, postgres.max_connections).await?
@@ -320,7 +320,7 @@ impl Server {
 			tokio::fs::create_dir_all(&artifacts_path)
 				.await
 				.wrap_err("Failed to create the artifacts directory.")?;
-	
+
 			// Start the VFS server.
 			let vfs = tangram_vfs::Server::start(&server, &artifacts_path)
 				.await

--- a/packages/server/src/options.rs
+++ b/packages/server/src/options.rs
@@ -24,8 +24,13 @@ pub struct Build {
 
 #[derive(Clone, Debug)]
 pub enum Database {
-	Sqlite,
+	Sqlite(SqliteDatabase),
 	Postgres(PostgresDatabase),
+}
+
+#[derive(Clone, Debug)]
+pub struct SqliteDatabase {
+	pub max_connections: usize,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
- Reimplement tangram_util::Pool on top of a tokio::sync::mpsc::channel, which helps avoid deadlocks under heavy contention.
- Provides an environment variable (TANGRAM_WORKER_THREADS) to overide the number of worker threads used by the tokio runtime.
- Support `database.max_connections` in configuration when `database.kind` is `sqlite`.

It's not immediately clear _why_ tangram_util::Pool deadlocks under some conditions. The deadlock is reproducible by building the default target in tangram.ts when the number of tokio worker threads is 1.
