### PR TITLE
fix: build cancellation

### DIFF
--- a/packages/client/src/build/get.rs
+++ b/packages/client/src/build/get.rs
@@ -33,6 +33,9 @@ pub struct Output {
 
 	pub retry: tg::build::Retry,
 
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub started_parent_count: Option<u64>,
+
 	pub status: tg::build::Status,
 
 	pub target: tg::target::Id,

--- a/packages/server/src/build/children.rs
+++ b/packages/server/src/build/children.rs
@@ -117,7 +117,7 @@ impl Server {
 		loop {
 			// Get the build's status.
 			let status = self
-				.try_get_build_status_local(id)
+				.try_get_current_build_status_local(id)
 				.await?
 				.ok_or_else(|| tg::error!(%build = id, "build does not exist"))?;
 

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -38,7 +38,7 @@ impl Server {
 
 		// If the build is finished, then return.
 		let status = self
-			.try_get_build_status_local(id)
+			.try_get_current_build_status_local(id)
 			.await?
 			.ok_or_else(|| tg::error!(%build = id, "build does not exist"))?;
 
@@ -124,7 +124,7 @@ impl Server {
 			.map(|child_id| async move {
 				// Check if the child is finished before awaiting its outcome.
 				let Some(tg::build::Status::Finished) =
-					self.try_get_build_status_local(child_id).await?
+					self.try_get_current_build_status_local(child_id).await?
 				else {
 					return Ok(None);
 				};

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -39,7 +39,7 @@ impl Server {
 
 		// If the build is finished, then return.
 		let status = self
-			.try_get_build_status_local(id)
+			.try_get_build_status_local_stream(id)
 			.await?
 			.ok_or_else(|| tg::error!("expected the build to exist"))?;
 		let status = pin!(status)
@@ -59,6 +59,36 @@ impl Server {
 			.connection(db::Priority::Low)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
+
+		// Decrement the reference count if the build is started.
+		if matches!(
+			status,
+			tg::build::status::Event::Status(tg::build::Status::Started)
+		) {
+			#[derive(serde::Deserialize)]
+			struct Row {
+				started_parent_count: u64,
+			}
+			let p = connection.p();
+			let statement = formatdoc!(
+				"
+					update builds
+					set started_parent_count = started_parent_count - 1
+					where id = {p}1 and started_parent_count > 0
+					returning started_parent_count;
+				"
+			);
+			let params = db::params![id];
+			let row = connection
+				.query_one_into::<Row>(statement, params)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
+
+			// Do nothing if the reference count is nonzero.
+			if row.started_parent_count > 0 {
+				return Ok(());
+			}
+		}
 
 		// Get the children.
 		let p = connection.p();
@@ -102,19 +132,27 @@ impl Server {
 		let outcomes = children
 			.iter()
 			.map(|child_id| async move {
+				// Check if the child is finished before awaiting its outcome.
+				let Some(tg::build::Status::Finished) = self.try_get_build_status_local(child_id).await? else {
+					return Ok(None)
+				};
+
+				// Get the outcome.
 				let outcome = self
 					.try_get_build_outcome_future(child_id)
 					.await?
 					.ok_or_else(|| tg::error!(%child_id, "failed to get the build"))?
 					.await?
-					.ok_or_else(|| tg::error!(%child_id, "expected the build to be finished"))?;
-				Ok::<_, tg::Error>(outcome)
+					.ok_or_else(|| tg::error!(%child_id, "expected an outcome"))?;
+				Ok::<_, tg::Error>(Some(outcome))
 			})
 			.collect::<FuturesUnordered<_>>()
 			.try_collect::<Vec<_>>()
 			.await?;
+
 		if outcomes
 			.iter()
+			.filter_map(Option::as_ref)
 			.any(|outcome| outcome.try_unwrap_canceled_ref().is_ok())
 		{
 			outcome = tg::build::outcome::Data::Canceled;
@@ -240,6 +278,7 @@ impl Server {
 					heartbeat_at = null,
 					log = {p}1,
 					outcome = {p}2,
+					started_parent_count = null,
 					status = {p}3,
 					finished_at = {p}4
 				where id = {p}5;

--- a/packages/server/src/build/get.rs
+++ b/packages/server/src/build/get.rs
@@ -48,6 +48,7 @@ impl Server {
 					outcomes_count,
 					outcomes_weight,
 					retry,
+					started_parent_count,
 					status,
 					target,
 					targets_complete,

--- a/packages/server/src/build/heartbeat.rs
+++ b/packages/server/src/build/heartbeat.rs
@@ -54,7 +54,7 @@ impl Server {
 			.query_one_value_into(statement, params)
 			.await
 			.inspect_err(|error| tracing::error!(%error, "failed to perform heartbeat query"))
-			.map_err(|source| tg::error!(!source, "the query failed"))?;
+			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
 		// Drop the database connection.
 		drop(connection);

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -139,15 +139,9 @@ impl Server {
 		loop {
 			// Get the build's status.
 			let status = self
-				.try_get_build_status_local_stream(id)
+				.try_get_build_status_local(id)
 				.await?
-				.unwrap()
-				.boxed()
-				.try_next()
-				.await?
-				.unwrap()
-				.try_unwrap_status()
-				.unwrap();
+				.ok_or_else(|| tg::error!(%build = id, "build does not exist"))?;
 
 			// Send as many data events as possible.
 			loop {

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -139,7 +139,7 @@ impl Server {
 		loop {
 			// Get the build's status.
 			let status = self
-				.try_get_build_status_local(id)
+				.try_get_current_build_status_local(id)
 				.await?
 				.ok_or_else(|| tg::error!(%build = id, "build does not exist"))?;
 
@@ -562,7 +562,7 @@ async fn poll_read_inner(
 	let rows = connection
 		.query_all_into::<Row>(statement, params)
 		.await
-		.map_err(|source| tg::error!(!source, "the query failed"))?;
+		.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
 	// Drop the database connection.
 	drop(connection);

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -139,7 +139,7 @@ impl Server {
 		loop {
 			// Get the build's status.
 			let status = self
-				.try_get_build_status_local(id)
+				.try_get_build_status_local_stream(id)
 				.await?
 				.unwrap()
 				.boxed()

--- a/packages/server/src/build/outcome.rs
+++ b/packages/server/src/build/outcome.rs
@@ -46,7 +46,7 @@ impl Server {
 	) -> tg::Result<Option<tg::build::Outcome>> {
 		// Wait for the build to finish.
 		let status = self
-			.try_get_build_status_local(id)
+			.try_get_build_status_local_stream(id)
 			.await?
 			.ok_or_else(|| tg::error!("expected the build to exist"))?;
 		let finished = status.try_filter_map(|status| {

--- a/packages/server/src/build/start.rs
+++ b/packages/server/src/build/start.rs
@@ -42,7 +42,11 @@ impl Server {
 		let statement = format!(
 			"
 				update builds
-				set status = 'started', started_at = {p}1, heartbeat_at = {p}1
+				set
+					started_parent_count = 1,
+					status = 'started',
+					started_at = {p}1,
+					heartbeat_at = {p}1
 				where id = {p}2 and (status = 'created' or status = 'dequeued')
 				returning 1;
 			"

--- a/packages/server/src/build/start.rs
+++ b/packages/server/src/build/start.rs
@@ -43,10 +43,10 @@ impl Server {
 			"
 				update builds
 				set
-					started_parent_count = 1,
-					status = 'started',
+					heartbeat_at = {p}1,
 					started_at = {p}1,
-					heartbeat_at = {p}1
+					started_parent_count = 1,
+					status = 'started'
 				where id = {p}2 and (status = 'created' or status = 'dequeued')
 				returning 1;
 			"

--- a/packages/server/src/build/status.rs
+++ b/packages/server/src/build/status.rs
@@ -89,7 +89,7 @@ impl Server {
 		Ok(Some(stream))
 	}
 
-	pub(crate) async fn try_get_build_status_local(
+	pub(crate) async fn try_get_current_build_status_local(
 		&self,
 		id: &tg::build::Id,
 	) -> tg::Result<Option<tg::build::Status>> {
@@ -98,8 +98,9 @@ impl Server {
 			return Ok(None);
 		}
 
-		// Get the status.
+		// Get the current status.
 		let status = self.try_get_build_status_local_inner(id).await?;
+
 		Ok(Some(status))
 	}
 

--- a/packages/server/src/build/status.rs
+++ b/packages/server/src/build/status.rs
@@ -89,7 +89,10 @@ impl Server {
 		Ok(Some(stream))
 	}
 
-	pub (crate) async fn try_get_build_status_local(&self, id: &tg::build::Id) -> tg::Result<Option<tg::build::Status>> {
+	pub(crate) async fn try_get_build_status_local(
+		&self,
+		id: &tg::build::Id,
+	) -> tg::Result<Option<tg::build::Status>> {
 		// Verify the build is local.
 		if !self.get_build_exists_local(id).await? {
 			return Ok(None);

--- a/packages/server/src/build/status.rs
+++ b/packages/server/src/build/status.rs
@@ -15,7 +15,7 @@ impl Server {
 		id: &tg::build::Id,
 	) -> tg::Result<Option<impl Stream<Item = tg::Result<tg::build::status::Event>> + Send + 'static>>
 	{
-		if let Some(status) = self.try_get_build_status_local(id).await? {
+		if let Some(status) = self.try_get_build_status_local_stream(id).await? {
 			Ok(Some(status.left_stream()))
 		} else if let Some(status) = self.try_get_build_status_remote(id).await? {
 			let status = status.right_stream();
@@ -25,7 +25,7 @@ impl Server {
 		}
 	}
 
-	pub(crate) async fn try_get_build_status_local(
+	pub(crate) async fn try_get_build_status_local_stream(
 		&self,
 		id: &tg::build::Id,
 	) -> tg::Result<Option<impl Stream<Item = tg::Result<tg::build::status::Event>> + Send + 'static>>
@@ -87,6 +87,17 @@ impl Server {
 			.chain(stream::once(future::ok(tg::build::status::Event::End)));
 
 		Ok(Some(stream))
+	}
+
+	pub (crate) async fn try_get_build_status_local(&self, id: &tg::build::Id) -> tg::Result<Option<tg::build::Status>> {
+		// Verify the build is local.
+		if !self.get_build_exists_local(id).await? {
+			return Ok(None);
+		}
+
+		// Get the status.
+		let status = self.try_get_build_status_local_inner(id).await?;
+		Ok(Some(status))
 	}
 
 	async fn try_get_build_status_local_inner(

--- a/packages/server/src/migrations.rs
+++ b/packages/server/src/migrations.rs
@@ -84,6 +84,7 @@ async fn migration_0000(path: &Path) -> tg::Result<()> {
 				outcomes_count integer,
 				outcomes_weight integer,
 				retry text not null,
+				started_parent_count integer,
 				status text not null,
 				target text not null,
 				targets_complete integer not null default 0,


### PR DESCRIPTION
- Add `started_parent_count` to builds table.
- Use `started_parent_count` as a reference count, and only cancel builds when the count hits zero.
- Rename `try_get_build_status_local` to `try_get_build_status_local_stream`.
- Add new `try_get_build_status_local` for callers that do not want to wait for status changes to check the builds' status.