### PR TITLE
Support retries in tg::Handle

### DIFF
--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -2,6 +2,7 @@ use crate::Cli;
 use tangram_client as tg;
 
 pub mod cancel;
+pub mod children;
 pub mod get;
 pub mod log;
 pub mod outcome;
@@ -9,6 +10,7 @@ pub mod output;
 pub mod pull;
 pub mod push;
 pub mod put;
+pub mod status;
 pub mod tree;
 
 /// Build a target or manage builds.
@@ -27,6 +29,7 @@ pub struct Args {
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum Command {
 	Cancel(self::cancel::Args),
+	Children(self::children::Args),
 	Get(self::get::Args),
 	Log(self::log::Args),
 	Outcome(self::outcome::Args),
@@ -34,6 +37,7 @@ pub enum Command {
 	Pull(self::pull::Args),
 	Push(self::push::Args),
 	Put(self::put::Args),
+	Status(self::status::Args),
 	Tree(self::tree::Args),
 }
 
@@ -45,6 +49,9 @@ impl Cli {
 			},
 			Some(Command::Cancel(args)) => {
 				self.command_build_cancel(args).await?;
+			},
+			Some(Command::Children(args)) => {
+				self.command_build_children(args).await?;
 			},
 			Some(Command::Get(args)) => {
 				self.command_build_get(args).await?;
@@ -66,6 +73,9 @@ impl Cli {
 			},
 			Some(Command::Put(args)) => {
 				self.command_build_put(args).await?;
+			},
+			Some(Command::Status(args)) => {
+				self.command_build_status(args).await?;
 			},
 			Some(Command::Tree(args)) => {
 				self.command_build_tree(args).await?;

--- a/packages/cli/src/build/children.rs
+++ b/packages/cli/src/build/children.rs
@@ -1,0 +1,48 @@
+use crate::Cli;
+use futures::StreamExt;
+use tangram_client::{self as tg, Handle as _};
+
+/// List a build's children.
+#[derive(Clone, Debug, clap::Args)]
+#[group(skip)]
+pub struct Args {
+	#[arg(short, long)]
+	pub position: Option<u64>,
+
+	#[arg(short, long)]
+	pub length: Option<u64>,
+
+	#[arg(short, long)]
+	pub size: Option<u64>,
+
+	#[arg(short, long)]
+	pub timeout: Option<f64>,
+
+	pub build: tg::build::Id,
+}
+
+impl Cli {
+	pub async fn command_build_children(&self, args: Args) -> tg::Result<()> {
+		let arg = tg::build::children::Arg {
+			position: args.position.map(std::io::SeekFrom::Start),
+			length: args.length,
+			size: args.size,
+			timeout: args.timeout.map(std::time::Duration::from_secs_f64),
+		};
+		let mut stream = self
+			.handle
+			.try_get_build_children(&args.build, arg)
+			.await?
+			.ok_or_else(|| tg::error!(%id = args.build, "expected the build to exist"))?
+			.boxed();
+
+		while let Some(chunk) = stream.next().await {
+			let chunk = chunk.map_err(|source| tg::error!(!source, "expected a chunk"))?;
+			for item in chunk.items {
+				println!("{item}");
+			}
+		}
+
+		Ok(())
+	}
+}

--- a/packages/cli/src/build/status.rs
+++ b/packages/cli/src/build/status.rs
@@ -1,0 +1,34 @@
+use crate::Cli;
+use futures::StreamExt;
+use tangram_client::{self as tg, Handle as _};
+
+/// List a build's children.
+#[derive(Clone, Debug, clap::Args)]
+#[group(skip)]
+pub struct Args {
+	#[arg(short, long)]
+	pub timeout: Option<f64>,
+
+	pub build: tg::build::Id,
+}
+
+impl Cli {
+	pub async fn command_build_status(&self, args: Args) -> tg::Result<()> {
+		let arg = tg::build::status::Arg {
+			timeout: args.timeout.map(std::time::Duration::from_secs_f64),
+		};
+		let mut stream = self
+			.handle
+			.try_get_build_status(&args.build, arg)
+			.await?
+			.ok_or_else(|| tg::error!(%id = args.build, "expected the build to exist"))?
+			.boxed();
+
+		while let Some(status) = stream.next().await {
+			let status = status.map_err(|source| tg::error!(!source, "expected a status"))?;
+			println!("{status}");
+		}
+
+		Ok(())
+	}
+}

--- a/packages/client/src/build/children.rs
+++ b/packages/client/src/build/children.rs
@@ -74,7 +74,7 @@ impl tg::Build {
 }
 
 impl tg::Client {
-	pub async fn try_get_build_children(
+	pub async fn try_get_build_children_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::children::Arg,

--- a/packages/client/src/build/log.rs
+++ b/packages/client/src/build/log.rs
@@ -69,7 +69,7 @@ impl tg::Build {
 }
 
 impl tg::Client {
-	pub async fn try_get_build_log(
+	pub async fn try_get_build_log_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::Arg,

--- a/packages/client/src/build/outcome.rs
+++ b/packages/client/src/build/outcome.rs
@@ -119,7 +119,7 @@ impl tg::Build {
 }
 
 impl tg::Client {
-	pub async fn try_get_build_outcome(
+	pub async fn try_get_build_outcome_future(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::outcome::Arg,

--- a/packages/client/src/build/status.rs
+++ b/packages/client/src/build/status.rs
@@ -51,7 +51,7 @@ impl tg::Build {
 }
 
 impl tg::Client {
-	pub async fn try_get_build_status(
+	pub async fn try_get_build_status_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::status::Arg,

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -107,7 +107,7 @@ where
 		}
 	}
 
-	fn try_get_build_status(
+	fn try_get_build_status_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::status::Arg,
@@ -128,7 +128,7 @@ where
 		}
 	}
 
-	fn try_get_build_children(
+	fn try_get_build_children_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::children::Arg,
@@ -160,7 +160,7 @@ where
 		}
 	}
 
-	async fn try_get_build_log(
+	async fn try_get_build_log_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::Arg,
@@ -189,7 +189,7 @@ where
 		}
 	}
 
-	fn try_get_build_outcome(
+	fn try_get_build_outcome_future(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::outcome::Arg,

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -623,17 +623,17 @@ impl tg::Handle for Client {
 		self.heartbeat_build(id)
 	}
 
-	fn try_get_build_status(
+	fn try_get_build_status_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::status::Arg,
 	) -> impl Future<
 		Output = tg::Result<Option<impl Stream<Item = Result<tg::build::Status>> + Send + 'static>>,
 	> {
-		self.try_get_build_status(id, arg)
+		self.try_get_build_status_stream(id, arg)
 	}
 
-	fn try_get_build_children(
+	fn try_get_build_children_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::children::Arg,
@@ -642,7 +642,7 @@ impl tg::Handle for Client {
 			Option<impl Stream<Item = Result<tg::build::children::Chunk>> + Send + 'static>,
 		>,
 	> {
-		self.try_get_build_children(id, arg)
+		self.try_get_build_children_stream(id, arg)
 	}
 
 	fn add_build_child(
@@ -653,7 +653,7 @@ impl tg::Handle for Client {
 		self.add_build_child(build_id, child_id)
 	}
 
-	fn try_get_build_log(
+	fn try_get_build_log_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::Arg,
@@ -662,7 +662,7 @@ impl tg::Handle for Client {
 			Option<impl Stream<Item = Result<tg::build::log::Chunk>> + Send + 'static>,
 		>,
 	> {
-		self.try_get_build_log(id, arg)
+		self.try_get_build_log_stream(id, arg)
 	}
 
 	fn add_build_log(
@@ -673,7 +673,7 @@ impl tg::Handle for Client {
 		self.add_build_log(id, bytes)
 	}
 
-	fn try_get_build_outcome(
+	fn try_get_build_outcome_future(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::outcome::Arg,
@@ -682,7 +682,7 @@ impl tg::Handle for Client {
 			Option<impl Future<Output = tg::Result<Option<tg::build::Outcome>>> + 'static>,
 		>,
 	> {
-		self.try_get_build_outcome(id, arg)
+		self.try_get_build_outcome_future(id, arg)
 	}
 
 	fn finish_build(

--- a/packages/server/src/build/children.rs
+++ b/packages/server/src/build/children.rs
@@ -14,7 +14,7 @@ use tangram_messenger::Messenger as _;
 use tokio_stream::wrappers::IntervalStream;
 
 impl Server {
-	pub async fn try_get_build_children(
+	pub async fn try_get_build_children_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::children::Arg,
@@ -314,7 +314,7 @@ impl Server {
 		let Some(remote) = self.remotes.first() else {
 			return Ok(None);
 		};
-		let Some(stream) = remote.try_get_build_children(id, arg).await? else {
+		let Some(stream) = remote.try_get_build_children_stream(id, arg).await? else {
 			return Ok(None);
 		};
 		Ok(Some(stream))

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -99,7 +99,7 @@ impl Server {
 				let arg = tg::build::outcome::Arg {
 					timeout: Some(std::time::Duration::ZERO),
 				};
-				self.try_get_build_outcome(child_id, arg)
+				self.try_get_build_outcome_future(child_id, arg)
 					.await?
 					.ok_or_else(|| tg::error!(%child_id, "failed to get the build"))?
 					.await?

--- a/packages/server/src/build/get.rs
+++ b/packages/server/src/build/get.rs
@@ -88,7 +88,7 @@ impl Server {
 				..Default::default()
 			};
 			let children = self
-				.try_get_build_children(id, arg)
+				.try_get_build_children_stream(id, arg)
 				.await?
 				.ok_or_else(|| tg::error!("expected the build to exist"))?
 				.map_ok(|chunk| stream::iter(chunk.items).map(Ok::<_, tg::Error>))

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -36,7 +36,7 @@ type ReadFuture = BoxFuture<'static, tg::Result<Option<Cursor<Bytes>>>>;
 type SeekFuture = BoxFuture<'static, tg::Result<u64>>;
 
 impl Server {
-	pub async fn try_get_build_log(
+	pub async fn try_get_build_log_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::Arg,
@@ -268,7 +268,7 @@ impl Server {
 		let Some(remote) = self.remotes.first() else {
 			return Ok(None);
 		};
-		let Some(log) = remote.try_get_build_log(id, arg).await? else {
+		let Some(log) = remote.try_get_build_log_stream(id, arg).await? else {
 			return Ok(None);
 		};
 		Ok(Some(log))

--- a/packages/server/src/build/outcome.rs
+++ b/packages/server/src/build/outcome.rs
@@ -7,7 +7,7 @@ use tangram_database::{self as db, prelude::*};
 use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
 
 impl Server {
-	pub async fn try_get_build_outcome(
+	pub async fn try_get_build_outcome_future(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::outcome::Arg,
@@ -102,7 +102,7 @@ impl Server {
 		let Some(remote) = self.remotes.first() else {
 			return Ok(None);
 		};
-		let Some(outcome) = remote.try_get_build_outcome(id, arg).await? else {
+		let Some(outcome) = remote.try_get_build_outcome_future(id, arg).await? else {
 			return Ok(None);
 		};
 		Ok(Some(outcome))

--- a/packages/server/src/build/status.rs
+++ b/packages/server/src/build/status.rs
@@ -9,7 +9,7 @@ use tangram_messenger::Messenger as _;
 use tokio_stream::wrappers::IntervalStream;
 
 impl Server {
-	pub async fn try_get_build_status(
+	pub async fn try_get_build_status_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::status::Arg,
@@ -136,7 +136,7 @@ impl Server {
 		let Some(remote) = self.remotes.first() else {
 			return Ok(None);
 		};
-		let Some(stream) = remote.try_get_build_status(id, arg).await? else {
+		let Some(stream) = remote.try_get_build_status_stream(id, arg).await? else {
 			return Ok(None);
 		};
 		Ok(Some(stream))

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -815,7 +815,7 @@ impl tg::Handle for Server {
 		self.try_start_build(id)
 	}
 
-	fn try_get_build_status(
+	fn try_get_build_status_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::status::Arg,
@@ -824,10 +824,10 @@ impl tg::Handle for Server {
 			Option<impl Stream<Item = tg::Result<tg::build::Status>> + Send + 'static>,
 		>,
 	> {
-		self.try_get_build_status(id, arg)
+		self.try_get_build_status_stream(id, arg)
 	}
 
-	fn try_get_build_children(
+	fn try_get_build_children_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::children::Arg,
@@ -836,7 +836,7 @@ impl tg::Handle for Server {
 			Option<impl Stream<Item = tg::Result<tg::build::children::Chunk>> + Send + 'static>,
 		>,
 	> {
-		self.try_get_build_children(id, arg)
+		self.try_get_build_children_stream(id, arg)
 	}
 
 	fn add_build_child(
@@ -847,7 +847,7 @@ impl tg::Handle for Server {
 		self.add_build_child(build_id, child_id)
 	}
 
-	fn try_get_build_log(
+	fn try_get_build_log_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::Arg,
@@ -856,7 +856,7 @@ impl tg::Handle for Server {
 			Option<impl Stream<Item = tg::Result<tg::build::log::Chunk>> + Send + 'static>,
 		>,
 	> {
-		self.try_get_build_log(id, arg)
+		self.try_get_build_log_stream(id, arg)
 	}
 
 	fn add_build_log(
@@ -867,7 +867,7 @@ impl tg::Handle for Server {
 		self.add_build_log(build_id, bytes)
 	}
 
-	fn try_get_build_outcome(
+	fn try_get_build_outcome_future(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::outcome::Arg,
@@ -876,7 +876,7 @@ impl tg::Handle for Server {
 			Option<impl Future<Output = tg::Result<Option<tg::build::Outcome>>> + Send + 'static>,
 		>,
 	> {
-		self.try_get_build_outcome(id, arg)
+		self.try_get_build_outcome_future(id, arg)
 	}
 
 	fn finish_build(

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -129,7 +129,7 @@ impl tg::Handle for Proxy {
 		Err(tg::error!("forbidden"))
 	}
 
-	fn try_get_build_status(
+	fn try_get_build_status_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::status::Arg,
@@ -138,10 +138,10 @@ impl tg::Handle for Proxy {
 			Option<impl Stream<Item = tg::Result<tg::build::Status>> + Send + 'static>,
 		>,
 	> {
-		self.server.try_get_build_status(id, arg)
+		self.server.try_get_build_status_stream(id, arg)
 	}
 
-	fn try_get_build_children(
+	fn try_get_build_children_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::children::Arg,
@@ -150,7 +150,7 @@ impl tg::Handle for Proxy {
 			Option<impl Stream<Item = tg::Result<tg::build::children::Chunk>> + Send + 'static>,
 		>,
 	> {
-		self.server.try_get_build_children(id, arg)
+		self.server.try_get_build_children_stream(id, arg)
 	}
 
 	async fn add_build_child(
@@ -161,7 +161,7 @@ impl tg::Handle for Proxy {
 		Err(tg::error!("forbidden"))
 	}
 
-	fn try_get_build_log(
+	fn try_get_build_log_stream(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::Arg,
@@ -170,14 +170,14 @@ impl tg::Handle for Proxy {
 			Option<impl Stream<Item = tg::Result<tg::build::log::Chunk>> + Send + 'static>,
 		>,
 	> {
-		self.server.try_get_build_log(id, arg)
+		self.server.try_get_build_log_stream(id, arg)
 	}
 
 	async fn add_build_log(&self, _build_id: &tg::build::Id, _bytes: Bytes) -> tg::Result<()> {
 		Err(tg::error!("forbidden"))
 	}
 
-	fn try_get_build_outcome(
+	fn try_get_build_outcome_future(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::outcome::Arg,
@@ -186,7 +186,7 @@ impl tg::Handle for Proxy {
 			Option<impl Future<Output = tg::Result<Option<tg::build::Outcome>>> + Send + 'static>,
 		>,
 	> {
-		self.server.try_get_build_outcome(id, arg)
+		self.server.try_get_build_outcome_future(id, arg)
 	}
 
 	async fn finish_build(


### PR DESCRIPTION
Implement retry logic for try_get_build_outcome, try_get_build_status, try_get_build_children, and try_get_build_log