### PR TITLE
feat: support --locked flag for all relevant package commands

### DIFF
--- a/packages/cli/src/build/tree.rs
+++ b/packages/cli/src/build/tree.rs
@@ -9,6 +9,7 @@ use tangram_client as tg;
 #[group(skip)]
 pub struct Args {
 	pub build: tg::build::Id,
+
 	#[arg(long)]
 	pub depth: Option<u32>,
 }

--- a/packages/cli/src/package/check.rs
+++ b/packages/cli/src/package/check.rs
@@ -25,7 +25,10 @@ impl Cli {
 		}
 
 		// Check the package.
-		let diagnostics = self.handle.check_package(&args.package).await?;
+		let arg = tg::package::check::Arg {
+			locked: args.locked,
+		};
+		let diagnostics = self.handle.check_package(&args.package, arg).await?;
 
 		// Print the diagnostics.
 		for diagnostic in &diagnostics {

--- a/packages/cli/src/package/doc.rs
+++ b/packages/cli/src/package/doc.rs
@@ -33,7 +33,12 @@ impl Cli {
 			self.handle.get_js_runtime_doc().await?
 		} else {
 			self.handle
-				.try_get_package_doc(&args.package)
+				.try_get_package_doc(
+					&args.package,
+					tg::package::doc::Arg {
+						locked: args.locked,
+					},
+				)
 				.await?
 				.ok_or_else(|| tg::error!("failed to get the package"))?
 		};

--- a/packages/cli/src/package/outdated.rs
+++ b/packages/cli/src/package/outdated.rs
@@ -12,6 +12,10 @@ pub struct Args {
 	#[arg(long)]
 	pub json: bool,
 
+	/// If this flag is set, the package's lockfile will not be updated.
+	#[arg(long)]
+	pub locked: bool,
+
 	#[arg(short, long, default_value = ".")]
 	pub path: tg::Path,
 }
@@ -30,7 +34,12 @@ impl Cli {
 
 		let outdated = self
 			.handle
-			.get_package_outdated(&dependency)
+			.get_package_outdated(
+				&dependency,
+				tg::package::outdated::Arg {
+					locked: args.locked,
+				},
+			)
 			.await
 			.map_err(
 				|source| tg::error!(!source, %dependency, "failed to get outdated packages"),

--- a/packages/cli/src/package/publish.rs
+++ b/packages/cli/src/package/publish.rs
@@ -8,6 +8,9 @@ use tangram_client::{self as tg, Handle as _};
 pub struct Args {
 	#[arg(short, long, default_value = ".")]
 	pub package: tg::Dependency,
+
+	#[arg(long, default_value = "false")]
+	pub locked: bool,
 }
 
 impl Cli {
@@ -23,7 +26,9 @@ impl Cli {
 		}
 
 		// Create the package.
-		let (package, _) = tg::package::get_with_lock(&self.handle, &dependency).await?;
+		let (package, _) = tg::package::get_with_lock(&self.handle, &dependency, args.locked)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get the package"))?;
 
 		// Get the package ID.
 		let id = package.id(&self.handle, None).await?;

--- a/packages/cli/src/package/tree.rs
+++ b/packages/cli/src/package/tree.rs
@@ -11,6 +11,10 @@ pub struct Args {
 
 	#[arg(short, long)]
 	pub depth: Option<u32>,
+
+	/// If this flag is set, the package's lockfile will not be updated.
+	#[arg(long)]
+	pub locked: bool,
 }
 
 impl Cli {
@@ -26,9 +30,8 @@ impl Cli {
 		}
 
 		// Create the package.
-		let (package, lock) = tg::package::get_with_lock(&self.handle, &dependency)
-			.await
-			.map_err(|source| tg::error!(!source, %dependency, "failed to get the lock"))?;
+		let (package, lock) =
+			tg::package::get_with_lock(&self.handle, &dependency, args.locked).await?;
 
 		let mut visited = BTreeSet::new();
 		let tree = self

--- a/packages/cli/src/package/update.rs
+++ b/packages/cli/src/package/update.rs
@@ -24,7 +24,7 @@ impl Cli {
 				.ok();
 		}
 
-		let _ = tg::package::get_with_lock(&self.handle, &dependency)
+		let _ = tg::package::get_with_lock(&self.handle, &dependency, false)
 			.await
 			.map_err(|source| tg::error!(!source, %dependency, "failed to create a new lock"))?;
 

--- a/packages/cli/src/target/build.rs
+++ b/packages/cli/src/target/build.rs
@@ -151,7 +151,8 @@ impl Cli {
 
 				// Create the package.
 				let (package, lock) =
-					tg::package::get_with_lock(&self.handle, &specifier.package).await?;
+					tg::package::get_with_lock(&self.handle, &specifier.package, args.locked)
+						.await?;
 
 				// Create the target.
 				let host = "js";

--- a/packages/cli/src/tree.rs
+++ b/packages/cli/src/tree.rs
@@ -12,6 +12,10 @@ pub struct Args {
 	#[arg(short, long, conflicts_with_all = ["package", "object", "arg"])]
 	pub build: Option<tg::build::Id>,
 
+	/// Force the use of an existing lockfile.
+	#[arg(long, default_value = "false")]
+	pub locked: bool,
+
 	/// The package to view.
 	#[arg(short, long, conflicts_with_all = ["build", "object", "arg"])]
 	pub package: Option<tg::Dependency>,
@@ -70,6 +74,7 @@ impl Cli {
 				let args = super::package::tree::Args {
 					package,
 					depth: args.depth,
+					locked: args.locked,
 				};
 				self.command_package_tree(args).await?;
 			},

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -10,6 +10,10 @@ pub struct Args {
 	#[arg(short, long, conflicts_with_all = ["object", "package", "arg"])]
 	pub build: Option<tg::build::Id>,
 
+	/// If this flag is set, the package's lockfile will not be updated.
+	#[arg(long)]
+	pub locked: bool,
+
 	/// The object to view.
 	#[arg(short, long, conflicts_with_all = ["build", "package", "arg"])]
 	pub object: Option<tg::object::Id>,
@@ -60,9 +64,12 @@ impl Cli {
 				}
 
 				// Create the package and lock.
-				let (package, lock) = tg::package::get_with_lock(&self.handle, &dependency)
-					.await
-					.map_err(|source| tg::error!(!source, "failed to get the package and lock"))?;
+				let (package, lock) =
+					tg::package::get_with_lock(&self.handle, &dependency, args.locked)
+						.await
+						.map_err(|source| {
+							tg::error!(!source, "failed to get the package and lock")
+						})?;
 
 				tui::Item::Package {
 					dependency,

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -252,18 +252,21 @@ pub trait Handle: Clone + Unpin + Send + Sync + 'static {
 	fn check_package(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::check::Arg,
 	) -> impl Future<Output = tg::Result<Vec<tg::Diagnostic>>> + Send;
 
 	fn try_get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::doc::Arg,
 	) -> impl Future<Output = tg::Result<Option<serde_json::Value>>> + Send;
 
 	fn get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::doc::Arg,
 	) -> impl Future<Output = tg::Result<serde_json::Value>> + Send {
-		self.try_get_package_doc(dependency).map(|result| {
+		self.try_get_package_doc(dependency, arg).map(|result| {
 			result.and_then(|option| option.ok_or_else(|| tg::error!("failed to get the package")))
 		})
 	}
@@ -276,6 +279,7 @@ pub trait Handle: Clone + Unpin + Send + Sync + 'static {
 	fn get_package_outdated(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::outdated::Arg,
 	) -> impl Future<Output = tg::Result<tg::package::outdated::Output>> + Send;
 
 	fn publish_package(&self, id: &tg::artifact::Id)

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -322,10 +322,11 @@ where
 	fn check_package(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::check::Arg,
 	) -> impl Future<Output = tg::Result<Vec<tg::Diagnostic>>> {
 		match self {
-			Either::Left(s) => s.check_package(dependency).left_future(),
-			Either::Right(s) => s.check_package(dependency).right_future(),
+			Either::Left(s) => s.check_package(dependency, arg).left_future(),
+			Either::Right(s) => s.check_package(dependency, arg).right_future(),
 		}
 	}
 
@@ -339,20 +340,22 @@ where
 	fn try_get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::doc::Arg,
 	) -> impl Future<Output = tg::Result<Option<serde_json::Value>>> {
 		match self {
-			Either::Left(s) => s.try_get_package_doc(dependency).left_future(),
-			Either::Right(s) => s.try_get_package_doc(dependency).right_future(),
+			Either::Left(s) => s.try_get_package_doc(dependency, arg).left_future(),
+			Either::Right(s) => s.try_get_package_doc(dependency, arg).right_future(),
 		}
 	}
 
 	fn get_package_outdated(
 		&self,
-		arg: &tg::Dependency,
+		package: &tg::Dependency,
+		arg: tg::package::outdated::Arg,
 	) -> impl Future<Output = tg::Result<tg::package::outdated::Output>> {
 		match self {
-			Either::Left(s) => s.get_package_outdated(arg).left_future(),
-			Either::Right(s) => s.get_package_outdated(arg).right_future(),
+			Either::Left(s) => s.get_package_outdated(package, arg).left_future(),
+			Either::Right(s) => s.get_package_outdated(package, arg).right_future(),
 		}
 	}
 

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -751,8 +751,9 @@ impl tg::Handle for Client {
 	fn check_package(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::check::Arg,
 	) -> impl Future<Output = tg::Result<Vec<tg::Diagnostic>>> {
-		self.check_package(dependency)
+		self.check_package(dependency, arg)
 	}
 
 	fn format_package(&self, dependency: &tg::Dependency) -> impl Future<Output = tg::Result<()>> {
@@ -762,15 +763,17 @@ impl tg::Handle for Client {
 	fn try_get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::doc::Arg,
 	) -> impl Future<Output = tg::Result<Option<serde_json::Value>>> {
-		self.try_get_package_doc(dependency)
+		self.try_get_package_doc(dependency, arg)
 	}
 
 	fn get_package_outdated(
 		&self,
-		arg: &tg::Dependency,
+		package: &tg::Dependency,
+		arg: tg::package::outdated::Arg,
 	) -> impl Future<Output = tg::Result<tg::package::outdated::Output>> {
-		self.get_package_outdated(arg)
+		self.get_package_outdated(package, arg)
 	}
 
 	fn publish_package(&self, id: &tg::artifact::Id) -> impl Future<Output = tg::Result<()>> {

--- a/packages/client/src/package/check.rs
+++ b/packages/client/src/package/check.rs
@@ -1,15 +1,22 @@
 use crate as tg;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Arg {
+	pub locked: bool,
+}
+
 impl tg::Client {
 	pub async fn check_package(
 		&self,
 		dependency: &tg::Dependency,
+		arg: Arg,
 	) -> tg::Result<Vec<tg::Diagnostic>> {
 		let method = http::Method::POST;
 		let dependency = dependency.to_string();
 		let dependency = urlencoding::encode(&dependency);
-		let uri = format!("/packages/{dependency}/check");
+		let query = serde_urlencoded::to_string(&arg).unwrap();
+		let uri = format!("/packages/{dependency}/check?{query}");
 		let request = http::request::Builder::default().method(method).uri(uri);
 		let request = request.empty().unwrap();
 		let response = self.send(request).await?;

--- a/packages/client/src/package/check.rs
+++ b/packages/client/src/package/check.rs
@@ -12,7 +12,7 @@ impl tg::Client {
 		dependency: &tg::Dependency,
 		arg: Arg,
 	) -> tg::Result<Vec<tg::Diagnostic>> {
-		let method = http::Method::POST;
+		let method = http::Method::GET;
 		let dependency = dependency.to_string();
 		let dependency = urlencoding::encode(&dependency);
 		let query = serde_urlencoded::to_string(&arg).unwrap();

--- a/packages/client/src/package/doc.rs
+++ b/packages/client/src/package/doc.rs
@@ -1,15 +1,22 @@
 use crate as tg;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Arg {
+	pub locked: bool,
+}
+
 impl tg::Client {
 	pub async fn try_get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: Arg,
 	) -> tg::Result<Option<serde_json::Value>> {
 		let method = http::Method::GET;
 		let dependency = dependency.to_string();
 		let dependency = urlencoding::encode(&dependency);
-		let uri = format!("/packages/{dependency}/doc");
+		let query = serde_urlencoded::to_string(&arg).unwrap();
+		let uri = format!("/packages/{dependency}/doc?{query}");
 		let request = http::request::Builder::default().method(method).uri(uri);
 		let request = request.empty().unwrap();
 		let response = self.send(request).await?;

--- a/packages/client/src/package/get.rs
+++ b/packages/client/src/package/get.rs
@@ -6,6 +6,7 @@ use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 pub struct Arg {
 	pub dependencies: bool,
 	pub lock: bool,
+	pub locked: bool,
 	pub metadata: bool,
 	pub path: bool,
 	pub yanked: bool,
@@ -45,11 +46,12 @@ where
 pub async fn get_with_lock<H>(
 	handle: &H,
 	dependency: &tg::Dependency,
+	locked: bool,
 ) -> tg::Result<(tg::Artifact, tg::Lock)>
 where
 	H: tg::Handle,
 {
-	try_get_with_lock(handle, dependency)
+	try_get_with_lock(handle, dependency, locked)
 		.await?
 		.ok_or_else(|| tg::error!(%dependency, "failed to find the package"))
 }
@@ -57,12 +59,14 @@ where
 pub async fn try_get_with_lock<H>(
 	handle: &H,
 	dependency: &tg::Dependency,
+	locked: bool,
 ) -> tg::Result<Option<(tg::Artifact, tg::Lock)>>
 where
 	H: tg::Handle,
 {
 	let arg = tg::package::get::Arg {
 		lock: true,
+		locked,
 		..Default::default()
 	};
 	let Some(output) = handle.try_get_package(dependency, arg).await? else {

--- a/packages/client/src/package/outdated.rs
+++ b/packages/client/src/package/outdated.rs
@@ -3,6 +3,11 @@ use serde_with::{serde_as, DisplayFromStr};
 use std::collections::BTreeMap;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+pub struct Arg {
+	pub locked: bool,
+}
+
 #[serde_as]
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Output {
@@ -27,11 +32,13 @@ impl tg::Client {
 	pub async fn get_package_outdated(
 		&self,
 		dependency: &tg::Dependency,
+		arg: Arg,
 	) -> tg::Result<tg::package::outdated::Output> {
 		let method = http::Method::POST;
 		let dependency = dependency.to_string();
 		let dependency = urlencoding::encode(&dependency);
-		let uri = format!("/packages/{dependency}/outdated");
+		let query = serde_urlencoded::to_string(&arg).unwrap();
+		let uri = format!("/packages/{dependency}/outdated?{query}");
 		let request = http::request::Builder::default()
 			.method(method)
 			.uri(uri)

--- a/packages/client/src/package/outdated.rs
+++ b/packages/client/src/package/outdated.rs
@@ -34,7 +34,7 @@ impl tg::Client {
 		dependency: &tg::Dependency,
 		arg: Arg,
 	) -> tg::Result<tg::package::outdated::Output> {
-		let method = http::Method::POST;
+		let method = http::Method::GET;
 		let dependency = dependency.to_string();
 		let dependency = urlencoding::encode(&dependency);
 		let query = serde_urlencoded::to_string(&arg).unwrap();

--- a/packages/server/src/compiler/resolve.rs
+++ b/packages/server/src/compiler/resolve.rs
@@ -114,7 +114,8 @@ impl Compiler {
 				}
 
 				// Get the package and lock for the dependency.
-				let (package, lock) = tg::package::get_with_lock(&self.server, &dependency).await?;
+				let (package, lock) =
+					tg::package::get_with_lock(&self.server, &dependency, false).await?;
 
 				// Create a module for the package.
 				self.module_for_package_with_kind(package, lock, import.kind)

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -952,15 +952,17 @@ impl tg::Handle for Server {
 	fn check_package(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::check::Arg,
 	) -> impl Future<Output = tg::Result<Vec<tg::Diagnostic>>> {
-		self.check_package(dependency)
+		self.check_package(dependency, arg)
 	}
 
 	fn try_get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::doc::Arg,
 	) -> impl Future<Output = tg::Result<Option<serde_json::Value>>> {
-		self.try_get_package_doc(dependency)
+		self.try_get_package_doc(dependency, arg)
 	}
 
 	fn format_package(&self, dependency: &tg::Dependency) -> impl Future<Output = tg::Result<()>> {
@@ -970,8 +972,9 @@ impl tg::Handle for Server {
 	fn get_package_outdated(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::outdated::Arg,
 	) -> impl Future<Output = tg::Result<tg::package::outdated::Output>> {
-		self.get_package_outdated(dependency)
+		self.get_package_outdated(dependency, arg)
 	}
 
 	fn publish_package(&self, id: &tg::artifact::Id) -> impl Future<Output = tg::Result<()>> {

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -651,7 +651,7 @@ impl Server {
 			(http::Method::GET, ["packages", dependency]) => {
 				Self::handle_get_package_request(handle, request, dependency).boxed()
 			},
-			(http::Method::POST, ["packages", dependency, "check"]) => {
+			(http::Method::GET, ["packages", dependency, "check"]) => {
 				Self::handle_check_package_request(handle, request, dependency).boxed()
 			},
 			(http::Method::GET, ["packages", dependency, "doc"]) => {
@@ -663,7 +663,7 @@ impl Server {
 			(http::Method::POST, ["packages", dependency, "format"]) => {
 				Self::handle_format_package_request(handle, request, dependency).boxed()
 			},
-			(http::Method::POST, ["packages", dependency, "outdated"]) => {
+			(http::Method::GET, ["packages", dependency, "outdated"]) => {
 				Self::handle_outdated_package_request(handle, request, dependency).boxed()
 			},
 			(http::Method::POST, ["packages", id, "publish"]) => {

--- a/packages/server/src/package/check.rs
+++ b/packages/server/src/package/check.rs
@@ -1,14 +1,17 @@
 use crate::Server;
 use tangram_client as tg;
-use tangram_http::{outgoing::response::Ext as _, Incoming, Outgoing};
+use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
 
 impl Server {
 	pub async fn check_package(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::check::Arg,
 	) -> tg::Result<Vec<tg::Diagnostic>> {
 		// Get the package.
-		let (package, lock) = tg::package::get_with_lock(self, dependency).await?;
+		let (package, lock) = tg::package::get_with_lock(self, dependency, arg.locked)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get the package and lock"))?;
 
 		// Create the root module.
 		let module = tg::Module::with_package_and_lock(self, &package, &lock).await?;
@@ -26,7 +29,7 @@ impl Server {
 impl Server {
 	pub(crate) async fn handle_check_package_request<H>(
 		handle: &H,
-		_request: http::Request<Incoming>,
+		request: http::Request<Incoming>,
 		dependency: &str,
 	) -> tg::Result<http::Response<Outgoing>>
 	where
@@ -38,7 +41,8 @@ impl Server {
 		let Ok(dependency) = dependency.parse() else {
 			return Ok(http::Response::builder().bad_request().empty().unwrap());
 		};
-		let output = handle.check_package(&dependency).await?;
+		let arg = request.query_params().transpose()?.unwrap_or_default();
+		let output = handle.check_package(&dependency, arg).await?;
 		let response = http::Response::builder().json(output).unwrap();
 		Ok(response)
 	}

--- a/packages/server/src/package/doc.rs
+++ b/packages/server/src/package/doc.rs
@@ -1,14 +1,17 @@
 use crate::Server;
 use tangram_client as tg;
-use tangram_http::{outgoing::response::Ext as _, Incoming, Outgoing};
+use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
 
 impl Server {
 	pub async fn try_get_package_doc(
 		&self,
 		dependency: &tg::Dependency,
+		arg: tg::package::doc::Arg,
 	) -> tg::Result<Option<serde_json::Value>> {
 		// Get the package.
-		let Some((package, lock)) = tg::package::try_get_with_lock(self, dependency).await? else {
+		let Some((package, lock)) =
+			tg::package::try_get_with_lock(self, dependency, arg.locked).await?
+		else {
 			return Ok(None);
 		};
 
@@ -28,7 +31,7 @@ impl Server {
 impl Server {
 	pub(crate) async fn handle_get_package_doc_request<H>(
 		handle: &H,
-		_request: http::Request<Incoming>,
+		request: http::Request<Incoming>,
 		dependency: &str,
 	) -> tg::Result<http::Response<Outgoing>>
 	where
@@ -40,9 +43,10 @@ impl Server {
 		let Ok(dependency) = dependency.parse() else {
 			return Ok(http::Response::builder().bad_request().empty().unwrap());
 		};
+		let arg = request.query_params().transpose()?.unwrap_or_default();
 
 		// Get the doc.
-		let Some(output) = handle.try_get_package_doc(&dependency).await? else {
+		let Some(output) = handle.try_get_package_doc(&dependency, arg).await? else {
 			return Ok(http::Response::builder().not_found().empty().unwrap());
 		};
 

--- a/packages/server/src/package/get.rs
+++ b/packages/server/src/package/get.rs
@@ -29,7 +29,7 @@ impl Server {
 		let lock = if arg.lock {
 			let path = dependency.path.as_ref();
 			let lock = self
-				.get_or_create_package_lock(path, &analysis)
+				.get_or_create_package_lock(path, &analysis, arg.locked)
 				.await
 				.map_err(|error| {
 					if let Some(path) = path {

--- a/packages/server/src/package/lock.rs
+++ b/packages/server/src/package/lock.rs
@@ -102,6 +102,7 @@ impl Server {
 		&self,
 		path: Option<&tg::Path>,
 		analysis: &Analysis,
+		locked: bool,
 	) -> tg::Result<tg::Lock> {
 		// If this is a path dependency, then attempt to read the lock from the lockfile.
 		let lock = if let Some(path) = path {
@@ -135,6 +136,11 @@ impl Server {
 			}
 			Some(lock)
 		};
+
+		// Avoid creating a lock file if the caller requested it.
+		if locked {
+			return lock.ok_or_else(|| tg::error!("missing lock file"));
+		}
 
 		// Otherwise, create the lock.
 		let mut created = false;

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -259,13 +259,18 @@ impl tg::Handle for Proxy {
 		Err(tg::error!("forbidden"))
 	}
 
-	async fn check_package(&self, _dependency: &tg::Dependency) -> tg::Result<Vec<tg::Diagnostic>> {
+	async fn check_package(
+		&self,
+		_dependency: &tg::Dependency,
+		_arg: tg::package::check::Arg,
+	) -> tg::Result<Vec<tg::Diagnostic>> {
 		Err(tg::error!("forbidden"))
 	}
 
 	async fn try_get_package_doc(
 		&self,
 		_dependency: &tg::Dependency,
+		_arg: tg::package::doc::Arg,
 	) -> tg::Result<Option<serde_json::Value>> {
 		Err(tg::error!("forbidden"))
 	}
@@ -277,6 +282,7 @@ impl tg::Handle for Proxy {
 	async fn get_package_outdated(
 		&self,
 		_dependency: &tg::Dependency,
+		_arg: tg::package::outdated::Arg,
 	) -> tg::Result<tg::package::outdated::Output> {
 		Err(tg::error!("forbidden"))
 	}


### PR DESCRIPTION
- Add `locked: bool` field to args for `tg package get`, `tg package tree`, `tg package outdated`, `tg package check`, `tg package publish`
- Add `Arg` type to client methods that require it.
- Implement `--locked` for `tg target build`.
- Add `locked` argument to `tg::package::get_with_lock`. 

