### PR TITLE
fix(client): correct strip_prefix

### DIFF
--- a/packages/client/src/path.rs
+++ b/packages/client/src/path.rs
@@ -125,9 +125,13 @@ impl Path {
 
 	#[must_use]
 	pub fn strip_prefix(&self, prefix: &Self) -> Option<Self> {
-		self.string
-			.strip_prefix(prefix.as_str())
-			.map(|string| string.parse().unwrap())
+		self.string.strip_prefix(prefix.as_str()).map(|string| {
+			let mut string = string.to_string();
+			if string.starts_with('/') {
+				string.remove(0);
+			}
+			string.parse().unwrap()
+		})
 	}
 
 	#[must_use]
@@ -296,5 +300,13 @@ mod tests {
 
 		let path: Path = "./bar/baz".parse().unwrap();
 		assert_eq!(path.normalize().to_string(), "bar/baz");
+	}
+
+	#[test]
+	fn strip_prefix() {
+		let path: Path = "/hello/world".parse().unwrap();
+		let prefix: Path = "/hello".parse().unwrap();
+		let expected: Path = "world".parse().unwrap();
+		assert_eq!(path.strip_prefix(&prefix).unwrap(), expected);
 	}
 }


### PR DESCRIPTION
This PR updates `tg::Path::strip_prefix` to prevent adding an erroneous `Root` component at the front after stripping.