### PR TITLE
fix(vscode): update language configuration json files

### DIFF
--- a/packages/vscode/tangram-javascript-language-configuration.json
+++ b/packages/vscode/tangram-javascript-language-configuration.json
@@ -3,28 +3,13 @@
 	// Note that this file should stay in sync with 'javascript-language-basics/javascript-language-configuration.json'
 	"comments": {
 		"lineComment": "//",
-		"blockComment": [
-			"/*",
-			"*/"
-		]
+		"blockComment": ["/*", "*/"]
 	},
 	"brackets": [
-		[
-			"${",
-			"}"
-		],
-		[
-			"{",
-			"}"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"(",
-			")"
-		]
+		["${", "}"],
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
 	],
 	"autoClosingPairs": [
 		{
@@ -42,81 +27,38 @@
 		{
 			"open": "'",
 			"close": "'",
-			"notIn": [
-				"string",
-				"comment"
-			]
+			"notIn": ["string", "comment"]
 		},
 		{
 			"open": "\"",
 			"close": "\"",
-			"notIn": [
-				"string"
-			]
+			"notIn": ["string"]
 		},
 		{
 			"open": "`",
 			"close": "`",
-			"notIn": [
-				"string",
-				"comment"
-			]
+			"notIn": ["string", "comment"]
 		},
 		{
 			"open": "/**",
 			"close": " */",
-			"notIn": [
-				"string"
-			]
+			"notIn": ["string"]
 		}
 	],
 	"surroundingPairs": [
-		[
-			"{",
-			"}"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"(",
-			")"
-		],
-		[
-			"'",
-			"'"
-		],
-		[
-			"\"",
-			"\""
-		],
-		[
-			"`",
-			"`"
-		],
-		[
-			"<",
-			">"
-		]
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["'", "'"],
+		["\"", "\""],
+		["`", "`"],
+		["<", ">"]
 	],
 	"colorizedBracketPairs": [
-		[
-			"(",
-			")"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"{",
-			"}"
-		],
-		[
-			"<",
-			">"
-		]
+		["(", ")"],
+		["[", "]"],
+		["{", "}"],
+		["<", ">"]
 	],
 	"autoCloseBefore": ";:.,=}])>` \n\t",
 	"folding": {
@@ -126,18 +68,21 @@
 		}
 	},
 	"wordPattern": {
-		"pattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\@\\~\\!\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>/\\?\\s]+)",
+		"pattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\@\\~\\!\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>/\\?\\s]+)"
 	},
 	"indentationRules": {
 		"decreaseIndentPattern": {
-			"pattern": "^((?!.*?/\\*).*\\*\/)?\\s*[\\}\\]].*$"
+			"pattern": "^((?!.*?/\\*).*\\*/)?\\s*[\\}\\]\\)].*$"
 		},
 		"increaseIndentPattern": {
 			"pattern": "^((?!//).)*(\\{([^}\"'`/]*|(\\t|[ ])*//.*)|\\([^)\"'`/]*|\\[[^\\]\"'`/]*)$"
 		},
 		// e.g.  * ...| or */| or *-----*/|
 		"unIndentedLinePattern": {
-			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$"
+		},
+		"indentNextLinePattern": {
+			"pattern": "^((.*=>\\s*)|((.*[^\\w]+|\\s*)(if|while|for)\\s*\\(.*\\)\\s*))$"
 		}
 	},
 	"onEnterRules": [
@@ -167,7 +112,7 @@
 		{
 			// e.g.  * ...|
 			"beforeText": {
-				"pattern": "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+				"pattern": "^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$"
 			},
 			"previousLineText": {
 				"pattern": "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))"
@@ -185,7 +130,7 @@
 			"action": {
 				"indent": "none",
 				"removeText": 1
-			},
+			}
 		},
 		{
 			// e.g.  *-----*/|
@@ -195,7 +140,7 @@
 			"action": {
 				"indent": "none",
 				"removeText": 1
-			},
+			}
 		},
 		{
 			"beforeText": {
@@ -215,6 +160,33 @@
 			"beforeText": "^\\s+([^{i\\s]|i(?!f\\b))",
 			"action": {
 				"indent": "outdent"
+			}
+		},
+		// Indent when pressing enter from inside ()
+		{
+			"beforeText": "^.*\\([^\\)]*$",
+			"afterText": "^\\s*\\).*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t"
+			}
+		},
+		// Indent when pressing enter from inside {}
+		{
+			"beforeText": "^.*\\{[^\\}]*$",
+			"afterText": "^\\s*\\}.*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t"
+			}
+		},
+		// Indent when pressing enter from inside []
+		{
+			"beforeText": "^.*\\[[^\\]]*$",
+			"afterText": "^\\s*\\].*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t"
 			}
 		}
 	]

