### PR TITLE
fix(server/vfs/provider): assume depth=1 for checked out node

### DIFF
--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -309,16 +309,11 @@ impl vfs::Provider for Provider {
 
 		// Handle the case that it is checked out.
 		if checkout {
-			let mut target = tg::Path::new();
-			let depth = self.depth(id).await?;
-			for _ in 0..depth {
-				target.push(tg::path::Component::Parent);
-			}
 			let id = artifact.unwrap().id(&self.server).await.map_err(|error| {
 				tracing::error!(%error, "failed to get artifact id");
 				std::io::Error::from_raw_os_error(libc::EIO)
 			})?;
-			let target = target
+			let target = tg::Path::from("..")
 				.join("checkouts")
 				.join(id.to_string())
 				.to_string()


### PR DESCRIPTION
This PR removes the `depth()` call in `Provider::readlink()` when it is known to always be 1.