### PR TITLE
feat(runtime): implement path remapping

### DIFF
--- a/packages/client/src/path.rs
+++ b/packages/client/src/path.rs
@@ -1,6 +1,6 @@
 use crate::{self as tg, error};
 use derive_more::{TryUnwrap, Unwrap};
-use std::path::PathBuf;
+use std::{ffi::OsStr, path::PathBuf};
 
 /// Any path.
 #[derive(
@@ -124,6 +124,13 @@ impl Path {
 	}
 
 	#[must_use]
+	pub fn strip_prefix(&self, prefix: &Self) -> Option<Self> {
+		self.string
+			.strip_prefix(prefix.as_str())
+			.map(|string| string.parse().unwrap())
+	}
+
+	#[must_use]
 	pub fn is_absolute(&self) -> bool {
 		matches!(self.components().first(), Some(Component::Root))
 	}
@@ -134,6 +141,21 @@ impl Path {
 			.last()
 			.and_then(|component| component.try_unwrap_normal_ref().ok())
 			.and_then(|name| name.split('.').last())
+	}
+
+	#[must_use]
+	pub fn as_str(&self) -> &str {
+		self.string.as_str()
+	}
+
+	#[must_use]
+	pub fn as_os_str(&self) -> &OsStr {
+		std::path::Path::new(self.string.as_str()).as_os_str()
+	}
+
+	#[must_use]
+	pub fn as_path(&self) -> &std::path::Path {
+		std::path::Path::new(self.string.as_str())
 	}
 }
 
@@ -240,15 +262,21 @@ impl<'a> TryFrom<&'a std::path::Path> for Path {
 	}
 }
 