--- a/packages/vscode/tangram-typescript-language-configuration.json
+++ b/packages/vscode/tangram-typescript-language-configuration.json
@@ -3,28 +3,13 @@
 	// Note that this file should stay in sync with 'javascript-language-basics/javascript-language-configuration.json'
 	"comments": {
 		"lineComment": "//",
-		"blockComment": [
-			"/*",
-			"*/"
-		]
+		"blockComment": ["/*", "*/"]
 	},
 	"brackets": [
-		[
-			"${",
-			"}"
-		],
-		[
-			"{",
-			"}"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"(",
-			")"
-		]
+		["${", "}"],
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
 	],
 	"autoClosingPairs": [
 		{
@@ -42,81 +27,38 @@
 		{
 			"open": "'",
 			"close": "'",
-			"notIn": [
-				"string",
-				"comment"
-			]
+			"notIn": ["string", "comment"]
 		},
 		{
 			"open": "\"",
 			"close": "\"",
-			"notIn": [
-				"string"
-			]
+			"notIn": ["string"]
 		},
 		{
 			"open": "`",
 			"close": "`",
-			"notIn": [
-				"string",
-				"comment"
-			]
+			"notIn": ["string", "comment"]
 		},
 		{
 			"open": "/**",
 			"close": " */",
-			"notIn": [
-				"string"
-			]
+			"notIn": ["string"]
 		}
 	],
 	"surroundingPairs": [
-		[
-			"{",
-			"}"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"(",
-			")"
-		],
-		[
-			"'",
-			"'"
-		],
-		[
-			"\"",
-			"\""
-		],
-		[
-			"`",
-			"`"
-		],
-		[
-			"<",
-			">"
-		]
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["'", "'"],
+		["\"", "\""],
+		["`", "`"],
+		["<", ">"]
 	],
 	"colorizedBracketPairs": [
-		[
-			"(",
-			")"
-		],
-		[
-			"[",
-			"]"
-		],
-		[
-			"{",
-			"}"
-		],
-		[
-			"<",
-			">"
-		]
+		["(", ")"],
+		["[", "]"],
+		["{", "}"],
+		["<", ">"]
 	],
 	"autoCloseBefore": ";:.,=}])>` \n\t",
 	"folding": {
@@ -126,18 +68,21 @@
 		}
 	},
 	"wordPattern": {
-		"pattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\@\\~\\!\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>/\\?\\s]+)",
+		"pattern": "(-?\\d*\\.\\d\\w*)|([^\\`\\@\\~\\!\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\,\\.\\<\\>/\\?\\s]+)"
 	},
 	"indentationRules": {
 		"decreaseIndentPattern": {
-			"pattern": "^((?!.*?/\\*).*\\*\/)?\\s*[\\}\\]].*$"
+			"pattern": "^((?!.*?/\\*).*\\*/)?\\s*[\\}\\]\\)].*$"
 		},
 		"increaseIndentPattern": {
 			"pattern": "^((?!//).)*(\\{([^}\"'`/]*|(\\t|[ ])*//.*)|\\([^)\"'`/]*|\\[[^\\]\"'`/]*)$"
 		},
 		// e.g.  * ...| or */| or *-----*/|
 		"unIndentedLinePattern": {
-			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$"
+		},
+		"indentNextLinePattern": {
+			"pattern": "^((.*=>\\s*)|((.*[^\\w]+|\\s*)(if|while|for)\\s*\\(.*\\)\\s*))$"
 		}
 	},
 	"onEnterRules": [
@@ -167,7 +112,7 @@
 		{
 			// e.g.  * ...|
 			"beforeText": {
-				"pattern": "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+				"pattern": "^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$"
 			},
 			"previousLineText": {
 				"pattern": "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))"
@@ -185,7 +130,7 @@
 			"action": {
 				"indent": "none",
 				"removeText": 1
-			},
+			}
 		},
 		{
 			// e.g.  *-----*/|
@@ -195,7 +140,7 @@
 			"action": {
 				"indent": "none",
 				"removeText": 1
-			},
+			}
 		},
 		{
 			"beforeText": {
@@ -215,6 +160,33 @@
 			"beforeText": "^\\s+([^{i\\s]|i(?!f\\b))",
 			"action": {
 				"indent": "outdent"
+			}
+		},
+		// Indent when pressing enter from inside ()
+		{
+			"beforeText": "^.*\\([^\\)]*$",
+			"afterText": "^\\s*\\).*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t"
+			}
+		},
+		// Indent when pressing enter from inside {}
+		{
+			"beforeText": "^.*\\{[^\\}]*$",
+			"afterText": "^\\s*\\}.*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t"
+			}
+		},
+		// Indent when pressing enter from inside []
+		{
+			"beforeText": "^.*\\[[^\\]]*$",
+			"afterText": "^\\s*\\].*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t"
 			}
 		}
 	]


### PR DESCRIPTION
This PR recreates the language configuration JSON files from [https://github.com/microsoft/vscode/blob/main/extensions/typescript-basics/language-configuration.json](https://github.com/microsoft/vscode/blob/main/extensions/typescript-basics/language-configuration.json). Line comment toggling now works.