### PR TITLE
fix: destroy all `Compiler`s after use and on `Server` shutdown

### DIFF
--- a/packages/server/src/artifact/checkout.rs
+++ b/packages/server/src/artifact/checkout.rs
@@ -149,7 +149,7 @@ impl Server {
 		&self,
 		id: &tg::artifact::Id,
 		arg: &tg::artifact::checkout::Arg,
-		cache_path: &PathBuf,
+		cache_path: &Path,
 		files: Arc<DashMap<tg::file::Id, PathBuf, fnv::FnvBuildHasher>>,
 		visited: Arc<DashSet<PathBuf, fnv::FnvBuildHasher>>,
 		progress: &crate::progress::Handle<tg::artifact::checkout::Output>,
@@ -194,7 +194,7 @@ impl Server {
 			let arg = InnerArg {
 				arg: arg.clone(),
 				artifact: artifact.clone(),
-				cache_path: cache_path.clone(),
+				cache_path: cache_path.to_owned(),
 				existing_artifact: existing_artifact.clone(),
 				files: files.clone(),
 				temp_path: path.clone(),
@@ -234,7 +234,7 @@ impl Server {
 			let arg = InnerArg {
 				arg: arg.clone(),
 				artifact: artifact.clone(),
-				cache_path: cache_path.clone(),
+				cache_path: cache_path.to_owned(),
 				existing_artifact: None,
 				files,
 				temp_path: temp.path.clone(),
@@ -656,10 +656,10 @@ impl Server {
 			// Get the artifact ID.
 			let id = artifact.id(self).await?;
 
-			if final_path.starts_with(&root_path) {
+			if final_path.starts_with(root_path) {
 				// If this symlink is within the root being checked in, the target is relative to that root.
 				let diff =
-					crate::util::path::diff(&final_path.parent().unwrap(), &root_path).unwrap();
+					crate::util::path::diff(final_path.parent().unwrap(), root_path).unwrap();
 				target.push(diff);
 			} else {
 				// Otherwise, the target is relative to the cache path.

--- a/packages/server/src/compiler.rs
+++ b/packages/server/src/compiler.rs
@@ -46,12 +46,6 @@ const SOURCE_MAP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compiler.js.
 #[derive(Clone)]
 pub struct Compiler(Arc<Inner>);
 
-impl PartialEq for Compiler {
-	fn eq(&self, other: &Self) -> bool {
-		Arc::ptr_eq(&self.0, &other.0)
-	}
-}
-
 pub struct Inner {
 	/// The diagnostics.
 	diagnostics: tokio::sync::RwLock<BTreeMap<lsp::Uri, Vec<tg::Diagnostic>>>,
@@ -80,8 +74,8 @@ pub struct Inner {
 	/// The server.
 	server: Server,
 
-	/// The stop task.
-	stop_task: Mutex<Option<Task<()>>>,
+	/// The task.
+	task: Mutex<Option<Task<()>>>,
 
 	/// The workspaces.
 	workspaces: tokio::sync::RwLock<BTreeSet<PathBuf>>,
@@ -146,27 +140,44 @@ impl Compiler {
 			sender,
 			serve_task,
 			server: server.clone(),
-			stop_task,
+			task: stop_task,
 			workspaces,
 		}));
 
 		// Spawn the task.
-		let task = Task::spawn(|stop| {
+		let shutdown = {
 			let compiler = compiler.clone();
 			async move {
-				stop.wait().await;
+				// Stop and wait the serve task.
+				let serve_task = compiler.serve_task.lock().await.clone();
+				if let Some(serve_task) = serve_task {
+					serve_task.stop();
+					serve_task.wait().await.unwrap();
+				}
+
+				// Stop and wait the request task.
 				compiler.request_sender.lock().unwrap().take();
 				let task = compiler.request_task.lock().unwrap().take();
 				if let Some(task) = task {
 					task.await.unwrap();
 				}
+
+				// Remove the compiler from the server.
 				let mut compilers = compiler.server.compilers.write().unwrap();
 				if let Some(pos) = compilers.iter().position(|c| *c == compiler) {
 					compilers.remove(pos);
 				}
 			}
+		};
+
+		// Spawn the task.
+		let task = Task::spawn(|stop| async move {
+			stop.wait().await;
+			shutdown.await;
 		});
-		compiler.stop_task.lock().unwrap().replace(task);
+		compiler.task.lock().unwrap().replace(task);
+
+		// Add the compiler to the server.
 		compiler
 			.server
 			.compilers
@@ -178,27 +189,32 @@ impl Compiler {
 	}
 
 	pub async fn serve(
-		self,
+		&self,
 		input: impl AsyncBufRead + Send + Unpin + 'static,
 		output: impl AsyncWrite + Send + Unpin + 'static,
 	) -> tg::Result<()> {
 		let task = Task::spawn(|stop| {
 			let compiler = self.clone();
 			async move {
-				future::select(pin!(stop.wait()), pin!(compiler.serve_inner(input, output))).await;
+				compiler.serve_inner(input, output, stop).await;
 			}
 		});
 		self.serve_task.lock().await.replace(task.clone());
 		task.wait()
 			.await
-			.map_err(|source| tg::error!(!source, "the compiler serve task failed"))
+			.map_err(|source| tg::error!(!source, "the compiler serve task failed"))?;
+		Ok(())
 	}
 
 	async fn serve_inner(
-		self,
+		&self,
 		mut input: impl AsyncBufRead + Send + Unpin + 'static,
 		mut output: impl AsyncWrite + Send + Unpin + 'static,
-	) -> tg::Result<()> {
+		stop: Stop,
+	) {
+		// Create the task tracker.
+		let task_tracker = tokio_util::task::TaskTracker::new();
+
 		// Create a channel to send outgoing messages.
 		let (outgoing_message_sender, mut outgoing_message_receiver) =
 			tokio::sync::mpsc::unbounded_channel::<jsonrpc::Message>();
@@ -234,8 +250,22 @@ impl Compiler {
 		// Read incoming messages.
 		loop {
 			// Read a message.
-			let Some(message) = Self::read_incoming_message(&mut input).await? else {
-				break;
+			let read = Self::read_incoming_message(&mut input);
+			let result = match future::select(pin!(read), pin!(stop.wait())).await {
+				future::Either::Left((result, _)) => result,
+				future::Either::Right(((), _)) => {
+					break;
+				},
+			};
+			let message = match result {
+				Ok(Some(message)) => message,
+				Ok(None) => {
+					break;
+				},
+				Err(error) => {
+					tracing::error!(?error, "failed to read an incoming message");
+					break;
+				},
 			};
 
 			// If the message is the exit notification, then break.
@@ -249,21 +279,29 @@ impl Compiler {
 			};
 
 			// Spawn a task to handle the message.
-			tokio::spawn({
-				let server = self.clone();
+			task_tracker.spawn({
+				let compiler = self.clone();
 				async move {
-					server.handle_message(message).await;
+					compiler.handle_message(message).await;
 				}
 			});
 		}
+
+		// Wait for all tasks to complete.
+		task_tracker.close();
+		task_tracker.wait().await;
 
 		// Drop the outgoing message sender.
 		self.sender.write().unwrap().take().unwrap();
 
 		// Wait for the outgoing message task to complete.
-		outgoing_message_task.await.unwrap()?;
-
-		Ok(())
+		outgoing_message_task
+			.await
+			.unwrap()
+			.inspect_err(|error| {
+				tracing::error!(?error, "the outgoing message task failed");
+			})
+			.ok();
 	}
 
 	async fn read_incoming_message<R>(reader: &mut R) -> tg::Result<Option<jsonrpc::Message>>
@@ -680,20 +718,12 @@ impl Compiler {
 	}
 
 	pub async fn stop(&self) {
-		self.stop_task.lock().unwrap().as_ref().unwrap().stop();
-		let serve_task = self.serve_task.lock().await.clone();
-		if let Some(serve_task) = serve_task {
-			serve_task.stop();
-		}
+		self.task.lock().unwrap().as_ref().unwrap().stop();
 	}
 
 	pub async fn wait(&self) {
-		let stop_task = self.stop_task.lock().unwrap().clone().unwrap();
-		stop_task.wait().await.unwrap();
-		let serve_task = self.serve_task.lock().await.clone();
-		if let Some(serve_task) = serve_task {
-			serve_task.wait().await.unwrap();
-		}
+		let task = self.task.lock().unwrap().clone().unwrap();
+		task.wait().await.unwrap();
 	}
 
 	async fn module_for_lsp_uri(&self, uri: &lsp::Uri) -> tg::Result<tg::Module> {
@@ -870,9 +900,7 @@ impl crate::Server {
 	pub async fn format(&self, text: String) -> tg::Result<String> {
 		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
 		let text = compiler.format(text).await?;
-
 		compiler.stop().await;
-
 		Ok(text)
 	}
 
@@ -882,11 +910,8 @@ impl crate::Server {
 		output: impl AsyncWrite + Send + Unpin + 'static,
 	) -> tg::Result<()> {
 		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
-
-		compiler.clone().serve(input, output).await?;
-
+		compiler.serve(input, output).await?;
 		compiler.stop().await;
-
 		Ok(())
 	}
 }
@@ -959,5 +984,11 @@ impl std::ops::Deref for Compiler {
 
 	fn deref(&self) -> &Self::Target {
 		&self.0
+	}
+}
+
+impl PartialEq for Compiler {
+	fn eq(&self, other: &Self) -> bool {
+		Arc::ptr_eq(&self.0, &other.0)
 	}
 }

--- a/packages/server/src/compiler/resolve/tests.rs
+++ b/packages/server/src/compiler/resolve/tests.rs
@@ -1,4 +1,4 @@
-use crate::{Config, Server};
+use crate::{compiler::Compiler, Config, Server};
 use futures::{Future, FutureExt};
 use pretty_assertions::assert_eq;
 use std::{panic::AssertUnwindSafe, path::PathBuf};
@@ -147,9 +147,7 @@ where
 	let temp = Temp::new();
 	let options = Config::with_path(temp.path().to_owned());
 	let server = Server::start(options).await?;
-	let compiler = server
-		.start_compiler(&tokio::runtime::Handle::current())
-		.await;
+	let compiler = Compiler::new(&server, tokio::runtime::Handle::current());
 	let result = AssertUnwindSafe(async {
 		let temp = Temp::new();
 		artifact.to_path(temp.as_ref()).await.map_err(
@@ -203,9 +201,7 @@ where
 	let temp = Temp::new();
 	let options = Config::with_path(temp.path().to_owned());
 	let server = Server::start(options).await?;
-	let compiler = server
-		.start_compiler(&tokio::runtime::Handle::current())
-		.await;
+	let compiler = Compiler::new(&server, tokio::runtime::Handle::current());
 	let result = AssertUnwindSafe(async {
 		let directory = Temp::new();
 		artifact.to_path(directory.as_ref()).await.map_err(

--- a/packages/server/src/compiler/resolve/tests.rs
+++ b/packages/server/src/compiler/resolve/tests.rs
@@ -1,4 +1,4 @@
-use crate::{compiler::Compiler, Config, Server};
+use crate::{Config, Server};
 use futures::{Future, FutureExt};
 use pretty_assertions::assert_eq;
 use std::{panic::AssertUnwindSafe, path::PathBuf};
@@ -147,7 +147,9 @@ where
 	let temp = Temp::new();
 	let options = Config::with_path(temp.path().to_owned());
 	let server = Server::start(options).await?;
-	let compiler = Compiler::new(&server, tokio::runtime::Handle::current());
+	let compiler = server
+		.start_compiler(&tokio::runtime::Handle::current())
+		.await;
 	let result = AssertUnwindSafe(async {
 		let temp = Temp::new();
 		artifact.to_path(temp.as_ref()).await.map_err(
@@ -201,7 +203,9 @@ where
 	let temp = Temp::new();
 	let options = Config::with_path(temp.path().to_owned());
 	let server = Server::start(options).await?;
-	let compiler = Compiler::new(&server, tokio::runtime::Handle::current());
+	let compiler = server
+		.start_compiler(&tokio::runtime::Handle::current())
+		.await;
 	let result = AssertUnwindSafe(async {
 		let directory = Temp::new();
 		artifact.to_path(directory.as_ref()).await.map_err(

--- a/packages/server/src/package/check.rs
+++ b/packages/server/src/package/check.rs
@@ -1,7 +1,10 @@
-use crate::{compiler::Compiler, Server};
+use crate::Server;
 use tangram_client as tg;
 use tangram_either::Either;
 use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
+
+#[cfg(test)]
+mod tests;
 
 impl Server {
 	pub async fn check_package(
@@ -25,7 +28,9 @@ impl Server {
 		}
 
 		// Create the compiler.
-		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
+		let compiler = self
+			.start_compiler(&tokio::runtime::Handle::current())
+			.await;
 
 		// Create the module.
 		let module = self
@@ -37,6 +42,9 @@ impl Server {
 
 		// Create the output.
 		let output = tg::package::check::Output { diagnostics };
+
+		// Stop the compiler.
+		self.stop_compiler(&compiler).await;
 
 		Ok(output)
 	}

--- a/packages/server/src/package/check.rs
+++ b/packages/server/src/package/check.rs
@@ -1,4 +1,4 @@
-use crate::Server;
+use crate::{compiler::Compiler, Server};
 use tangram_client as tg;
 use tangram_either::Either;
 use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
@@ -28,9 +28,7 @@ impl Server {
 		}
 
 		// Create the compiler.
-		let compiler = self
-			.start_compiler(&tokio::runtime::Handle::current())
-			.await;
+		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
 
 		// Create the module.
 		let module = self
@@ -44,7 +42,7 @@ impl Server {
 		let output = tg::package::check::Output { diagnostics };
 
 		// Stop the compiler.
-		self.stop_compiler(&compiler).await;
+		compiler.stop().await;
 
 		Ok(output)
 	}

--- a/packages/server/src/package/check/tests.rs
+++ b/packages/server/src/package/check/tests.rs
@@ -1,0 +1,79 @@
+use crate::{util::fs::cleanup, Config, Server};
+use futures::FutureExt as _;
+use indoc::indoc;
+use insta::assert_json_snapshot;
+use std::{future::Future, panic::AssertUnwindSafe};
+use tangram_client as tg;
+use tangram_temp::{self as temp, Temp};
+
+#[tokio::test]
+async fn hello_world() -> tg::Result<()> {
+	test(
+		temp::directory! {
+			"tangram.ts" => indoc!(r#"
+				export default tg.target(() => "Hello, World!");
+			"#),
+		},
+		|_, output| async move {
+			assert_json_snapshot!(output, @"");
+			Ok(())
+		},
+	)
+	.await
+}
+
+#[tokio::test]
+async fn nonexistent_function() -> tg::Result<()> {
+	test(
+		temp::directory! {
+			"tangram.ts" => indoc!(r"
+				export default tg.target(() => foo());
+			"),
+		},
+		|_, output| async move {
+			assert_json_snapshot!(output, @"");
+			Ok(())
+		},
+	)
+	.await
+}
+
+async fn test<F, Fut>(artifact: temp::Artifact, assertions: F) -> tg::Result<()>
+where
+	F: FnOnce(Server, tg::package::check::Output) -> Fut,
+	Fut: Future<Output = tg::Result<()>>,
+{
+	let directory = Temp::new_persistent();
+	artifact.to_path(directory.as_ref()).await.map_err(
+		|source| tg::error!(!source, %path = directory.path().display(), "failed to write the artifact"),
+	)?;
+	let temp = Temp::new_persistent();
+	let options = Config::with_path(temp.path().to_owned());
+	let server = Server::start(options).await?;
+	let result = AssertUnwindSafe(async {
+		let checkin_arg = tg::artifact::checkin::Arg {
+			destructive: false,
+			deterministic: false,
+			ignore: true,
+			locked: false,
+			path: directory.to_owned(),
+		};
+		let package = tg::Artifact::check_in(&server, checkin_arg)
+			.await?
+			.try_unwrap_directory()
+			.map_err(|source| tg::error!(!source, "expected a directory"))?;
+		let package = package.id(&server).await?;
+		let arg = tg::package::check::Arg {
+			package,
+			remote: None,
+		};
+		let server = server.clone();
+		let output = server.check_package(arg).await?;
+		(assertions)(server.clone(), output).await?;
+		Ok(())
+	})
+	.catch_unwind()
+	.await;
+	cleanup(temp, server).await;
+	result.unwrap()
+}

--- a/packages/server/src/package/document.rs
+++ b/packages/server/src/package/document.rs
@@ -1,4 +1,4 @@
-use crate::{compiler::Compiler, Server};
+use crate::Server;
 use tangram_client as tg;
 use tangram_either::Either;
 use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
@@ -25,7 +25,9 @@ impl Server {
 		}
 
 		// Create the compiler.
-		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
+		let compiler = self
+			.start_compiler(&tokio::runtime::Handle::current())
+			.await;
 
 		// Create the module.
 		let module = self
@@ -34,6 +36,8 @@ impl Server {
 
 		// Document the module.
 		let output = compiler.document(&module).await?;
+
+		self.stop_compiler(&compiler).await;
 
 		Ok(output)
 	}

--- a/packages/server/src/package/document.rs
+++ b/packages/server/src/package/document.rs
@@ -1,4 +1,4 @@
-use crate::Server;
+use crate::{compiler::Compiler, Server};
 use tangram_client as tg;
 use tangram_either::Either;
 use tangram_http::{incoming::request::Ext as _, outgoing::response::Ext as _, Incoming, Outgoing};
@@ -25,9 +25,7 @@ impl Server {
 		}
 
 		// Create the compiler.
-		let compiler = self
-			.start_compiler(&tokio::runtime::Handle::current())
-			.await;
+		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
 
 		// Create the module.
 		let module = self
@@ -37,7 +35,8 @@ impl Server {
 		// Document the module.
 		let output = compiler.document(&module).await?;
 
-		self.stop_compiler(&compiler).await;
+		// Stop the compiler.
+		compiler.stop().await;
 
 		Ok(output)
 	}

--- a/packages/server/src/runtime.rs
+++ b/packages/server/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::{compiler::Compiler, Server};
+use crate::Server;
 use tangram_client as tg;
 use tangram_http::{outgoing::response::Ext as _, Incoming, Outgoing};
 
@@ -49,10 +49,15 @@ impl Server {
 		};
 
 		// Create the compiler.
-		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
+		let compiler = self
+			.start_compiler(&tokio::runtime::Handle::current())
+			.await;
 
 		// Get the doc.
 		let doc = compiler.document(&module).await?;
+
+		// Stop the compiler.
+		self.stop_compiler(&compiler).await;
 
 		Ok(doc)
 	}

--- a/packages/server/src/runtime.rs
+++ b/packages/server/src/runtime.rs
@@ -1,4 +1,4 @@
-use crate::Server;
+use crate::{compiler::Compiler, Server};
 use tangram_client as tg;
 use tangram_http::{outgoing::response::Ext as _, Incoming, Outgoing};
 
@@ -49,15 +49,13 @@ impl Server {
 		};
 
 		// Create the compiler.
-		let compiler = self
-			.start_compiler(&tokio::runtime::Handle::current())
-			.await;
+		let compiler = Compiler::new(self, tokio::runtime::Handle::current());
 
 		// Get the doc.
 		let doc = compiler.document(&module).await?;
 
 		// Stop the compiler.
-		self.stop_compiler(&compiler).await;
+		compiler.stop().await;
 
 		Ok(doc)
 	}

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -165,7 +165,7 @@ impl Runtime {
 			build: build.clone(),
 			futures: RefCell::new(FuturesUnordered::new()),
 			global_source_map: Some(SourceMap::from_slice(SOURCE_MAP).unwrap()),
-			compiler: Compiler::new(server, main_runtime_handle.clone()),
+			compiler: server.start_compiler(&main_runtime_handle).await,
 			log_sender: RefCell::new(Some(log_sender)),
 			main_runtime_handle,
 			modules: RefCell::new(Vec::new()),
@@ -375,6 +375,8 @@ impl Runtime {
 		log_task
 			.await
 			.map_err(|source| tg::error!(!source, "failed to join the log task"))?;
+
+		server.stop_compiler(&state.compiler).await;
 
 		result
 	}

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -165,7 +165,7 @@ impl Runtime {
 			build: build.clone(),
 			futures: RefCell::new(FuturesUnordered::new()),
 			global_source_map: Some(SourceMap::from_slice(SOURCE_MAP).unwrap()),
-			compiler: server.start_compiler(&main_runtime_handle).await,
+			compiler: Compiler::new(server, main_runtime_handle.clone()),
 			log_sender: RefCell::new(Some(log_sender)),
 			main_runtime_handle,
 			modules: RefCell::new(Vec::new()),
@@ -376,7 +376,8 @@ impl Runtime {
 			.await
 			.map_err(|source| tg::error!(!source, "failed to join the log task"))?;
 
-		server.stop_compiler(&state.compiler).await;
+		// Stop the compiler.
+		state.compiler.stop().await;
 
 		result
 	}


### PR DESCRIPTION
This change adds `.start_compiler()` and `.stop_compiler()` to `Server` and uses them throughout the codebase for managing `Compiler` lifecycles. We also stop all compilers in `Server`'s `shutdown`.