### PR TITLE
fix(server): use one database transaction during check ins

### DIFF
--- a/packages/server/src/blob.rs
+++ b/packages/server/src/blob.rs
@@ -1,0 +1,89 @@
+use crate::{database, Server};
+use bytes::Bytes;
+use futures::{stream, StreamExt, TryStreamExt};
+use num::ToPrimitive;
+use tangram_client as tg;
+use tangram_error::{Error, Result, WrapErr};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+const MAX_BRANCH_CHILDREN: usize = 1024;
+
+const MAX_LEAF_SIZE: usize = 262_144;
+
+impl Server {
+	pub async fn create_blob_with_reader(
+		&self,
+		mut reader: impl AsyncRead + Unpin,
+		txn: &database::Transaction<'_>,
+	) -> Result<tg::blob::Id> {
+		let mut leaves = Vec::new();
+		let mut bytes = vec![0u8; MAX_LEAF_SIZE];
+		loop {
+			// Read up to `MAX_LEAF_BLOCK_DATA_SIZE` bytes from the reader.
+			let mut position = 0;
+			loop {
+				let n = reader
+					.read(&mut bytes[position..])
+					.await
+					.wrap_err("Failed to read from the reader.")?;
+				position += n;
+				if n == 0 || position == bytes.len() {
+					break;
+				}
+			}
+			if position == 0 {
+				break;
+			}
+			let size = position.to_u64().unwrap();
+
+			// Create the leaf.
+			let bytes = Bytes::copy_from_slice(&bytes[..position]);
+			let data = tg::leaf::Data { bytes };
+			let id = tg::leaf::Id::new(&data.serialize()?);
+			self.put_complete_object_with_transaction(id.clone().into(), data.into(), txn)
+				.await?;
+
+			leaves.push(tg::branch::child::Data {
+				blob: id.into(),
+				size,
+			});
+		}
+
+		// Create the tree.
+		while leaves.len() > MAX_BRANCH_CHILDREN {
+			leaves = stream::iter(leaves)
+				.chunks(MAX_BRANCH_CHILDREN)
+				.flat_map(|chunk| {
+					if chunk.len() == MAX_BRANCH_CHILDREN {
+						stream::once(async move {
+							let size = chunk.len().to_u64().unwrap();
+							let data = tg::branch::Data { children: chunk };
+							let id = tg::branch::Id::new(&data.serialize()?);
+							self.put_complete_object_with_transaction(
+								id.clone().into(),
+								data.into(),
+								txn,
+							)
+							.await?;
+							Ok::<_, Error>(tg::branch::child::Data {
+								blob: id.into(),
+								size,
+							})
+						})
+						.boxed_local()
+					} else {
+						stream::iter(chunk.into_iter().map(Result::Ok)).boxed_local()
+					}
+				})
+				.try_collect()
+				.await?;
+		}
+
+		// Create the blob.
+		let data = tg::branch::Data { children: leaves };
+		let id = tg::branch::Id::new(&data.serialize()?);
+		self.put_complete_object_with_transaction(id.clone().into(), data.into(), txn)
+			.await?;
+		Ok(id.into())
+	}
+}

--- a/packages/server/src/clean.rs
+++ b/packages/server/src/clean.rs
@@ -1,13 +1,12 @@
 use super::Server;
