### PR TITLE
feat(runtime): runtime server proxy

### DIFF
--- a/packages/cli/src/commands/server.rs
+++ b/packages/cli/src/commands/server.rs
@@ -281,7 +281,7 @@ impl Cli {
 			let server = server.clone();
 			async move {
 				tokio::signal::ctrl_c().await.ok();
-				server.stop().await.ok();
+				server.stop();
 				tokio::signal::ctrl_c().await.ok();
 				std::process::exit(130);
 			}

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -103,20 +103,18 @@ pub struct Runtime {
 }
 
 impl Client {
-	pub fn with_runtime() -> Result<Self> {
-		let json = std::env::var("TANGRAM_RUNTIME")
-			.wrap_err("Failed to get the TANGRAM_RUNTIME environment variable.")?;
-		let runtime = serde_json::from_str::<Runtime>(&json)
-			.wrap_err("Failed to deserialize the TANGRAM_RUNTIME environment variable.")?;
-		let address = runtime.address;
-		let build = Some(runtime.build);
-		let file_descriptor_semaphore = tokio::sync::Semaphore::new(16);
+	pub fn with_env() -> Result<Self> {
+		let address = std::env::var("TANGRAM_ADDRESS")
+			.wrap_err("Failed to get the TANGRAM_ADDRESS environment variable.")?
+			.parse()
+			.wrap_err("Could not parse an address from TANGRAM_ADDRESS environment variable.")?;
+		let file_descriptor_semaphore = tokio::sync::Semaphore::new(32);
 		let sender = tokio::sync::Mutex::new(None);
 		let tls = false;
 		let user = None;
 		let inner = Arc::new(Inner {
 			address,
-			build,
+			build: None,
 			file_descriptor_semaphore,
 			sender,
 			tls,

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -61,7 +61,6 @@ pub struct Client {
 #[derive(Debug)]
 struct Inner {
 	address: Address,
-	build: Option<tg::build::Id>,
 	file_descriptor_semaphore: tokio::sync::Semaphore,
 	sender: tokio::sync::Mutex<
 		Option<hyper::client::conn::http2::SendRequest<tangram_util::http::Outgoing>>,
@@ -91,7 +90,6 @@ pub enum Host {
 
 pub struct Builder {
 	address: Address,
-	build: Option<build::Id>,
 	tls: Option<bool>,
 	user: Option<User>,
 }
@@ -114,7 +112,6 @@ impl Client {
 		let user = None;
 		let inner = Arc::new(Inner {
 			address,
-			build: None,
 			file_descriptor_semaphore,
 			sender,
 			tls,
@@ -122,11 +119,6 @@ impl Client {
 		});
 		let client = Client { inner };
 		Ok(client)
-	}
-
-	#[must_use]
-	pub fn build(&self) -> Option<&build::Id> {
-		self.inner.build.as_ref()
 	}
 
 	pub async fn connect(&self) -> Result<()> {
@@ -437,16 +429,9 @@ impl Builder {
 	pub fn new(address: Address) -> Self {
 		Self {
 			address,
-			build: None,
 			tls: None,
 			user: None,
 		}
-	}
-
-	#[must_use]
-	pub fn build_(mut self, build: build::Id) -> Self {
-		self.build = Some(build);
-		self
 	}
 
 	#[must_use]
@@ -464,14 +449,12 @@ impl Builder {
 	#[must_use]
 	pub fn build(self) -> Client {
 		let address = self.address;
-		let build = self.build;
 		let file_descriptor_semaphore = tokio::sync::Semaphore::new(16);
 		let sender = tokio::sync::Mutex::new(None);
 		let tls = self.tls.unwrap_or(false);
 		let user = self.user;
 		let inner = Arc::new(Inner {
 			address,
-			build,
 			file_descriptor_semaphore,
 			sender,
 			tls,

--- a/packages/server/src/artifact.rs
+++ b/packages/server/src/artifact.rs
@@ -494,7 +494,7 @@ impl Server {
 				path: None,
 			};
 			self.check_out_artifact(arg).await?;
-			let src = self.artifacts_path().join(file.id(self).await?.to_string());
+			let src = self.checkouts_path().join(file.id(self).await?.to_string());
 			tokio::fs::hard_link(&src, path)
 				.await
 				.wrap_err("Failed to create the hard link.")?;

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -201,7 +201,7 @@ impl Server {
 							.try_collect::<Vec<_>>()
 							.await?;
 					}
-					crate::runtime::darwin::build(self, &build, &self.inner.path).await
+					crate::runtime::darwin::build(self, &build).await
 				}
 				#[cfg(not(target_os = "macos"))]
 				{

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -201,7 +201,7 @@ impl Server {
 							.try_collect::<Vec<_>>()
 							.await?;
 					}
-					crate::runtime::darwin::build(self, &build).await
+					crate::runtime::darwin::build(self, &build, &self.inner.path).await
 				}
 				#[cfg(not(target_os = "macos"))]
 				{

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -285,7 +285,6 @@ impl Server {
 		id: &tg::build::Id,
 		bytes: Bytes,
 	) -> Result<bool> {
-		eprint!("{}", String::from_utf8_lossy(&bytes));
 		// Verify the build is local.
 		if !self.get_build_exists_local(id).await? {
 			return Ok(false);

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -285,6 +285,7 @@ impl Server {
 		id: &tg::build::Id,
 		bytes: Bytes,
 	) -> Result<bool> {
+		eprint!("{}", String::from_utf8_lossy(&bytes));
 		// Verify the build is local.
 		if !self.get_build_exists_local(id).await? {
 			return Ok(false);

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -334,8 +334,7 @@ impl Server {
 		Ok(server)
 	}
 
-	#[allow(clippy::unused_async)]
-	pub async fn stop(&self) -> Result<()> {
+	pub fn stop(&self) {
 		let server = self.clone();
 		let task = tokio::spawn(async move {
 			// Stop the http server.
@@ -395,11 +394,8 @@ impl Server {
 
 			Ok(())
 		});
-
 		self.inner.shutdown_task.lock().unwrap().replace(task);
 		self.inner.shutdown.send_replace(true);
-
-		Ok(())
 	}
 
 	pub async fn join(&self) -> Result<()> {
@@ -1004,7 +1000,8 @@ impl tg::Handle for Server {
 	}
 
 	async fn stop(&self) -> Result<()> {
-		self.stop().await
+		self.stop();
+		Ok(())
 	}
 
 	async fn create_login(&self) -> Result<tg::user::Login> {

--- a/packages/server/src/runtime.rs
+++ b/packages/server/src/runtime.rs
@@ -3,4 +3,5 @@ pub mod darwin;
 pub mod js;
 #[cfg(target_os = "linux")]
 pub mod linux;
+mod proxy;
 pub mod util;

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -8,17 +8,19 @@ use std::{
 	ffi::{CStr, CString},
 	fmt::Write,
 	os::unix::prelude::OsStrExt,
+	path::Path,
 };
 use tangram_client as tg;
 use tangram_error::{error, Error, Result, Wrap, WrapErr};
 use tokio::io::AsyncReadExt;
 
-pub async fn build(tg: &dyn tg::Handle, build: &tg::Build) -> Result<tg::Value> {
+pub async fn build(
+	tg: &dyn tg::Handle,
+	build: &tg::Build,
+	server_directory_path: &Path,
+) -> Result<tg::Value> {
 	// Get the target.
 	let target = build.target(tg).await?;
-
-	// Get the server directory path.
-	let server_directory_path: std::path::PathBuf = tg.path().await?.unwrap().into();
 
 	// Get the artifacts path.
 	let artifacts_directory_path = server_directory_path.join("artifacts");

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -1,6 +1,10 @@
 use super::{proxy::Proxy, util::render};
+use crate::Server;
 use bytes::Bytes;
-use futures::{stream::FuturesOrdered, TryStreamExt};
+use futures::{
+	stream::{FuturesOrdered, FuturesUnordered},
+	TryStreamExt,
+};
 use indoc::writedoc;
 use num::ToPrimitive;
 use std::{
@@ -8,25 +12,37 @@ use std::{
 	ffi::{CStr, CString},
 	fmt::Write,
 	os::unix::prelude::OsStrExt,
-	path::Path,
 };
 use tangram_client as tg;
 use tangram_error::{error, Error, Result, Wrap, WrapErr};
 use tokio::io::AsyncReadExt;
 
-pub async fn build(
-	tg: &dyn tg::Handle,
-	build: &tg::Build,
-	server_directory_path: &Path,
-) -> Result<tg::Value> {
+pub async fn build(server: &Server, build: &tg::Build) -> Result<tg::Value> {
 	// Get the target.
-	let target = build.target(tg).await?;
+	let target = build.target(server).await?;
+
+	// If the VFS is disabled, then perform an internal checkout of the target's references.
+	if server.inner.vfs.lock().unwrap().is_none() {
+		target
+			.data(server)
+			.await?
+			.children()
+			.into_iter()
+			.filter_map(|id| id.try_into().ok())
+			.map(|id| async move {
+				let artifact = tg::Artifact::with_id(id);
+				artifact.check_out(server, None).await
+			})
+			.collect::<FuturesUnordered<_>>()
+			.try_collect::<Vec<_>>()
+			.await?;
+	}
 
 	// Get the artifacts path.
-	let artifacts_directory_path = server_directory_path.join("artifacts");
+	let artifacts_directory_path = server.inner.path.join("artifacts");
 
 	// Get the server temp directory path.
-	let server_directory_temp_path = server_directory_path.join("tmp");
+	let server_directory_temp_path = server.inner.path.join("tmp");
 	tokio::fs::create_dir_all(&server_directory_temp_path)
 		.await
 		.wrap_err("Failed to create the server temp directory.")?;
@@ -61,16 +77,21 @@ pub async fn build(
 		.wrap_err("Failed to create the working directory.")?;
 
 	// Render the executable.
-	let executable = target.executable(tg).await?;
-	let executable = render(tg, &executable.clone().into(), &artifacts_directory_path).await?;
+	let executable = target.executable(server).await?;
+	let executable = render(
+		server,
+		&executable.clone().into(),
+		&artifacts_directory_path,
+	)
+	.await?;
 
 	// Render the env.
-	let env = target.env(tg).await?;
+	let env = target.env(server).await?;
 	let mut env: BTreeMap<String, String> = env
 		.iter()
 		.map(|(key, value)| async {
 			let key = key.clone();
-			let value = render(tg, value, &artifacts_directory_path).await?;
+			let value = render(server, value, &artifacts_directory_path).await?;
 			Ok::<_, Error>((key, value))
 		})
 		.collect::<FuturesOrdered<_>>()
@@ -78,11 +99,11 @@ pub async fn build(
 		.await?;
 
 	// Render the args.
-	let args = target.args(tg).await?;
+	let args = target.args(server).await?;
 	let args: Vec<String> = args
 		.iter()
 		.map(|value| async {
-			let value = render(tg, value, &artifacts_directory_path).await?;
+			let value = render(server, value, &artifacts_directory_path).await?;
 			Ok::<_, Error>(value)
 		})
 		.collect::<FuturesOrdered<_>>()
@@ -90,7 +111,7 @@ pub async fn build(
 		.await?;
 
 	// Enable the network if a checksum was provided.
-	let network_enabled = target.checksum(tg).await?.is_some();
+	let network_enabled = target.checksum(server).await?.is_some();
 
 	// Set `$HOME`.
 	env.insert(
@@ -116,7 +137,7 @@ pub async fn build(
 	);
 
 	// Create a proxied server handle and start listening on a new socket.
-	let proxy_server = Proxy::start(tg.clone_box().into(), build.id(), proxy_server_address)
+	let proxy = Proxy::start(server, build.id(), proxy_server_address)
 		.await
 		.wrap_err("Could not create proxy server")?;
 
@@ -328,7 +349,7 @@ pub async fn build(
 	let mut stdout = child.stdout.take().unwrap();
 	let log_task = tokio::task::spawn({
 		let build = build.clone();
-		let tg = tg.clone_box();
+		let server = server.clone();
 		async move {
 			let mut buf = [0; 512];
 			loop {
@@ -337,7 +358,7 @@ pub async fn build(
 					Ok(0) => return Ok(()),
 					Ok(size) => {
 						let log = Bytes::copy_from_slice(&buf[0..size]);
-						build.add_log(tg.as_ref(), log).await?;
+						build.add_log(&server, log).await?;
 					},
 				}
 			}
@@ -388,8 +409,9 @@ pub async fn build(
 		.wrap_err("Failed to join the log task.")?
 		.wrap_err("The log task failed.")?;
 
-	// Stop the proxy server.
-	proxy_server.stop().await?;
+	// Stop and join the proxy server.
+	proxy.stop();
+	proxy.join().await?;
 
 	// Return an error if the process did not exit successfully.
 	if !exit_status.success() {
@@ -402,14 +424,14 @@ pub async fn build(
 		.wrap_err("Failed to determine if the path exists.")?
 	{
 		// Check in the output.
-		let artifact = tg::Artifact::check_in(tg, &output_path.clone().try_into()?)
+		let artifact = tg::Artifact::check_in(server, &output_path.clone().try_into()?)
 			.await
 			.wrap_err("Failed to check in the output.")?;
 
 		// Verify the checksum if one was provided.
-		if let Some(expected) = target.checksum(tg).await?.clone() {
+		if let Some(expected) = target.checksum(server).await?.clone() {
 			let actual = artifact
-				.checksum(tg, expected.algorithm())
+				.checksum(server, expected.algorithm())
 				.await
 				.wrap_err("Failed to compute the checksum.")?;
 			if expected != tg::Checksum::Unsafe && expected != actual {

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -138,7 +138,7 @@ pub async fn build(
 	let artifacts_directory_guest_path = server_directory_guest_path.join("artifacts");
 
 	// Create the host and guest paths for the proxy server socket.
-	let proxy_server_socket_host_path = server_directory_host_path.join(".socket");
+	let proxy_server_socket_host_path = server_directory_host_path.join("socket");
 	let proxy_server_socket_guest_path = server_directory_guest_path.join("socket");
 
 	// Create the host and guest paths for the home directory, with inner .tangram directory.

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -137,17 +137,17 @@ pub async fn build(
 	let _artifacts_directory_host_path = server_directory_host_path.join("artifacts");
 	let artifacts_directory_guest_path = server_directory_guest_path.join("artifacts");
 
-	// Create the host and guest paths for the proxy server socket.
-	let proxy_server_socket_host_path = server_directory_host_path.join("socket");
-	let proxy_server_socket_guest_path = server_directory_guest_path.join("socket");
-
 	// Create the host and guest paths for the home directory, with inner .tangram directory.
 	let home_directory_host_path =
 		root_directory_host_path.join(HOME_DIRECTORY_GUEST_PATH.strip_prefix('/').unwrap());
 	let home_directory_guest_path = PathBuf::from(HOME_DIRECTORY_GUEST_PATH);
-	tokio::fs::create_dir_all(&home_directory_host_path)
+	tokio::fs::create_dir_all(&home_directory_host_path.join(".tangram"))
 		.await
 		.wrap_err("Failed to create the home directory.")?;
+
+	// Create the host and guest paths for the proxy server socket.
+	let proxy_server_socket_host_path = home_directory_host_path.join(".tangram/socket");
+	let proxy_server_socket_guest_path = home_directory_guest_path.join(".tangram/socket");
 
 	// Create the host and guest paths for the working directory.
 	let working_directory_host_path =

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -1,7 +1,10 @@
 use super::util::render;
-use crate::runtime::proxy::Proxy;
+use crate::{runtime::proxy::Proxy, Server};
 use bytes::Bytes;
-use futures::{stream::FuturesOrdered, TryStreamExt};
+use futures::{
+	stream::{FuturesOrdered, FuturesUnordered},
+	TryStreamExt,
+};
 use indoc::formatdoc;
 use itertools::Itertools;
 use std::{
@@ -52,16 +55,29 @@ const SH_X8664_LINUX: &[u8] = include_bytes!(concat!(
 	"/src/runtime/linux/bin/sh_x86_64_linux"
 ));
 
-pub async fn build(
-	tg: &dyn tg::Handle,
-	build: &tg::Build,
-	server_directory_path: &Path,
-) -> Result<tg::Value> {
+pub async fn build(server: &Server, build: &tg::Build) -> Result<tg::Value> {
 	// Get the target.
-	let target = build.target(tg).await?;
+	let target = build.target(server).await?;
+
+	// If the VFS is disabled, then perform an internal checkout of the target's references.
+	if server.inner.vfs.lock().unwrap().is_none() {
+		target
+			.data(server)
+			.await?
+			.children()
+			.into_iter()
+			.filter_map(|id| id.try_into().ok())
+			.map(|id| async move {
+				let artifact = tg::Artifact::with_id(id);
+				artifact.check_out(server, None).await
+			})
+			.collect::<FuturesUnordered<_>>()
+			.try_collect::<Vec<_>>()
+			.await?;
+	}
 
 	// Get the server directory path.
-	let server_directory_host_path = server_directory_path;
+	let server_directory_host_path = server.inner.path.clone();
 	let server_directory_guest_path = PathBuf::from(SERVER_DIRECTORY_GUEST_PATH);
 
 	// Get the server temp directory path.
@@ -82,7 +98,7 @@ pub async fn build(
 	let env_path = root_directory_host_path.join("usr/bin/env");
 	let sh_path = root_directory_host_path.join("bin/sh");
 	let (env_bytes, sh_bytes) = match target
-		.host(tg)
+		.host(server)
 		.await?
 		.arch()
 		.ok_or(error!("Unrecognized target arch"))?
@@ -157,21 +173,21 @@ pub async fn build(
 		.wrap_err("Failed to create the working directory.")?;
 
 	// Render the executable.
-	let executable = target.executable(tg).await?;
+	let executable = target.executable(server).await?;
 	let executable = render(
-		tg,
+		server,
 		&executable.clone().into(),
 		&artifacts_directory_guest_path,
 	)
 	.await?;
 
 	// Render the env.
-	let env = target.env(tg).await?;
+	let env = target.env(server).await?;
 	let mut env: BTreeMap<String, String> = env
 		.iter()
 		.map(|(key, value)| async {
 			let key = key.clone();
-			let value = render(tg, value, &artifacts_directory_guest_path).await?;
+			let value = render(server, value, &artifacts_directory_guest_path).await?;
 			Ok::<_, Error>((key, value))
 		})
 		.collect::<FuturesOrdered<_>>()
@@ -179,11 +195,11 @@ pub async fn build(
 		.await?;
 
 	// Render the args.
-	let args = target.args(tg).await?;
+	let args = target.args(server).await?;
 	let args: Vec<String> = args
 		.iter()
 		.map(|value| async {
-			let value = render(tg, value, &artifacts_directory_guest_path).await?;
+			let value = render(server, value, &artifacts_directory_guest_path).await?;
 			Ok::<_, Error>(value)
 		})
 		.collect::<FuturesOrdered<_>>()
@@ -191,7 +207,7 @@ pub async fn build(
 		.await?;
 
 	// Enable the network if a checksum was provided.
-	let network_enabled = target.checksum(tg).await?.is_some();
+	let network_enabled = target.checksum(server).await?.is_some();
 
 	// Set `$HOME`.
 	env.insert(
@@ -214,9 +230,9 @@ pub async fn build(
 
 	// Create proxy server.
 	let proxy_server_host_address = tg::Address::Unix(proxy_server_socket_host_path);
-	let proxy_server = Proxy::start(tg.clone_box().into(), build.id(), proxy_server_host_address)
+	let proxy_server = Proxy::start(server, build.id(), proxy_server_host_address)
 		.await
-		.wrap_err("Could not create proxy server")?;
+		.wrap_err("Failed to create the proxy server.")?;
 
 	// Create /etc.
 	tokio::fs::create_dir_all(root_directory_host_path.join("etc"))
@@ -524,7 +540,7 @@ pub async fn build(
 	// Spawn the log task.
 	let log_task = tokio::task::spawn({
 		let build = build.clone();
-		let tg = tg.clone_box();
+		let server = server.clone();
 		async move {
 			let mut buf = vec![0; 512];
 			loop {
@@ -533,7 +549,7 @@ pub async fn build(
 					Ok(0) => return Ok(()),
 					Ok(size) => {
 						let log = Bytes::copy_from_slice(&buf[0..size]);
-						build.add_log(tg.as_ref(), log).await?;
+						build.add_log(&server, log).await?;
 					},
 				}
 			}
@@ -645,9 +661,10 @@ pub async fn build(
 		},
 	};
 
-	// Stop the proxy server.
+	// Stop and join the proxy server.
+	proxy_server.stop();
 	proxy_server
-		.stop()
+		.join()
 		.await
 		.wrap_err("Failed to stop the proxy server.")?;
 
@@ -657,14 +674,14 @@ pub async fn build(
 		.wrap_err("Failed to determine in the path exists.")?
 	{
 		// Check in the output.
-		let artifact = tg::Artifact::check_in(tg, &output_host_path.clone().try_into()?)
+		let artifact = tg::Artifact::check_in(server, &output_host_path.clone().try_into()?)
 			.await
 			.wrap_err("Failed to check in the output.")?;
 
 		// Verify the checksum if one was provided.
-		if let Some(expected) = target.checksum(tg).await?.clone() {
+		if let Some(expected) = target.checksum(server).await?.clone() {
 			let actual = artifact
-				.checksum(tg, expected.algorithm())
+				.checksum(server, expected.algorithm())
 				.await
 				.wrap_err("Failed to compute the checksum.")?;
 			if expected != tg::Checksum::Unsafe && expected != actual {

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -1,0 +1,397 @@
+use crate::Http;
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use std::sync::Arc;
+use tangram_client as tg;
+use tangram_error::{error, Result, WrapErr};
+use tangram_util::fs::rmrf;
+use tokio::io::{AsyncRead, AsyncWrite};
+use url::Url;
+
+#[derive(Clone)]
+pub struct Proxy {
+	inner: Arc<Inner>,
+}
+
+pub struct Inner {
+	http: std::sync::Mutex<Option<Http>>,
+	parent_build_id: tg::build::Id,
+	parent_server: Arc<dyn tg::Handle>,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct GetOrCreateProxiedArg {
+	pub remote: bool,
+	pub retry: tg::build::Retry,
+	pub target: tg::target::Id,
+}
+
+impl From<GetOrCreateProxiedArg> for tg::build::GetOrCreateArg {
+	fn from(arg: GetOrCreateProxiedArg) -> Self {
+		tg::build::GetOrCreateArg {
+			parent: None,
+			remote: arg.remote,
+			retry: arg.retry,
+			target: arg.target,
+		}
+	}
+}
+
+impl Proxy {
+	pub async fn start(
+		parent_server: Arc<dyn tg::Handle>,
+		build_id: &tg::build::Id,
+		address: tg::Address,
+	) -> Result<Self> {
+		// Create an owned copy of the parent build id to be used in the proxy server.
+		let parent_build_id = build_id.clone();
+
+		// Set up a mutex to store an HTTP server.
+		let http = std::sync::Mutex::new(None);
+
+		// Construct the proxy server.
+		let inner = Inner {
+			http,
+			parent_build_id,
+			parent_server,
+		};
+		let proxy = Proxy {
+			inner: Arc::new(inner),
+		};
+
+		// Remove an existing socket file.
+		if let tg::Address::Unix(ref address_path) = address {
+			rmrf(address_path)
+				.await
+				.wrap_err("Failed to remove existing socket file")?;
+
+			// Start the HTTP server.
+			proxy
+				.inner
+				.http
+				.lock()
+				.unwrap()
+				.replace(Http::start(&proxy, address));
+		} else {
+			return Err(error!("Expected Unix address, got {:?}", address));
+		}
+
+		Ok(proxy)
+	}
+
+	pub async fn stop(&self) -> Result<()> {
+		let server = self.clone();
+		tokio::spawn(async move {
+			// Stop the http server.
+			if let Some(http) = server.inner.http.lock().unwrap().as_ref() {
+				http.stop();
+			}
+
+			// Join the http server.
+			let http = server.inner.http.lock().unwrap().take();
+			if let Some(http) = http {
+				http.join().await?;
+			}
+
+			Ok::<_, tangram_error::Error>(())
+		});
+
+		Ok(())
+	}
+
+	pub async fn get_or_create_build_proxied(
+		&self,
+		user: Option<&tg::User>,
+		arg: GetOrCreateProxiedArg,
+	) -> Result<tg::build::GetOrCreateOutput> {
+		let arg = tg::build::GetOrCreateArg {
+			parent: Some(self.inner.parent_build_id.clone()),
+			..arg.into()
+		};
+		self.inner
+			.parent_server
+			.get_or_create_build(user, arg)
+			.await
+	}
+}
+
+#[async_trait]
+impl tg::Handle for Proxy {
+	fn clone_box(&self) -> Box<dyn tg::Handle> {
+		Box::new(self.clone())
+	}
+
+	async fn path(&self) -> Result<Option<tg::Path>> {
+		self.inner.parent_server.path().await
+	}
+
+	async fn format(&self, _text: String) -> Result<String> {
+		Err(error!("Not supported"))
+	}
+
+	fn file_descriptor_semaphore(&self) -> &tokio::sync::Semaphore {
+		self.inner.parent_server.file_descriptor_semaphore()
+	}
+
+	async fn check_in_artifact(
+		&self,
+		arg: tg::artifact::CheckInArg,
+	) -> Result<tg::artifact::CheckInOutput> {
+		self.inner.parent_server.check_in_artifact(arg).await
+	}
+
+	async fn check_out_artifact(&self, arg: tg::artifact::CheckOutArg) -> Result<()> {
+		self.inner.parent_server.check_out_artifact(arg).await
+	}
+
+	async fn list_builds(&self, arg: tg::build::ListArg) -> Result<tg::build::ListOutput> {
+		self.inner.parent_server.list_builds(arg).await
+	}
+
+	async fn try_get_build(
+		&self,
+		id: &tg::build::Id,
+		arg: tg::build::GetArg,
+	) -> Result<Option<tg::build::GetOutput>> {
+		self.inner.parent_server.try_get_build(id, arg).await
+	}
+
+	async fn put_build(
+		&self,
+		user: Option<&tg::User>,
+		id: &tg::build::Id,
+		arg: &tg::build::PutArg,
+	) -> Result<()> {
+		self.inner.parent_server.put_build(user, id, arg).await
+	}
+
+	async fn push_build(&self, user: Option<&tg::User>, id: &tg::build::Id) -> Result<()> {
+		self.inner.parent_server.push_build(user, id).await
+	}
+
+	async fn pull_build(&self, id: &tg::build::Id) -> Result<()> {
+		self.inner.parent_server.pull_build(id).await
+	}
+
+	async fn get_or_create_build(
+		&self,
+		user: Option<&tg::User>,
+		arg: tg::build::GetOrCreateArg,
+	) -> Result<tg::build::GetOrCreateOutput> {
+		if arg.parent.is_some() {
+			return Err(error!("Using proxied server, parent should be set to None"));
+		}
+		let arg = GetOrCreateProxiedArg {
+			remote: arg.remote,
+			retry: arg.retry,
+			target: arg.target,
+		};
+		self.get_or_create_build_proxied(user, arg).await
+	}
+
+	async fn try_get_build_status(
+		&self,
+		id: &tg::build::Id,
+		arg: tg::build::status::GetArg,
+		stop: Option<tokio::sync::watch::Receiver<bool>>,
+	) -> Result<Option<BoxStream<'static, Result<tg::build::Status>>>> {
+		self.inner
+			.parent_server
+			.try_get_build_status(id, arg, stop)
+			.await
+	}
+
+	async fn set_build_status(
+		&self,
+		user: Option<&tg::User>,
+		id: &tg::build::Id,
+		status: tg::build::Status,
+	) -> Result<()> {
+		self.inner
+			.parent_server
+			.set_build_status(user, id, status)
+			.await
+	}
+
+	async fn try_get_build_children(
+		&self,
+		id: &tg::build::Id,
+		arg: tg::build::children::GetArg,
+		stop: Option<tokio::sync::watch::Receiver<bool>>,
+	) -> Result<Option<BoxStream<'static, Result<tg::build::children::Chunk>>>> {
+		self.inner
+			.parent_server
+			.try_get_build_children(id, arg, stop)
+			.await
+	}
+
+	async fn add_build_child(
+		&self,
+		user: Option<&tg::User>,
+		build_id: &tg::build::Id,
+		child_id: &tg::build::Id,
+	) -> Result<()> {
+		self.inner
+			.parent_server
+			.add_build_child(user, build_id, child_id)
+			.await
+	}
+
+	async fn try_get_build_log(
+		&self,
+		id: &tg::build::Id,
+		arg: tg::build::log::GetArg,
+		stop: Option<tokio::sync::watch::Receiver<bool>>,
+	) -> Result<Option<BoxStream<'static, Result<tg::build::log::Chunk>>>> {
+		self.inner
+			.parent_server
+			.try_get_build_log(id, arg, stop)
+			.await
+	}
+
+	async fn add_build_log(
+		&self,
+		user: Option<&tg::User>,
+		build_id: &tg::build::Id,
+		bytes: Bytes,
+	) -> Result<()> {
+		self.inner
+			.parent_server
+			.add_build_log(user, build_id, bytes)
+			.await
+	}
+
+	async fn try_get_build_outcome(
+		&self,
+		id: &tg::build::Id,
+		arg: tg::build::outcome::GetArg,
+		stop: Option<tokio::sync::watch::Receiver<bool>>,
+	) -> Result<Option<Option<tg::build::Outcome>>> {
+		self.inner
+			.parent_server
+			.try_get_build_outcome(id, arg, stop)
+			.await
+	}
+
+	async fn set_build_outcome(
+		&self,
+		user: Option<&tg::User>,
+		id: &tg::build::Id,
+		outcome: tg::build::Outcome,
+	) -> Result<()> {
+		self.inner
+			.parent_server
+			.set_build_outcome(user, id, outcome)
+			.await
+	}
+
+	async fn try_get_object(&self, id: &tg::object::Id) -> Result<Option<tg::object::GetOutput>> {
+		self.inner.parent_server.try_get_object(id).await
+	}
+
+	async fn put_object(
+		&self,
+		id: &tg::object::Id,
+		arg: &tg::object::PutArg,
+	) -> Result<tg::object::PutOutput> {
+		self.inner.parent_server.put_object(id, arg).await
+	}
+
+	async fn push_object(&self, id: &tg::object::Id) -> Result<()> {
+		self.inner.parent_server.push_object(id).await
+	}
+
+	async fn pull_object(&self, id: &tg::object::Id) -> Result<()> {
+		self.inner.parent_server.pull_object(id).await
+	}
+
+	async fn search_packages(
+		&self,
+		_arg: tg::package::SearchArg,
+	) -> Result<tg::package::SearchOutput> {
+		Err(error!("Not supported"))
+	}
+
+	async fn try_get_package(
+		&self,
+		_dependency: &tg::Dependency,
+		_arg: tg::package::GetArg,
+	) -> Result<Option<tg::package::GetOutput>> {
+		Err(error!("Not supported"))
+	}
+
+	async fn try_get_package_versions(
+		&self,
+		_dependency: &tg::Dependency,
+	) -> Result<Option<Vec<String>>> {
+		Err(error!("Not supported"))
+	}
+
+	async fn publish_package(
+		&self,
+		_user: Option<&tg::User>,
+		_id: &tg::directory::Id,
+	) -> Result<()> {
+		Err(error!("Not supported"))
+	}
+
+	async fn check_package(&self, _dependency: &tg::Dependency) -> Result<Vec<tg::Diagnostic>> {
+		Err(error!("Not supported"))
+	}
+
+	async fn format_package(&self, _dependency: &tg::Dependency) -> Result<()> {
+		Err(error!("Not supported"))
+	}
+
+	async fn get_runtime_doc(&self) -> Result<serde_json::Value> {
+		Err(error!("Not supported"))
+	}
+
+	async fn try_get_package_doc(
+		&self,
+		_dependency: &tg::Dependency,
+	) -> Result<Option<serde_json::Value>> {
+		Err(error!("Not supported"))
+	}
+
+	async fn lsp(
+		&self,
+		_input: Box<dyn AsyncRead + Send + Unpin + 'static>,
+		_output: Box<dyn AsyncWrite + Send + Unpin + 'static>,
+	) -> Result<()> {
+		Err(error!("Not supported"))
+	}
+
+	async fn health(&self) -> Result<tg::server::Health> {
+		self.inner.parent_server.health().await
+	}
+
+	async fn clean(&self) -> Result<()> {
+		Err(error!("Not supported"))
+	}
+
+	async fn stop(&self) -> Result<()> {
+		Err(error!("Not supported"))
+	}
+
+	async fn create_login(&self) -> Result<tg::user::Login> {
+		Err(error!("Not supported"))
+	}
+
+	async fn get_login(&self, _id: &tg::Id) -> Result<Option<tg::user::Login>> {
+		Err(error!("Not supported"))
+	}
+
+	async fn get_user_for_token(&self, _token: &str) -> Result<Option<tg::user::User>> {
+		Err(error!("Not supported"))
+	}
+
+	async fn create_oauth_url(&self, _id: &tg::Id) -> Result<Url> {
+		Err(error!("Not supported"))
+	}
+
+	async fn complete_login(&self, _id: &tg::Id, _code: String) -> Result<()> {
+		Err(error!("Not supported"))
+	}
+}


### PR DESCRIPTION
This PR adds a proxy server to the Linux and Darwin runtimes that handles passing the build ID automatically, allowing us to avoid exposing this ID to the running process itself.