### PR TITLE
fix(database): set busy_timeout per-connection

### DIFF
--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -458,7 +458,7 @@ impl Provider {
 		connection
 			.with(move |connection| {
 				connection
-					.execute(&statement, [])
+					.execute_batch(&statement)
 					.map_err(|source| tg::error!(!source, "failed to create the database"))?;
 				Ok::<_, tg::Error>(())
 			})


### PR DESCRIPTION
Per the [SQLite docs](https://www.sqlite.org/c3ref/busy_handler.html) the `busy_timeout` PRAGMA is associated with a single connection:
```
The sqlite3_busy_handler(D,X,P) routine sets a callback function X that might be invoked with argument P whenever an attempt is made to access a database table associated with [database connection](https://www.sqlite.org/c3ref/sqlite3.html) D when another thread or process has the table locked. The sqlite3_busy_handler() interface is used to implement [sqlite3_busy_timeout()](https://www.sqlite.org/c3ref/busy_timeout.html) and [PRAGMA busy_timeout](https://www.sqlite.org/pragma.html#pragma_busy_timeout).
```
As a result, the value set in a connection on database creation does not persist to new connections, and must be individually configured per-connection.

This can be verified by removing any existing `.tangram` directory, running the server, and querying the pragmas:
```
SQLite version 3.45.1 2024-01-30 16:01:20
Enter ".help" for usage hints.
sqlite> PRAGMA journal_mode;
wal
sqlite> PRAGMA busy_timeout;
0
sqlite> PRAGMA synchronous;
2
```

The `journal_mode` setting persisted, but neither `busy_timeout` nor `synchronous` were set.

As a result, this PR removes both pragrams from database creation, and adds the `busy_timeout` PRAGMA to the new connection logic instead.