### PR TITLE
feat: add tag to module

### DIFF
--- a/packages/client/src/module.rs
+++ b/packages/client/src/module.rs
@@ -9,6 +9,7 @@ pub struct Module {
 	pub kind: Kind,
 	pub object: Option<Either<tg::object::Id, PathBuf>>,
 	pub path: Option<PathBuf>,
+	pub tag: Option<tg::Tag>,
 }
 
 #[derive(
@@ -83,6 +84,7 @@ impl Module {
 			kind,
 			object: Some(object),
 			path: Some(path),
+			tag: None,
 		};
 		Ok(Some(module))
 	}
@@ -119,6 +121,7 @@ impl Module {
 			kind,
 			object: package,
 			path: Some(path.to_owned()),
+			tag: None,
 		};
 
 		Ok(module)

--- a/packages/compiler/src/module.ts
+++ b/packages/compiler/src/module.ts
@@ -2,6 +2,7 @@ export type Module = {
 	kind: Module.Kind;
 	object: string | undefined;
 	path: string | undefined;
+	tag: string | undefined;
 };
 
 export namespace Module {

--- a/packages/server/src/compiler.rs
+++ b/packages/server/src/compiler.rs
@@ -630,7 +630,12 @@ impl Compiler {
 			let kind = tg::module::Kind::Dts;
 			let object = None;
 			let path = Some(path.to_owned());
-			return Ok(tg::Module { kind, object, path });
+			return Ok(tg::Module {
+				kind,
+				object,
+				path,
+				tag: None,
+			});
 		}
 
 		// Handle a path in the checkouts directory.
@@ -671,7 +676,12 @@ impl Compiler {
 			} else {
 				Some(path)
 			};
-			return Ok(tg::Module { kind, object, path });
+			return Ok(tg::Module {
+				kind,
+				object,
+				path,
+				tag: None,
+			});
 		}
 
 		tg::Module::with_path(path).await

--- a/packages/server/src/runtime.rs
+++ b/packages/server/src/runtime.rs
@@ -42,6 +42,7 @@ impl Server {
 			kind: tg::module::Kind::Dts,
 			object: None,
 			path: Some("tangram.d.ts".into()),
+			tag: None,
 		};
 
 		// Create the compiler.


### PR DESCRIPTION
This change adds the `tag` information to modules to aid in our autogenerated documentation. We also need to add the tag to the root as this only gets `tag` information from imported packages.