### PR TITLE
fix(server): re-create package locks for path dependencies after a database clean

### DIFF
--- a/packages/server/src/package.rs
+++ b/packages/server/src/package.rs
@@ -44,11 +44,11 @@ impl Server {
 			let lock = self
 				.get_or_create_package_lock(path, &analysis)
 				.await
-				.map_err(|error| {
+				.map_err(|source| {
 					if let Some(path) = path {
-						tg::error!(source = error, %path, "failed to get or create the lock")
+						tg::error!(!source, %path, "failed to get or create the lock")
 					} else {
-						tg::error!(source = error, "failed to get or create the lock")
+						tg::error!(!source, "failed to get or create the lock")
 					}
 				})?;
 			let lock = lock.id(self, None).await?;


### PR DESCRIPTION
After a database is wiped, locks referred to by lockfiles with path dependencies are removed. This commit recreates those locks while trying to add path dependencies back to the lock, in the event that the lock's object can't be loaded. 