### PR TITLE
fix(runtime/proxy): correctly handle root path remapping

### DIFF
--- a/packages/server/src/artifact/checkin.rs
+++ b/packages/server/src/artifact/checkin.rs
@@ -65,7 +65,7 @@ impl Server {
 		// Canonicalize the path's parent.
 		arg.path = crate::util::fs::canonicalize_parent(&arg.path)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to canonicalize the path's parent"))?;
+			.map_err(|source| tg::error!(!source, %path = &arg.path.display(), "failed to canonicalize the path's parent"))?;
 
 		// If this is a checkin of a path in the cache directory, then retrieve the corresponding artifact.
 		if let Ok(path) = arg.path.strip_prefix(self.cache_path()) {

--- a/packages/server/src/artifact/checkin/input.rs
+++ b/packages/server/src/artifact/checkin/input.rs
@@ -492,7 +492,7 @@ impl Server {
 							.path
 							.clone();
 
-						let absolute_path = crate::util::fs::canonicalize_parent(path.parent().unwrap().join(import_path)).await.map_err(|source| tg::error!(!source, "failed to canonicalize the path's parent"))?;
+						let absolute_path = crate::util::fs::canonicalize_parent(path.parent().unwrap().join(import_path)).await.map_err(|source| tg::error!(!source, %path = path.display(), "failed to canonicalize the path's parent"))?;
 						let is_external = absolute_path.strip_prefix(&root_path).is_err();
 
 						// If the import is of a module and points outside the root, return an error.
@@ -605,7 +605,7 @@ impl Server {
 			crate::util::fs::canonicalize_parent(path.parent().unwrap().join(&target))
 				.await
 				.map_err(|source| {
-					tg::error!(!source, "failed to canonicalize the path's parent")
+					tg::error!(!source, %path = path.display(), "failed to canonicalize the path's parent")
 				})?;
 
 		// Check if this is a checkin of an artifact.

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -48,7 +48,7 @@ impl Proxy {
 		if let Ok(path) = path.strip_prefix(&path_map.output_guest) {
 			path_map.output_host.join(path)
 		} else {
-			path_map.root_host.join(path)
+			path_map.root_host.join(path.strip_prefix("/").unwrap_or(path.as_ref()))
 		}
 	}
 


### PR DESCRIPTION
Fix `host_path_for_guest_path` by stripping the leading root component. The implementation uses `PathBuf::join`, which replaces the current path if the path being pushed is absolute.