### PR TITLE
fix: add checkouts to sandbox, unrender templates with a prefix

### DIFF
--- a/packages/client/src/template.rs
+++ b/packages/client/src/template.rs
@@ -86,11 +86,12 @@ impl Template {
 			.join(""))
 	}
 
-	pub fn unrender(string: &str) -> tg::Result<Self> {
+	pub fn unrender(prefix: &str, string: &str) -> tg::Result<Self> {
 		// Create the regex.
+		let prefix = regex::escape(prefix);
 		let regex =
-			r"/\.tangram/artifacts/((?:dir_|fil_|sym_)01[0123456789abcdefghjkmnpqrstvwxyz]{52})";
-		let regex = regex::Regex::new(regex).unwrap();
+			format!(r"{prefix}/((?:dir_|fil_|sym_)01[0123456789abcdefghjkmnpqrstvwxyz]{{52}})");
+		let regex = regex::Regex::new(&regex).unwrap();
 
 		let mut i = 0;
 		let mut components = Vec::new();
@@ -254,8 +255,8 @@ mod tests {
 		let id = "dir_010000000000000000000000000000000000000000000000000000"
 			.parse()
 			.unwrap();
-		let string = format!("foo /.tangram/artifacts/{id} bar");
-		let template = tg::Template::unrender(&string).unwrap();
+		let string = format!("foo /path/to/.tangram/artifacts/{id} bar");
+		let template = tg::Template::unrender("/path/to/.tangram/artifacts", &string).unwrap();
 
 		let left = template.components().first().unwrap().unwrap_string_ref();
 		let right = "foo ";

--- a/packages/server/src/artifact/checkin.rs
+++ b/packages/server/src/artifact/checkin.rs
@@ -203,7 +203,11 @@ impl Server {
 		let target = target
 			.to_str()
 			.ok_or_else(|| tg::error!("the symlink target must be valid UTF-8"))?;
-		let target = tg::Template::unrender(target)?;
+		let artifacts_path = self.artifacts_path();
+		let artifacts_path = artifacts_path
+			.to_str()
+			.ok_or_else(|| tg::error!("the artifacts path must be valid UTF-8"))?;
+		let target = tg::Template::unrender(artifacts_path, target)?;
 
 		// Get the artifact and path.
 		let (artifact, path) = if target.components.len() == 1 {

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -56,6 +56,7 @@ impl Runtime {
 
 		// Get the artifacts path.
 		let artifacts_directory_path = server.path.join("artifacts");
+		let checkouts_directory_path = server.path.join("checkouts");
 
 		let root_directory_tmp = Tmp::new(server);
 		tokio::fs::create_dir_all(&root_directory_tmp)
@@ -292,9 +293,20 @@ impl Runtime {
 				(allow process-exec* (subpath {0}))
 				(allow file-read* (path-ancestors {0}))
 				(allow file-read* (subpath {0}))
-				(allow file-write* (subpath {0}))
 			"#,
 			escape(artifacts_directory_path.as_os_str().as_bytes())
+		)
+		.unwrap();
+
+		// Allow read access to the checkouts directory.
+		writedoc!(
+			profile,
+			r#"
+				(allow process-exec* (subpath {0}))
+				(allow file-read* (path-ancestors {0}))
+				(allow file-read* (subpath {0}))
+			"#,
+			escape(checkouts_directory_path.as_os_str().as_bytes())
 		)
 		.unwrap();
 


### PR DESCRIPTION
This PR makes two changes to support building with the VFS disabled on macOS:

- Expose the server checkouts directory in addition to the artifacts directory in the macOS sandbox profile
- Add an argument to `Template::unrender` to provide the path to the artifacts directory, instead of simply assuming `/.tangram/artifacts`.