-impl AsRef<std::path::Path> for Path {
-	fn as_ref(&self) -> &std::path::Path {
-		std::path::Path::new(self.string.as_str())
+impl AsRef<str> for Path {
+	fn as_ref(&self) -> &str {
+		self.as_str()
 	}
 }
 
-impl AsRef<std::ffi::OsStr> for Path {
-	fn as_ref(&self) -> &std::ffi::OsStr {
-		std::path::Path::new(self.string.as_str()).as_os_str()
+impl AsRef<OsStr> for Path {
+	fn as_ref(&self) -> &OsStr {
+		self.as_os_str()
+	}
+}
+
+impl AsRef<std::path::Path> for Path {
+	fn as_ref(&self) -> &std::path::Path {
+		self.as_path()
 	}
 }
 

--- a/packages/server/src/package.rs
+++ b/packages/server/src/package.rs
@@ -57,7 +57,11 @@ impl Server {
 				.await
 				.map_err(|source| tg::error!(!source, "failed to canonicalize the path"))?;
 			if !tokio::fs::try_exists(&path).await.map_err(|error| {
-				tg::error!(source = error, "failed to get the metadata for the path")
+				tg::error!(
+					source = error,
+					?path,
+					"failed to get the metadata for the path"
+				)
 			})? {
 				return Ok(None);
 			}

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -160,7 +160,7 @@ impl Runtime {
 		env.insert("TANGRAM_URL".to_owned(), proxy_server_url.to_string());
 
 		// Start the proxy server.
-		let proxy = proxy::Server::start(server, build.id(), proxy_server_url)
+		let proxy = proxy::Server::start(server, build.id(), proxy_server_url, None)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to start the proxy server"))?;
 

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -234,17 +234,16 @@ impl Runtime {
 		let proxy_server_guest_url = Url::parse(&proxy_server_guest_url).unwrap();
 		env.insert("TANGRAM_URL".to_owned(), proxy_server_guest_url.to_string());
 
+		// Create the path map.
+		let path_map = proxy::PathMap {
+			output_host: output_parent_directory_host_path.try_into().unwrap(),
+			output_guest: output_parent_directory_guest_path.try_into().unwrap(),
+			root_host: root_directory_host_path.try_into().unwrap(),
+		};
+
 		// Start the proxy server.
 		let proxy_server_host_url = format!("unix:{}", proxy_server_socket_host_path.display());
 		let proxy_server_host_url = Url::parse(&proxy_server_host_url).unwrap();
-
-		let path_map = proxy::PathMap {
-			output_host: tg::Path::try_from(output_parent_directory_host_path.clone()).unwrap(),
-			output_guest: tg::Path::try_from(output_parent_directory_guest_path.clone()).unwrap(),
-			root_host: tg::Path::try_from(root_directory_host_path.clone()).unwrap(),
-			root_guest: tg::Path::with_components([tg::path::Component::Root]),
-		};
-
 		let proxy_server =
 			proxy::Server::start(server, build.id(), proxy_server_host_url, Some(path_map))
 				.await

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -1,8 +1,6 @@
 use crate::Http;
 use bytes::Bytes;
-use derive_more::FromStr;
 use futures::Stream;
-use itertools::Itertools;
 use std::sync::Arc;
 use tangram_client as tg;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -23,18 +21,10 @@ pub struct Inner {
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub struct GetOrCreateProxiedArg {
-	pub remote: bool,
-	pub retry: tg::build::Retry,
-	pub target: tg::target::Id,
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct PathMap {
-	pub output_host: tg::Path,
 	pub output_guest: tg::Path,
+	pub output_host: tg::Path,
 	pub root_host: tg::Path,
-	pub root_guest: tg::Path,
 }
 
 impl Server {
@@ -110,53 +100,21 @@ impl Server {
 		Ok(())
 	}
 
-	pub async fn get_or_create_build_proxied(
-		&self,
-		user: Option<&tg::User>,
-		arg: tg::build::GetOrCreateArg,
-	) -> tg::Result<tg::build::GetOrCreateOutput> {
-		if arg.parent.is_some() {
-			return Err(tg::error!(
-				"using proxied server, parent should be set to none"
-			));
-		}
-		let arg = tg::build::GetOrCreateArg {
-			parent: Some(self.inner.build.clone()),
-			remote: arg.remote,
-			retry: arg.retry,
-			target: arg.target,
+	fn host_path_for_guest_path(&self, path: tg::Path) -> tg::Result<tg::Path> {
+		// Get the path map. If there is no path map, then the guest path is the host path.
+		let Some(path_map) = &self.inner.path_map else {
+			return Ok(path);
 		};
-		self.inner.server.get_or_create_build(user, arg).await
-	}
 
-	fn host_path_from_guest_path(&self, guest_path: tg::Path) -> tg::Result<tg::Path> {
-		if self.inner.path_map.is_none() {
-			return Ok(guest_path);
-		}
-		let path_map = self.inner.path_map.as_ref().unwrap();
-		let guest_path_components = guest_path.clone().into_components();
-		let guest_output_components = path_map.output_guest.components();
-		let guest_root_components = path_map.root_guest.components();
-
-		let host_path = if guest_path_components.starts_with(guest_output_components) {
-			let output_components = tg::Path::with_components(
-				guest_path_components
-					.into_iter()
-					.skip(guest_output_components.len()),
-			);
-			path_map.output_host.clone().join(output_components)
-		} else if guest_path_components.starts_with(guest_root_components) {
-			let output_components = tg::Path::with_components(
-				guest_path_components
-					.into_iter()
-					.skip(guest_root_components.len()),
-			);
-			path_map.root_host.clone().join(output_components)
+		// Map the path.
+		if let Some(path) = path.strip_prefix(&path_map.output_guest) {
+			Ok(path_map.output_host.clone().join(path))
 		} else {
-			return Err(tg::error!(%guest_path, "invalid path"));
-		};
-
-		Ok(host_path)
+			let path = path
+				.strip_prefix(&"/".parse().unwrap())
+				.ok_or_else(|| tg::error!("the path must be absolute"))?;
+			Ok(path_map.root_host.clone().join(path))
+		}
 	}
 }
 
@@ -165,78 +123,23 @@ impl tg::Handle for Server {
 		self.inner.server.path().await
 	}
 
-	async fn format(&self, _text: String) -> tg::Result<String> {
-		Err(tg::error!("not supported"))
-	}
-
 	fn file_descriptor_semaphore(&self) -> &tokio::sync::Semaphore {
 		self.inner.server.file_descriptor_semaphore()
 	}
 
 	async fn check_in_artifact(
 		&self,
-		arg: tg::artifact::CheckInArg,
+		mut arg: tg::artifact::CheckInArg,
 	) -> tg::Result<tg::artifact::CheckInOutput> {
-		// Remap incoming path.
-		let host_path = self.host_path_from_guest_path(arg.path.clone())?;
+		// Replace the path with the host path.
+		arg.path = self.host_path_for_guest_path(arg.path)?;
 
-		// Check if the path points into a Tangram artifact.
-		let host_path_string = host_path.to_string();
-		let output = if host_path_string.contains(".tangram/artifacts") {
-			let parts = host_path_string.split("tangram/artifacts").collect_vec();
-			if parts.len() != 2 {
-				return Err(tg::error!(%host_path, "invalid artifact path"));
-			}
-			let artifact_subpath = tg::Path::from_str(parts[1])?;
-			let artifact_subpath_components = artifact_subpath.into_components();
-			if artifact_subpath_components.is_empty() {
-				return Err(tg::error!(%host_path, "invalid artifact path"));
-			}
-			// Skip the root component, the next will be the artifact ID.
-			let toplevel_artifact_id = &artifact_subpath_components[1];
-			let toplevel_artifact_id = if let tg::path::Component::Normal(artifact_id) =
-				toplevel_artifact_id
-			{
-				tg::artifact::Id::from_str(artifact_id)?
-			} else {
-				return Err(tg::error!(%host_path, "invalid artifact path, bat component type"));
-			};
+		// Perform the checkin.
+		let output = self.inner.server.check_in_artifact(arg).await?;
 
-			// If there was no additional subpath, return the artifact ID.
-			if artifact_subpath_components.len() == 1 {
-				tg::artifact::CheckInOutput {
-					id: toplevel_artifact_id,
-				}
-			} else {
-				// If there was an additional subpath, locate the ID of the inner artifact.
-				let toplevel_artifact = tg::Artifact::with_id(toplevel_artifact_id);
-				let trailing_subpath =
-					tg::Path::with_components(artifact_subpath_components[2..].iter().cloned())
-						.to_string();
-				let object = tg::symlink::Object {
-					artifact: Some(toplevel_artifact),
-					path: Some(trailing_subpath),
-				};
-				let symlink = tg::symlink::Symlink::with_object(object);
-				let target = symlink
-					.resolve(&self.inner.server)
-					.await?
-					.ok_or(tg::error!("could not resolve symlink"))?;
-				let target_id = target.id(&self.inner.server).await?;
-				tg::artifact::CheckInOutput { id: target_id }
-			}
-		} else {
-			// Otherwise, perform the checkin.
-			let arg = tg::artifact::CheckInArg { path: host_path };
-			self.inner.server.check_in_artifact(arg).await?
-		};
-
-		// If the VFS is disabled, immediately perform an internal checkout of the newly checked-in artifact.
+		// If the VFS is disabled, then check out the artifact.
 		if !self.inner.server.inner.options.vfs.enable {
-			let arg = tg::artifact::CheckOutArg {
-				path: None,
-				..Default::default()
-			};
+			let arg = tg::artifact::CheckOutArg::default();
 			self.check_out_artifact(&output.id, arg).await?;
 		}
 
@@ -246,22 +149,19 @@ impl tg::Handle for Server {
 	async fn check_out_artifact(
 		&self,
 		id: &tg::artifact::Id,
-		arg: tg::artifact::CheckOutArg,
+		mut arg: tg::artifact::CheckOutArg,
 	) -> tg::Result<tg::artifact::CheckOutOutput> {
-		let arg = if let Some(path) = arg.path {
-			let path = self.host_path_from_guest_path(path)?;
-			tg::artifact::CheckOutArg {
-				path: Some(path),
-				..arg
-			}
-		} else {
-			arg
-		};
+		// Replace the path with the host path.
+		if let Some(path) = &mut arg.path {
+			*path = self.host_path_for_guest_path(path.clone())?;
+		}
+
+		// Perform the checkout.
 		self.inner.server.check_out_artifact(id, arg).await
 	}
 
-	async fn list_builds(&self, arg: tg::build::ListArg) -> tg::Result<tg::build::ListOutput> {
-		self.inner.server.list_builds(arg).await
+	async fn list_builds(&self, _arg: tg::build::ListArg) -> tg::Result<tg::build::ListOutput> {
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_build(
@@ -274,27 +174,28 @@ impl tg::Handle for Server {
 
 	async fn put_build(
 		&self,
-		user: Option<&tg::User>,
-		id: &tg::build::Id,
-		arg: &tg::build::PutArg,
+		_user: Option<&tg::User>,
+		_id: &tg::build::Id,
+		_arg: &tg::build::PutArg,
 	) -> tg::Result<()> {
-		self.inner.server.put_build(user, id, arg).await
+		Err(tg::error!("forbidden"))
 	}
 
-	async fn push_build(&self, user: Option<&tg::User>, id: &tg::build::Id) -> tg::Result<()> {
-		self.inner.server.push_build(user, id).await
+	async fn push_build(&self, _user: Option<&tg::User>, _id: &tg::build::Id) -> tg::Result<()> {
+		Err(tg::error!("forbidden"))
 	}
 
-	async fn pull_build(&self, id: &tg::build::Id) -> tg::Result<()> {
-		self.inner.server.pull_build(id).await
+	async fn pull_build(&self, _id: &tg::build::Id) -> tg::Result<()> {
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn get_or_create_build(
 		&self,
 		user: Option<&tg::User>,
-		arg: tg::build::GetOrCreateArg,
+		mut arg: tg::build::GetOrCreateArg,
 	) -> tg::Result<tg::build::GetOrCreateOutput> {
-		self.get_or_create_build_proxied(user, arg).await
+		arg.parent = Some(self.inner.build.clone());
+		self.inner.server.get_or_create_build(user, arg).await
 	}
 
 	async fn try_get_build_status(
@@ -308,11 +209,11 @@ impl tg::Handle for Server {
 
 	async fn set_build_status(
 		&self,
-		user: Option<&tg::User>,
-		id: &tg::build::Id,
-		status: tg::build::Status,
+		_user: Option<&tg::User>,
+		_id: &tg::build::Id,
+		_status: tg::build::Status,
 	) -> tg::Result<()> {
-		self.inner.server.set_build_status(user, id, status).await
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_build_children(
@@ -331,17 +232,11 @@ impl tg::Handle for Server {
 
 	async fn add_build_child(
 		&self,
-		user: Option<&tg::User>,
+		_user: Option<&tg::User>,
 		_build_id: &tg::build::Id,
-		child_id: &tg::build::Id,
+		_child_id: &tg::build::Id,
 	) -> tg::Result<()> {
-		// Discard incoming build ID, use the one from the proxy server.
-		let build_id = &self.inner.build;
-
-		self.inner
-			.server
-			.add_build_child(user, build_id, child_id)
-			.await
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_build_log(
@@ -356,11 +251,11 @@ impl tg::Handle for Server {
 
 	async fn add_build_log(
 		&self,
-		user: Option<&tg::User>,
-		build_id: &tg::build::Id,
-		bytes: Bytes,
+		_user: Option<&tg::User>,
+		_build_id: &tg::build::Id,
+		_bytes: Bytes,
 	) -> tg::Result<()> {
-		self.inner.server.add_build_log(user, build_id, bytes).await
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_build_outcome(
@@ -374,11 +269,11 @@ impl tg::Handle for Server {
 
 	async fn set_build_outcome(
 		&self,
-		user: Option<&tg::User>,
-		id: &tg::build::Id,
-		outcome: tg::build::Outcome,
+		_user: Option<&tg::User>,
+		_id: &tg::build::Id,
+		_outcome: tg::build::Outcome,
 	) -> tg::Result<()> {
-		self.inner.server.set_build_outcome(user, id, outcome).await
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_object(
@@ -396,19 +291,19 @@ impl tg::Handle for Server {
 		self.inner.server.put_object(id, arg).await
 	}
 
-	async fn push_object(&self, id: &tg::object::Id) -> tg::Result<()> {
-		self.inner.server.push_object(id).await
+	async fn push_object(&self, _id: &tg::object::Id) -> tg::Result<()> {
+		Err(tg::error!("forbidden"))
 	}
 
-	async fn pull_object(&self, id: &tg::object::Id) -> tg::Result<()> {
-		self.inner.server.pull_object(id).await
+	async fn pull_object(&self, _id: &tg::object::Id) -> tg::Result<()> {
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn search_packages(
 		&self,
 		_arg: tg::package::SearchArg,
 	) -> tg::Result<tg::package::SearchOutput> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_package(
@@ -416,14 +311,14 @@ impl tg::Handle for Server {
 		_dependency: &tg::Dependency,
 		_arg: tg::package::GetArg,
 	) -> tg::Result<Option<tg::package::GetOutput>> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_package_versions(
 		&self,
 		_dependency: &tg::Dependency,
 	) -> tg::Result<Option<Vec<String>>> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn publish_package(
@@ -431,7 +326,7 @@ impl tg::Handle for Server {
 		_user: Option<&tg::User>,
 		_id: &tg::directory::Id,
 	) -> tg::Result<()> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn yank_package(
@@ -443,29 +338,33 @@ impl tg::Handle for Server {
 	}
 
 	async fn check_package(&self, _dependency: &tg::Dependency) -> tg::Result<Vec<tg::Diagnostic>> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn format_package(&self, _dependency: &tg::Dependency) -> tg::Result<()> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn get_package_outdated(
 		&self,
 		_dependency: &tg::Dependency,
 	) -> tg::Result<tg::package::OutdatedOutput> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn get_runtime_doc(&self) -> tg::Result<serde_json::Value> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_package_doc(
 		&self,
 		_dependency: &tg::Dependency,
 	) -> tg::Result<Option<serde_json::Value>> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
+	}
+
+	async fn format(&self, _text: String) -> tg::Result<String> {
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn lsp(
@@ -473,30 +372,30 @@ impl tg::Handle for Server {
 		_input: Box<dyn AsyncRead + Send + Unpin + 'static>,
 		_output: Box<dyn AsyncWrite + Send + Unpin + 'static>,
 	) -> tg::Result<()> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn health(&self) -> tg::Result<tg::server::Health> {
-		self.inner.server.health().await
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn clean(&self) -> tg::Result<()> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn stop(&self) -> tg::Result<()> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn create_login(&self) -> tg::Result<tg::user::Login> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn get_login(&self, _id: &tg::Id) -> tg::Result<Option<tg::user::Login>> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 
 	async fn get_user_for_token(&self, _token: &str) -> tg::Result<Option<tg::user::User>> {
-		Err(tg::error!("not supported"))
+		Err(tg::error!("forbidden"))
 	}
 }

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -231,6 +231,15 @@ impl tg::Handle for Server {
 			self.inner.server.check_in_artifact(arg).await?
 		};
 
+		// If the VFS is disabled, immediately perform an internal checkout of the newly checked-in artifact.
+		if !self.inner.server.inner.options.vfs.enable {
+			let arg = tg::artifact::CheckOutArg {
+				path: None,
+				..Default::default()
+			};
+			self.check_out_artifact(&output.id, arg).await?;
+		}
+
 		Ok(output)
 	}
 


### PR DESCRIPTION
This PR implements guest-to-host path remapping in the runtime proxy server for the `check_in_artifact` and `check_out_artifact` methods. Closes #90.

There are three possible remappings:

- An output path
- A root path pointing to a tangram artifacts directory in the guest root.
- A root path pointing anywhere else in the guest root.