### PR TITLE
fix: symlink resolve

### DIFF
--- a/packages/client/src/directory.rs
+++ b/packages/client/src/directory.rs
@@ -371,11 +371,7 @@ impl Directory {
 
 			// If the artifact is a symlink, then resolve it.
 			if let tg::Artifact::Symlink(symlink) = &artifact {
-				let from = tg::Symlink::with_artifact_and_subpath(
-					Some(self.clone().into()),
-					Some(current_path.clone()),
-				);
-				match Box::pin(symlink.try_resolve_from(handle, Some(from)))
+				match Box::pin(symlink.try_resolve(handle))
 					.await
 					.map_err(|source| tg::error!(!source, "failed to resolve the symlink"))?
 				{

--- a/packages/runtime/src/directory.ts
+++ b/packages/runtime/src/directory.ts
@@ -183,10 +183,7 @@ export class Directory {
 			if (entry === undefined) {
 				return undefined;
 			} else if (entry instanceof tg.Symlink) {
-				let resolved = await entry.resolve({
-					artifact: this,
-					subpath: currentPath,
-				});
+				let resolved = await entry.resolve();
 				if (resolved === undefined) {
 					return undefined;
 				}

--- a/packages/runtime/src/symlink.ts
+++ b/packages/runtime/src/symlink.ts
@@ -185,32 +185,16 @@ export class Symlink {
 		}
 	}
 
-	async resolve(
-		from?: Symlink.Arg,
-	): Promise<tg.Directory | tg.File | undefined> {
-		from = from ? await symlink(from) : undefined;
-		let fromArtifact = await from?.artifact();
-		if (fromArtifact instanceof Symlink) {
-			fromArtifact = await fromArtifact.resolve();
-		}
-		let fromPath = await from?.subpath();
+	async resolve(): Promise<tg.Directory | tg.File | undefined> {
 		let artifact = await this.artifact();
 		if (artifact instanceof Symlink) {
 			artifact = await artifact.resolve();
 		}
 		let subpath = await this.subpath();
-		if (artifact !== undefined && fromArtifact !== undefined) {
-			throw new Error("expected no `from` value when `artifact` is set");
-		}
 		if (artifact !== undefined && !subpath) {
 			return artifact;
-		} else if (artifact === undefined && subpath && fromPath) {
-			if (!(fromArtifact instanceof tg.Directory)) {
-				throw new Error("expected a directory");
-			}
-			return await fromArtifact.tryGet(
-				tg.path.join(tg.path.parent(fromPath) ?? "", subpath),
-			);
+		} else if (artifact === undefined && subpath) {
+			throw new Error("expected an artifact");
 		} else if (artifact !== undefined && subpath) {
 			if (!(artifact instanceof tg.Directory)) {
 				throw new Error("expected a directory");


### PR DESCRIPTION
- remove resolve_from in tangram_client and tangram_runtime
- define tests for directory.get() with symlinks in intermediate and final positions.

draft as both tests still fail.