### PR TITLE
Add priority to database connection pooling

### DIFF
--- a/packages/database/src/either.rs
+++ b/packages/database/src/either.rs
@@ -1,4 +1,4 @@
-use crate::{Connection, Database, Query, Row, Transaction, Value};
+use crate::{Connection, Database, Priority, Query, Row, Transaction, Value};
 use either::Either;
 use futures::{
 	Future, FutureExt as _, Stream, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
@@ -29,15 +29,15 @@ where
 
 	type T = Either<L::T, R::T>;
 
-	fn connection(&self) -> impl Future<Output = Result<Self::T, Self::Error>> {
+	fn connection(&self, priority: Priority) -> impl Future<Output = Result<Self::T, Self::Error>> {
 		match self {
 			Either::Left(left) => left
-				.connection()
+				.connection(priority)
 				.map_ok(Either::Left)
 				.map_err(|error| Error::Either(Either::Left(error)))
 				.left_future(),
 			Either::Right(right) => right
-				.connection()
+				.connection(priority)
 				.map_ok(Either::Right)
 				.map_err(|error| Error::Either(Either::Right(error)))
 				.right_future(),

--- a/packages/database/src/lib.rs
+++ b/packages/database/src/lib.rs
@@ -5,6 +5,7 @@ use itertools::Itertools as _;
 use std::pin::pin;
 
 pub use self::{row::Row, value::Value};
+pub use pool::Priority;
 
 pub mod either;
 pub mod pool;
@@ -26,7 +27,10 @@ pub trait Database {
 
 	type T;
 
-	fn connection(&self) -> impl Future<Output = Result<Self::T, Self::Error>> + Send;
+	fn connection(
+		&self,
+		priority: Priority,
+	) -> impl Future<Output = Result<Self::T, Self::Error>> + Send;
 }
 
 pub trait Connection {

--- a/packages/database/src/pool.rs
+++ b/packages/database/src/pool.rs
@@ -1,30 +1,63 @@
+use std::{collections::BinaryHeap, sync::Arc};
+
 pub struct Pool<T> {
+	pending: Arc<std::sync::Mutex<BinaryHeap<Pending<T>>>>,
 	sender: async_channel::Sender<T>,
 	receiver: async_channel::Receiver<T>,
+}
+
+struct Pending<T> {
+	priority: Priority,
+	send: tokio::sync::oneshot::Sender<T>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Priority {
+	Low,
+	High,
 }
 
 pub struct Guard<T> {
 	value: Option<T>,
 	sender: async_channel::Sender<T>,
+	pending: Arc<std::sync::Mutex<BinaryHeap<Pending<T>>>>,
 }
 
 impl<T> Pool<T> {
 	#[must_use]
 	pub fn new() -> Self {
+		let pending = Arc::new(std::sync::Mutex::new(BinaryHeap::new()));
 		let (sender, receiver) = async_channel::unbounded();
-		Self { sender, receiver }
+		Self {
+			pending,
+			sender,
+			receiver,
+		}
 	}
 
 	pub fn add(&self, value: T) {
 		self.sender.try_send(value).unwrap();
 	}
 
-	pub async fn get(&self) -> Guard<T> {
-		let value = self.receiver.recv().await.unwrap();
-		let sender = self.sender.clone();
+	pub async fn get(&self, priority: Priority) -> Guard<T> {
+		// First, try and receive from the channel.
+		if let Ok(value) = self.receiver.try_recv() {
+			return Guard {
+				value: Some(value),
+				sender: self.sender.clone(),
+				pending: self.pending.clone(),
+			};
+		}
+
+		// Otherwise create a pending object with priority.
+		let (send, recv) = tokio::sync::oneshot::channel();
+		let pending = Pending { priority, send };
+		self.pending.lock().unwrap().push(pending);
+		let value = recv.await.unwrap();
 		Guard {
 			value: Some(value),
-			sender,
+			sender: self.sender.clone(),
+			pending: self.pending.clone(),
 		}
 	}
 }
@@ -64,6 +97,32 @@ impl<T> AsMut<T> for Guard<T> {
 impl<T> Drop for Guard<T> {
 	fn drop(&mut self) {
 		let value = self.value.take().unwrap();
-		self.sender.try_send(value).ok();
+		if let Some(pending) = self.pending.lock().unwrap().pop() {
+			// First, try and wake the highest priority item.
+			pending.send.send(value).ok();
+		} else {
+			// Otherwise send along the channel.
+			self.sender.try_send(value).ok();
+		}
+	}
+}
+
+impl<T> PartialEq for Pending<T> {
+	fn eq(&self, other: &Self) -> bool {
+		self.priority == other.priority
+	}
+}
+
+impl<T> Eq for Pending<T> {}
+
+impl<T> PartialOrd for Pending<T> {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.priority.cmp(&other.priority))
+	}
+}
+
+impl<T> Ord for Pending<T> {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		self.partial_cmp(other).unwrap()
 	}
 }

--- a/packages/database/src/postgres.rs
+++ b/packages/database/src/postgres.rs
@@ -1,5 +1,5 @@
 use crate::{
-	pool::{self, Pool},
+	pool::{self, Pool, Priority},
 	Row, Value,
 };
 use futures::{future, Future, Stream, TryStreamExt as _};
@@ -110,8 +110,8 @@ impl super::Database for Database {
 
 	type T = pool::Guard<Connection>;
 
-	async fn connection(&self) -> Result<Self::T, Self::Error> {
-		let mut connection = self.pool.get().await;
+	async fn connection(&self, priority: Priority) -> Result<Self::T, Self::Error> {
+		let mut connection = self.pool.get(priority).await;
 		if connection.client.is_closed() {
 			connection.reconnect().await?;
 		}

--- a/packages/database/src/sqlite.rs
+++ b/packages/database/src/sqlite.rs
@@ -1,5 +1,5 @@
 use crate::{
-	pool::{self, Pool},
+	pool::{self, Pool, Priority},
 	Error as _, Row, Value,
 };
 use futures::{stream, Future, Stream};
@@ -225,8 +225,8 @@ impl super::Database for Database {
 
 	type T = pool::Guard<Connection>;
 
-	async fn connection(&self) -> Result<Self::T, Self::Error> {
-		Ok(self.pool.get().await)
+	async fn connection(&self, priority: Priority) -> Result<Self::T, Self::Error> {
+		Ok(self.pool.get(priority).await)
 	}
 }
 

--- a/packages/server/src/artifact/checkin.rs
+++ b/packages/server/src/artifact/checkin.rs
@@ -544,7 +544,7 @@ impl Server {
 		// Get a database connection.
 		let mut connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/blob/create.rs
+++ b/packages/server/src/blob/create.rs
@@ -304,7 +304,7 @@ impl Server {
 		// Get a database connection.
 		let mut connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get database connection"))?;
 

--- a/packages/server/src/build.rs
+++ b/packages/server/src/build.rs
@@ -24,7 +24,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/children.rs
+++ b/packages/server/src/build/children.rs
@@ -182,7 +182,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -216,7 +216,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -302,7 +302,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/dequeue.rs
+++ b/packages/server/src/build/dequeue.rs
@@ -36,7 +36,7 @@ impl Server {
 		while let Some(()) = events.next().await {
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 			let p = connection.p();

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -40,7 +40,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -156,7 +156,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/get.rs
+++ b/packages/server/src/build/get.rs
@@ -28,7 +28,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/heartbeat.rs
+++ b/packages/server/src/build/heartbeat.rs
@@ -29,7 +29,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -87,7 +87,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/index.rs
+++ b/packages/server/src/build/index.rs
@@ -21,7 +21,7 @@ impl Server {
 
 		loop {
 			// Attempt to get a build to index.
-			let connection = match self.database.connection().await {
+			let connection = match self.database.connection(db::Priority::Low).await {
 				Ok(connection) => connection,
 				Err(error) => {
 					tracing::error!(?error, "failed to get a database connection");
@@ -154,7 +154,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -200,7 +200,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -239,7 +239,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -283,10 +283,11 @@ impl Server {
 			// Set the count if possible.
 			if let Some(count) = count {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the count and weight.
 				let p = connection.p();
@@ -323,10 +324,11 @@ impl Server {
 			// Set the logs count if possible.
 			if count.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the logs count.
 				let p = connection.p();
@@ -363,10 +365,11 @@ impl Server {
 			// Set the logs weight if possible.
 			if weight.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the logs weight.
 				let p = connection.p();
@@ -395,7 +398,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -452,7 +455,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -504,10 +507,11 @@ impl Server {
 			// Set the outcomes count if possible.
 			if count.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the outcomes count.
 				let p = connection.p();
@@ -549,10 +553,11 @@ impl Server {
 			// Set the outcomes weight if possible.
 			if weight.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the outcomes weight.
 				let p = connection.p();
@@ -581,7 +586,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -652,7 +657,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -663,7 +668,7 @@ impl Server {
 					select build
 					from build_children
 					left join builds on builds.id = build_children.build
-					where 
+					where
 						build_children.child = {p}1 and
 						builds.status = 'finished' and
 						builds.outcomes_complete = 0;
@@ -699,10 +704,11 @@ impl Server {
 			// Set the targets count if possible.
 			if count.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the targets count.
 				let p = connection.p();
@@ -741,10 +747,11 @@ impl Server {
 			// Set the targets weight if possible.
 			if weight.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the targets weight.
 				let p = connection.p();
@@ -773,7 +780,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -830,7 +837,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -865,7 +872,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -898,7 +905,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -332,7 +332,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -544,7 +544,7 @@ async fn poll_read_inner(
 	// Get a database connection.
 	let connection = server
 		.database
-		.connection()
+		.connection(db::Priority::Low)
 		.await
 		.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -641,7 +641,7 @@ async fn poll_seek_inner(
 	// Get a database connection.
 	let connection = server
 		.database
-		.connection()
+		.connection(db::Priority::Low)
 		.await
 		.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/outcome.rs
+++ b/packages/server/src/build/outcome.rs
@@ -73,7 +73,7 @@ impl Server {
 		// Get the outcome.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 		let p = connection.p();

--- a/packages/server/src/build/put.rs
+++ b/packages/server/src/build/put.rs
@@ -19,7 +19,7 @@ impl Server {
 			// Get a database connection.
 			let mut connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -208,7 +208,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/start.rs
+++ b/packages/server/src/build/start.rs
@@ -33,7 +33,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/status.rs
+++ b/packages/server/src/build/status.rs
@@ -97,7 +97,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/build/touch.rs
+++ b/packages/server/src/build/touch.rs
@@ -26,7 +26,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/clean.rs
+++ b/packages/server/src/clean.rs
@@ -28,7 +28,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/object/get.rs
+++ b/packages/server/src/object/get.rs
@@ -81,7 +81,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 		// Get the object.

--- a/packages/server/src/object/index.rs
+++ b/packages/server/src/object/index.rs
@@ -21,7 +21,7 @@ impl Server {
 
 		loop {
 			// Attempt to get an object to index.
-			let connection = match self.database.connection().await {
+			let connection = match self.database.connection(db::Priority::Low).await {
 				Ok(connection) => connection,
 				Err(error) => {
 					tracing::error!(?error, "failed to get a database connection");
@@ -95,7 +95,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -143,7 +143,7 @@ impl Server {
 			// Get a database connection.
 			let mut connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -216,10 +216,11 @@ impl Server {
 			// Set the count if possible.
 			if count.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the count.
 				let p = connection.p();
@@ -253,10 +254,11 @@ impl Server {
 			// Set the weight if possible.
 			if weight.is_some() {
 				// Get a database connection.
-				let connection =
-					self.database.connection().await.map_err(|source| {
-						tg::error!(!source, "failed to get a database connection")
-					})?;
+				let connection = self
+					.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
 				// Set the weight.
 				let p = connection.p();
@@ -285,7 +287,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -324,7 +326,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -358,7 +360,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -369,7 +371,7 @@ impl Server {
 					select build
 					from build_objects
 					left join builds on builds.id = build_objects.build
-					where 
+					where
 						build_objects.object = {p}1 and
 						builds.status = 'finished' and (
 							(builds.logs_complete = 0 and builds.log = {p}1) or
@@ -396,7 +398,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 
@@ -429,7 +431,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/object/metadata.rs
+++ b/packages/server/src/object/metadata.rs
@@ -80,7 +80,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/object/put.rs
+++ b/packages/server/src/object/put.rs
@@ -15,7 +15,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::High)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/package/get.rs
+++ b/packages/server/src/package/get.rs
@@ -500,7 +500,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/package/list.rs
+++ b/packages/server/src/package/list.rs
@@ -28,7 +28,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/package/publish.rs
+++ b/packages/server/src/package/publish.rs
@@ -62,7 +62,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/package/versions.rs
+++ b/packages/server/src/package/versions.rs
@@ -37,7 +37,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/package/yank.rs
+++ b/packages/server/src/package/yank.rs
@@ -26,7 +26,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/root/delete.rs
+++ b/packages/server/src/root/delete.rs
@@ -9,7 +9,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/root/get.rs
+++ b/packages/server/src/root/get.rs
@@ -9,7 +9,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/root/list.rs
+++ b/packages/server/src/root/list.rs
@@ -12,7 +12,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/root/put.rs
+++ b/packages/server/src/root/put.rs
@@ -9,7 +9,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/target/build.rs
+++ b/packages/server/src/target/build.rs
@@ -35,7 +35,7 @@ impl Server {
 			// Get a database connection.
 			let connection = self
 				.database
-				.connection()
+				.connection(db::Priority::Low)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/user.rs
+++ b/packages/server/src/user.rs
@@ -9,7 +9,7 @@ impl Server {
 		// Get a database connection.
 		let connection = self
 			.database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 

--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -72,10 +72,14 @@ impl vfs::Provider for Provider {
 		}
 
 		// First, try to look up in the database.
-		let connection = self.database.connection().await.map_err(|error| {
-			tracing::error!(%error, "failed to get database a connection");
-			std::io::Error::from_raw_os_error(libc::EIO)
-		})?;
+		let connection = self
+			.database
+			.connection(db::Priority::Low)
+			.await
+			.map_err(|error| {
+				tracing::error!(%error, "failed to get database a connection");
+				std::io::Error::from_raw_os_error(libc::EIO)
+			})?;
 		#[derive(serde::Deserialize)]
 		struct Row {
 			id: u64,
@@ -146,10 +150,14 @@ impl vfs::Provider for Provider {
 			return Ok(node.parent);
 		}
 
-		let connection = self.database.connection().await.map_err(|error| {
-			tracing::error!(%error, "failed to get database a connection");
-			std::io::Error::from_raw_os_error(libc::EIO)
-		})?;
+		let connection = self
+			.database
+			.connection(db::Priority::Low)
+			.await
+			.map_err(|error| {
+				tracing::error!(%error, "failed to get database a connection");
+				std::io::Error::from_raw_os_error(libc::EIO)
+			})?;
 		#[derive(serde::Deserialize)]
 		struct Row {
 			parent: u64,
@@ -471,7 +479,7 @@ impl Provider {
 			.await
 			.map_err(|source| tg::error!(!source, "failed to create database"))?;
 		let connection = database
-			.connection()
+			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get database connection"))?;
 		connection
@@ -546,10 +554,14 @@ impl Provider {
 		}
 
 		// Get a database connection.
-		let connection = self.database.connection().await.map_err(|error| {
-			tracing::error!(%error, "failed to get a database connection");
-			std::io::Error::from_raw_os_error(libc::EIO)
-		})?;
+		let connection = self
+			.database
+			.connection(db::Priority::Low)
+			.await
+			.map_err(|error| {
+				tracing::error!(%error, "failed to get a database connection");
+				std::io::Error::from_raw_os_error(libc::EIO)
+			})?;
 
 		// Get the node from the database.
 		#[derive(serde::Deserialize)]
@@ -622,10 +634,14 @@ impl Provider {
 
 		// Insert the node.
 		tokio::spawn({
-			let connection = self.database.connection().await.map_err(|error| {
-				tracing::error!(%error, "failed to get database a connection");
-				std::io::Error::from_raw_os_error(libc::EIO)
-			})?;
+			let connection =
+				self.database
+					.connection(db::Priority::Low)
+					.await
+					.map_err(|error| {
+						tracing::error!(%error, "failed to get database a connection");
+						std::io::Error::from_raw_os_error(libc::EIO)
+					})?;
 			let pending_nodes = self.pending_nodes.clone();
 			let name = name.to_owned();
 			async move {
@@ -649,10 +665,14 @@ impl Provider {
 
 	async fn depth(&self, mut node: u64) -> std::io::Result<usize> {
 		// Get a database connection.
-		let mut connection = self.database.connection().await.map_err(|error| {
-			tracing::error!(%error, "failed to create database connection");
-			std::io::Error::from_raw_os_error(libc::EIO)
-		})?;
+		let mut connection =
+			self.database
+				.connection(db::Priority::Low)
+				.await
+				.map_err(|error| {
+					tracing::error!(%error, "failed to create database connection");
+					std::io::Error::from_raw_os_error(libc::EIO)
+				})?;
 
 		// Create a transaction.
 		let transaction = connection.transaction().await.map_err(|error| {


### PR DESCRIPTION
- Add a `priority: db::Priority::Low | High` argument to acquiring database connection for the caller to indicate the priority of acquiring this database connection.
- In practice, this will prioritize object puts over all other database traffic including indexing the objects that were just put.

Just altering the priority of acquiring the database connection for the `insert` into the objects table on object put is enough to notice a significant performance improvement, but it's unclear where else we should be establishing high priority connections. 