-use crate::database::Database;
+use crate::database::Connection;
 use tangram_error::{Result, WrapErr};
 
 impl Server {
 	pub async fn clean(&self) -> Result<()> {
 		// Clean the database.
-		if let Database::Sqlite(database) = &self.inner.database {
-			let connection = database.get().await?;
-			connection
+		if let Connection::Sqlite(database) = self.inner.database.get().await? {
+			database
 				.execute_batch(
 					"
 					delete from builds;
@@ -32,14 +31,6 @@ impl Server {
 			.await
 			.wrap_err("Failed to remove the temporary directory.")?;
 		tokio::fs::create_dir_all(self.tmp_path())
-			.await
-			.wrap_err("Failed to recreate the temporary directory.")?;
-
-		// Clean the checkouts directory.
-		tokio::fs::remove_dir_all(self.checkouts_path())
-			.await
-			.wrap_err("Failed to remove the temporary directory.")?;
-		tokio::fs::create_dir_all(self.checkouts_path())
 			.await
 			.wrap_err("Failed to recreate the temporary directory.")?;
 

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -32,6 +32,7 @@ use tokio::{
 use url::Url;
 
 mod artifact;
+mod blob;
 mod build;
 mod clean;
 mod database;

--- a/packages/server/src/object.rs
+++ b/packages/server/src/object.rs
@@ -1,6 +1,6 @@
 use super::Server;
 use crate::{
-	database::{Database, Postgres, Sqlite},
+	database::{self, Database, Postgres, Sqlite},
 	postgres_params, sqlite_params, Http,
 };
 use async_recursion::async_recursion;
@@ -482,6 +482,127 @@ impl Server {
 		let output = tg::object::PutOutput { incomplete };
 
 		Ok(output)
+	}
+
+	pub async fn put_complete_object_with_transaction(
+		&self,
+		id: tg::object::Id,
+		data: tg::object::Data,
+		txn: &database::Transaction<'_>,
+	) -> Result<()> {
+		match txn {
+			database::Transaction::Sqlite(txn) => {
+				self.put_complete_object_with_transaction_sqlite(&id, &data, txn)
+					.await
+			},
+			database::Transaction::Postgres(txn) => {
+				self.put_complete_object_with_transaction_postgres(&id, &data, txn)
+					.await
+			},
+		}
+	}
+
+	pub async fn put_complete_object_with_transaction_sqlite(
+		&self,
+		id: &tg::object::Id,
+		data: &tg::object::Data,
+		txn: &rusqlite::Transaction<'_>,
+	) -> Result<()> {
+		// Serialize the object.
+		let bytes = data.serialize()?.to_vec();
+
+		// Add the object.
+		{
+			let statement = "
+				insert into objects (id, bytes, complete, weight)
+				values (?1, ?2, false, null)
+				on conflict (id) do nothing;
+			";
+			let id = id.to_string();
+			let params = sqlite_params![id, bytes];
+			let mut statement = txn
+				.prepare_cached(statement)
+				.wrap_err("Failed to prepare the query.")?;
+			let n = statement
+				.execute(params)
+				.wrap_err("Failed to execute the statement.")?;
+			if n == 0 {
+				return Ok(());
+			}
+		}
+
+		// Add the children.
+		for child in data.children() {
+			let statement = "
+				insert into object_children (object, child)
+				values (?1, ?2)
+				on conflict (object, child) do nothing;
+			";
+			let object = id.to_string();
+			let child = child.to_string();
+			let params = sqlite_params![object, child];
+			let mut statement = txn
+				.prepare_cached(statement)
+				.wrap_err("Failed to prepare the query.")?;
+			statement
+				.execute(params)
+				.wrap_err("Failed to execute the statement.")?;
+		}
+
+		Ok(())
+	}
+
+	pub async fn put_complete_object_with_transaction_postgres(
+		&self,
+		id: &tg::object::Id,
+		data: &tg::object::Data,
+		txn: &database::PostgresTransaction<'_>,
+	) -> Result<()> {
+		// Serialize the object.
+		let bytes = data.serialize()?.to_vec();
+
+		// Add the object.
+		{
+			let statement = "
+				insert into objects (id, bytes, complete, weight)
+				values ($1, $2, false, null)
+				on conflict (id) do nothing;
+			";
+			let id = id.to_string();
+			let params = postgres_params![id, bytes];
+			let statement = txn
+				.prepare_cached(statement)
+				.await
+				.wrap_err("Failed to prepare the query.")?;
+			let n = txn
+				.execute(&statement, params)
+				.await
+				.wrap_err("Failed to execute the statement.")?;
+			if n == 0 {
+				return Ok(());
+			}
+		}
+
+		// Add the children.
+		for child in data.children() {
+			let statement = "
+				insert into object_children (object, child)
+				values ($1, $2)
+				on conflict (object, child) do nothing;
+			";
+			let object = id.to_string();
+			let child = child.to_string();
+			let params = postgres_params![object, child];
+			let statement = txn
+				.prepare(statement)
+				.await
+				.wrap_err("Failed to prepare the query.")?;
+			txn.execute(&statement, params)
+				.await
+				.wrap_err("Failed to execute the statement.")?;
+		}
+
+		Ok(())
 	}
 
 	pub async fn push_object(&self, id: &tg::object::Id) -> Result<()> {


### PR DESCRIPTION
- Add helper types (database::Connection and database::Transaction) to wrap database access.
- Implement Server::put_complete_object_with_transaction that puts objects using an existing transaction, assuming they are complete.
- Remove redundant code in Server::clean.