### PR TITLE
feat(runtime): add JS constructor for tg.Lock

### DIFF
--- a/packages/runtime/src/lock.ts
+++ b/packages/runtime/src/lock.ts
@@ -27,7 +27,7 @@ export class Lock {
 	static async new(...args: Args<Lock.Arg>): Promise<Lock> {
 		type Apply = {
 			root: number;
-			nodeArgs: Array<Lock.ArgObject>;
+			nodeArgs: Array<Lock.NodeArg>;
 		};
 		let { root, nodeArgs } = await Args.apply<Lock.Arg, Apply>(
 			args,
@@ -41,10 +41,13 @@ export class Lock {
 					};
 				} else if (typeof arg === "object") {
 					let object: MutationMap<Apply> = {};
-					if (arg.dependencies !== undefined) {
-						object.nodeArgs = Mutation.is(arg.dependencies)
-							? arg.dependencies
-							: await Mutation.arrayAppend(arg.dependencies);
+					if (arg.root !== undefined) {
+						object.root = arg.root;
+					}
+					if (arg.nodes !== undefined) {
+						object.nodeArgs = Mutation.is(arg.nodes)
+							? arg.nodes
+							: await Mutation.arrayAppend(arg.nodes);
 					}
 					return object;
 				} else {
@@ -54,7 +57,7 @@ export class Lock {
 		);
 		root ??= 0;
 		nodeArgs ??= [];
-		let nodes: Array<Lock.Node> = await Promise.all(
+		let nodes = await Promise.all(
 			nodeArgs.map(async (argObject) => {
 				let dependenciesKeys = Object.keys(argObject.dependencies ?? {});
 				let dependencies: { [dependency: string]: Lock } = {};
@@ -123,6 +126,11 @@ export namespace Lock {
 	export type Arg = Lock | ArgObject | Array<Arg>;
 
 	export type ArgObject = {
+		root?: number;
+		nodes?: Array<NodeArg>;
+	};
+
+	export type NodeArg = {
 		dependencies?: { [dependency: string]: Lock.Arg };
 	};
 

--- a/packages/runtime/src/lock.ts
+++ b/packages/runtime/src/lock.ts
@@ -1,6 +1,13 @@
-import { assert as assert_ } from "./assert.ts";
+import { Args } from "./args.ts";
+import { assert as assert_, unreachable } from "./assert.ts";
+import { Mutation } from "./mutation.ts";
 import { Object_ } from "./object.ts";
 import * as syscall from "./syscall.ts";
+import { MutationMap } from "./util.ts";
+
+export let lock = async (...args: Args<Lock.Arg>): Promise<Lock> => {
+	return await Lock.new(...args);
+};
 
 export class Lock {
 	#state: Lock.State;
@@ -15,6 +22,52 @@ export class Lock {
 
 	static withId(id: Lock.Id): Lock {
 		return new Lock({ id });
+	}
+
+	static async new(...args: Args<Lock.Arg>): Promise<Lock> {
+		type Apply = {
+			root: number;
+			nodeArgs: Array<Lock.ArgObject>;
+		};
+		let { root, nodeArgs } = await Args.apply<Lock.Arg, Apply>(
+			args,
+			async (arg) => {
+				if (arg === undefined) {
+					return {};
+				} else if (Lock.is(arg)) {
+					return {
+						root: await arg.root(),
+						nodes: await Mutation.arrayAppend(await arg.nodes()),
+					};
+				} else if (typeof arg === "object") {
+					let object: MutationMap<Apply> = {};
+					if (arg.dependencies !== undefined) {
+						object.nodeArgs = Mutation.is(arg.dependencies)
+							? arg.dependencies
+							: await Mutation.arrayAppend(arg.dependencies);
+					}
+					return object;
+				} else {
+					return unreachable();
+				}
+			},
+		);
+		root ??= 0;
+		nodeArgs ??= [];
+		let nodes: Array<Lock.Node> = await Promise.all(
+			nodeArgs.map(async (argObject) => {
+				let dependenciesKeys = Object.keys(argObject.dependencies ?? {});
+				let dependencies: { [dependency: string]: Lock } = {};
+				for (let key of dependenciesKeys) {
+					let dependency = argObject.dependencies![key];
+					if (dependency) {
+						dependencies[key] = await Lock.new(dependency);
+					}
+				}
+				return { dependencies };
+			}),
+		);
+		return new Lock({ object: { root, nodes } });
 	}
 
 	static is(value: unknown): value is Lock {

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -10,7 +10,7 @@ import { Error as Error_, prepareStackTrace } from "./error.ts";
 import { File, file } from "./file.ts";
 import { include } from "./include.ts";
 import { Leaf, leaf } from "./leaf.ts";
-import { Lock } from "./lock.ts";
+import { Lock, lock } from "./lock.ts";
 import { log } from "./log.ts";
 import { Mutation, mutation } from "./mutation.ts";
 import { resolve } from "./resolve.ts";
@@ -73,6 +73,7 @@ Object.assign(tg, {
 	file,
 	include,
 	leaf,
+	lock,
 	log,
 	mutation,
 	resolve,

--- a/packages/server/src/language/tangram.d.ts
+++ b/packages/server/src/language/tangram.d.ts
@@ -483,10 +483,16 @@ declare namespace tg {
 			  };
 	}
 
+	/** Create a lock. */
+	export let lock: (...args: Args<Lock.Arg>) => Promise<Lock>;
+
 	/** A lock. */
 	export class Lock {
 		/** Get a lock with an ID. */
 		static withId(id: Lock.Id): Lock;
+
+		/** Create a lock. */
+		static new(...args: Args<Lock.Arg>): Promise<Lock>;
 
 		/** Check if a value is a `tg.Lock`. */
 		static is(value: unknown): value is Lock;
@@ -502,6 +508,12 @@ declare namespace tg {
 	}
 
 	export namespace Lock {
+		export type Arg = Lock | ArgObject | Array<Arg>;
+
+		export type ArgObject = {
+			dependencies?: { [dependency: string]: Lock.Arg };
+		};
+
 		export type Id = string;
 	}
 
@@ -531,10 +543,10 @@ declare namespace tg {
 			| Template
 			? T
 			: T extends Array<infer U extends Value>
-				? Array<Unresolved<U>>
-				: T extends { [key: string]: Value }
-					? { [K in keyof T]: Unresolved<T[K]> }
-					: never
+			  ? Array<Unresolved<U>>
+			  : T extends { [key: string]: Value }
+			    ? { [K in keyof T]: Unresolved<T[K]> }
+			    : never
 	>;
 
 	/**
@@ -560,12 +572,12 @@ declare namespace tg {
 		| Template
 		? T
 		: T extends Array<infer U extends Unresolved<Value>>
-			? Array<Resolved<U>>
-			: T extends { [key: string]: Unresolved<Value> }
-				? { [K in keyof T]: Resolved<T[K]> }
-				: T extends Promise<infer U extends Unresolved<Value>>
-					? Resolved<U>
-					: never;
+		  ? Array<Resolved<U>>
+		  : T extends { [key: string]: Unresolved<Value> }
+		    ? { [K in keyof T]: Resolved<T[K]> }
+		    : T extends Promise<infer U extends Unresolved<Value>>
+		      ? Resolved<U>
+		      : never;
 
 	/** Sleep for the specified duration in seconds. */
 	export let sleep: (duration: number) => Promise<void>;
@@ -777,8 +789,8 @@ declare namespace tg {
 		| Template
 		? T
 		: T extends { [key: string]: Value }
-			? MutationMap<T>
-			: never;
+		  ? MutationMap<T>
+		  : never;
 
 	export type MaybeNestedArray<T> = T | Array<MaybeNestedArray<T>>;
 

--- a/packages/server/src/language/tangram.d.ts
+++ b/packages/server/src/language/tangram.d.ts
@@ -511,6 +511,11 @@ declare namespace tg {
 		export type Arg = Lock | ArgObject | Array<Arg>;
 
 		export type ArgObject = {
+			root?: number;
+			nodes?: Array<NodeArg>;
+		};
+
+		export type NodeArg = {
 			dependencies?: { [dependency: string]: Lock.Arg };
 		};
 


### PR DESCRIPTION
Adds a constructor to the `tg.Lock` type in the JS runtime global. Closes #58.