### PR TITLE
feat(runtime): accept graph objects in artifact constructors

### DIFF
--- a/packages/cli/tests/artifact/checkin.test.ts
+++ b/packages/cli/tests/artifact/checkin.test.ts
@@ -11,8 +11,10 @@ test("directory", async () => {
 		"child/link": await symlink("../link"),
 	});
 	let id = await server.tg`checkin ${dir}`.text().then((t) => t.trim());
-	let data =await server.tg`get ${id}`.text().then((t) => t.trim());
-	let metadata =await server.tg`object metadata ${id}`.text().then((t) => t.trim());
+	let data = await server.tg`get ${id}`.text().then((t) => t.trim());
+	let metadata = await server.tg`object metadata ${id}`
+		.text()
+		.then((t) => t.trim());
 
 	expect(id).toMatchSnapshot();
 	expect(data).toMatchSnapshot();
@@ -27,13 +29,14 @@ test("file", async () => {
 	let id = await server.tg`checkin ${dir}/hello.txt`
 		.text()
 		.then((t) => t.trim());
-	let data =await server.tg`get ${id}`.text().then((t) => t.trim());
-	let metadata =await server.tg`object metadata ${id}`.text().then((t) => t.trim());
+	let data = await server.tg`get ${id}`.text().then((t) => t.trim());
+	let metadata = await server.tg`object metadata ${id}`
+		.text()
+		.then((t) => t.trim());
 
 	expect(id).toMatchSnapshot();
 	expect(data).toMatchSnapshot();
 	expect(metadata).toMatchSnapshot();
-
 });
 
 test("symlink", async () => {
@@ -43,8 +46,10 @@ test("symlink", async () => {
 		link: symlink("file"),
 	});
 	let id = await server.tg`checkin ${dir}/link`.text().then((t) => t.trim());
-	let data =await server.tg`get ${id}`.text().then((t) => t.trim());
-	let metadata =await server.tg`object metadata ${id}`.text().then((t) => t.trim());
+	let data = await server.tg`get ${id}`.text().then((t) => t.trim());
+	let metadata = await server.tg`object metadata ${id}`
+		.text()
+		.then((t) => t.trim());
 
 	expect(id).toMatchSnapshot();
 	expect(data).toMatchSnapshot();
@@ -57,8 +62,10 @@ test("cycle", async () => {
 		link: await symlink("."),
 	});
 	let id = await server.tg`checkin ${dir}`.text().then((t) => t.trim());
-	let data =await server.tg`get ${id}`.text().then((t) => t.trim());
-	let metadata =await server.tg`object metadata ${id}`.text().then((t) => t.trim());
+	let data = await server.tg`get ${id}`.text().then((t) => t.trim());
+	let metadata = await server.tg`object metadata ${id}`
+		.text()
+		.then((t) => t.trim());
 
 	expect(id).toMatchSnapshot();
 	expect(data).toMatchSnapshot();
@@ -72,8 +79,10 @@ test("cyclic-path-dependencies", async () => {
 		"dependency.tg.ts": 'import * as root from "./tangram.ts"',
 	});
 	let id = await server.tg`checkin ${dir}`.text().then((t) => t.trim());
-	let data =await server.tg`get ${id}`.text().then((t) => t.trim());
-	let metadata =await server.tg`object metadata ${id}`.text().then((t) => t.trim());
+	let data = await server.tg`get ${id}`.text().then((t) => t.trim());
+	let metadata = await server.tg`object metadata ${id}`
+		.text()
+		.then((t) => t.trim());
 
 	expect(id).toMatchSnapshot();
 	expect(data).toMatchSnapshot();
@@ -88,8 +97,10 @@ test("executable", async () => {
 	let id = await server.tg`checkin ${dir}/executable`
 		.text()
 		.then((t) => t.trim());
-	let data =await server.tg`get ${id}`.text().then((t) => t.trim());
-	let metadata =await server.tg`object metadata ${id}`.text().then((t) => t.trim());
+	let data = await server.tg`get ${id}`.text().then((t) => t.trim());
+	let metadata = await server.tg`object metadata ${id}`
+		.text()
+		.then((t) => t.trim());
 
 	expect(id).toMatchSnapshot();
 	expect(data).toMatchSnapshot();

--- a/packages/cli/tests/runtime/__snapshots__/symlink.test.ts.snap
+++ b/packages/cli/tests/runtime/__snapshots__/symlink.test.ts.snap
@@ -1,0 +1,11 @@
+// Bun Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`constructor string 1`] = `"{"artifact":null,"path":"hello",}"`;
+
+exports[`constructor artifact 1`] = `"{"artifact":fil_011ha7t8w6e20epbfm71yyaqzqgv7ypm24thgs2awqbj67fycra150,"path":null,}"`;
+
+exports[`constructor object 1`] = `"{"artifact":dir_01vzsmc304fn7x92tzs48chcm35b6mtfgz3j9bgry8hd0y8h59gzgg,"path":"hello",}"`;
+
+exports[`constructor variadic overwrites completely 1`] = `"[dir_01tr0h205a3bmedm8smte5j8mk8ewmm0wzf0pwrnk1nn3wcvevvpd0,"hello",]"`;
+
+exports[`constructor graph 1`] = `"[dir_012er0x782axvp42narzyz58f81c474ktnsqak8r4cek3ech37cqq0,"hello",]"`;

--- a/packages/cli/tests/runtime/directory.test.ts
+++ b/packages/cli/tests/runtime/directory.test.ts
@@ -7,8 +7,8 @@ describe("constructor", () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => tg.directory());
-      `,
+				export default tg.target(async () => tg.directory());
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		const actual = await server.tg`checkout ${result}`
@@ -18,21 +18,22 @@ describe("constructor", () => {
 		const equal = await compare(actual, expected);
 		expect(equal).toBeTrue();
 	});
+
 	test("basic", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	let d = await tg.directory({
-        		hello: tg.file("hello!"),
-        		inner: {
-	        		goodbye: tg.file("goodbye!"),
-        		},
-        		link: tg.symlink("hello"),
-        	});
-        	return d;
-        });
-      `,
+				export default tg.target(async () => {
+					let d = await tg.directory({
+						hello: tg.file("hello!"),
+						inner: {
+							goodbye: tg.file("goodbye!"),
+						},
+						link: tg.symlink("hello"),
+					});
+					return d;
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		const actual = await server.tg`checkout ${result}`
@@ -48,20 +49,20 @@ describe("constructor", () => {
 		const equal = await compare(actual, expected);
 		expect(equal).toBeTrue();
 	});
+
 	test("variadic append", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	let d = await tg.directory({
-        		hello: tg.file("hello!"),
-        	},
-        	{
-        		goodbye: tg.file("goodbye!")
-        	});
-        	return d;
-        });
-      `,
+				export default tg.target(async () => {
+					let d = await tg.directory({
+						hello: tg.file("hello!"),
+					}, {
+						goodbye: tg.file("goodbye!")
+					});
+					return d;
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		const actual = await server.tg`checkout ${result}`
@@ -74,21 +75,21 @@ describe("constructor", () => {
 		const equal = await compare(actual, expected);
 		expect(equal).toBeTrue();
 	});
+
 	test("variadic remove", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	let d = await tg.directory({
-        		hello: tg.file("hello!"),
-        		goodbye: tg.file("goodbye!")
-        	},
-        	{
-        		goodbye: undefined
-        	});
-        	return d;
-        });
-      `,
+				export default tg.target(async () => {
+					let d = await tg.directory({
+						hello: tg.file("hello!"),
+						goodbye: tg.file("goodbye!")
+					}, {
+						goodbye: undefined
+					});
+					return d;
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		const actual = await server.tg`checkout ${result}`
@@ -100,21 +101,22 @@ describe("constructor", () => {
 		const equal = await compare(actual, expected);
 		expect(equal).toBeTrue();
 	});
+
 	test("graph", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const f = await tg.file("hello from inside a graph");
-        	const graph = await tg.graph({
-        		nodes: [
-        			{ kind: "directory", entries: { "hello": f } },
-        		]
-        	});
-          const d = await tg.directory({ graph, node: 0 });
-          return d;
-        });
-      `,
+				export default tg.target(async () => {
+					const f = await tg.file("hello from inside a graph");
+					const graph = await tg.graph({
+						nodes: [
+							{ kind: "directory", entries: { "hello": f } },
+						]
+					});
+					const d = await tg.directory({ graph, node: 0 });
+					return d;
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		const actual = await server.tg`checkout ${result}`
@@ -126,47 +128,49 @@ describe("constructor", () => {
 		const equal = await compare(actual, expected);
 		expect(equal).toBeTrue();
 	});
+
 	test("rejects mixed graph and regular objects", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const f = await tg.file("hello from inside a graph");
-        	const graph = await tg.graph({
-        		nodes: [
-        			{ kind: "directory", entries: { "hello": f } },
-        		]
-        	});
-        	const f2 = await tg.file("hello from outside a graph");
-          const d = await tg.directory({ graph, node: 0 }, { newFile: f2 });
-          return d;
-        });
-      `,
+				export default tg.target(async () => {
+					const f = await tg.file("hello from inside a graph");
+					const graph = await tg.graph({
+						nodes: [
+							{ kind: "directory", entries: { "hello": f } },
+						]
+					});
+					const f2 = await tg.file("hello from outside a graph");
+					const d = await tg.directory({ graph, node: 0 }, { newFile: f2 });
+					return d;
+				});
+			`,
 		});
 		const result = server.tg`build ${dir}`.quiet();
 		await expect((async () => await result)()).rejects.toThrow();
 	});
+
 	test("rejects multiple graph objects", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const f = await tg.file("hello from inside a graph");
-        	const graphA = await tg.graph({
-        		nodes: [
-        			{ kind: "directory", entries: { "hello": f } },
-        		]
-        	});
-        	const f2 = await tg.file("hello from outside a graph");
-        	const graphB = await tg.graph({
-        		nodes: [
-        			{ kind: "directory", entries: { "newFile": f2 } },
-        		]
-        	});
-          const d = await tg.directory({ graph: graphA, node: 0 }, { graph: graphB: node: 0 });
-          return d;
-        });
-      `,
+				export default tg.target(async () => {
+					const f = await tg.file("hello from inside a graph");
+					const graphA = await tg.graph({
+						nodes: [
+							{ kind: "directory", entries: { "hello": f } },
+						],
+					});
+					const f2 = await tg.file("hello from outside a graph");
+					const graphB = await tg.graph({
+						nodes: [
+							{ kind: "directory", entries: { "newFile": f2 } },
+						],
+					});
+					const d = await tg.directory({ graph: graphA, node: 0 }, { graph: graphB: node: 0 });
+					return d;
+				});
+			`,
 		});
 		const result = server.tg`build ${dir}`.quiet();
 		await expect((async () => await result)()).rejects.toThrow();

--- a/packages/cli/tests/runtime/directory.test.ts
+++ b/packages/cli/tests/runtime/directory.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import Server from "../server.ts";
+import { compare, directory, symlink } from "../util.ts";
+
+describe("constructor", () => {
+	test("empty", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => tg.directory());
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		const actual = await server.tg`checkout ${result}`
+			.text()
+			.then((t) => t.trim());
+		const expected = await directory();
+		const equal = await compare(actual, expected);
+		expect(equal).toBeTrue();
+	});
+	test("basic", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	let d = await tg.directory({
+        		hello: tg.file("hello!"),
+        		inner: {
+	        		goodbye: tg.file("goodbye!"),
+        		},
+        		link: tg.symlink("hello"),
+        	});
+        	return d;
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		const actual = await server.tg`checkout ${result}`
+			.text()
+			.then((t) => t.trim());
+		const expected = await directory({
+			hello: "hello!",
+			inner: {
+				goodbye: "goodbye!",
+			},
+			link: symlink("hello"),
+		});
+		const equal = await compare(actual, expected);
+		expect(equal).toBeTrue();
+	});
+	test("variadic append", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	let d = await tg.directory({
+        		hello: tg.file("hello!"),
+        	},
+        	{
+        		goodbye: tg.file("goodbye!")
+        	});
+        	return d;
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		const actual = await server.tg`checkout ${result}`
+			.text()
+			.then((t) => t.trim());
+		const expected = await directory({
+			hello: "hello!",
+			goodbye: "goodbye!",
+		});
+		const equal = await compare(actual, expected);
+		expect(equal).toBeTrue();
+	});
+	test("variadic remove", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	let d = await tg.directory({
+        		hello: tg.file("hello!"),
+        		goodbye: tg.file("goodbye!")
+        	},
+        	{
+        		goodbye: undefined
+        	});
+        	return d;
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		const actual = await server.tg`checkout ${result}`
+			.text()
+			.then((t) => t.trim());
+		const expected = await directory({
+			hello: "hello!",
+		});
+		const equal = await compare(actual, expected);
+		expect(equal).toBeTrue();
+	});
+	test("graph", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const f = await tg.file("hello from inside a graph");
+        	const graph = await tg.graph({
+        		nodes: [
+        			{ kind: "directory", entries: { "hello": f } },
+        		]
+        	});
+          const d = await tg.directory({ graph, node: 0 });
+          return d;
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		const actual = await server.tg`checkout ${result}`
+			.text()
+			.then((t) => t.trim());
+		const expected = await directory({
+			hello: "hello from inside a graph",
+		});
+		const equal = await compare(actual, expected);
+		expect(equal).toBeTrue();
+	});
+	test("rejects mixed graph and regular objects", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const f = await tg.file("hello from inside a graph");
+        	const graph = await tg.graph({
+        		nodes: [
+        			{ kind: "directory", entries: { "hello": f } },
+        		]
+        	});
+        	const f2 = await tg.file("hello from outside a graph");
+          const d = await tg.directory({ graph, node: 0 }, { newFile: f2 });
+          return d;
+        });
+      `,
+		});
+		const result = server.tg`build ${dir}`.quiet();
+		await expect((async () => await result)()).rejects.toThrow();
+	});
+	test("rejects multiple graph objects", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const f = await tg.file("hello from inside a graph");
+        	const graphA = await tg.graph({
+        		nodes: [
+        			{ kind: "directory", entries: { "hello": f } },
+        		]
+        	});
+        	const f2 = await tg.file("hello from outside a graph");
+        	const graphB = await tg.graph({
+        		nodes: [
+        			{ kind: "directory", entries: { "newFile": f2 } },
+        		]
+        	});
+          const d = await tg.directory({ graph: graphA, node: 0 }, { graph: graphB: node: 0 });
+          return d;
+        });
+      `,
+		});
+		const result = server.tg`build ${dir}`.quiet();
+		await expect((async () => await result)()).rejects.toThrow();
+	});
+});

--- a/packages/cli/tests/runtime/file.test.ts
+++ b/packages/cli/tests/runtime/file.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import Server from "../server.ts";
+import { directory } from "../util.ts";
+
+describe("constructor", () => {
+	test("string", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	let f = await tg.file("hello");
+        	return await f.text();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toBe(`"hello"`);
+	});
+	test("object", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	let f = await tg.file({ contents: "hello" });
+        	return await f.text();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toBe(`"hello"`);
+	});
+	test("uint8array", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	let f = await tg.file(new Uint8Array([0x68, 0x65, 0x6C, 0x6C, 0x6F]));
+        	return await f.text();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toBe(`"hello"`);
+	});
+	test("variadic appends contents", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+          const f = await tg.file({ contents: "hello, " }, { contents: "world" });
+          return await f.text();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toBe(`"hello, world"`);
+	});
+	test("variadic overwrites executable", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+          const f = await tg.file({ contents: "hello", executable: true }, { executable: false });
+          return [await f.text(), await f.executable()];
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toBe(`["hello",false,]`);
+	});
+	test("graph", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const graph = await tg.graph({ nodes: [{ kind: "file", contents: "hello from inside a graph" }] });
+          const f = await tg.file({ graph, node: 0 });
+          return await f.text();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toBe(`"hello from inside a graph"`);
+	});
+	test("rejects mixed graph and regular objects", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+		      export default tg.target(async () => {
+		      	const graph = await tg.graph({ nodes: [{ kind: "file", contents: "hello from inside a graph" }] });
+		        const f = await tg.file({ graph, node: 0 }, { contents: "world" });
+		        return await f.text();
+		      });
+		    `,
+		});
+		const result = server.tg`build ${dir}`.quiet();
+		await expect((async () => await result)()).rejects.toThrow();
+	});
+	test("rejects multiple graph objects", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+		      export default tg.target(async () => {
+		      	const graphA = await tg.graph({ nodes: [{ kind: "file", contents: "hello from inside a graph" }] });
+		      	const graphB = await tg.graph({ nodes: [{ kind: "file", contents: "hello from a different graph" }] });
+		        const f = await tg.file({ graph: graphA, node: 0 }, { graph: graphB, node: 0 });
+		        return await f.text();
+		      });
+		    `,
+		});
+		const result = server.tg`build ${dir}`.quiet();
+		await expect((async () => await result)()).rejects.toThrow();
+	});
+});

--- a/packages/cli/tests/runtime/symlink.test.ts
+++ b/packages/cli/tests/runtime/symlink.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import Server from "../server.ts";
+import { directory } from "../util.ts";
+
+describe("constructor", () => {
+	test("string", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const s = await tg.symlink("hello");
+        	return await s.object();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toMatchSnapshot();
+	});
+	test("artifact", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const f = await tg.file({ contents: "hello" });
+        	const s = await tg.symlink(f);
+        	return await s.object();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toMatchSnapshot();
+	});
+	test("object", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const f = await tg.file({ contents: "hello" });
+        	const d = await tg.directory({
+        		hello: tg.file("hello")
+        	});
+        	const s = await tg.symlink({ artifact: d, path: "hello" });
+        	return await s.object();
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toMatchSnapshot();
+	});
+	test("variadic overwrites completely", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const f = await tg.file({ contents: "hello" });
+        	const d1 = await tg.directory({
+        		hello: tg.file("hello from d1"),
+        	});
+        	const d2 = await tg.directory({
+        		hello: tg.file("hello from d2"),
+        	});
+        	const s = await tg.symlink({ artifact: d1, path: "hello" }, { artifact: d2 });
+        	return [await s.artifact(), await s.path()];
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toMatchSnapshot();
+	});
+	test("graph", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+        export default tg.target(async () => {
+        	const d1 = await tg.directory({
+        		hello: tg.file("hello from d1"),
+        	});
+        	const graph = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
+          const s = await tg.symlink({ graph, node: 0 });
+          return [await s.artifact(), await s.path()];
+        });
+      `,
+		});
+		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
+		expect(result).toMatchSnapshot();
+	});
+	test("rejects mixed graph and regular objects", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+		      export default tg.target(async () => {
+        	const d1 = await tg.directory({
+        		hello: tg.file("hello from d1"),
+        	});
+        	const graph = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
+		      const s = await tg.symlink({ graph, node: 0 }, { path: "world" });
+          return [await s.artifact(), await s.path()];
+		      });
+		    `,
+		});
+		const result = server.tg`build ${dir}`.quiet();
+		await expect((async () => await result)()).rejects.toThrow();
+	});
+	test("rejects multiple graph objects", async () => {
+		await using server = await Server.start();
+		const dir = await directory({
+			"tangram.ts": `
+		      export default tg.target(async () => {
+	        	const d1 = await tg.directory({
+	        		hello: tg.file("hello from d1"),
+	        	});
+	        	const graphA = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
+	        	let d2 = await tg.directory({
+	        		hello: tg.file("hello from d2"),
+	        	});
+	        	const graphB = tg.graph({ nodes: [{ kind: "symlink", artifact: d2, path: "hello" }] });
+		        const s = await tg.symlink({ graph: graphA, node: 0 }, { graph: graphB, node: 0 });
+          	return [await s.artifact(), await s.path()];
+		      });
+		    `,
+		});
+		const result = server.tg`build ${dir}`.quiet();
+		await expect((async () => await result)()).rejects.toThrow();
+	});
+});

--- a/packages/cli/tests/runtime/symlink.test.ts
+++ b/packages/cli/tests/runtime/symlink.test.ts
@@ -7,117 +7,123 @@ describe("constructor", () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const s = await tg.symlink("hello");
-        	return await s.object();
-        });
-      `,
+				export default tg.target(async () => {
+					const s = await tg.symlink("hello");
+					return await s.object();
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		expect(result).toMatchSnapshot();
 	});
+
 	test("artifact", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const f = await tg.file({ contents: "hello" });
-        	const s = await tg.symlink(f);
-        	return await s.object();
-        });
-      `,
+				export default tg.target(async () => {
+					const f = await tg.file({ contents: "hello" });
+					const s = await tg.symlink(f);
+					return await s.object();
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		expect(result).toMatchSnapshot();
 	});
+
 	test("object", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const f = await tg.file({ contents: "hello" });
-        	const d = await tg.directory({
-        		hello: tg.file("hello")
-        	});
-        	const s = await tg.symlink({ artifact: d, path: "hello" });
-        	return await s.object();
-        });
-      `,
+				export default tg.target(async () => {
+					const f = await tg.file({ contents: "hello" });
+					const d = await tg.directory({
+						hello: tg.file("hello")
+					});
+					const s = await tg.symlink({ artifact: d, path: "hello" });
+					return await s.object();
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		expect(result).toMatchSnapshot();
 	});
