### PR TITLE
feat(cli): increase open fd limit if configured higher than current 

### DIFF
--- a/packages/cli/src/commands/server.rs
+++ b/packages/cli/src/commands/server.rs
@@ -109,12 +109,21 @@ impl Cli {
 			.and_then(|config| config.build.as_ref())
 			.and_then(|build| build.enable)
 			.unwrap_or(true);
+		let file_descriptor_semaphore_count = config
+			.as_ref()
+			.and_then(|config| config.build.as_ref())
+			.and_then(|build| build.file_descriptor_permits)
+			.unwrap_or(tg::DEFAULT_FILE_DESCRIPTOR_PERMITS);
 		let permits = config
 			.as_ref()
 			.and_then(|config| config.build.as_ref())
 			.and_then(|build| build.permits)
 			.unwrap_or_else(|| std::thread::available_parallelism().unwrap().get());
-		let build = tangram_server::options::Build { enable, permits };
+		let build = tangram_server::options::Build {
+			enable,
+			file_descriptor_permits: file_descriptor_semaphore_count,
+			permits,
+		};
 
 		// Create the database options.
 		let database = config

--- a/packages/cli/src/commands/server.rs
+++ b/packages/cli/src/commands/server.rs
@@ -103,27 +103,24 @@ impl Cli {
 			.or(config.as_ref().and_then(|config| config.address.clone()))
 			.unwrap_or(tg::Address::Unix(default_path().join("socket")));
 
+		// Get the file descriptor permits.
+		let file_descriptor_permits = config
+			.as_ref()
+			.and_then(|config| config.file_descriptor_permits)
+			.unwrap_or(tg::DEFAULT_FILE_DESCRIPTOR_PERMITS);
+
 		// Create the build options.
 		let enable = config
 			.as_ref()
 			.and_then(|config| config.build.as_ref())
 			.and_then(|build| build.enable)
 			.unwrap_or(true);
-		let file_descriptor_semaphore_count = config
-			.as_ref()
-			.and_then(|config| config.build.as_ref())
-			.and_then(|build| build.file_descriptor_permits)
-			.unwrap_or(tg::DEFAULT_FILE_DESCRIPTOR_PERMITS);
 		let permits = config
 			.as_ref()
 			.and_then(|config| config.build.as_ref())
 			.and_then(|build| build.permits)
 			.unwrap_or_else(|| std::thread::available_parallelism().unwrap().get());
-		let build = tangram_server::options::Build {
-			enable,
-			file_descriptor_permits: file_descriptor_semaphore_count,
-			permits,
-		};
+		let build = tangram_server::options::Build { enable, permits };
 
 		// Create the database options.
 		let database = config
@@ -259,6 +256,7 @@ impl Cli {
 			address,
 			build,
 			database,
+			file_descriptor_permits,
 			messenger,
 			oauth,
 			path,

--- a/packages/cli/src/commands/server.rs
+++ b/packages/cli/src/commands/server.rs
@@ -106,7 +106,7 @@ impl Cli {
 		// Get the file descriptor semaphore size.
 		let file_descriptor_semaphore_size = config
 			.as_ref()
-			.and_then(|config| config.advanced)
+			.and_then(|config| config.advanced.as_ref())
 			.and_then(|advanced| advanced.file_descriptor_semaphore_size)
 			.unwrap_or(1024);
 

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -11,6 +11,9 @@ pub struct Config {
 	pub address: Option<tg::Address>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub advanced: Option<Advanced>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub autoenv: Option<Autoenv>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -18,9 +21,6 @@ pub struct Config {
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub database: Option<Database>,
-
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub file_descriptor_permits: Option<usize>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub messenger: Option<Messenger>,
@@ -45,6 +45,15 @@ pub struct Config {
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct Advanced {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file_descriptor_limit: Option<usize>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file_descriptor_semaphore_size: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Autoenv {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub paths: Vec<PathBuf>,
@@ -58,7 +67,7 @@ pub struct Build {
 
 	/// The maximum number of concurrent builds.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub permits: Option<usize>,
+	pub max_concurrency: Option<usize>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -20,6 +20,9 @@ pub struct Config {
 	pub database: Option<Database>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file_descriptor_permits: Option<usize>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub messenger: Option<Messenger>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -49,10 +52,6 @@ pub struct Autoenv {
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Build {
-	/// Set file descriptor semaphore count.
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub file_descriptor_permits: Option<usize>,
-
 	/// Enable builds.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub enable: Option<bool>,

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -49,6 +49,10 @@ pub struct Autoenv {
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Build {
+	/// Set file descriptor semaphore count.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file_descriptor_permits: Option<usize>,
+
 	/// Enable builds.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub enable: Option<bool>,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -98,6 +98,9 @@ fn main_inner() -> Result<()> {
 	// Read the config.
 	let config = Cli::read_config(args.config)?;
 
+	// Ensure the file descriptor limit is high enough for the configured semaphore count.
+	ensure_open_fd_rlimit(&config)?;
+
 	// Read the user.
 	let user = Cli::read_user(None)?;
 
@@ -317,6 +320,40 @@ impl Cli {
 		std::fs::write(path, user).wrap_err("Failed to save the user.")?;
 		Ok(())
 	}
+}
+
+fn ensure_open_fd_rlimit(config: &Option<Config>) -> Result<()> {
+	// Resolve the file descriptor limit from the config, falling back to the default if not set.
+	let file_descriptor_permits = config
+		.as_ref()
+		.and_then(|config| config.build.as_ref())
+		.and_then(|build| build.file_descriptor_permits)
+		.unwrap_or(tg::DEFAULT_FILE_DESCRIPTOR_PERMITS) as u64;
+
+	// Inspect the current limit.
+	let original_fd_rlimit = unsafe {
+		let mut rlimit = std::mem::MaybeUninit::uninit();
+		let result = libc::getrlimit(libc::RLIMIT_NOFILE, rlimit.as_mut_ptr());
+		if result != 0 {
+			return Err(error!("Failed to get the file descriptor limit."));
+		}
+		rlimit.assume_init()
+	};
+
+	// If the current limit is less than the desired limit, then set the limit.
+	if file_descriptor_permits > original_fd_rlimit.rlim_cur {
+		let new_fd_rlimit = libc::rlimit {
+			rlim_cur: file_descriptor_permits,
+			rlim_max: file_descriptor_permits.max(original_fd_rlimit.rlim_max),
+		};
+		unsafe {
+			let result = libc::setrlimit(libc::RLIMIT_NOFILE, &new_fd_rlimit);
+			if result != 0 {
+				return Err(error!("Failed to set the file descriptor limit."));
+			}
+		}
+	}
+	Ok(())
 }
 
 fn initialize_v8() {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -332,7 +332,7 @@ fn ensure_open_fd_rlimit(config: &Option<Config>) -> Result<()> {
 	// Set the soft limit to the configured value, and the max limit to the max allowed value.
 	let new_fd_rlimit = libc::rlimit {
 		rlim_cur: file_descriptor_permits,
-		rlim_max: libc::RLIM_INFINITY,
+		rlim_max: file_descriptor_permits,
 	};
 	let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &new_fd_rlimit) };
 	if result != 0 {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -334,11 +334,9 @@ fn ensure_open_fd_rlimit(config: &Option<Config>) -> Result<()> {
 		rlim_cur: file_descriptor_permits,
 		rlim_max: libc::RLIM_INFINITY,
 	};
-	unsafe {
-		let result = libc::setrlimit(libc::RLIMIT_NOFILE, &new_fd_rlimit);
-		if result != 0 {
-			return Err(error!("Failed to set the file descriptor limit."));
-		}
+	let result = unsafe { libc::setrlimit(libc::RLIMIT_NOFILE, &new_fd_rlimit) };
+	if result != 0 {
+		return Err(error!("Failed to set the file descriptor limit."));
 	}
 	Ok(())
 }

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -102,8 +102,6 @@ pub struct Runtime {
 	pub build: build::Id,
 }
 
-pub const DEFAULT_FILE_DESCRIPTOR_PERMITS: usize = 1024;
-
 impl Client {
 	pub fn with_runtime() -> Result<Self> {
 		let json = std::env::var("TANGRAM_RUNTIME")

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -102,6 +102,8 @@ pub struct Runtime {
 	pub build: build::Id,
 }
 
+pub const DEFAULT_FILE_DESCRIPTOR_PERMITS: usize = 1024;
+
 impl Client {
 	pub fn with_runtime() -> Result<Self> {
 		let json = std::env::var("TANGRAM_RUNTIME")

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -156,8 +156,7 @@ impl Server {
 		let build_state = std::sync::RwLock::new(HashMap::default());
 
 		// Create the build semaphore.
-		let permits = options.build.permits;
-		let build_semaphore = Arc::new(tokio::sync::Semaphore::new(permits));
+		let build_semaphore = Arc::new(tokio::sync::Semaphore::new(options.build.max_concurrency));
 
 		// Create the database.
 		let database = match options.database {
@@ -183,7 +182,7 @@ impl Server {
 
 		// Create the file system semaphore.
 		let file_descriptor_semaphore =
-			tokio::sync::Semaphore::new(options.file_descriptor_permits);
+			tokio::sync::Semaphore::new(options.file_descriptor_semaphore_size);
 
 		// Create the http server.
 		let http = std::sync::Mutex::new(None);

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -183,7 +183,7 @@ impl Server {
 
 		// Create the file system semaphore.
 		let file_descriptor_semaphore =
-			tokio::sync::Semaphore::new(options.build.file_descriptor_permits);
+			tokio::sync::Semaphore::new(options.file_descriptor_permits);
 
 		// Create the http server.
 		let http = std::sync::Mutex::new(None);

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -182,7 +182,8 @@ impl Server {
 		};
 
 		// Create the file system semaphore.
-		let file_descriptor_semaphore = tokio::sync::Semaphore::new(16);
+		let file_descriptor_semaphore =
+			tokio::sync::Semaphore::new(options.build.file_descriptor_permits);
 
 		// Create the http server.
 		let http = std::sync::Mutex::new(None);

--- a/packages/server/src/options.rs
+++ b/packages/server/src/options.rs
@@ -6,6 +6,7 @@ pub struct Options {
 	pub address: tg::Address,
 	pub build: Build,
 	pub database: Database,
+	pub file_descriptor_permits: usize,
 	pub messenger: Messenger,
 	pub oauth: Oauth,
 	pub path: PathBuf,
@@ -19,7 +20,6 @@ pub struct Options {
 #[derive(Clone, Debug)]
 pub struct Build {
 	pub enable: bool,
-	pub file_descriptor_permits: usize,
 	pub permits: usize,
 }
 

--- a/packages/server/src/options.rs
+++ b/packages/server/src/options.rs
@@ -6,7 +6,7 @@ pub struct Options {
 	pub address: tg::Address,
 	pub build: Build,
 	pub database: Database,
-	pub file_descriptor_permits: usize,
+	pub file_descriptor_semaphore_size: usize,
 	pub messenger: Messenger,
 	pub oauth: Oauth,
 	pub path: PathBuf,
@@ -20,7 +20,7 @@ pub struct Options {
 #[derive(Clone, Debug)]
 pub struct Build {
 	pub enable: bool,
-	pub permits: usize,
+	pub max_concurrency: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/packages/server/src/options.rs
+++ b/packages/server/src/options.rs
@@ -19,6 +19,7 @@ pub struct Options {
 #[derive(Clone, Debug)]
 pub struct Build {
 	pub enable: bool,
+	pub file_descriptor_permits: usize,
 	pub permits: usize,
 }
 


### PR DESCRIPTION
This PR adds a config option to set the number of available file semaphore permits, and will increase the current setting via `libc::setrlimit` if it's lower than configured.