### PR TITLE
feat(global): fill in Graph.arg/Graph.new

### DIFF
--- a/packages/runtime/src/graph.ts
+++ b/packages/runtime/src/graph.ts
@@ -127,8 +127,24 @@ export class Graph {
 
 				return ret;
 			} else if (nodeArg.kind === "symlink") {
-				// NOTE: There are no indices to update in a symlink.
-				return nodeArg;
+				let ret: Graph.SymlinkNodeArg = {
+					kind: "symlink",
+				};
+
+				// Handle artifact if present.
+				if (nodeArg.artifact !== undefined) {
+					ret.artifact =
+						typeof nodeArg.artifact === "number"
+							? nodeArg.artifact + offset
+							: nodeArg.artifact;
+				}
+
+				// Handle path if present.
+				if (nodeArg.path !== undefined) {
+					ret.path = nodeArg.path;
+				}
+
+				return ret;
 			} else {
 				return tg.unreachable(nodeArg);
 			}
@@ -141,7 +157,7 @@ export class Graph {
 		for (let arg of flattened) {
 			let argNodes = arg instanceof Graph ? await arg.nodes() : arg.nodes || [];
 			let renumberedNodes = argNodes.map((node) => addOffset(node, offset));
-			nodes.push(...renumberedNodes);
+			nodes = nodes.concat(renumberedNodes);
 			offset += renumberedNodes.length;
 		}
 
@@ -217,7 +233,7 @@ export namespace Graph {
 
 	export type SymlinkNodeArg = {
 		kind: "symlink";
-		artifact?: tg.Artifact | undefined;
+		artifact?: number | tg.Artifact | undefined;
 		path?: tg.Path.Arg | undefined;
 	};
 
@@ -244,7 +260,7 @@ export namespace Graph {
 
 	export type SymlinkNode = {
 		kind: "symlink";
-		artifact: tg.Artifact | undefined;
+		artifact: number | tg.Artifact | undefined;
 		path: tg.Path | undefined;
 	};
 

--- a/packages/runtime/src/graph.ts
+++ b/packages/runtime/src/graph.ts
@@ -45,7 +45,7 @@ export class Graph {
 				} else {
 					return tg.unreachable(node);
 				}
-			}),
+			})
 		);
 		return new Graph({ object: { nodes } });
 	}
@@ -66,6 +66,8 @@ export class Graph {
 							for (let name in argNode.entries) {
 								if (typeof argNode.entries[name] === "number") {
 									node.entries[name] = argNode.entries[name] + offset;
+								} else if (tg.Artifact.is(argNode.entries[name])) {
+									node.entries[name] = argNode.entries[name];
 								}
 							}
 						} else {
@@ -79,15 +81,23 @@ export class Graph {
 						contents: argNode.contents,
 					};
 					if ("dependencies" in argNode) {
-						if (
-							argNode.dependencies !== undefined &&
-							!Array.isArray(argNode.dependencies)
-						) {
-							node.dependencies = {};
-							for (let reference in argNode.dependencies) {
-								if (typeof argNode.dependencies[reference] === "number") {
-									node.dependencies[reference] =
-										argNode.dependencies[reference] + offset;
+						if (argNode.dependencies !== undefined) {
+							if (Array.isArray(argNode.dependencies)) {
+								node.dependencies = argNode.dependencies.map((dependency) =>
+									typeof dependency === "number"
+										? dependency + offset
+										: dependency
+								);
+							} else {
+								node.dependencies = {};
+								for (let reference in argNode.dependencies) {
+									if (typeof argNode.dependencies[reference] === "number") {
+										node.dependencies[reference] =
+											argNode.dependencies[reference] + offset;
+									} else if (tg.Object.is(argNode.dependencies[reference])) {
+										node.dependencies[reference] =
+											argNode.dependencies[reference];
+									}
 								}
 							}
 						} else {

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -452,7 +452,7 @@ declare namespace tg {
 
 		type DirectoryNodeArg = {
 			kind: "directory";
-			entries?: { [name: string]: number | tg.Artifact };
+			entries?: { [name: string]: number | tg.Artifact } | undefined;
 		};
 
 		type FileNodeArg = {

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -462,12 +462,12 @@ declare namespace tg {
 				| Array<number | tg.Object>
 				| { [reference: string]: number | tg.Object }
 				| undefined;
-			executable?: boolean;
+			executable?: boolean | undefined;
 		};
 
 		type SymlinkNodeArg = {
 			kind: "symlink";
-			artifact?: tg.Artifact | undefined;
+			artifact?: number | tg.Artifact | undefined;
 			path?: tg.Path.Arg | undefined;
 		};
 
@@ -487,7 +487,7 @@ declare namespace tg {
 
 		type SymlinkNode = {
 			kind: "symlink";
-			artifact: tg.Artifact | undefined;
+			artifact: number | tg.Artifact | undefined;
 			path: tg.Path | undefined;
 		};
 	}


### PR DESCRIPTION
This PR implements the `Graph.arg` and `Graph.new` methods in the `tg` global.