+
 	test("variadic overwrites completely", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const f = await tg.file({ contents: "hello" });
-        	const d1 = await tg.directory({
-        		hello: tg.file("hello from d1"),
-        	});
-        	const d2 = await tg.directory({
-        		hello: tg.file("hello from d2"),
-        	});
-        	const s = await tg.symlink({ artifact: d1, path: "hello" }, { artifact: d2 });
-        	return [await s.artifact(), await s.path()];
-        });
-      `,
+				export default tg.target(async () => {
+					const f = await tg.file({ contents: "hello" });
+					const d1 = await tg.directory({
+						hello: tg.file("hello from d1"),
+					});
+					const d2 = await tg.directory({
+						hello: tg.file("hello from d2"),
+					});
+					const s = await tg.symlink({ artifact: d1, path: "hello" }, { artifact: d2 });
+					return [await s.artifact(), await s.path()];
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		expect(result).toMatchSnapshot();
 	});
+
 	test("graph", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-        export default tg.target(async () => {
-        	const d1 = await tg.directory({
-        		hello: tg.file("hello from d1"),
-        	});
-        	const graph = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
-          const s = await tg.symlink({ graph, node: 0 });
-          return [await s.artifact(), await s.path()];
-        });
-      `,
+				export default tg.target(async () => {
+					const d1 = await tg.directory({
+						hello: tg.file("hello from d1"),
+					});
+					const graph = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
+					const s = await tg.symlink({ graph, node: 0 });
+					return [await s.artifact(), await s.path()];
+				});
+			`,
 		});
 		const result = await server.tg`build ${dir}`.text().then((t) => t.trim());
 		expect(result).toMatchSnapshot();
 	});
+
 	test("rejects mixed graph and regular objects", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-		      export default tg.target(async () => {
-        	const d1 = await tg.directory({
-        		hello: tg.file("hello from d1"),
-        	});
-        	const graph = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
-		      const s = await tg.symlink({ graph, node: 0 }, { path: "world" });
-          return [await s.artifact(), await s.path()];
-		      });
-		    `,
+					export default tg.target(async () => {
+					const d1 = await tg.directory({
+						hello: tg.file("hello from d1"),
+					});
+					const graph = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
+					const s = await tg.symlink({ graph, node: 0 }, { path: "world" });
+					return [await s.artifact(), await s.path()];
+				});
+			`,
 		});
 		const result = server.tg`build ${dir}`.quiet();
 		await expect((async () => await result)()).rejects.toThrow();
 	});
+
 	test("rejects multiple graph objects", async () => {
 		await using server = await Server.start();
 		const dir = await directory({
 			"tangram.ts": `
