### PR TITLE
fix(path): add is/assert/expect, better log

### DIFF
--- a/packages/client/src/path.rs
+++ b/packages/client/src/path.rs
@@ -88,6 +88,12 @@ impl Path {
 				self.components = vec![Component::Root];
 			},
 
+			// If the component is a normal component following a root component, add it directly.
+			(Component::Normal(name), Component::Root) => {
+				self.string.push_str(&name);
+				self.components.push(Component::Normal(name));
+			},
+
 			// If the component is a normal component, then add it.
 			(Component::Normal(name), _) => {
 				self.string.push('/');

--- a/packages/runtime/src/log.ts
+++ b/packages/runtime/src/log.ts
@@ -129,7 +129,7 @@ let stringifyObject = (value: object, visited: WeakSet<object>): string => {
 let stringifyState = (
 	kind: string,
 	state: Object_.State<string, object>,
-	visited: WeakSet<object>
+	visited: WeakSet<object>,
 ): string => {
 	let { id, object } = state;
 	if (id !== undefined) {

--- a/packages/runtime/src/log.ts
+++ b/packages/runtime/src/log.ts
@@ -7,6 +7,7 @@ import { Leaf } from "./leaf.ts";
 import { Lock } from "./lock.ts";
 import { Mutation } from "./mutation.ts";
 import type { Object_ } from "./object.ts";
+import { Path } from "./path.ts";
 import { Symlink } from "./symlink.ts";
 import { Target } from "./target.ts";
 import { Template } from "./template.ts";
@@ -73,6 +74,8 @@ let stringifyObject = (value: object, visited: WeakSet<object>): string => {
 		return value.message;
 	} else if (value instanceof Promise) {
 		return "(promise)";
+	} else if (Path.is(value)) {
+		return `(tg.path "${value}")`;
 	} else if (Leaf.is(value)) {
 		return stringifyState("leaf", value.state, visited);
 	} else if (Branch.is(value)) {
@@ -126,7 +129,7 @@ let stringifyObject = (value: object, visited: WeakSet<object>): string => {
 let stringifyState = (
 	kind: string,
 	state: Object_.State<string, object>,
-	visited: WeakSet<object>,
+	visited: WeakSet<object>
 ): string => {
 	let { id, object } = state;
 	if (id !== undefined) {

--- a/packages/runtime/src/path.ts
+++ b/packages/runtime/src/path.ts
@@ -1,4 +1,4 @@
-import { unreachable } from "./assert.ts";
+import { unreachable, assert as assert_ } from "./assert.ts";
 
 export let path = (...args: Array<Path.Arg>): Path => {
 	return Path.new(args);
@@ -125,6 +125,19 @@ export class Path {
 
 	isAbsolute(): boolean {
 		return this.components.at(0)! === Path.Component.Root;
+	}
+
+	static is(value: unknown): value is Path {
+		return value instanceof Path;
+	}
+
+	static expect(value: unknown): Path {
+		assert_(Path.is(value));
+		return value;
+	}
+
+	static assert(value: unknown): asserts value is Path {
+		assert_(Path.is(value));
 	}
 
 	toString(): string {

--- a/packages/runtime/src/path.ts
+++ b/packages/runtime/src/path.ts
@@ -1,4 +1,4 @@
-import { unreachable, assert as assert_ } from "./assert.ts";
+import { assert as assert_, unreachable } from "./assert.ts";
 
 export let path = (...args: Array<Path.Arg>): Path => {
 	return Path.new(args);

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -16,12 +16,12 @@ declare namespace tg {
 	export namespace Args {
 		export let apply: <
 			A extends Value = Value,
-			R extends { [key: string]: Value } = { [key: string]: Value },
+			R extends { [key: string]: Value } = { [key: string]: Value }
 		>(
 			args: Args<A>,
 			map: (
-				arg: MaybeMutationMap<Exclude<A, Array<Value>>>,
-			) => Promise<MaybeNestedArray<MutationMap<R>>>,
+				arg: MaybeMutationMap<Exclude<A, Array<Value>>>
+			) => Promise<MaybeNestedArray<MutationMap<R>>>
 		) => Promise<Partial<R>>;
 	}
 
@@ -49,14 +49,14 @@ declare namespace tg {
 		/** Extract an artifact from an archive. **/
 		export let extract: (
 			blob: Blob,
-			format: ArchiveFormat,
+			format: ArchiveFormat
 		) => Promise<Artifact>;
 	}
 
 	/** Assert that a condition is truthy. If not, throw an error with an optional message. */
 	export let assert: (
 		condition: unknown,
-		message?: string,
+		message?: string
 	) => asserts condition;
 
 	/** Throw an error indicating that unimplemented code has been reached. */
@@ -85,7 +85,7 @@ declare namespace tg {
 	/** Compute the checksum of the provided bytes with the specified algorithm. */
 	export let checksum: (
 		algorithm: Checksum.Algorithm,
-		bytes: string | Uint8Array,
+		bytes: string | Uint8Array
 	) => Checksum;
 
 	/** A checksum. */
@@ -97,7 +97,7 @@ declare namespace tg {
 		/** Compute the checksum of the provided bytes with the specified algorithm. */
 		export let new_: (
 			algorithm: Algorithm,
-			bytes: string | Uint8Array,
+			bytes: string | Uint8Array
 		) => Checksum;
 		export { new_ as new };
 	}
@@ -385,18 +385,18 @@ declare namespace tg {
 
 	/** Create a mutation. */
 	export function mutation<T extends Value = Value>(
-		arg: Unresolved<Mutation.Arg<T>>,
+		arg: Unresolved<Mutation.Arg<T>>
 	): Promise<Mutation<T>>;
 
 	export class Mutation<T extends Value = Value> {
 		/** Create a mutation. */
 		static new<T extends Value = Value>(
-			arg: Unresolved<Mutation.Arg<T>>,
+			arg: Unresolved<Mutation.Arg<T>>
 		): Promise<Mutation<T>>;
 
 		/** Create a "set" mutation. */
 		static set<T extends Value = Value>(
-			value: Unresolved<T>,
+			value: Unresolved<T>
 		): Promise<Mutation<T>>;
 
 		/** Create an "unset" mutation. */
@@ -404,29 +404,29 @@ declare namespace tg {
 
 		/** Create a "set_if_unset" mutation. */
 		static setIfUnset<T extends Value = Value>(
-			value: Unresolved<T>,
+			value: Unresolved<T>
 		): Promise<Mutation<T>>;
 
 		/** Create an "array_prepend" mutation. */
 		static arrayPrepend<T extends Value = Value>(
-			values: Unresolved<MaybeNestedArray<T>>,
+			values: Unresolved<MaybeNestedArray<T>>
 		): Promise<Mutation<Array<T>>>;
 
 		/** Create an "array_append" mutation. */
 		static arrayAppend<T extends Value = Value>(
-			values: Unresolved<MaybeNestedArray<T>>,
+			values: Unresolved<MaybeNestedArray<T>>
 		): Promise<Mutation<Array<T>>>;
 
 		/** Create a "template_prepend" mutation. */
 		static templatePrepend(
 			template: Unresolved<Template.Arg>,
-			separator?: string | undefined,
+			separator?: string | undefined
 		): Promise<Mutation<Template>>;
 
 		/** Create a "template_append" mutation. */
 		static templateAppend(
 			template: Unresolved<Template.Arg>,
-			separator?: string | undefined,
+			separator?: string | undefined
 		): Promise<Mutation<Template>>;
 
 		static is(value: unknown): value is Mutation;
@@ -527,7 +527,7 @@ declare namespace tg {
 
 	/** Resolve all deeply nested promises in an unresolved value. */
 	export let resolve: <T extends Unresolved<Value>>(
-		value: T,
+		value: T
 	) => Promise<Resolved<T>>;
 
 	/**
@@ -552,10 +552,10 @@ declare namespace tg {
 			| Template
 			? T
 			: T extends Array<infer U extends Value>
-				? Array<Unresolved<U>>
-				: T extends { [key: string]: Value }
-					? { [K in keyof T]: Unresolved<T[K]> }
-					: never
+			? Array<Unresolved<U>>
+			: T extends { [key: string]: Value }
+			? { [K in keyof T]: Unresolved<T[K]> }
+			: never
 	>;
 
 	/**
@@ -582,12 +582,12 @@ declare namespace tg {
 		| Template
 		? T
 		: T extends Array<infer U extends Unresolved<Value>>
-			? Array<Resolved<U>>
-			: T extends { [key: string]: Unresolved<Value> }
-				? { [K in keyof T]: Resolved<T[K]> }
-				: T extends Promise<infer U extends Unresolved<Value>>
-					? Resolved<U>
-					: never;
+		? Array<Resolved<U>>
+		: T extends { [key: string]: Unresolved<Value> }
+		? { [K in keyof T]: Resolved<T[K]> }
+		: T extends Promise<infer U extends Unresolved<Value>>
+		? Resolved<U>
+		: never;
 
 	/** Sleep for the specified duration in seconds. */
 	export let sleep: (duration: number) => Promise<void>;
@@ -646,11 +646,11 @@ declare namespace tg {
 	/** Create a target. */
 	export function target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value,
+		R extends Value = Value
 	>(function_: (...args: A) => Unresolved<R>): Target<A, R>;
 	export function target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value,
+		R extends Value = Value
 	>(...args: Args<Target.Arg>): Promise<Target<A, R>>;
 
 	/** Create and build a target. */
@@ -659,7 +659,7 @@ declare namespace tg {
 	/** A target. */
 	export interface Target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value,
+		R extends Value = Value
 	> {
 		/** Build this target. */
 		// biome-ignore lint/style/useShorthandFunctionType:
@@ -669,7 +669,7 @@ declare namespace tg {
 	/** A target. */
 	export class Target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value,
+		R extends Value = Value
 	> extends globalThis.Function {
 		/** Get a target with an ID. */
 		static withId(id: Target.Id): Target;
@@ -802,15 +802,15 @@ declare namespace tg {
 		| Template
 		? T
 		: T extends { [key: string]: Value }
-			? MutationMap<T>
-			: never;
+		? MutationMap<T>
+		: never;
 
 	export type MaybeNestedArray<T> = T | Array<MaybeNestedArray<T>>;
 
 	export type MaybePromise<T> = T | Promise<T>;
 
 	export type MutationMap<
-		T extends { [key: string]: Value } = { [key: string]: Value },
+		T extends { [key: string]: Value } = { [key: string]: Value }
 	> = {
 		[K in keyof T]?: MaybeMutation<T[K]>;
 	};
@@ -847,6 +847,15 @@ declare namespace tg {
 
 		/** Normalize this path. **/
 		normalize(): Path;
+
+		/** Check if a value is a `Path`. */
+		static is(value: unknown): value is Path;
+
+		/** Expect that a value is a `Path`. */
+		static expect(value: unknown): Path;
+
+		/** Assert that a value is a `Path`. */
+		static assert(value: unknown): asserts value is Path;
 
 		/** Return true if this path begins with a current component. **/
 		isInternal(): boolean;

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -16,12 +16,12 @@ declare namespace tg {
 	export namespace Args {
 		export let apply: <
 			A extends Value = Value,
-			R extends { [key: string]: Value } = { [key: string]: Value }
+			R extends { [key: string]: Value } = { [key: string]: Value },
 		>(
 			args: Args<A>,
 			map: (
-				arg: MaybeMutationMap<Exclude<A, Array<Value>>>
-			) => Promise<MaybeNestedArray<MutationMap<R>>>
+				arg: MaybeMutationMap<Exclude<A, Array<Value>>>,
+			) => Promise<MaybeNestedArray<MutationMap<R>>>,
 		) => Promise<Partial<R>>;
 	}
 
@@ -49,14 +49,14 @@ declare namespace tg {
 		/** Extract an artifact from an archive. **/
 		export let extract: (
 			blob: Blob,
-			format: ArchiveFormat
+			format: ArchiveFormat,
 		) => Promise<Artifact>;
 	}
 
 	/** Assert that a condition is truthy. If not, throw an error with an optional message. */
 	export let assert: (
 		condition: unknown,
-		message?: string
+		message?: string,
 	) => asserts condition;
 
 	/** Throw an error indicating that unimplemented code has been reached. */
@@ -85,7 +85,7 @@ declare namespace tg {
 	/** Compute the checksum of the provided bytes with the specified algorithm. */
 	export let checksum: (
 		algorithm: Checksum.Algorithm,
-		bytes: string | Uint8Array
+		bytes: string | Uint8Array,
 	) => Checksum;
 
 	/** A checksum. */
@@ -97,7 +97,7 @@ declare namespace tg {
 		/** Compute the checksum of the provided bytes with the specified algorithm. */
 		export let new_: (
 			algorithm: Algorithm,
-			bytes: string | Uint8Array
+			bytes: string | Uint8Array,
 		) => Checksum;
 		export { new_ as new };
 	}
@@ -385,18 +385,18 @@ declare namespace tg {
 
 	/** Create a mutation. */
 	export function mutation<T extends Value = Value>(
-		arg: Unresolved<Mutation.Arg<T>>
+		arg: Unresolved<Mutation.Arg<T>>,
 	): Promise<Mutation<T>>;
 
 	export class Mutation<T extends Value = Value> {
 		/** Create a mutation. */
 		static new<T extends Value = Value>(
-			arg: Unresolved<Mutation.Arg<T>>
+			arg: Unresolved<Mutation.Arg<T>>,
 		): Promise<Mutation<T>>;
 
 		/** Create a "set" mutation. */
 		static set<T extends Value = Value>(
-			value: Unresolved<T>
+			value: Unresolved<T>,
 		): Promise<Mutation<T>>;
 
 		/** Create an "unset" mutation. */
@@ -404,29 +404,29 @@ declare namespace tg {
 
 		/** Create a "set_if_unset" mutation. */
 		static setIfUnset<T extends Value = Value>(
-			value: Unresolved<T>
+			value: Unresolved<T>,
 		): Promise<Mutation<T>>;
 
 		/** Create an "array_prepend" mutation. */
 		static arrayPrepend<T extends Value = Value>(
-			values: Unresolved<MaybeNestedArray<T>>
+			values: Unresolved<MaybeNestedArray<T>>,
 		): Promise<Mutation<Array<T>>>;
 
 		/** Create an "array_append" mutation. */
 		static arrayAppend<T extends Value = Value>(
-			values: Unresolved<MaybeNestedArray<T>>
+			values: Unresolved<MaybeNestedArray<T>>,
 		): Promise<Mutation<Array<T>>>;
 
 		/** Create a "template_prepend" mutation. */
 		static templatePrepend(
 			template: Unresolved<Template.Arg>,
-			separator?: string | undefined
+			separator?: string | undefined,
 		): Promise<Mutation<Template>>;
 
 		/** Create a "template_append" mutation. */
 		static templateAppend(
 			template: Unresolved<Template.Arg>,
-			separator?: string | undefined
+			separator?: string | undefined,
 		): Promise<Mutation<Template>>;
 
 		static is(value: unknown): value is Mutation;
@@ -527,7 +527,7 @@ declare namespace tg {
 
 	/** Resolve all deeply nested promises in an unresolved value. */
 	export let resolve: <T extends Unresolved<Value>>(
-		value: T
+		value: T,
 	) => Promise<Resolved<T>>;
 
 	/**
@@ -552,10 +552,10 @@ declare namespace tg {
 			| Template
 			? T
 			: T extends Array<infer U extends Value>
-			? Array<Unresolved<U>>
-			: T extends { [key: string]: Value }
-			? { [K in keyof T]: Unresolved<T[K]> }
-			: never
+				? Array<Unresolved<U>>
+				: T extends { [key: string]: Value }
+					? { [K in keyof T]: Unresolved<T[K]> }
+					: never
 	>;
 
 	/**
@@ -582,12 +582,12 @@ declare namespace tg {
 		| Template
 		? T
 		: T extends Array<infer U extends Unresolved<Value>>
-		? Array<Resolved<U>>
-		: T extends { [key: string]: Unresolved<Value> }
-		? { [K in keyof T]: Resolved<T[K]> }
-		: T extends Promise<infer U extends Unresolved<Value>>
-		? Resolved<U>
-		: never;
+			? Array<Resolved<U>>
+			: T extends { [key: string]: Unresolved<Value> }
+				? { [K in keyof T]: Resolved<T[K]> }
+				: T extends Promise<infer U extends Unresolved<Value>>
+					? Resolved<U>
+					: never;
 
 	/** Sleep for the specified duration in seconds. */
 	export let sleep: (duration: number) => Promise<void>;
@@ -646,11 +646,11 @@ declare namespace tg {
 	/** Create a target. */
 	export function target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value
+		R extends Value = Value,
 	>(function_: (...args: A) => Unresolved<R>): Target<A, R>;
 	export function target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value
+		R extends Value = Value,
 	>(...args: Args<Target.Arg>): Promise<Target<A, R>>;
 
 	/** Create and build a target. */
@@ -659,7 +659,7 @@ declare namespace tg {
 	/** A target. */
 	export interface Target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value
+		R extends Value = Value,
 	> {
 		/** Build this target. */
 		// biome-ignore lint/style/useShorthandFunctionType:
@@ -669,7 +669,7 @@ declare namespace tg {
 	/** A target. */
 	export class Target<
 		A extends Array<Value> = Array<Value>,
-		R extends Value = Value
+		R extends Value = Value,
 	> extends globalThis.Function {
 		/** Get a target with an ID. */
 		static withId(id: Target.Id): Target;
@@ -802,15 +802,15 @@ declare namespace tg {
 		| Template
 		? T
 		: T extends { [key: string]: Value }
-		? MutationMap<T>
-		: never;
+			? MutationMap<T>
+			: never;
 
 	export type MaybeNestedArray<T> = T | Array<MaybeNestedArray<T>>;
 
 	export type MaybePromise<T> = T | Promise<T>;
 
 	export type MutationMap<
-		T extends { [key: string]: Value } = { [key: string]: Value }
+		T extends { [key: string]: Value } = { [key: string]: Value },
 	> = {
 		[K in keyof T]?: MaybeMutation<T[K]>;
 	};
@@ -845,9 +845,6 @@ declare namespace tg {
 		/** Join this path with another path. **/
 		join(other: Path.Arg): Path;
 
-		/** Normalize this path. **/
-		normalize(): Path;
-
 		/** Check if a value is a `Path`. */
 		static is(value: unknown): value is Path;
 
@@ -856,6 +853,9 @@ declare namespace tg {
 
 		/** Assert that a value is a `Path`. */
 		static assert(value: unknown): asserts value is Path;
+
+		/** Normalize this path. **/
+		normalize(): Path;
 
 		/** Return true if this path begins with a current component. **/
 		isInternal(): boolean;


### PR DESCRIPTION
This PR implements the following features for `tg::Path`:

-  `tg.Path.is`/`tg.Path.assert`/`tg.Path.expect`
- A JS log implementation
- Prevents adding an extra `/` when pushing the first normal component after the root