### PR TITLE
feat(server): use content-defined chunking for blob creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastcdc"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71061d097bfa9a5a4d2efdec57990d9a88745020b365191d37e48541a1628f2"
+dependencies = [
+ "async-stream",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,6 +4167,7 @@ dependencies = [
  "data-encoding-macro",
  "derive_more",
  "either",
+ "fastcdc",
  "fnv",
  "futures",
  "http 1.1.0",
@@ -4240,6 +4252,7 @@ dependencies = [
  "data-encoding-macro",
  "derive_more",
  "either",
+ "fastcdc",
  "filetime",
  "fnv",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
   "packages/client",
   "packages/error",
   "packages/fuse",
-  "packages/nfs",  
+  "packages/nfs",
   "packages/server",
   "packages/util",
 ]
@@ -48,6 +48,7 @@ data-encoding-macro = "0.1"
 derive_more = { version = "1.0.0-beta.6", features = ["full"] }
 dialoguer = "0.11"
 either = { version = "1", features = ["serde"] }
+fastcdc = { version = "3", features = ["tokio"] }
 filetime = "0.2"
 fnv = "1"
 futures = "0.3"

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -307,13 +307,18 @@ impl Cli {
 			})
 			.unwrap();
 		let path = path.unwrap_or_else(|| PathBuf::from(home).join(".config/tangram/config.json"));
-		let config = match std::fs::read_to_string(path) {
+		let config = match std::fs::read_to_string(&path) {
 			Ok(config) => config,
 			Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-			Err(error) => return Err(error!(source = error, "failed to read the config file")),
+			Err(error) => {
+				return Err(
+					error!(source = error, %path = path.display(), "failed to read the config file"),
+				)
+			},
 		};
-		let config = serde_json::from_str(&config)
-			.map_err(|source| error!(!source, "failed to deserialize the config"))?;
+		let config = serde_json::from_str(&config).map_err(
+			|source| error!(!source, %path = path.display(), "failed to deserialize the config"),
+		)?;
 		Ok(Some(config))
 	}
 

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -25,6 +25,7 @@ data-encoding = { workspace = true }
 data-encoding-macro = { workspace = true }
 derive_more = { workspace = true }
 either = { workspace = true }
+fastcdc = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -28,6 +28,7 @@ data-encoding-macro = { workspace = true }
 derive_more = { workspace = true }
 either = { workspace = true }
 filetime = { workspace = true }
+fastcdc = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 glob = { workspace = true }

--- a/packages/server/src/blob.rs
+++ b/packages/server/src/blob.rs
@@ -1,53 +1,48 @@
 use crate::{database, Server};
-use bytes::Bytes;
 use futures::{stream, StreamExt, TryStreamExt};
 use num::ToPrimitive;
 use tangram_client as tg;
 use tangram_error::{error, Error, Result};
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::AsyncRead;
 
 const MAX_BRANCH_CHILDREN: usize = 1024;
 
-const MAX_LEAF_SIZE: usize = 262_144;
+const MIN_LEAF_SIZE: u32 = 4096;
+const AVG_LEAF_SIZE: u32 = 16_384;
+const MAX_LEAF_SIZE: u32 = 65_536;
 
 impl Server {
 	pub async fn create_blob_with_reader(
 		&self,
-		mut reader: impl AsyncRead + Unpin,
+		reader: impl AsyncRead + Unpin,
 		txn: &database::Transaction<'_>,
 	) -> Result<tg::blob::Id> {
-		let mut leaves = Vec::new();
-		let mut bytes = vec![0u8; MAX_LEAF_SIZE];
-		loop {
-			// Read up to `MAX_LEAF_BLOCK_DATA_SIZE` bytes from the reader.
-			let mut position = 0;
-			loop {
-				let n = reader
-					.read(&mut bytes[position..])
-					.await
-					.map_err(|source| error!(!source, "failed to read from the reader"))?;
-				position += n;
-				if n == 0 || position == bytes.len() {
-					break;
-				}
-			}
-			if position == 0 {
-				break;
-			}
-			let size = position.to_u64().unwrap();
-
-			// Create the leaf.
-			let bytes = Bytes::copy_from_slice(&bytes[..position]);
-			let data = tg::leaf::Data { bytes };
-			let id = tg::leaf::Id::new(&data.serialize()?);
-			self.put_complete_object_with_transaction(id.clone().into(), data.into(), txn)
-				.await?;
-
-			leaves.push(tg::branch::child::Data {
-				blob: id.into(),
-				size,
-			});
-		}
+		let mut chunker = fastcdc::v2020::AsyncStreamCDC::new(
+			reader,
+			MIN_LEAF_SIZE,
+			AVG_LEAF_SIZE,
+			MAX_LEAF_SIZE,
+		);
+		let stream = chunker.as_stream();
+		let mut leaves = stream
+			.then(|chunk| async {
+				let bytes = chunk
+					.map_err(|source| error!(!source, "failed to read data"))?
+					.data;
+				let size = bytes.len().to_u64().unwrap();
+				let data = tg::leaf::Data {
+					bytes: bytes.into(),
+				};
+				let id = tg::leaf::Id::new(&data.serialize()?);
+				self.put_complete_object_with_transaction(id.clone().into(), data.into(), txn)
+					.await?;
+				Ok::<_, tangram_error::Error>(tg::branch::child::Data {
+					blob: id.into(),
+					size,
+				})
+			})
+			.try_collect::<Vec<_>>()
+			.await?;
 
 		// Create the tree.
 		while leaves.len() > MAX_BRANCH_CHILDREN {

--- a/packages/server/src/blob.rs
+++ b/packages/server/src/blob.rs
@@ -51,7 +51,10 @@ impl Server {
 				.flat_map(|chunk| {
 					if chunk.len() == MAX_BRANCH_CHILDREN {
 						stream::once(async move {
-							let size = chunk.len().to_u64().unwrap();
+							let size = chunk
+								.iter()
+								.fold(0, |acc, data| acc + data.size);
+
 							let data = tg::branch::Data { children: chunk };
 							let id = tg::branch::Id::new(&data.serialize()?);
 							self.put_complete_object_with_transaction(


### PR DESCRIPTION
- Use the `fastcdc` crate to determine chunk boundaries when creating blobs.
   - Implemented both client side and server side.
- Small doc comment/error message improvements.

Resolves #53