-		      export default tg.target(async () => {
-	        	const d1 = await tg.directory({
-	        		hello: tg.file("hello from d1"),
-	        	});
-	        	const graphA = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
-	        	let d2 = await tg.directory({
-	        		hello: tg.file("hello from d2"),
-	        	});
-	        	const graphB = tg.graph({ nodes: [{ kind: "symlink", artifact: d2, path: "hello" }] });
-		        const s = await tg.symlink({ graph: graphA, node: 0 }, { graph: graphB, node: 0 });
-          	return [await s.artifact(), await s.path()];
-		      });
-		    `,
+				export default tg.target(async () => {
+					const d1 = await tg.directory({
+						hello: tg.file("hello from d1"),
+					});
+					const graphA = tg.graph({ nodes: [{ kind: "symlink", artifact: d1, path: "hello" }] });
+					let d2 = await tg.directory({
+						hello: tg.file("hello from d2"),
+					});
+					const graphB = tg.graph({ nodes: [{ kind: "symlink", artifact: d2, path: "hello" }] });
+					const s = await tg.symlink({ graph: graphA, node: 0 }, { graph: graphB, node: 0 });
+					return [await s.artifact(), await s.path()];
+				});
+			`,
 		});
 		const result = server.tg`build ${dir}`.quiet();
 		await expect((async () => await result)()).rejects.toThrow();

