### PR TITLE
fix(server/compiler/lsp): correct LSP path resolution and error serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5645,6 +5645,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_with",
  "serde_yaml",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ rustls = "0.23"
 scopeguard = "1"
 serde = { version = "1", features = ["rc", "derive"] }
 serde_json = "1"
+serde_repr = "0.1.19"
 serde_urlencoded = "0.7"
 serde_with = { version = "3", features = ["time_0_3"] }
 serde_yaml = { version = "0.9" }

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -74,6 +74,7 @@ rusqlite = { workspace = true }
 scopeguard = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_repr = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 sourcemap = { workspace = true }

--- a/packages/server/src/compiler.rs
+++ b/packages/server/src/compiler.rs
@@ -699,6 +699,7 @@ impl Compiler {
 				},
 				..
 			} => {
+				let path = path.strip_prefix("./").unwrap_or(path);
 				let contents = self::load::LIBRARY
 					.get_file(path)
 					.ok_or_else(|| tg::error!("invalid path"))?

--- a/packages/server/src/compiler/jsonrpc.rs
+++ b/packages/server/src/compiler/jsonrpc.rs
@@ -40,7 +40,8 @@ pub struct ResponseError {
 	pub message: String,
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, serde_repr::Serialize_repr, serde_repr::Deserialize_repr)]
+#[repr(i64)]
 pub enum ResponseErrorCode {
 	// The following error codes are defined by JSON-RPC.
 	ParseError = -32700,


### PR DESCRIPTION
This fixes `ResponseErrorCode` serialization so that the editor doesn't kill our LSP. Additionally, we now strip the leading `./` from the `path` when resolving module URIs.

TODO: confirm that this is where we want to strip the `./`