### PR TITLE
fix(server): properly handle path dependencies in normalized locks

### DIFF
--- a/packages/client/src/lock.rs
+++ b/packages/client/src/lock.rs
@@ -197,7 +197,7 @@ impl Lock {
 
 impl Lock {
 	/// Return the direct dependencies specified by this lock (the dependencies of the root package).
-	pub async fn direct_dependencies(&self, tg: &dyn Handle) -> Result<Vec<Dependency>> {
+	pub async fn dependencies(&self, tg: &dyn Handle) -> Result<Vec<Dependency>> {
 		let object = self.object(tg).await?;
 		let dependencies = object.nodes[object.root]
 			.dependencies

--- a/packages/client/src/lock.rs
+++ b/packages/client/src/lock.rs
@@ -196,6 +196,17 @@ impl Lock {
 }
 
 impl Lock {
+	/// Return the direct dependencies specified by this lock (the dependencies of the root package).
+	pub async fn direct_dependencies(&self, tg: &dyn Handle) -> Result<Vec<Dependency>> {
+		let object = self.object(tg).await?;
+		let dependencies = object.nodes[object.root]
+			.dependencies
+			.keys()
+			.cloned()
+			.collect();
+		Ok(dependencies)
+	}
+
 	pub async fn get(
 		&self,
 		tg: &dyn Handle,

--- a/packages/server/src/package/lock.rs
+++ b/packages/server/src/package/lock.rs
@@ -169,7 +169,7 @@ impl Server {
 		let deps_in_package = self
 			.get_package_dependencies(&package_with_path_dependencies.package)
 			.await?;
-		let deps_in_lock = lock.direct_dependencies(self).await?;
+		let deps_in_lock = lock.dependencies(self).await?;
 
 		// Verify that the dependencies match.
 		if !itertools::equal(deps_in_package, deps_in_lock) {

--- a/packages/server/src/package/outdated.rs
+++ b/packages/server/src/package/outdated.rs
@@ -62,14 +62,13 @@ impl Server {
 		});
 
 		// Visit every dependency.
-		let data = lock.data(self).await?;
 		let mut dependencies = BTreeMap::new();
-		for dependency in data.nodes[data.root].dependencies.keys() {
-			let Some((package, lock)) = lock.get(self, dependency).await? else {
+		for dependency in lock.direct_dependencies(self).await? {
+			let Some((package, lock)) = lock.get(self, &dependency).await? else {
 				continue;
 			};
 			let outdated = self
-				.get_outdated_inner(dependency, package, lock, visited)
+				.get_outdated_inner(&dependency, package, lock, visited)
 				.await?;
 			if outdated.info.is_some() || !outdated.dependencies.is_empty() {
 				dependencies.insert(dependency.clone(), outdated);

--- a/packages/server/src/package/outdated.rs
+++ b/packages/server/src/package/outdated.rs
@@ -63,7 +63,7 @@ impl Server {
 
 		// Visit every dependency.
 		let mut dependencies = BTreeMap::new();
-		for dependency in lock.direct_dependencies(self).await? {
+		for dependency in lock.dependencies(self).await? {
 			let Some((package, lock)) = lock.get(self, &dependency).await? else {
 				continue;
 			};
@@ -75,8 +75,10 @@ impl Server {
 			}
 		}
 		let outdated = tg::package::OutdatedOutput { info, dependencies };
+
 		// Mark this package as visited.
 		visited.insert(id.clone(), outdated.clone());
+
 		Ok(outdated)
 	}
 }


### PR DESCRIPTION
- Add a new method `tg::Lock::direct_dependencies` which returns the direct dependencies of that lock (dependencies of the root)
- Use this method everywhere (`tg package outdated`, `tg package tree`)
- Fix check of lock agains scanned dependencies when lock is normalized.
- Fix adding path dependencies to lock when the lock is normalized.