--- a/packages/runtime/src/directory.ts
+++ b/packages/runtime/src/directory.ts
@@ -27,12 +27,11 @@ export class Directory {
 	): Promise<Directory> {
 		let resolved = await Promise.all(args.map(tg.resolve));
 		if (resolved.length === 1) {
-			const singleArg = resolved[0];
-			if (isGraphObject(singleArg)) {
-				return new Directory({ object: singleArg });
+			const arg = resolved[0];
+			if (isGraphArg(arg)) {
+				return new Directory({ object: arg });
 			}
 		}
-
 		let entries = await resolved.reduce<
 			Promise<{ [key: string]: tg.Artifact }>
 		>(async function reduce(promiseEntries, arg) {
@@ -61,10 +60,8 @@ export class Directory {
 					entries = await reduce(Promise.resolve(entries), argEntry);
 				}
 			} else if (typeof arg === "object") {
-				if (isGraphObject(arg)) {
-					throw new Error(
-						"Graph objects must be the only argument to the directory constructor",
-					);
+				if (isGraphArg(arg)) {
+					throw new Error("nested graph args are not allowed");
 				}
 
 				// If the arg is an object, then apply each entry.
@@ -269,11 +266,8 @@ export class Directory {
 	}
 }
 
-const isGraphObject = (
-	obj: unknown,
-): obj is { graph: tg.Graph; node: number } => {
+const isGraphArg = (obj: unknown): obj is { graph: tg.Graph; node: number } => {
 	return (
-		obj !== undefined &&
 		typeof obj === "object" &&
 		obj !== null &&
 		"graph" in obj &&

--- a/packages/runtime/src/resolve.ts
+++ b/packages/runtime/src/resolve.ts
@@ -1,6 +1,6 @@
+import * as im from "immutable";
 import * as tg from "./index.ts";
 import type { MaybePromise } from "./util.ts";
-import * as im from "immutable";
 
 export type Unresolved<T extends tg.Value> = MaybePromise<
 	T extends

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -324,15 +324,17 @@ declare namespace tg {
 
 		export type Arg = undefined | tg.Directory | ArgObject;
 
-		type ArgObject = {
-			[key: string]:
-				| undefined
-				| string
-				| Uint8Array
-				| tg.Blob
-				| tg.Artifact
-				| ArgObject;
-		};
+		type ArgObject =
+			| {
+					[key: string]:
+						| undefined
+						| string
+						| Uint8Array
+						| tg.Blob
+						| tg.Artifact
+						| ArgObject;
+			  }
+			| { graph: tg.Graph; node: number };
 	}
 
 	/** Create a file. */
@@ -390,11 +392,13 @@ declare namespace tg {
 			| tg.File
 			| ArgObject;
 
-		type ArgObject = {
-			contents?: tg.Blob.Arg | undefined;
-			dependencies?: { [reference: string]: Dependency } | undefined;
-			executable?: boolean | undefined;
-		};
+		type ArgObject =
+			| {
+					contents?: tg.Blob.Arg | undefined;
+					dependencies?: { [reference: string]: Dependency } | undefined;
+					executable?: boolean | undefined;
+			  }
+			| { graph: tg.Graph; node: number };
 
 		export type Dependency = {
 			object: tg.Object;
@@ -443,10 +447,12 @@ declare namespace tg {
 			| tg.Symlink
 			| ArgObject;
 
-		type ArgObject = {
-			artifact?: tg.Artifact | undefined;
-			path?: string | undefined;
-		};
+		type ArgObject =
+			| {
+					artifact?: tg.Artifact | undefined;
+					path?: string | undefined;
+			  }
+			| { graph: tg.Graph; node: number };
 	}
 
 	/** Create a graph. */

--- a/tangram.ts
+++ b/tangram.ts
@@ -30,9 +30,9 @@ export default tg.target(async () => {
 	);
 	const output = cargo.build({
 		buildInTree: true,
+		checksum: "unsafe",
 		source: source(),
 		env,
-		parallelJobs: 4,
 	});
 	return tg.directory(output, {
 		["bin/tg"]: tg.symlink("tangram"),


### PR DESCRIPTION
Augments the constructors for `tg.File`, `tg.Symlink`, and `tg.Directory` to accept a single `{ graph, node }` object in addition to the variadic arguments already supported. Will throw if encountering multiple graphs or a mix of graphs and non-graph arguments.

Additionally defines tests for each constructor.

Closes #292.