### PR TITLE
fix: checkin logic for symlinks

### DIFF
--- a/packages/server/src/artifact/checkin/object.rs
+++ b/packages/server/src/artifact/checkin/object.rs
@@ -265,10 +265,10 @@ impl Server {
 		file_metadata: &mut BTreeMap<usize, tg::object::Metadata>,
 	) -> tg::Result<tg::graph::data::Node> {
 		// Get the input metadata, or skip if the node is an object.
-		let (path, metadata) = match graph.nodes[index].unify.object.clone() {
+		let (input_index, path, metadata) = match graph.nodes[index].unify.object.clone() {
 			Either::Left(input_index) => {
 				let input = &input.nodes[input_index];
-				(input.arg.path.clone(), input.metadata.clone())
+				(input_index, input.arg.path.clone(), input.metadata.clone())
 			},
 			Either::Right(_) => {
 				return Err(tg::error!("expected a node"));
@@ -322,22 +322,36 @@ impl Server {
 				.await?;
 			tg::graph::data::Node::File(file)
 		} else if metadata.is_symlink() {
-			let edge = edges.first().cloned().unwrap();
-			let artifact = edge.id.map_right(|object| match object {
-				tg::object::Id::Directory(a) => a.into(),
-				tg::object::Id::File(a) => a.into(),
-				tg::object::Id::Symlink(a) => a.into(),
-				_ => unreachable!(),
-			});
-			let subpath = edge
-				.subpath
-				.map(|path| path.strip_prefix("./").unwrap_or(&path).to_owned());
-			let symlink = tg::graph::data::Symlink {
-				artifact: Some(artifact),
-				subpath,
-			};
-
-			tg::graph::data::Node::Symlink(symlink)
+			if let Some(edge) = edges.first().cloned() {
+				let artifact = edge.id.map_right(|object| match object {
+					tg::object::Id::Directory(a) => a.into(),
+					tg::object::Id::File(a) => a.into(),
+					tg::object::Id::Symlink(a) => a.into(),
+					_ => unreachable!(),
+				});
+				let subpath = edge
+					.subpath
+					.map(|path| path.strip_prefix("./").unwrap_or(&path).to_owned());
+				let symlink = tg::graph::data::Symlink {
+					artifact: Some(artifact),
+					subpath,
+				};
+				tg::graph::data::Node::Symlink(symlink)
+			} else {
+				let target = input.nodes[input_index]
+					.edges
+					.first()
+					.ok_or_else(|| tg::error!("invalid input graph"))?
+					.reference
+					.item()
+					.try_unwrap_path_ref()
+					.map_err(|_| tg::error!("expected a path item"))?;
+				let symlink = tg::graph::data::Symlink {
+					artifact: None,
+					subpath: Some(target.clone()),
+				};
+				tg::graph::data::Node::Symlink(symlink)
+			}
 		} else {
 			return Err(tg::error!("invalid file type"));
 		};

--- a/packages/server/src/artifact/checkin/tests.rs
+++ b/packages/server/src/artifact/checkin/tests.rs
@@ -67,11 +67,7 @@ async fn external_symlink() -> tg::Result<()> {
    		"dependencies": {
    			"../b/c": {
    				"item": tg.symlink({
-   					"artifact": tg.directory({
-   						"d": tg.file({
-   							"contents": tg.leaf("hello, world!"),
-   						}),
-   					}),
+   					"subpath": "./e",
    				}),
    			},
    		},
@@ -271,21 +267,9 @@ async fn symlink() -> tg::Result<()> {
 		|_, _, output| async move {
 			assert_snapshot!(output, @r#"
    tg.directory({
-   	"graph": tg.graph({
-   		"nodes": [
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"link": 1,
-   				},
-   			},
-   			{
-   				"kind": "symlink",
-   				"artifact": 0,
-   			},
-   		],
+   	"link": tg.symlink({
+   		"subpath": ".",
    	}),
-   	"node": 0,
    })
    "#);
 			Ok::<_, tg::Error>(())
@@ -372,37 +356,17 @@ async fn directory() -> tg::Result<()> {
 		|_, _, output| async move {
 			assert_snapshot!(output, @r#"
    tg.directory({
-   	"graph": tg.graph({
-   		"nodes": [
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"hello.txt": tg.file({
-   						"contents": tg.leaf("Hello, world!"),
-   					}),
-   					"link": 3,
-   					"subdirectory": 1,
-   				},
-   			},
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"sublink": 2,
-   				},
-   			},
-   			{
-   				"kind": "symlink",
-   				"artifact": 0,
-   				"subpath": "link",
-   			},
-   			{
-   				"kind": "symlink",
-   				"artifact": 0,
-   				"subpath": "hello.txt",
-   			},
-   		],
+   	"hello.txt": tg.file({
+   		"contents": tg.leaf("Hello, world!"),
    	}),
-   	"node": 0,
+   	"link": tg.symlink({
+   		"subpath": "./hello.txt",
+   	}),
+   	"subdirectory": tg.directory({
+   		"sublink": tg.symlink({
+   			"subpath": "../link",
+   		}),
+   	}),
    })
    "#);
 			Ok::<_, tg::Error>(())
@@ -546,51 +510,23 @@ async fn directory_destructive() -> tg::Result<()> {
 		|_, _, output| async move {
 			assert_snapshot!(output, @r#"
    tg.directory({
-   	"graph": tg.graph({
-   		"nodes": [
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"a": 1,
-   				},
-   			},
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"b": 4,
-   					"d": 2,
-   					"f": tg.directory({
-   						"g": tg.file({
-   							"contents": tg.leaf(""),
-   						}),
-   					}),
-   				},
-   			},
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"e": 3,
-   				},
-   			},
-   			{
-   				"kind": "symlink",
-   				"artifact": 0,
-   				"subpath": "a/f/g",
-   			},
-   			{
-   				"kind": "directory",
-   				"entries": {
-   					"c": 5,
-   				},
-   			},
-   			{
-   				"kind": "symlink",
-   				"artifact": 0,
-   				"subpath": "a/d/e",
-   			},
-   		],
+   	"a": tg.directory({
+   		"b": tg.directory({
+   			"c": tg.symlink({
+   				"subpath": "../../a/d/e",
+   			}),
+   		}),
+   		"d": tg.directory({
+   			"e": tg.symlink({
+   				"subpath": "../../a/f/g",
+   			}),
+   		}),
+   		"f": tg.directory({
+   			"g": tg.file({
+   				"contents": tg.leaf(""),
+   			}),
+   		}),
    	}),
-   	"node": 0,
    })
    "#);
 			Ok::<_, tg::Error>(())

--- a/packages/server/src/artifact/checkin/unify.rs
+++ b/packages/server/src/artifact/checkin/unify.rs
@@ -227,7 +227,11 @@ impl Server {
 					};
 					edges.insert(reference, edge);
 				},
-				tg::reference::Item::Path(_) => return Err(tg::error!("unimplemented")),
+				tg::reference::Item::Path(_) => {
+					if !input_node.metadata.is_symlink() {
+						return Err(tg::error!("invalid input graph"));
+					}
+				},
 			}
 		}
 


### PR DESCRIPTION
- if a symlink is of the form <artifacts_directory/<id>/subpath, the symlink will have artifact: Some(id)
- else, the symlink's subpath will contain the path that is reported by readlink()