### PR TITLE
feat(server/build.rs): allow providing runtime components via env var

### DIFF
--- a/tangram.lock
+++ b/tangram.lock
@@ -9,7 +9,6 @@
           "path": "../std"
         },
         {
-          "artifact": "dir_014fncnxyyac4pvpxj9scc89zjqvs1sekm3sc0hezx23g5r6w2ketg",
           "lock": 0
         }
       ]
@@ -21,7 +20,6 @@
           "path": "../m4"
         },
         {
-          "artifact": "dir_01jj06sqdw7am9e65pg7k3gwfgpydvcpfqdwjacj4nyya31va32w30",
           "lock": 1
         }
       ],
@@ -31,7 +29,6 @@
           "path": "../std"
         },
         {
-          "artifact": "dir_014fncnxyyac4pvpxj9scc89zjqvs1sekm3sc0hezx23g5r6w2ketg",
           "lock": 0
         }
       ]
@@ -43,7 +40,6 @@
           "path": "../bison"
         },
         {
-          "artifact": "dir_01emecd6zcsz65yty69yg1541tdffqs73q03rv4p84xe1nhhk36jmg",
           "lock": 2
         }
       ],
@@ -53,7 +49,6 @@
           "path": "../libffi"
         },
         {
-          "artifact": "dir_0102cgckbhccawtk0xgn1qj2wgfk8apek51k6x5wpev92t8wt8wxxg",
           "lock": 1
         }
       ],
@@ -63,7 +58,6 @@
           "path": "../m4"
         },
         {
-          "artifact": "dir_01jj06sqdw7am9e65pg7k3gwfgpydvcpfqdwjacj4nyya31va32w30",
           "lock": 1
         }
       ],
@@ -73,7 +67,6 @@
           "path": "../std"
         },
         {
-          "artifact": "dir_014fncnxyyac4pvpxj9scc89zjqvs1sekm3sc0hezx23g5r6w2ketg",
           "lock": 0
         }
       ],
@@ -83,7 +76,6 @@
           "path": "../zlib"
         },
         {
-          "artifact": "dir_01shsba998f2z1sek88b7q7ak52xp4h12ft9k3n9mt56p05n28epk0",
           "lock": 1
         }
       ]
@@ -95,7 +87,6 @@
           "path": "../perl"
         },
         {
-          "artifact": "dir_019j4a5s9y8686j2ejgpj80avw55414ww98rt51ey22mq04gdcmms0",
           "lock": 3
         }
       ],
@@ -105,7 +96,6 @@
           "path": "../std"
         },
         {
-          "artifact": "dir_014fncnxyyac4pvpxj9scc89zjqvs1sekm3sc0hezx23g5r6w2ketg",
           "lock": 0
         }
       ]
@@ -117,7 +107,6 @@
           "path": "../openssl"
         },
         {
-          "artifact": "dir_013fqbn16d4rp7rbn2jvk500htvayp93k72axkzrvtr9gbxw8m29hg",
           "lock": 4
         }
       ],
@@ -127,7 +116,6 @@
           "path": "../std"
         },
         {
-          "artifact": "dir_014fncnxyyac4pvpxj9scc89zjqvs1sekm3sc0hezx23g5r6w2ketg",
           "lock": 0
         }
       ],
@@ -137,7 +125,6 @@
           "path": "../zlib"
         },
         {
-          "artifact": "dir_01shsba998f2z1sek88b7q7ak52xp4h12ft9k3n9mt56p05n28epk0",
           "lock": 1
         }
       ]
@@ -145,19 +132,28 @@
     [
       [
         {
-          "name": "rust"
+          "name": "bun",
+          "path": "../packages/packages/bun"
         },
         {
-          "artifact": "dir_01cfrwg68jea8n4vfmv5twpfhqpzbtx3xn5910839jngn7eh7t5vh0",
+          "lock": 1
+        }
+      ],
+      [
+        {
+          "name": "rust",
+          "path": "../packages/packages/rust"
+        },
+        {
           "lock": 5
         }
       ],
       [
         {
-          "name": "std"
+          "name": "std",
+          "path": "../packages/packages/std"
         },
         {
-          "artifact": "dir_014fncnxyyac4pvpxj9scc89zjqvs1sekm3sc0hezx23g5r6w2ketg",
           "lock": 0
         }
       ]


### PR DESCRIPTION
This PR updates the `tangram_server` build script to allow providing the archives containing the Linux runtime component pieces via environment variable instead of downloading directly. This allows the `tangram.ts` to build Tangram in a build process with no internet access.

It additionally imports `bun` from a package instead of defining the build locally.