### PR TITLE
fix: fix various bugs in artifact checkin

### DIFF
--- a/packages/client/src/import.rs
+++ b/packages/client/src/import.rs
@@ -39,10 +39,6 @@ impl Import {
 				);
 				let attributes = serde_json::from_value::<tg::reference::Query>(attributes)
 					.map_err(|source| tg::error!(!source, "invalid attributes"))?;
-				let follow = reference
-					.query()
-					.and_then(|query| query.follow)
-					.or(attributes.follow);
 				let name = reference
 					.query()
 					.and_then(|query| query.name.clone())
@@ -60,7 +56,6 @@ impl Import {
 					.and_then(|query| query.remote.clone())
 					.or(attributes.remote);
 				let query = tg::reference::Query {
-					follow,
 					name,
 					overrides,
 					path,

--- a/packages/client/src/reference.rs
+++ b/packages/client/src/reference.rs
@@ -32,9 +32,6 @@ pub enum Path {
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct Query {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub follow: Option<bool>,
-
-	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]

--- a/packages/server/src/artifact/checkin.rs
+++ b/packages/server/src/artifact/checkin.rs
@@ -127,6 +127,7 @@ impl Server {
 			.map_err(
 				|source| tg::error!(!source, %path = arg.path.display(), "failed to collect check-in input"),
 			)?;
+		input::Graph::validate(input.clone()).await?;
 		self.select_lockfiles(input.clone()).await?;
 		progress.finish_input().await;
 
@@ -219,8 +220,9 @@ impl Server {
 			let child_output = output
 				.read()
 				.unwrap()
-				.dependencies
-				.get(&reference)
+				.edges
+				.iter()
+				.find(|edge| edge.reference == reference)
 				.ok_or_else(
 					|| tg::error!(%referrer = path.display(), %reference, "missing output reference"),
 				)?
@@ -257,6 +259,7 @@ impl Server {
 
 		match id {
 			tg::artifact::Id::File(_) => {
+				// If we're storing a file, we can short circuit and read the file data from its xattr directly.
 				let data = self
 					.create_file_data(path.as_ref())
 					.await
@@ -267,6 +270,7 @@ impl Server {
 			},
 
 			tg::artifact::Id::Symlink(_) => {
+				// If we're storing a symlink, we can read its data directly.
 				let data = self
 					.create_symlink_data(path.as_ref())
 					.await
@@ -277,6 +281,7 @@ impl Server {
 			},
 
 			tg::artifact::Id::Directory(_) => {
+				// Otherwise for directories, we need to recurse the object to collect its data.
 				let arg = tg::artifact::checkin::Arg {
 					deterministic: false,
 					destructive: false,

--- a/packages/server/src/artifact/checkin/input.rs
+++ b/packages/server/src/artifact/checkin/input.rs
@@ -6,7 +6,7 @@ use futures::{
 };
 use itertools::Itertools;
 use std::{
-	collections::{BTreeMap, BTreeSet, VecDeque},
+	collections::{BTreeMap, BTreeSet},
 	path::{Path, PathBuf},
 	sync::{Arc, Weak},
 };
@@ -22,7 +22,7 @@ const IGNORE_FILES: [&str; 2] = [".tgignore", ".gitignore"];
 pub struct Graph {
 	pub arg: tg::artifact::checkin::Arg,
 	pub edges: Vec<Edge>,
-	pub is_root: bool,
+	pub root: Option<PathBuf>,
 	pub is_direct_dependency: bool,
 	pub metadata: std::fs::Metadata,
 	pub lockfile: Option<(Arc<tg::Lockfile>, usize)>,
@@ -32,8 +32,6 @@ pub struct Graph {
 #[derive(Clone, Debug)]
 pub struct Edge {
 	pub reference: tg::Reference,
-	pub follow_symlinks: bool,
-	pub unify_tags: bool,
 	pub graph: Option<Node>,
 	pub object: Option<tg::object::Id>,
 	pub tag: Option<tg::Tag>,
@@ -43,19 +41,8 @@ pub type Node = Either<Arc<RwLock<Graph>>, Weak<RwLock<Graph>>>;
 
 struct State {
 	ignore: Ignore,
-	roots: Vec<PathBuf>,
+	roots: BTreeMap<PathBuf, Arc<RwLock<Graph>>>,
 	visited: BTreeMap<PathBuf, Weak<RwLock<Graph>>>,
-}
-
-#[derive(Clone)]
-struct Arg {
-	#[allow(clippy::struct_field_names)]
-	arg: tg::artifact::checkin::Arg,
-	follow_symlinks: bool,
-	is_direct_dependency: bool,
-	parent: Option<Weak<RwLock<Graph>>>,
-	root: usize,
-	unify_tags: bool,
 }
 
 impl Server {
@@ -126,156 +113,223 @@ impl Server {
 
 		let state = RwLock::new(State {
 			ignore,
-			roots: Vec::new(),
+			roots: BTreeMap::new(),
 			visited: BTreeMap::new(),
 		});
-		let arg = Arg {
-			arg,
-			follow_symlinks: false,
-			is_direct_dependency: false,
-			parent: None,
-			root: 0,
-			unify_tags: false,
-		};
+
 		let input = self
-			.collect_input_inner(arg.clone(), &state, progress)
+			.collect_input_inner(None, arg.path.as_ref(), &arg, &state, progress)
 			.await?
 			.unwrap_left();
-		if input.read().await.metadata.is_dir() {
-			self.reparent_file_path_dependencies(input.clone()).await?;
-		}
+
 		Ok(input)
 	}
-
-	#[allow(clippy::too_many_arguments)]
 	async fn collect_input_inner(
 		&self,
-		arg: Arg,
+		referrer: Option<Node>,
+		path: &std::path::Path,
+		arg: &tg::artifact::checkin::Arg,
 		state: &RwLock<State>,
 		progress: &super::ProgressState,
 	) -> tg::Result<Node> {
-		if !arg.arg.path.is_absolute() {
-			return Err(tg::error!(%path = arg.arg.path.display(), "expected an absolute path"));
+		let absolute_path = match &referrer {
+			_ if path.is_absolute() => path.to_owned(),
+			Some(Either::Left(strong)) => strong.read().await.arg.path.join(path),
+			Some(Either::Right(weak)) => weak.upgrade().unwrap().read().await.arg.path.join(path),
+			None => return Err(tg::error!("expeccted a referrer")),
+		};
+		let absolute_path = tokio::fs::canonicalize(&absolute_path).await.map_err(
+			|source| tg::error!(!source, %path = absolute_path.display(), "failed to canonicalize the path"),
+		)?;
+
+		let node = if path.is_absolute() {
+			// If this is an absolute path, create a new node.
+			self.get_or_create_input_node(referrer, &absolute_path, arg, state)
+				.await
+				.map_err(
+					|source| tg::error!(!source, %path = path.display(), "failed to create input node"),
+				)?
+		} else {
+			// Otherwise, create a node for all the paths along the way.
+			let mut node = referrer
+				.ok_or_else(|| tg::error!(%path = path.display(), "expected a referrer"))?;
+
+			// Walk the components of the path.
+			let mut components = path.components().peekable();
+			while let Some(component) = components.next() {
+				let is_end = components.peek().is_none();
+				node = match component {
+					// Ignore "." components.
+					std::path::Component::CurDir => continue,
+
+					// Try and get the parent of the current node.
+					std::path::Component::ParentDir => {
+						let node = match &node {
+							Either::Left(strong) => strong.clone(),
+							Either::Right(weak) => weak.upgrade().unwrap(),
+						};
+
+						if !node.read().await.metadata.is_dir() {
+							return Err(
+								tg::error!(%path = node.read().await.arg.path.display(), "expected a directory"),
+							);
+						}
+
+						let parent = node.read().await.parent.clone().ok_or_else(
+							|| tg::error!(%path = path.display(), "expected a parent node"),
+						)?;
+
+						Either::Right(parent)
+					},
+
+					// If this is the last component, recurse.
+					std::path::Component::Normal(name) if is_end => {
+						if name.to_str().is_none() {
+							return Err(
+								tg::error!(%path = absolute_path.display(), "invalid path"),
+							);
+						}
+						let child = self
+							.get_or_create_input_node(
+								Some(node.clone()),
+								&absolute_path,
+								arg,
+								state,
+							)
+							.await?;
+
+						// Add to the parent.
+						let parent = match &node {
+							Either::Left(strong) => strong.clone(),
+							Either::Right(weak) => weak.upgrade().unwrap(),
+						};
+						let edge = Edge {
+							reference: tg::Reference::with_path(name),
+							graph: Some(child.clone()),
+							object: None,
+							tag: None,
+						};
+						add_edge(parent, edge).await;
+						child
+					},
+
+					// Otherwise get or create intermediate directories.
+					std::path::Component::Normal(name) => {
+						let node = match &node {
+							Either::Left(strong) => strong.clone(),
+							Either::Right(weak) => weak.upgrade().unwrap(),
+						};
+						let name = name
+							.to_str()
+							.ok_or_else(|| tg::error!("invalid directory entry name"))?
+							.to_owned();
+						self.get_or_create_intermediate_input_node(node, name, arg, state)
+							.await?
+					},
+
+					// Error for root/prefix components.
+					_ => {
+						return Err(tg::error!(%path = path.display(), "unexpected path component"))
+					},
+				}
+			}
+
+			node
+		};
+
+		// If the node is a weak reference, don't recurse.
+		let Either::Left(node) = node else {
+			return Ok(node);
+		};
+
+		// Recurse.
+		let edges = self
+			.get_edges(node.clone(), absolute_path.as_ref(), arg, state, progress)
+			.await?;
+		for edge in edges {
+			add_edge(node.clone(), edge).await;
 		}
-		let canonical_path = if arg.follow_symlinks {
-			tokio::fs::canonicalize(&arg.arg.path).await.map_err(
-				|source| tg::error!(!source, %path = arg.arg.path.display(), "failed to canonicalize path"),
-			)?
-		} else {
-			arg.arg.path.normalize()
-		};
-
-		if let Some(visited) = state.read().await.visited.get(&canonical_path).cloned() {
-			return Ok(Either::Right(visited));
-		}
-
-		// Detect if this is a root or not.
-		let is_root = !state.read().await.roots.iter().any(|root| {
-			let diff = canonical_path.diff(root).unwrap();
-			matches!(
-				diff.components().next(),
-				Some(std::path::Component::CurDir | std::path::Component::Normal(_))
-			)
-		});
-
-		// Add to the roots if necessary.
-		let root = if is_root {
-			let mut state_ = state.write().await;
-			let root = state_.roots.len();
-			state_.roots.push(canonical_path.clone());
-			root
-		} else {
-			arg.root
-		};
-
-		// Get the file system metatadata.
-		let permit = self.file_descriptor_semaphore.acquire().await.unwrap();
-		let metadata = if arg.follow_symlinks {
-			tokio::fs::metadata(&arg.arg.path).await.map_err(
-				|source| tg::error!(!source, %path = arg.arg.path.display(), "failed to get file metadata"),
-			)?
-		} else {
-			tokio::fs::symlink_metadata(&arg.arg.path).await.map_err(
-				|source| tg::error!(!source, %path = arg.arg.path.display(), "failed to get file metadata"),
-			)?
-		};
-		drop(permit);
-
-		// Create the input, without its dependencies.
-		let input = Arc::new(RwLock::new(Graph {
-			arg: tg::artifact::checkin::Arg {
-				path: canonical_path.clone(),
-				..arg.arg.clone()
-			},
-			edges: Vec::new(),
-			is_root,
-			is_direct_dependency: arg.is_direct_dependency,
-			lockfile: None,
-			metadata: metadata.clone(),
-			parent: arg.parent.clone(),
-		}));
-
-		// Update state.
-		state
-			.write()
-			.await
-			.visited
-			.insert(canonical_path.clone(), Arc::downgrade(&input));
-
-		// Get the edges.
-		let arg_ = Arg {
-			arg: tg::artifact::checkin::Arg {
-				path: canonical_path,
-				..arg.arg.clone()
-			},
-			parent: Some(Arc::downgrade(&input)),
-			root,
-			..arg.clone()
-		};
-
-		let mut edges = self.get_edges(arg_, state, progress, &metadata).await?;
-		edges.sort_unstable_by_key(|edge| edge.reference.clone());
-
-		input.write().await.edges = edges;
 
 		// Send a new progress report.
 		progress.report_input_progress();
 
-		Ok(Either::Left(input))
+		// Return the node.
+		Ok(Either::Left(node))
 	}
 
+	async fn try_resolve_symlink_node(&self, mut node: Node) -> tg::Result<Option<Node>> {
+		loop {
+			let strong = match &node {
+				Either::Left(strong) => strong.clone(),
+				Either::Right(weak) => weak.upgrade().unwrap(),
+			};
+			let strong_ = strong.read().await;
+			if strong_.metadata.is_symlink() {
+				let Some(next) = strong_.edges.first().and_then(|edge| edge.graph.clone()) else {
+					return Ok(None);
+				};
+				node = next;
+			} else {
+				return Ok(Some(node));
+			}
+		}
+	}
 	async fn get_edges(
 		&self,
-		arg: Arg,
+		referrer: Arc<RwLock<Graph>>,
+		path: &std::path::Path,
+		arg: &tg::artifact::checkin::Arg,
 		state: &RwLock<State>,
 		progress: &super::ProgressState,
-		metadata: &std::fs::Metadata,
 	) -> tg::Result<Vec<Edge>> {
+		let metadata = referrer.read().await.metadata.clone();
 		if metadata.is_dir() {
 			if let Some(root_module_file_name) =
-				tg::package::try_get_root_module_file_name_for_package_path(arg.arg.path.as_ref())
-					.await?
+				tg::package::try_get_root_module_file_name_for_package_path(path).await?
 			{
-				let follow_symlinks = arg.follow_symlinks;
-				let unify_tags = arg.unify_tags;
-				let mut arg = arg.clone();
-				arg.arg.path = arg.arg.path.join(root_module_file_name).normalize();
-				let graph = Box::pin(self.collect_input_inner(arg, state, progress)).await?;
+				let graph = Box::pin(self.collect_input_inner(
+					Some(Either::Left(referrer.clone())),
+					root_module_file_name.as_ref(),
+					arg,
+					state,
+					progress,
+				))
+				.await
+				.map_err(
+					|source| tg::error!(!source, %path = path.display(), "failed to collect package input"),
+				)?;
+
 				let edge = Edge {
 					reference: tg::Reference::with_path(root_module_file_name),
-					follow_symlinks,
-					unify_tags,
 					graph: Some(graph),
 					object: None,
 					tag: None,
 				};
 				return Ok(vec![edge]);
 			}
-			self.get_directory_edges(arg, state, progress).await
+			self.get_directory_edges(referrer, path, arg, state, progress)
+				.await
 		} else if metadata.is_file() {
-			self.get_file_edges(arg, state, progress).await
+			self.get_file_edges(referrer, path, arg, state, progress)
+				.await
 		} else if metadata.is_symlink() {
-			Ok(Vec::new())
+			let target = tokio::fs::read_link(path).await.map_err(
+				|source| tg::error!(!source, %path = path.display(), "failed to read symlink"),
+			)?;
+			let child = Box::pin(self.collect_input_inner(
+				Some(Either::Left(referrer)),
+				&target,
+				arg,
+				state,
+				progress,
+			))
+			.await?;
+			Ok(vec![Edge {
+				reference: tg::Reference::with_path(target),
+				graph: Some(child),
+				object: None,
+				tag: None,
+			}])
 		} else {
 			Err(tg::error!("invalid file type"))
 		}
@@ -283,12 +337,14 @@ impl Server {
 
 	async fn get_directory_edges(
 		&self,
-		arg: Arg,
+		referrer: Arc<RwLock<Graph>>,
+		path: &std::path::Path,
+		arg: &tg::artifact::checkin::Arg,
 		state: &RwLock<State>,
 		progress: &super::ProgressState,
 	) -> tg::Result<Vec<Edge>> {
 		let _permit = self.file_descriptor_semaphore.acquire().await.unwrap();
-		let entries = tokio::fs::read_dir(&arg.arg.path)
+		let entries = tokio::fs::read_dir(&path)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to read directory"))?;
 		let vec: Vec<_> = stream::try_unfold(entries, |mut entries| async {
@@ -306,7 +362,7 @@ impl Server {
 				.to_str()
 				.ok_or_else(|| tg::error!("non-utf8 file name"))?
 				.to_owned();
-			let path = arg.arg.path.clone().join(&name);
+			let path = path.join(&name);
 
 			// Check if we should ignore it.
 			let metadata = entry
@@ -317,7 +373,7 @@ impl Server {
 				.write()
 				.await
 				.ignore
-				.should_ignore(&path, &metadata)
+				.should_ignore(path.as_ref(), &metadata)
 				.await
 				.map_err(|source| {
 					tg::error!(!source, "failed to check if the path should be ignored")
@@ -327,19 +383,23 @@ impl Server {
 
 			// Create edge metadata.
 			let reference = tg::Reference::with_path(&name);
-			let follow_symlinks = arg.follow_symlinks;
-			let unify_tags = arg.unify_tags;
 
 			// Follow the edge.
-			let mut arg = arg.clone();
-			arg.arg.path = path;
-			let graph = Box::pin(self.collect_input_inner(arg, state, progress)).await?;
+			let graph = Box::pin(self.collect_input_inner(
+				Some(Either::Right(Arc::downgrade(&referrer))),
+				name.as_ref(),
+				arg,
+				state,
+				progress,
+			))
+			.await
+			.map_err(
+				|source| tg::error!(!source, %path = path.join(name).display(), "failed to collect child input"),
+			)?;
 
 			// Create the edge.
 			let edge = Edge {
 				reference,
-				follow_symlinks,
-				unify_tags,
 				graph: Some(graph),
 				object: None,
 				tag: None,
@@ -355,11 +415,13 @@ impl Server {
 
 	async fn get_file_edges(
 		&self,
-		arg: Arg,
+		referrer: Arc<RwLock<Graph>>,
+		path: &std::path::Path,
+		arg: &tg::artifact::checkin::Arg,
 		state: &RwLock<State>,
 		progress: &super::ProgressState,
 	) -> tg::Result<Vec<Edge>> {
-		if let Some(data) = xattr::get(&arg.arg.path, tg::file::XATTR_NAME)
+		if let Some(data) = xattr::get(path, tg::file::XATTR_NAME)
 			.map_err(|source| tg::error!(!source, "failed to read file xattr"))?
 		{
 			let xattr = serde_json::from_slice(&data)
@@ -414,23 +476,24 @@ impl Server {
 				.into_iter()
 				.map(|(reference, dependency)| {
 					let arg = arg.clone();
+					let referrer = referrer.clone();
 					async move {
-						let root_path = state.read().await.roots[arg.root].clone();
+						let referrer_ = referrer.read().await;
+						let root_path = referrer_
+							.root
+							.clone()
+							.unwrap_or_else(|| referrer_.arg.path.clone());
 						let id = dependency.object;
 						let path = reference
 							.path()
 							.try_unwrap_path_ref()
 							.ok()
-							.or_else(|| reference.query()?.path.as_ref())
-							.map(|path| arg.arg.path.parent().unwrap().join(path));
-
-						let follow_symlinks =
-							reference.query().and_then(|q| q.follow).unwrap_or(false);
-						let unify_tags = true;
+							.or_else(|| reference.query()?.path.as_ref());
 
 						// Don't follow paths that point outside the root.
 						let is_external_path = path
 							.as_ref()
+							.map(|path| referrer_.arg.path.parent().unwrap().join(path))
 							.and_then(|path| path.diff(&root_path))
 							.map_or(false, |path| {
 								matches!(
@@ -442,19 +505,26 @@ impl Server {
 						let graph = if is_external_path {
 							None
 						} else if let Some(path) = path {
-							// Follow the path.
-							let mut arg_ = arg.arg.clone();
-							arg_.path = path;
-							let arg = Arg {
-								arg: arg_,
-								follow_symlinks,
-								unify_tags,
-								is_direct_dependency: true,
-								..arg.clone()
-							};
+							// Get the parent of the referrer.
+							let parent = referrer_
+								.parent
+								.as_ref()
+								.ok_or_else(|| tg::error!("expected a parent"))?
+								.clone();
 
-							let graph =
-								Box::pin(self.collect_input_inner(arg, state, progress)).await?;
+							// Recurse.
+							let graph = self
+								.collect_input_inner(
+									Some(Either::Right(parent)),
+									path,
+									&arg,
+									state,
+									progress,
+								)
+								.await
+								.map_err(|source| {
+									tg::error!(!source, "failed to collect child input")
+								})?;
 
 							Some(graph)
 						} else {
@@ -462,8 +532,6 @@ impl Server {
 						};
 						let edge = Edge {
 							reference,
-							follow_symlinks,
-							unify_tags,
 							graph,
 							object: Some(id),
 							tag: dependency.tag,
@@ -479,8 +547,10 @@ impl Server {
 			return Ok(edges);
 		}
 
-		if tg::package::is_module_path(arg.arg.path.as_ref()) {
-			return self.get_module_edges(arg, state, progress).await;
+		if tg::package::is_module_path(path) {
+			return self
+				.get_module_edges(referrer, path, arg, state, progress)
+				.await;
 		}
 
 		Ok(Vec::new())
@@ -488,78 +558,73 @@ impl Server {
 
 	async fn get_module_edges(
 		&self,
-		arg: Arg,
+		referrer: Arc<RwLock<Graph>>,
+		path: &std::path::Path,
+		arg: &tg::artifact::checkin::Arg,
 		state: &RwLock<State>,
 		progress: &super::ProgressState,
 	) -> tg::Result<Vec<Edge>> {
 		let permit = self.file_descriptor_semaphore.acquire().await.unwrap();
-		let text = tokio::fs::read_to_string(&arg.arg.path)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to read file contents"))?;
+		let text = tokio::fs::read_to_string(path).await.map_err(
+			|source| tg::error!(!source, %path = path.display(), "failed to read file contents"),
+		)?;
 		drop(permit);
-		let analysis = crate::compiler::Compiler::analyze_module(text)
-			.map_err(|source| tg::error!(!source, "failed to analyze module"))?;
+		let analysis = crate::compiler::Compiler::analyze_module(text).map_err(
+			|source| tg::error!(!source, %path = path.display(), "failed to analyze module"),
+		)?;
 
 		let edges = analysis
 			.imports
 			.into_iter()
 			.map(|import| {
 				let arg = arg.clone();
+				let referrer = referrer.clone();
+
 				async move {
-					let follow_symlinks = import
-						.reference
-						.query()
-						.and_then(|query| query.follow)
-						.unwrap_or(true);
-
-					let unify_tags = true;
-
 					// Follow path dependencies.
-					let path = import
+					let import_path = import
 						.reference
 						.path()
 						.try_unwrap_path_ref()
 						.ok()
 						.or_else(|| import.reference.query()?.path.as_ref());
-					if let Some(path) = path {
+					if let Some(import_path) = import_path {
 						// Create the reference.
 						let reference = import.reference.clone();
 
-						// Create the path.
-						let path = arg.arg.path.parent().unwrap().to_owned().join(path);
-
 						// Check if the import points outside the package.
-						let root_path = state.read().await.roots[arg.root].clone();
-						if path.diff(&root_path).map_or(false, |path| {
-							matches!(
-								path.components().next(),
-								Some(std::path::Component::ParentDir)
-							)
-						}) && tg::package::is_module_path(path.as_ref())
-						{
+						let root_path = {
+							let referrer = referrer.read().await;
+							referrer.root.clone().unwrap_or_else(|| referrer.arg.path.clone())
+						};
+
+						let absolute_path = path.parent().unwrap().join(import_path.strip_prefix("./").unwrap_or(import_path));
+						let is_external = absolute_path.diff(&root_path).map_or(false, |path| path.is_external());
+
+						// If the import is of a module and points outside the root, return an error.
+						if (import_path.is_absolute() ||
+							is_external) && tg::package::is_module_path(import_path.as_ref()) {
 							return Err(
-								tg::error!(%root = root_path.display(), %path = path.display(), "cannot import module outside of the package"),
+								tg::error!(%root = root_path.display(), %path = import_path.display(), "cannot import module outside of the package"),
 							);
 						}
 
-						// Follow the path.
-						let mut arg_ = arg.arg.clone();
-						arg_.path = path;
-						let arg = Arg {
-							arg: arg_,
-							follow_symlinks,
-							unify_tags,
-							is_direct_dependency: true,
-							..arg.clone()
+						let graph = if is_external {
+							// If this is an external import, treat it as a root using the absolute path.
+							self.collect_input_inner(Some(Either::Left(referrer)), &absolute_path, &arg, state, progress).await.map_err(|source| tg::error!(!source, "failed to collect child input"))?
+						} else {
+							// Otherwise, treat it as a relative path.
+
+							// Get the parent of the referrer.
+							let parent = referrer.read().await.parent.as_ref().ok_or_else(|| tg::error!("expected a parent"))?.clone();
+
+							// Recurse.
+							self.collect_input_inner(Some(Either::Right(parent)), import_path.as_ref(), &arg, state, progress).await.map_err(|source| tg::error!(!source, "failed to collect child input"))?
 						};
-						let graph =
-							Box::pin(self.collect_input_inner(arg, state, progress)).await?;
 
 						// Create the edge.
 						let edge = Edge {
 							reference,
-							follow_symlinks,
-							unify_tags,
 							graph: Some(graph),
 							object: None,
 							tag: None,
@@ -570,8 +635,6 @@ impl Server {
 
 					Ok(Edge {
 						reference: import.reference,
-						follow_symlinks,
-						unify_tags,
 						graph: None,
 						object: None,
 						tag: None,
@@ -585,171 +648,183 @@ impl Server {
 		Ok(edges)
 	}
 
-	async fn reparent_file_path_dependencies(&self, input: Arc<RwLock<Graph>>) -> tg::Result<()> {
-		let mut visited = BTreeSet::new();
-		let mut queue: VecDeque<_> = vec![input].into();
+	async fn get_or_create_input_node(
+		&self,
+		referrer: Option<Node>,
+		path: &std::path::Path,
+		arg: &tg::artifact::checkin::Arg,
+		state: &RwLock<State>,
+	) -> tg::Result<Node> {
+		let mut state = state.write().await;
 
-		// We explicitly use breadth-first traversal here as a heuristic, to ensure that most nodes' parents are already reparented.
-		while let Some(input) = queue.pop_front() {
-			// Check if we've visited this node.
-			let absolute_path = input.read().await.arg.path.clone();
-			if visited.contains(&absolute_path) {
-				continue;
-			}
-			visited.insert(absolute_path.clone());
-
-			// Get the dependencies.
-			let edges = input.read().await.edges.clone();
-
-			// If this input is a file, reparent its children.
-			if input.read().await.metadata.is_file() {
-				let dependencies = edges.iter().filter_map(|edge| {
-					let child = edge.node()?;
-					edge.reference
-						.path()
-						.try_unwrap_path_ref()
-						.ok()
-						.or_else(|| edge.reference.query()?.path.as_ref())
-						.map(|_| child)
-				});
-				for child in dependencies {
-					self.reparent_file_path_dependency(child).await?;
-				}
-			}
-
-			// Add its children to the stack.
-			let children = edges.into_iter().filter_map(|edge| edge.node());
-			queue.extend(children);
+		// Avoid a subtle race condition by checking if this path has been added yet.
+		if let Some(weak) = state.visited.get(path) {
+			return Ok(Either::Right(weak.clone()));
 		}
-		Ok(())
+
+		// Get the root.
+		let root = state.roots.iter().find_map(|(root, node)| {
+			let diff = path.diff(root);
+			diff.map_or(false, |diff| {
+				matches!(
+					diff.components().next(),
+					Some(std::path::Component::CurDir | std::path::Component::Normal(_))
+				)
+			})
+			.then_some((root.clone(), node.clone()))
+		});
+
+		// This should never happen, but if it does it means the code is incorrect higher up.
+		if let Some((root_path, _node)) = &root {
+			if root_path == path {
+				return Err(tg::error!(%path = path.display(), "multiple instances of a root"));
+			}
+		}
+
+		// If this isn't a root, get the parent.
+		let parent = if root.is_none() {
+			None
+		} else {
+			let referrer = referrer
+				.ok_or_else(|| tg::error!(%path = path.display(), "expected a referrer"))?;
+			let parent = match referrer {
+				Either::Left(strong) => Arc::downgrade(&strong),
+				Either::Right(weak) => weak.clone(),
+			};
+			Some(parent)
+		};
+
+		// Get the file system metadata.
+		let _permit = self.file_descriptor_semaphore.acquire().await.unwrap();
+		let metadata = tokio::fs::symlink_metadata(path).await.map_err(
+			|source| tg::error!(!source, %path = path.display(), "failed to get the file's metadata"),
+		)?;
+
+		// Validate.
+		if !(metadata.is_dir() || metadata.is_file() || metadata.is_symlink()) {
+			return Err(tg::error!(%path = path.display(), "invalid file type"));
+		}
+
+		// Create the node.
+		let path = path.to_owned();
+		let node = Arc::new(RwLock::new(Graph {
+			arg: tg::artifact::checkin::Arg {
+				path: path.clone(),
+				..arg.clone()
+			},
+			edges: Vec::new(),
+			root: root.as_ref().map(|(path, _)| path.clone()),
+			is_direct_dependency: false,
+			metadata,
+			lockfile: None,
+			parent,
+		}));
+
+		// Add to the roots if necessary.
+		if root.is_none() {
+			state.roots.insert(path.clone(), node.clone());
+		}
+
+		// Update the state.
+		state.visited.insert(path, Arc::downgrade(&node));
+
+		Ok(Either::Left(node))
 	}
 
-	async fn reparent_file_path_dependency(&self, child: Arc<RwLock<Graph>>) -> tg::Result<()> {
-		if child.read().await.is_root {
-			return Ok(());
-		}
-		let Some(parent) = child.read().await.parent.as_ref().map(Weak::upgrade) else {
-			return Ok(());
-		};
-		let parent = parent.unwrap();
-
-		// Check if this node has already been reparented.
-		if parent.read().await.metadata.is_dir() {
-			return Ok(());
-		}
-
-		// Reparent the parent. This short circuits if the parent is already re-parented.
-		Box::pin(self.reparent_file_path_dependency(parent.clone())).await?;
-
-		// Otherwise get the grandparent.
-		let grandparent = parent
-			.read()
-			.await
-			.parent
-			.clone()
-			.ok_or_else(|| tg::error!("invalid path"))?
-			.upgrade()
-			.unwrap();
-		if !grandparent.read().await.metadata.is_dir() {
+	async fn get_or_create_intermediate_input_node(
+		&self,
+		referrer: Arc<RwLock<Graph>>,
+		name: String,
+		arg: &tg::artifact::checkin::Arg,
+		state: &RwLock<State>,
+	) -> tg::Result<Node> {
+		if !referrer.read().await.metadata.is_dir() {
 			return Err(
-				tg::error!(%parent = parent.read().await.arg.path.display(), %grandparent = grandparent.read().await.arg.path.display(), "expected a directory"),
+				tg::error!(%path = referrer.read().await.arg.path.display(), "expected a directory"),
 			);
 		}
-		let mut parent = grandparent;
 
-		// Get the path to the child relative to the parent.
-		let diff = child
-			.read()
-			.await
-			.arg
-			.path
-			.diff(&parent.read().await.arg.path)
-			.unwrap();
-		let mut components = diff.components().collect::<VecDeque<_>>();
-
-		// Walk up.
-		while let Some(std::path::Component::ParentDir) = components.front() {
-			components.pop_front();
-			let new_parent = parent
+		let child = 'a: {
+			// Check for an existing child.
+			let reference = tg::Reference::with_path(&name);
+			let child = referrer
 				.read()
 				.await
-				.parent
-				.clone()
-				.ok_or_else(|| tg::error!("invalid path"))?
-				.upgrade()
-				.unwrap();
-			if !new_parent.read().await.metadata.is_dir() {
-				return Err(
-					tg::error!(%path = new_parent.read().await.arg.path.display(), "expected a directory"),
-				);
-			}
-			parent = new_parent;
-		}
+				.edges
+				.iter()
+				.find(|edge| edge.reference == reference)
+				.map(|edge| {
+					edge.graph
+						.clone()
+						.ok_or_else(|| tg::error!("expected a child node"))
+				})
+				.transpose()?;
+			if let Some(child) = child {
+				break 'a child;
+			};
 
-		// Walk down.
-		while let Some(component) = components.pop_front() {
-			match component {
-				std::path::Component::CurDir => (),
-				std::path::Component::Normal(name) if components.is_empty() => {
-					let name = name.to_str().ok_or_else(|| tg::error!("non-utf8 path"))?;
-					let reference = tg::Reference::with_path(name);
-					let edge = Edge {
-						reference,
-						follow_symlinks: true,
-						unify_tags: false,
-						graph: Some(Either::Right(Arc::downgrade(&child))),
-						object: None,
-						tag: None,
-					};
-					parent.write().await.edges.push(edge);
-					child.write().await.parent.replace(Arc::downgrade(&parent));
-					return Ok(());
-				},
-				std::path::Component::Normal(name) => {
-					let name = name.to_str().ok_or_else(|| tg::error!("non-utf8 path"))?;
-					let reference = tg::Reference::with_path(name);
-					let input = parent
-						.read()
-						.await
-						.edges
-						.iter()
-						.find(|edge| edge.reference == reference)
-						.and_then(Edge::node);
-					if let Some(input) = input {
-						parent = input;
-						continue;
-					}
-					let arg = parent.read().await.arg.clone();
-					let path = arg.path.clone().join(name).normalize();
-					let metadata = tokio::fs::metadata(&path).await.map_err(|source| {
-						tg::error!(!source, "failed to get directory metadata")
-					})?;
-					let arg = tg::artifact::checkin::Arg { path, ..arg };
-					let graph = Arc::new(RwLock::new(Graph {
-						arg,
-						edges: Vec::new(),
-						is_root: false,
-						is_direct_dependency: false,
-						metadata,
-						lockfile: parent.read().await.lockfile.clone(),
-						parent: Some(Arc::downgrade(&parent)),
-					}));
-					let edge = Edge {
-						reference,
-						follow_symlinks: true,
-						unify_tags: false,
-						graph: Some(Either::Left(graph.clone())),
-						object: None,
-						tag: None,
-					};
-					parent.write().await.edges.push(edge);
-					parent = graph;
-				},
-				_ => return Err(tg::error!(%diff = diff.display(), "unexpected path component")),
-			}
-		}
+			// Get the referrer's path and root.
+			let referrer_path = referrer.read().await.arg.path.clone();
+			let referrer_root = referrer.read().await.root.clone();
 
-		Err(tg::error!("failed to reparent orphaned input node"))
+			// Lock the state to avoid TOCTOU races.
+			let mut state = state.write().await;
+
+			// Create the absolute path.
+			let path = referrer_path.join(name);
+
+			// Check if a node has already been created.
+			if let Some(node) = state.visited.get(&path) {
+				break 'a Either::Right(node.clone());
+			}
+
+			// Add the referrer as a root if necessary.
+			if referrer_root.is_none() {
+				state.roots.insert(referrer_path.clone(), referrer.clone());
+			}
+
+			// Get the root path.
+			let root = referrer_root.unwrap_or_else(|| referrer_path.clone());
+
+			// Get the metadata.
+			let metadata = tokio::fs::symlink_metadata(&path).await.map_err(
+				|source| tg::error!(!source, %path = path.display(), "failed to get metadata"),
+			)?;
+
+			// Create the child node.
+			let child = Arc::new(RwLock::new(Graph {
+				arg: tg::artifact::checkin::Arg {
+					path: path.clone(),
+					..arg.clone()
+				},
+				edges: Vec::new(),
+				root: Some(root),
+				is_direct_dependency: false,
+				metadata,
+				lockfile: None,
+				parent: Some(Arc::downgrade(&referrer)),
+			}));
+
+			// Update state.
+			state.visited.insert(path.clone(), Arc::downgrade(&child));
+			drop(state);
+
+			// Update the referrer.
+			let edge = Edge {
+				reference,
+				graph: Some(Either::Left(child.clone())),
+				object: None,
+				tag: None,
+			};
+			add_edge(referrer, edge).await;
+
+			Either::Right(Arc::downgrade(&child))
+		};
+
+		// Resolve any symlinks.
+		self.try_resolve_symlink_node(child)
+			.await?
+			.ok_or_else(|| tg::error!("failed to resolve symlinks"))
 	}
 }
 
@@ -856,4 +931,82 @@ impl Edge {
 			Either::Right(node) => node.upgrade().unwrap(),
 		})
 	}
+}
+
+impl Graph {
+	#[allow(dead_code)]
+	async fn print(self_: Arc<RwLock<Graph>>) {
+		let mut stack = vec![(Either::Left(self_), 0)];
+		while let Some((node, depth)) = stack.pop() {
+			for _ in 0..depth {
+				eprint!("..");
+			}
+			match node {
+				Either::Left(strong) => {
+					let path = strong.read().await.arg.path.clone();
+					eprintln!("strong {path:#?} {:x?}", Arc::as_ptr(&strong));
+					stack.extend(
+						strong
+							.read()
+							.await
+							.edges
+							.iter()
+							.filter_map(|edge| Some((edge.graph.clone()?, depth + 1))),
+					);
+				},
+				Either::Right(weak) => {
+					let path = weak.upgrade().unwrap().read().await.arg.path.clone();
+					eprintln!("weak {path:#?} {:x?}", Weak::as_ptr(&weak));
+				},
+			}
+		}
+	}
+
+	pub(super) async fn validate(this: Arc<RwLock<Graph>>) -> tg::Result<()> {
+		let mut paths = BTreeMap::new();
+		let mut stack = vec![this];
+		while let Some(node) = stack.pop() {
+			let path = node.read().await.arg.path.clone();
+			if paths.contains_key(&path) {
+				continue;
+			}
+			paths.insert(path, node.clone());
+			for edge in &node.read().await.edges {
+				if let Some(child) = &edge.graph {
+					let child = match child {
+						Either::Left(child) => child.clone(),
+						Either::Right(child) => child.upgrade().unwrap(),
+					};
+					stack.push(child);
+				}
+			}
+		}
+
+		for (path, node) in &paths {
+			if node.read().await.root.is_none() {
+				continue;
+			}
+			let parent = path.parent().ok_or_else(
+				|| tg::error!(%path = path.display(), "expected path to have a parent"),
+			)?;
+			let root = node.read().await.root.clone().unwrap();
+			let _parent = paths.get(parent)
+				.ok_or_else(|| tg::error!(%root = root.display(), %path = path.display(), %parent = parent.display(), "missing parent node"))?;
+		}
+
+		Ok(())
+	}
+}
+
+async fn add_edge(node: Arc<RwLock<Graph>>, edge: Edge) {
+	let mut node = node.write().await;
+	for existing_edge in &mut node.edges {
+		if existing_edge.reference == edge.reference {
+			if let Some(Either::Left(strong)) = &edge.graph {
+				existing_edge.graph.replace(Either::Left(strong.clone()));
+			}
+			return;
+		}
+	}
+	node.edges.push(edge);
 }

--- a/packages/server/src/artifact/checkin/lockfile.rs
+++ b/packages/server/src/artifact/checkin/lockfile.rs
@@ -317,7 +317,7 @@ impl Server {
 
 		for child in children {
 			// Skip any paths outside the workspace.
-			if child.read().await.is_root {
+			if child.read().await.root.is_none() {
 				continue;
 			}
 			Box::pin(self.write_lockfiles_inner(child, lockfile, visited)).await?;

--- a/packages/server/src/artifact/checkin/output.rs
+++ b/packages/server/src/artifact/checkin/output.rs
@@ -23,11 +23,16 @@ pub struct Graph {
 	pub data: tg::artifact::Data,
 	pub lock_index: usize,
 	pub weight: usize,
-	pub dependencies: BTreeMap<tg::Reference, Edge>,
+	pub edges: Vec<Edge>,
 }
 
 #[derive(Clone, Debug)]
-pub struct Edge(Either<Arc<RwLock<Graph>>, Weak<RwLock<Graph>>>);
+pub struct Edge {
+	pub reference: tg::Reference,
+	pub graph: Either<Arc<RwLock<Graph>>, Weak<RwLock<Graph>>>,
+}
+
+type Node = Either<Arc<RwLock<Graph>>, Weak<RwLock<Graph>>>;
 
 struct State {
 	root: PathBuf,
@@ -37,6 +42,94 @@ struct State {
 }
 
 impl Server {
+	pub(super) async fn collect_output(
+		&self,
+		input: Arc<tokio::sync::RwLock<input::Graph>>,
+		lockfile: tg::Lockfile,
+		progress: &super::ProgressState,
+	) -> tg::Result<Arc<RwLock<Graph>>> {
+		let root = input.read().await.arg.path.clone();
+		let artifacts = self.create_artifact_data_for_lockfile(&lockfile).await?;
+		let mut state = State {
+			root,
+			artifacts,
+			lockfile,
+			visited: BTreeMap::new(),
+		};
+		let output = self
+			.collect_output_inner(input, &mut state, progress)
+			.await?
+			.unwrap_left();
+		Ok(output)
+	}
+
+	async fn collect_output_inner(
+		&self,
+		input: Arc<tokio::sync::RwLock<input::Graph>>,
+		state: &mut State,
+		progress: &super::ProgressState,
+	) -> tg::Result<Node> {
+		let path = input.read().await.arg.path.clone();
+		let path = path.diff(&state.root).unwrap();
+		if let Some(node) = state.visited.get(&path) {
+			return Ok(Either::Right(node.clone()));
+		}
+
+		// Find the entry in the lockfile.
+		let lock_index = *state
+			.lockfile
+			.paths
+			.get(&path)
+			.and_then(|nodes| nodes.first())
+			.ok_or_else(|| tg::error!(%path = path.display(), "missing path in lockfile"))?;
+
+		// Get the data.
+		let data = state
+			.artifacts
+			.get(&lock_index)
+			.ok_or_else(|| tg::error!("missing artifact data"))?
+			.clone();
+
+		// Compute the ID.
+		let id = data.id()?;
+
+		// Update the total bytes that will be copied.
+		if input.read().await.metadata.is_file() {
+			let size = input.read().await.metadata.size().to_u64().unwrap();
+			progress.update_output_total(size);
+		}
+
+		// Create the output.
+		let output = Arc::new(RwLock::new(Graph {
+			input: input.clone(),
+			id: id.clone(),
+			data,
+			weight: 0,
+			lock_index,
+			edges: Vec::new(),
+		}));
+		state.visited.insert(path.clone(), Arc::downgrade(&output));
+
+		// Recurse.
+		let input_dependencies = input
+			.read()
+			.await
+			.edges
+			.iter()
+			.filter_map(|edge| {
+				let child = edge.node()?;
+				Some((edge.reference.clone(), child))
+			})
+			.collect::<Vec<_>>();
+		for (reference, input) in input_dependencies {
+			let graph = Box::pin(self.collect_output_inner(input, state, progress)).await?;
+			let edge = Edge { reference, graph };
+			add_edge(output.clone(), edge).await;
+		}
+
+		Ok(Either::Left(output))
+	}
+
 	pub async fn compute_count_and_weight(
 		&self,
 		output: Arc<RwLock<Graph>>,
@@ -52,7 +145,7 @@ impl Server {
 			}
 			visited.insert(id);
 			order.push(output.clone());
-			stack.extend(output.read().unwrap().dependencies.values().map(Edge::node));
+			stack.extend(output.read().unwrap().edges.iter().map(Edge::node));
 		}
 		order.reverse();
 
@@ -143,7 +236,7 @@ impl Server {
 					tg::error!(!source, "failed to put the artifact into the database")
 				})?;
 
-			stack.extend(output.read().unwrap().dependencies.values().map(Edge::node));
+			stack.extend(output.read().unwrap().edges.iter().map(Edge::node));
 		}
 
 		// Commit the transaction.
@@ -184,100 +277,6 @@ impl Server {
 			})?;
 
 		Ok(())
-	}
-}
-
-// Output.
-impl Server {
-	pub(super) async fn collect_output(
-		&self,
-		input: Arc<tokio::sync::RwLock<input::Graph>>,
-		lockfile: tg::Lockfile,
-		progress: &super::ProgressState,
-	) -> tg::Result<Arc<RwLock<Graph>>> {
-		let root = input.read().await.arg.path.clone();
-		let artifacts = self.create_artifact_data_for_lockfile(&lockfile).await?;
-		let mut state = State {
-			root,
-			artifacts,
-			lockfile,
-			visited: BTreeMap::new(),
-		};
-		let output = self
-			.collect_output_inner(input, &mut state, progress)
-			.await?
-			.0
-			.unwrap_left();
-		Ok(output)
-	}
-
-	async fn collect_output_inner(
-		&self,
-		input: Arc<tokio::sync::RwLock<input::Graph>>,
-		state: &mut State,
-		progress: &super::ProgressState,
-	) -> tg::Result<Edge> {
-		let path = input.read().await.arg.path.clone();
-		let path = path.diff(&state.root).unwrap();
-		if let Some(output) = state.visited.get(&path) {
-			let edge = Edge(Either::Right(output.clone()));
-			return Ok(edge);
-		}
-
-		// Find the entry in the lockfile.
-		let lock_index = *state
-			.lockfile
-			.paths
-			.get(&path)
-			.and_then(|nodes| nodes.first())
-			.ok_or_else(|| tg::error!(%path = path.display(), "missing path in lockfile"))?;
-
-		// Get the data.
-		let data = state
-			.artifacts
-			.get(&lock_index)
-			.ok_or_else(|| tg::error!("missing artifact data"))?
-			.clone();
-
-		// Compute the ID.
-		let id = data.id()?;
-
-		// Update the total bytes that will be copied.
-		if input.read().await.metadata.is_file() {
-			let size = input.read().await.metadata.size().to_u64().unwrap();
-			progress.update_output_total(size);
-		}
-
-		// Create the output.
-		let output = Arc::new(RwLock::new(Graph {
-			input: input.clone(),
-			id: id.clone(),
-			data,
-			weight: 0,
-			lock_index,
-			dependencies: BTreeMap::new(),
-		}));
-		state.visited.insert(path.clone(), Arc::downgrade(&output));
-
-		// Recurse.
-		let mut output_dependencies = BTreeMap::new();
-		let input_dependencies = input
-			.read()
-			.await
-			.edges
-			.iter()
-			.filter_map(|edge| {
-				let child = edge.node()?;
-				Some((edge.reference.clone(), child))
-			})
-			.collect::<Vec<_>>();
-		for (reference, input) in input_dependencies {
-			let output = Box::pin(self.collect_output_inner(input, state, progress)).await?;
-			output_dependencies.insert(reference, output);
-		}
-
-		output.write().unwrap().dependencies = output_dependencies;
-		Ok(Edge(Either::Left(output)))
 	}
 }
 
@@ -715,19 +714,20 @@ impl Server {
 		}
 
 		// Recurse.
-		let dependencies = output.read().unwrap().dependencies.clone();
-		for (reference, child_output) in dependencies {
-			let child_output = child_output.node();
+		let edges = output.read().unwrap().edges.clone();
+		for edge in edges {
+			let child_output = edge.node();
 			let input = child_output.read().unwrap().input.clone();
-			let path = if input.read().await.is_root {
+			let path = if input.read().await.root.is_none() {
 				self.checkouts_path()
 					.join(child_output.read().unwrap().data.id()?.to_string())
 			} else {
-				let path_ = reference
+				let path_ = edge
+					.reference
 					.path()
 					.try_unwrap_path_ref()
 					.ok()
-					.or_else(|| reference.query()?.path.as_ref())
+					.or_else(|| edge.reference.query()?.path.as_ref())
 					.cloned()
 					.ok_or_else(|| tg::error!("expected a path dependency"))?;
 				// We could use metadata from the input, or the data, this avoids having to acquire a lock.
@@ -813,10 +813,10 @@ impl Server {
 			if visited.contains(&id) {
 				continue;
 			}
-			visited.insert(id);
+			visited.insert(id.clone());
 
 			let input = output.read().unwrap().input.clone();
-			if input.read().await.is_root {
+			if input.read().await.root.is_none() {
 				// Create a temp.
 				let temp = Tmp::new(self);
 
@@ -851,7 +851,7 @@ impl Server {
 			}
 
 			// Recurse.
-			stack.extend(output.read().unwrap().dependencies.values().map(Edge::node));
+			stack.extend(output.read().unwrap().edges.iter().map(Edge::node));
 		}
 		Ok(())
 	}
@@ -869,6 +869,7 @@ impl Server {
 			return Ok(());
 		}
 		visited.insert(input.arg.path.clone());
+
 		if input.metadata.is_dir() {
 			if input.arg.destructive {
 				match tokio::fs::rename(&input.arg.path, &dest).await {
@@ -881,15 +882,15 @@ impl Server {
 			tokio::fs::create_dir_all(&dest)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to create directory"))?;
-			let dependencies = output.read().unwrap().dependencies.clone();
-			for (_, output) in dependencies {
-				let output = output.node();
+			let dependencies = output.read().unwrap().edges.clone();
+			for edge in dependencies {
+				let output = edge.node();
 				let input_ = output.read().unwrap().input.clone();
-				if input_.read().await.is_root {
+				if input_.read().await.root.is_none() {
 					continue;
 				}
 				let diff = input_.read().await.arg.path.diff(&input.arg.path).unwrap();
-				let dest = dest.join(diff).normalize();
+				let dest = dest.join(&diff).normalize();
 				Box::pin(self.copy_or_move_all(dest, output, visited, progress)).await?;
 			}
 		} else if input.metadata.is_symlink() {
@@ -987,7 +988,9 @@ impl Server {
 				let permissions = if executable { 0o0755 } else { 0o0644 };
 				tokio::fs::set_permissions(&dest, std::fs::Permissions::from_mode(permissions))
 					.await
-					.map_err(|source| tg::error!(!source, "failed to set file permissions"))?;
+					.map_err(
+						|source| tg::error!(!source, %path = dest.display(), "failed to set file permissions"),
+					)?;
 
 				let json = serde_json::to_vec(&file)
 					.map_err(|source| tg::error!(!source, "failed to serialize file data"))?;
@@ -998,7 +1001,9 @@ impl Server {
 			tg::artifact::Data::Directory(_) => {
 				let permissions = tokio::fs::metadata(&dest)
 					.await
-					.unwrap()
+					.map_err(
+						|source| tg::error!(!source, %dest = dest.display(), "failed to get metadata"),
+					)?
 					.permissions()
 					.mode();
 				let mode = format!("{permissions:o}");
@@ -1012,20 +1017,19 @@ impl Server {
 		}
 
 		// Recurse over path dependencies.
-		let dependencies = output.read().unwrap().dependencies.clone();
+		let dependencies = output.read().unwrap().edges.clone();
 		let dependencies = dependencies
 			.into_iter()
-			.map(|(reference, child)| async move {
-				let child = child.node();
+			.map(|edge| async move {
+				let child = edge.node();
 				let input = child.read().unwrap().input.clone();
-				if input.read().await.is_root {
-					return None;
-				}
-				let path = reference
+				input.read().await.root.as_ref()?;
+				let path = edge
+					.reference
 					.path()
 					.try_unwrap_path_ref()
 					.ok()
-					.or_else(|| reference.query()?.path.as_ref())?;
+					.or_else(|| edge.reference.query()?.path.as_ref())?;
 				Some((path.clone(), child.clone()))
 			})
 			.collect::<FuturesUnordered<_>>()
@@ -1070,9 +1074,48 @@ fn set_file_times_to_epoch_inner(path: &Path, recursive: bool) -> tg::Result<()>
 
 impl Edge {
 	pub fn node(&self) -> Arc<RwLock<Graph>> {
-		match &self.0 {
+		match &self.graph {
 			Either::Left(strong) => strong.clone(),
 			Either::Right(weak) => weak.upgrade().unwrap(),
 		}
 	}
+}
+
+impl Graph {
+	#[allow(dead_code)]
+	async fn print(self_: Arc<RwLock<Graph>>) {
+		let mut stack = vec![(tg::Reference::with_path("."), Either::Left(self_), 0)];
+		while let Some((reference, node, depth)) = stack.pop() {
+			for _ in 0..depth {
+				eprint!("..");
+			}
+			match node {
+				Either::Left(strong) => {
+					eprintln!("strong {reference} {:x?}", Arc::as_ptr(&strong));
+					stack.extend(strong.read().unwrap().edges.iter().map(|edge| {
+						let reference = edge.reference.clone();
+						let graph = edge.graph.clone();
+						let depth = depth + 1;
+						(reference, graph, depth)
+					}));
+				},
+				Either::Right(weak) => {
+					eprintln!("weak {reference} {:x?}", Weak::as_ptr(&weak));
+				},
+			}
+		}
+	}
+}
+
+async fn add_edge(node: Arc<RwLock<Graph>>, edge: Edge) {
+	let mut node = node.write().unwrap();
+	for existing_edge in &mut node.edges {
+		if existing_edge.reference == edge.reference {
+			if let Either::Left(strong) = &edge.graph {
+				existing_edge.graph = Either::Left(strong.clone());
+			}
+			return;
+		}
+	}
+	node.edges.push(edge);
 }


### PR DESCRIPTION
- always follow symlinks
- construct intermediate directories on the fly instead of in a separate pass
- remove unify, follow fields from tg::Reference
- use same design pattern for input and output graph