### PR TITLE
fix(runtime): handle undefined in applyMutations

### DIFF
--- a/packages/runtime/src/args.ts
+++ b/packages/runtime/src/args.ts
@@ -97,6 +97,9 @@ export namespace Args {
 	): Promise<T> => {
 		return await mutations.reduce(
 			async (object, mutations) => {
+				if (mutations === undefined) {
+					return Promise.resolve({}) as Promise<T>;
+				}
 				for (let [key, mutation] of Object.entries(mutations)) {
 					await mutate(await object, key, mutation);
 				}


### PR DESCRIPTION
This PR correctly clears the object being mutated when encountering an `undefined` entry.