### PR TITLE
fix: refactor server::checkout

### DIFF
--- a/packages/server/src/artifact/checkout.rs
+++ b/packages/server/src/artifact/checkout.rs
@@ -3,7 +3,7 @@ use dashmap::{DashMap, DashSet};
 use futures::{stream::FuturesUnordered, FutureExt, Stream, StreamExt as _, TryStreamExt as _};
 use itertools::Itertools;
 use std::{
-	collections::{BTreeMap, BTreeSet},
+	collections::BTreeMap,
 	future::Future,
 	os::unix::fs::PermissionsExt as _,
 	path::{Path, PathBuf},
@@ -18,18 +18,36 @@ use tangram_http::{incoming::request::Ext as _, Incoming, Outgoing};
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct InnerArg {
-	arg: tg::artifact::checkout::Arg,
-	artifact: tg::Artifact,
-	root_artifact: tg::Artifact,
-	cache_path: PathBuf,
+	// An existing artifact at the destination path.
 	existing_artifact: Option<tg::Artifact>,
-	files: Arc<DashMap<tg::file::Id, PathBuf, fnv::FnvBuildHasher>>,
-	temp_path: PathBuf,
+
+	// The path to move to.
 	final_path: PathBuf,
-	root_path: PathBuf,
-	progress: crate::progress::Handle<tg::artifact::checkout::Output>,
+
+	// The current artifact being checked out.
+	new_artifact: tg::artifact::Id,
+}
+
+#[derive(Clone, Debug)]
+struct State {
+	// The top level checkout arg.
+	arg: tg::artifact::checkout::Arg,
+
+	// The root artifact being checked out.
+	artifact: tg::artifact::Id,
+
+	// The path to the current cache directory, either internal or external.
+	cache_path: PathBuf,
+
+	// Set of visited files and their paths.
+	files: Arc<DashMap<tg::file::Id, PathBuf, fnv::FnvBuildHasher>>,
+
+	// Current progress.
+	_progress: crate::progress::Handle<tg::artifact::checkout::Output>,
+
+	// Set of visited paths.
 	visited: Arc<DashSet<PathBuf, fnv::FnvBuildHasher>>,
 }
 
@@ -41,13 +59,18 @@ impl Server {
 	) -> tg::Result<
 		impl Stream<Item = tg::Result<tg::progress::Event<tg::artifact::checkout::Output>>>,
 	> {
+		// Create the progress handle.
 		let progress = crate::progress::Handle::new();
+
+		// Spawn the task.
 		let task = tokio::spawn({
 			let server = self.clone();
 			let id = id.clone();
 			let progress = progress.clone();
-			async move { server.check_out_artifact_task(&id, arg, &progress).await }
+			async move { server.check_out_artifact_task(id, arg, &progress).await }
 		});
+
+		// Spawn the progress task.
 		tokio::spawn({
 			let progress = progress.clone();
 			async move {
@@ -64,46 +87,63 @@ impl Server {
 				};
 			}
 		});
+
+		// Create the stream.
 		let stream = progress.stream();
 		Ok(stream)
 	}
 
 	async fn check_out_artifact_task(
 		&self,
-		id: &tg::artifact::Id,
+		artifact: tg::artifact::Id,
 		arg: tg::artifact::checkout::Arg,
 		progress: &crate::progress::Handle<tg::artifact::checkout::Output>,
 	) -> tg::Result<tg::artifact::checkout::Output> {
 		// Get or spawn the task.
 		let spawn = |_| {
 			let server = self.clone();
-			let id = id.clone();
 			let arg = arg.clone();
+			let artifact = artifact.clone();
 			let files = Arc::new(DashMap::default());
-			let visited = Arc::new(DashSet::default());
 			let progress = progress.clone();
+			let visited = Arc::new(DashSet::default());
 
 			async move {
 				// Compute the cache path.
 				let cache_path = server
-					.get_cache_path_for_path(&id, arg.path.as_deref())
+					.get_cache_path_for_path(&artifact, arg.path.as_deref())
 					.await?;
 
-				// Checkout the artifact.
-				let output = server
-					.check_out_artifact_with_files(
-						&id,
-						&arg,
-						&cache_path,
-						files,
-						visited,
-						&progress,
-					)
-					.await?;
+				// Create the arg.
+				let final_path = arg
+					.path
+					.clone()
+					.unwrap_or_else(|| cache_path.join(artifact.to_string()));
+				let inner_arg = InnerArg {
+					existing_artifact: None,
+					final_path: arg
+						.path
+						.clone()
+						.unwrap_or_else(|| cache_path.join(artifact.to_string())),
+					new_artifact: artifact.clone(),
+				};
 
+				// Create the state.
+				let state = State {
+					arg: arg.clone(),
+					artifact: artifact.clone(),
+					cache_path,
+					files,
+					_progress: progress,
+					visited,
+				};
+
+				// Perform the checkout.
+				server.check_out_artifact_inner(inner_arg, state).await?;
+
+				// If this is an external checkout, create a lockfile and write it if non-empty.
 				if let Some(path) = arg.path {
-					// Create the lockfile for external checkouts.
-					let artifact = tg::Artifact::with_id(id.clone());
+					let artifact = tg::Artifact::with_id(artifact.clone());
 					let lockfile = server
 						.create_lockfile_with_artifact(&artifact)
 						.await
@@ -127,12 +167,12 @@ impl Server {
 					}
 				}
 
-				Ok(output)
+				Ok(tg::artifact::checkout::Output { path: final_path })
 			}
 		};
 		let internal = arg.path.is_none();
 		let task = if internal {
-			self.checkout_task_map.get_or_spawn(id.clone(), spawn)
+			self.checkout_task_map.get_or_spawn(artifact.clone(), spawn)
 		} else {
 			Task::spawn(spawn)
 		};
@@ -146,258 +186,136 @@ impl Server {
 		Ok(output)
 	}
 
-	async fn check_out_artifact_with_files(
-		&self,
-		id: &tg::artifact::Id,
-		arg: &tg::artifact::checkout::Arg,
-		cache_path: &Path,
-		files: Arc<DashMap<tg::file::Id, PathBuf, fnv::FnvBuildHasher>>,
-		visited: Arc<DashSet<PathBuf, fnv::FnvBuildHasher>>,
-		progress: &crate::progress::Handle<tg::artifact::checkout::Output>,
-	) -> tg::Result<tg::artifact::checkout::Output> {
-		// Get the artifact.
-		let artifact = tg::Artifact::with_id(id.clone());
-
-		if let Some(path) = arg.path.clone() {
-			if !path.is_absolute() {
-				return Err(tg::error!(%path = path.display(), "the path must be absolute"));
-			}
-			let exists = tokio::fs::try_exists(&path).await.map_err(
-				|source| tg::error!(!source, %path = path.display(), "failed to stat the path"),
-			)?;
-			if exists && !arg.force {
-				return Err(
-					tg::error!(%path = path.display(), "there is already a file system object at the path"),
-				);
-			}
-			if (path.as_ref() as &Path).starts_with(self.cache_path()) {
-				return Err(
-					tg::error!(%path = path.display(), "cannot check out an artifact to the cache path"),
-				);
-			}
-
-			// Check in an existing artifact at the path.
-			let existing_artifact = if exists {
-				let arg = tg::artifact::checkin::Arg {
-					destructive: false,
-					deterministic: true,
-					ignore: true,
-					locked: true,
-					path: path.clone(),
-				};
-				let artifact = tg::Artifact::check_in(self, arg).await?;
-				Some(artifact)
-			} else {
-				None
-			};
-
-			// Perform the checkout.
-			let arg = InnerArg {
-				arg: arg.clone(),
-				artifact: artifact.clone(),
-				root_artifact: artifact.clone(),
-				cache_path: cache_path.to_owned(),
-				existing_artifact: existing_artifact.clone(),
-				files: files.clone(),
-				temp_path: path.clone(),
-				final_path: path.clone(),
-				root_path: path.clone(),
-				progress: progress.clone(),
-				visited: visited.clone(),
-			};
-			Box::pin(self.check_out_inner(arg)).await?;
-
-			// Create the output.
-			let output = tg::artifact::checkout::Output { path };
-
-			Ok(output)
-		} else {
-			// Get the path in the cache path.
-			let id = artifact.id(self).await?;
-			let path = cache_path.join(id.to_string());
-			let artifact_path = self.artifacts_path().join(id.to_string());
-
-			// If there is already a file system object at the path, then return.
-			if tokio::fs::try_exists(&path).await.map_err(
-				|source| tg::error!(!source, %path = path.display(), "failed to stat the path"),
-			)? {
-				let output = tg::artifact::checkout::Output {
-					path: artifact_path,
-				};
-				return Ok(output);
-			}
-
-			// Create a temp.
-			let temp = Temp::new(self);
-
-			// Perform the checkout to the temp.
-			let files = Arc::new(DashMap::default());
-			let arg = InnerArg {
-				arg: arg.clone(),
-				artifact: artifact.clone(),
-				root_artifact: artifact.clone(),
-				cache_path: cache_path.to_owned(),
-				existing_artifact: None,
-				files,
-				temp_path: temp.path.clone(),
-				final_path: path.clone(),
-				root_path: path.clone(),
-				progress: progress.clone(),
-				visited: visited.clone(),
-			};
-			Box::pin(self.check_out_inner(arg)).await?;
-			if let Some(parent) = path.parent() {
-				tokio::fs::create_dir_all(parent)
-					.await
-					.map_err(|source| tg::error!(!source, "failed to create output directory"))?;
-			}
-
-			// Move the checkout to the cache path.
-			match tokio::fs::rename(&temp.path, &path).await {
-				Ok(()) => (),
-
-				// If the entry in the cache path exists, then remove the checkout to the temp.
-				Err(error)
-					if matches!(error.raw_os_error(), Some(libc::ENOTEMPTY | libc::EEXIST)) =>
-				{
-					crate::util::fs::remove(&temp.path).await.ok();
-				},
-
-				// Otherwise, return the error.
-				Err(source) => {
-					return Err(
-						tg::error!(!source, %temp = temp.path.display(), %path = path.display(), "failed to move the checkout to the cache directory"),
-					);
-				},
-			};
-
-			// Create the output.
-			let output = tg::artifact::checkout::Output {
-				path: artifact_path,
-			};
-
-			Ok(output)
-		}
-	}
-
-	async fn check_out_inner(&self, arg: InnerArg) -> tg::Result<()> {
+	async fn check_out_artifact_inner(&self, arg: InnerArg, state: State) -> tg::Result<()> {
 		let InnerArg {
-			arg,
-			artifact,
-			root_artifact,
-			cache_path,
 			existing_artifact,
-			files,
-			temp_path,
 			final_path,
-			root_path,
-			progress,
-			visited,
+			new_artifact,
 		} = arg;
 
-		// Check if this artifact has already been checked out by this task to avoid cycles.
-		if !visited.insert(final_path.clone()) {
+		// Check if we've already visited this item.
+		if !state.visited.insert(final_path.clone()) {
 			return Ok(());
 		}
 
-		// If the artifact is the same as the existing artifact, then return.
-		let id = artifact.id(self).await?;
-		match &existing_artifact {
-			None => (),
-			Some(existing_artifact) => {
-				if id == existing_artifact.id(self).await? {
-					return Ok(());
-				}
-			},
-		}
-
-		// Call the appropriate function for the artifact's type.
-		let arg_ = InnerArg {
-			arg: arg.clone(),
-			artifact: artifact.clone(),
-			root_artifact,
-			cache_path,
-			existing_artifact,
-			files,
-			temp_path: temp_path.clone(),
-			final_path,
-			root_path,
-			progress,
-			visited,
+		// Create a temp and compute the dest path.
+		let temp = Temp::new(self);
+		let dest_path = if final_path.starts_with(self.cache_path()) {
+			temp.path.clone()
+		} else {
+			final_path.clone()
 		};
-		match artifact {
-			tg::Artifact::Directory(_) => {
-				Box::pin(self.check_out_directory(&arg_)).await.map_err(
-					|source| tg::error!(!source, %id, %path = temp_path.display(), "failed to check out the directory"),
-				)?;
-			},
 
-			tg::Artifact::File(_) => {
-				Box::pin(self.check_out_file(&arg_)).await.map_err(
-					|source| tg::error!(!source, %id, %path = temp_path.display(), "failed to check out the file"),
-				)?;
-			},
+		// Check if the destination exists.
+		let exists = tokio::fs::try_exists(&final_path).await.unwrap_or(false);
 
-			tg::Artifact::Symlink(_) => {
-				Box::pin(self.check_out_symlink(&arg_)).await.map_err(
-					|source| tg::error!(!source, %id, %path = temp_path.display(), "failed to check out the symlink"),
-				)?;
-			},
+		// Skip duplicate checkouts to the cache.
+		if exists && final_path.starts_with(&state.cache_path) {
+			return Ok(());
 		}
 
-		// If this is an internal checkout, then set the file system object's modified time to the epoch.
-		if arg.path.is_none() {
-			tokio::task::spawn_blocking({
-				let path = temp_path.clone();
-				move || {
-					let epoch =
-						filetime::FileTime::from_system_time(std::time::SystemTime::UNIX_EPOCH);
-					filetime::set_symlink_file_times(path, epoch, epoch)
-						.map_err(|source| tg::error!(!source, "failed to set the modified time"))?;
-					Ok::<_, tg::Error>(())
-				}
-			})
-			.await
-			.unwrap()?;
+		// If the destination exists and this isn't a forced checkout, return an error.
+		if exists && !state.arg.force {
+			return Err(
+				tg::error!(%path = final_path.display(), "there is already a file system object at the path"),
+			);
+		}
+
+		// If the object exists, try and perform a checkin.
+		let existing_artifact = if exists && existing_artifact.is_none() {
+			let arg = tg::artifact::checkin::Arg {
+				destructive: false,
+				deterministic: true,
+				ignore: true,
+				locked: true,
+				path: final_path.clone(),
+			};
+			let artifact = tg::Artifact::check_in(self, arg).await
+				.map_err(|source| tg::error!(!source, %path = final_path.display(), "failed to check in existing artifact"))?;
+			Some(artifact)
+		} else {
+			// Reuse the artifact passed as an arg.
+			existing_artifact
+		};
+
+		// Perform the checkout.
+		match new_artifact {
+			tg::artifact::Id::Directory(artifact) => {
+				self.check_out_directory(artifact, &dest_path, existing_artifact, state)
+					.await?;
+			},
+			tg::artifact::Id::File(artifact) => {
+				self.check_out_file(artifact, &dest_path, existing_artifact, state)
+					.await?;
+			},
+			tg::artifact::Id::Symlink(artifact) => {
+				self.check_out_symlink(artifact, &dest_path, &final_path, existing_artifact, state)
+					.await?;
+			},
+		};
+
+		// Set the file system object's modified time to the epoch.
+		tokio::task::spawn_blocking({
+			let path = dest_path.clone();
+			move || {
+				let epoch = filetime::FileTime::from_system_time(std::time::SystemTime::UNIX_EPOCH);
+				filetime::set_symlink_file_times(path, epoch, epoch)
+					.map_err(|source| tg::error!(!source, "failed to set the modified time"))?;
+				Ok::<_, tg::Error>(())
+			}
+		})
+		.await
+		.unwrap()?;
+
+		// There is no additional work to do if the dest/final paths are the same.
+		if dest_path == final_path {
+			return Ok(());
+		}
+
+		// Rename if necessary.
+		let _permit = self.file_descriptor_semaphore.acquire().await.unwrap();
+		match tokio::fs::rename(&dest_path, &final_path).await {
+			Ok(()) => (),
+			Err(ref error)
+				if matches!(error.raw_os_error(), Some(libc::ENOTEMPTY | libc::EEXIST)) => {},
+			Err(source) => {
+				return Err(
+					tg::error!(!source, %src = dest_path.display(), %dst = final_path.display(), "failed to rename artifact"),
+				)
+			},
 		}
 
 		Ok(())
 	}
 
-	async fn check_out_directory(&self, arg: &InnerArg) -> tg::Result<()> {
-		let InnerArg {
-			arg,
-			artifact,
-			root_artifact,
-			cache_path,
-			existing_artifact,
-			files,
-			temp_path,
-			final_path,
-			root_path,
-			progress,
-			visited,
-		} = arg;
-
-		let directory = artifact
-			.try_unwrap_directory_ref()
-			.ok()
-			.ok_or_else(|| tg::error!("expected a directory"))?;
+	async fn check_out_directory(
+		&self,
+		directory: tg::directory::Id,
+		dest: &Path,
+		existing_artifact: Option<tg::Artifact>,
+		state: State,
+	) -> tg::Result<()> {
+		// Create the directory handle.
+		let directory = tg::Directory::with_id(directory);
 
 		// Handle an existing artifact at the path.
-		match existing_artifact {
+		match &existing_artifact {
 			// If there is an existing directory, then remove any extraneous entries.
 			Some(tg::Artifact::Directory(existing_directory)) => {
 				existing_directory
 					.entries(self)
 					.await?
 					.keys()
-					.map(|name| async move {
-						if !directory.entries(self).await?.contains_key(name) {
-							let entry_path = temp_path.clone().join(name);
-							crate::util::fs::remove(&entry_path).await.ok();
+					.map(|name| {
+						let directory = directory.clone();
+						let dest = dest.to_owned();
+						async move {
+							if !directory.entries(self).await?.contains_key(name) {
+								let entry_path = dest.join(name);
+								crate::util::fs::remove(&entry_path).await.ok();
+							}
+							Ok::<_, tg::Error>(())
 						}
-						Ok::<_, tg::Error>(())
 					})
 					.collect::<FuturesUnordered<_>>()
 					.try_collect::<()>()
@@ -406,15 +324,15 @@ impl Server {
 
 			// If there is an existing file system object at the path and it is not a directory, then remove it, create a directory, and continue.
 			Some(_) => {
-				crate::util::fs::remove(temp_path).await.ok();
-				tokio::fs::create_dir_all(temp_path)
+				crate::util::fs::remove(dest).await.ok();
+				tokio::fs::create_dir_all(dest)
 					.await
 					.map_err(|source| tg::error!(!source, "failed to create the directory"))?;
 			},
 
 			// If there is no artifact at this path, then create a directory.
 			None => {
-				tokio::fs::create_dir_all(temp_path)
+				tokio::fs::create_dir_all(dest)
 					.await
 					.map_err(|source| tg::error!(!source, "failed to create the directory"))?;
 			},
@@ -422,44 +340,40 @@ impl Server {
 
 		// Recurse into the entries.
 		#[allow(clippy::manual_async_fn)]
-		fn future(server: Server, arg: InnerArg) -> impl Future<Output = tg::Result<()>> + Send {
-			async move { server.check_out_inner(arg).await }
+		fn future(
+			server: Server,
+			arg: InnerArg,
+			state: State,
+		) -> impl Future<Output = tg::Result<()>> + Send + 'static {
+			async move { server.check_out_artifact_inner(arg, state).await }
 		}
 
+		// Check out children.
 		directory
 			.entries(self)
 			.await?
-			.iter()
+			.into_iter()
 			.map(|(name, artifact)| {
-				let existing_artifact = &existing_artifact;
-				let files = files.clone();
-				let visited = visited.clone();
+				let server = self.clone();
+				let state = state.clone();
+				let existing_artifact = existing_artifact.clone();
 				async move {
-					// Retrieve an existing artifact.
-					let existing_artifact = match existing_artifact {
-						Some(tg::Artifact::Directory(existing_directory)) => {
-							existing_directory.try_get(self, name).await?
-						},
-						_ => None,
-					};
-
-					// Recurse.
-					let temp_path = temp_path.clone().join(name);
-					let final_path = final_path.clone().join(name);
+					let existing_artifact =
+						if let Some(tg::Artifact::Directory(existing_directory)) =
+							&existing_artifact
+						{
+							existing_directory.try_get_entry(&server, &name).await?
+						} else {
+							None
+						};
+					let final_path = dest.join(&name);
+					let new_artifact = artifact.id(&server).await?;
 					let arg = InnerArg {
-						arg: arg.clone(),
-						artifact: artifact.clone(),
-						root_artifact: root_artifact.clone(),
-						cache_path: cache_path.clone(),
-						existing_artifact: existing_artifact.clone(),
-						files,
-						temp_path,
+						existing_artifact,
 						final_path,
-						root_path: root_path.clone(),
-						progress: progress.clone(),
-						visited,
+						new_artifact,
 					};
-					tokio::spawn(future(self.clone(), arg))
+					tokio::spawn(future(self.clone(), arg, state.clone()))
 						.map(|result| result.unwrap())
 						.await?;
 					Ok::<_, tg::Error>(())
@@ -472,106 +386,109 @@ impl Server {
 		Ok(())
 	}
 
-	async fn check_out_file(&self, arg: &InnerArg) -> tg::Result<()> {
-		let InnerArg {
-			arg,
-			artifact,
-			cache_path,
-			existing_artifact,
-			files,
-			temp_path,
-			progress,
-			visited,
-			..
-		} = arg;
-
-		let file = artifact
-			.try_unwrap_file_ref()
-			.ok()
-			.ok_or_else(|| tg::error!("expected a file"))?;
+	async fn check_out_file(
+		&self,
+		artifact: tg::file::Id,
+		dest: &Path,
+		existing_artifact: Option<tg::Artifact>,
+		state: State,
+	) -> tg::Result<()> {
+		let file = tg::File::with_id(artifact.clone());
 
 		// Handle an existing artifact at the path.
 		if existing_artifact.is_some() {
-			crate::util::fs::remove(temp_path).await.ok();
+			crate::util::fs::remove(dest).await.ok();
 		};
 
 		// Check out the file's dependencies.
-		let dependencies = artifact
-			.dependencies(self)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get the file's dependencies"))?
-			.iter()
-			.map(|artifact| artifact.id(self))
-			.collect::<FuturesUnordered<_>>()
-			.try_collect::<BTreeSet<_>>()
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get the file's dependencies"))?;
+		if state.arg.dependencies {
+			let dependencies = file
+				.dependencies(self)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to get the file's dependencies"))?
+				.values()
+				.cloned()
+				.collect::<Vec<_>>();
 
-		if arg.dependencies && !dependencies.is_empty() {
-			dependencies
-				.iter()
-				.map(|artifact| async {
-					// Don't recurse on artifacts that have already been checked out.
-					if visited.contains(&cache_path.join(artifact.to_string())) {
+			#[allow(clippy::manual_async_fn)]
+			fn future(
+				server: Server,
+				referent: tg::Referent<tg::Object>,
+				state: State,
+			) -> impl Future<Output = tg::Result<()>> + Send + 'static {
+				async move {
+					// Skip object dependencies.
+					let new_artifact: tg::Artifact = match referent.item {
+						tg::Object::Directory(directory) => directory.into(),
+						tg::Object::File(file) => file.into(),
+						tg::Object::Symlink(symlink) => symlink.into(),
+						_ => return Ok(()),
+					};
+					let new_artifact = new_artifact.id(&server).await?;
+
+					// Skip checkouts within the same root.
+					if new_artifact == state.artifact {
 						return Ok(());
 					}
-					let arg = tg::artifact::checkout::Arg {
-						force: false,
-						path: None,
-						dependencies: true,
+
+					// Create a new arg
+					let final_path = state.cache_path.join(new_artifact.to_string());
+					let arg = InnerArg {
+						existing_artifact: None,
+						final_path,
+						new_artifact: new_artifact.clone(),
 					};
-					Box::pin(self.check_out_artifact_with_files(
-						artifact,
-						&arg,
-						cache_path,
-						files.clone(),
-						visited.clone(),
-						progress,
-					))
-					.await?;
-					Ok::<_, tg::Error>(())
+
+					// Create a new state.
+					let state = State {
+						arg: tg::artifact::checkout::Arg {
+							path: None,
+							..state.arg.clone()
+						},
+						artifact: new_artifact,
+						..state.clone()
+					};
+
+					// Check out the dependency.
+					server.check_out_artifact_inner(arg, state).await
+				}
+			}
+			dependencies
+				.into_iter()
+				.map(|referent| {
+					let server = self.clone();
+					let state = state.clone();
+					async move { tokio::spawn(future(server, referent, state)).await.unwrap() }
 				})
 				.collect::<FuturesUnordered<_>>()
-				.try_collect::<Vec<_>>()
-				.await
-				.map_err(|source| {
-					tg::error!(!source, "failed to check out the file's dependencies")
-				})?;
+				.try_collect::<()>()
+				.await?;
 		}
 
 		// Attempt to copy the file from another file in the checkout.
-		let id = file.id(self).await?;
-		let existing_path = files.get(&id).map(|path| path.clone());
+		let existing_path = state.files.get(&artifact).map(|path| path.clone());
 		if let Some(existing_path) = existing_path {
 			let _permit = self.file_descriptor_semaphore.acquire().await.unwrap();
-			tokio::fs::copy(&existing_path, &temp_path).await.map_err(
-				|source| tg::error!(!source, %existing_path = temp_path.display(), %to = temp_path.display(), %id, "failed to copy the file"),
+			tokio::fs::copy(&existing_path, dest).await.map_err(
+				|source| tg::error!(!source, %existing_path = existing_path.display(), %to = dest.display(), %artifact, "failed to copy the file"),
 			)?;
 			return Ok(());
 		}
 
 		// Attempt to use the file from an internal checkout.
-		let internal_checkout_path = cache_path.join(id.to_string());
-		if arg.path.is_none() {
-			// If this checkout is internal, then create a hard link.
-			let result = tokio::fs::hard_link(&internal_checkout_path, temp_path).await;
-			if result.is_ok() {
-				return Ok(());
-			}
-		} else {
-			// If this checkout is external, then copy the file.
-			let _permit = self.file_descriptor_semaphore.acquire().await.unwrap();
-			let result = tokio::fs::copy(&internal_checkout_path, temp_path).await;
-			if result.is_ok() {
-				return Ok(());
-			}
+		let internal_checkout_path = state.cache_path.join(artifact.to_string());
+		let permit = self.file_descriptor_semaphore.acquire().await.unwrap();
+		let result = tokio::fs::copy(&internal_checkout_path, dest).await;
+		drop(permit);
+		if result.is_ok() {
+			return Ok(());
 		}
 
 		// Create the file.
 		let permit = self.file_descriptor_semaphore.acquire().await.unwrap();
 		tokio::io::copy(
 			&mut file.reader(self).await?,
-			&mut tokio::fs::File::create(temp_path)
+			&mut tokio::fs::File::create(dest)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to create the file"))?,
 		)
@@ -582,7 +499,7 @@ impl Server {
 		// Make the file executable if necessary.
 		if file.executable(self).await? {
 			let permissions = std::fs::Permissions::from_mode(0o755);
-			tokio::fs::set_permissions(temp_path, permissions)
+			tokio::fs::set_permissions(dest, permissions)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to set the permissions"))?;
 		}
@@ -592,84 +509,110 @@ impl Server {
 		let xattr = file.data(self).await?;
 		let json = serde_json::to_vec(&xattr)
 			.map_err(|error| tg::error!(source = error, "failed to serialize the dependencies"))?;
-		xattr::set(temp_path, name, &json).map_err(|source| {
+		xattr::set(dest, name, &json).map_err(|source| {
 			tg::error!(!source, "failed to set the extended attribute for the file")
 		})?;
 
 		// Add the path to the files map.
-		files.insert(id.clone(), temp_path.clone());
+		if let dashmap::Entry::Vacant(vacant) = state.files.entry(artifact.clone()) {
+			vacant.insert(dest.to_owned());
+		}
 
 		Ok(())
 	}
 
-	async fn check_out_symlink(&self, arg: &InnerArg) -> tg::Result<()> {
-		let InnerArg {
-			arg,
-			artifact,
-			root_artifact,
-			cache_path,
-			existing_artifact,
-			files,
-			temp_path,
-			final_path,
-			root_path,
-			progress,
-			visited,
-		} = arg;
-
-		let symlink = artifact
-			.try_unwrap_symlink_ref()
-			.ok()
-			.ok_or_else(|| tg::error!("expected a symlink"))?;
+	async fn check_out_symlink(
+		&self,
+		artifact: tg::symlink::Id,
+		dest: &Path,
+		final_path: &Path,
+		existing_artifact: Option<tg::Artifact>,
+		state: State,
+	) -> tg::Result<()> {
+		let symlink = tg::Symlink::with_id(artifact.clone());
 
 		// Handle an existing artifact at the path.
 		if existing_artifact.is_some() {
-			crate::util::fs::remove(&temp_path).await.ok();
+			crate::util::fs::remove(dest).await.ok();
 		};
 
-		// Render the target.
+		// Get the symlink's data.
 		let target = symlink.target(self).await?;
-		let artifact = symlink.artifact(self).await?;
+		let target_artifact = symlink.artifact(self).await?;
 		let subpath = symlink.subpath(self).await?;
-		let target = if let Some(target) = &target {
-			target.to_owned()
-		} else if let Some(artifact) = &artifact {
-			// If dependencies are enabled, then check out the symlink's artifact.
-			if arg.dependencies {
-				let target_id = artifact.id(self).await?;
 
-				// Don't recurse on artifacts that are already checked out.
-				if !visited.contains(&cache_path.join(target_id.to_string())) {
-					let arg = tg::artifact::checkout::Arg::default();
-					Box::pin(self.check_out_artifact_with_files(
-						&target_id,
-						&arg,
-						cache_path,
-						files.clone(),
-						visited.clone(),
-						progress,
-					))
-					.await?;
+		// Fail if the symlink is invalid.
+		if target_artifact.is_none() && subpath.is_none() {
+			return Err(tg::error!(
+				"invalid symlink, expected an artifact and/or a subpath"
+			));
+		}
+
+		// Render the target.
+		let target = if let Some(target) = target {
+			target
+		} else if let Some(target_artifact) = &target_artifact {
+			// Check out the symlink's artifact if necessary.
+			if state.arg.dependencies {
+				let new_artifact = target_artifact.id(self).await?;
+
+				// If this is an external symlink, check out its artifact.
+				if new_artifact != state.artifact {
+					// Create a new arg.
+					let final_path = state.cache_path.join(new_artifact.to_string());
+					let arg = InnerArg {
+						existing_artifact: None,
+						final_path,
+						new_artifact: new_artifact.clone(),
+					};
+
+					// Create a new state.
+					let state = State {
+						arg: tg::artifact::checkout::Arg {
+							path: None,
+							..state.arg.clone()
+						},
+						artifact: new_artifact,
+						..state.clone()
+					};
+
+					// Spawn instead of Box to avoid stack overflow.
+					#[allow(clippy::manual_async_fn)]
+					fn future(
+						server: Server,
+						arg: InnerArg,
+						state: State,
+					) -> impl Future<Output = tg::Result<()>> + Send + 'static {
+						async move { server.check_out_artifact_inner(arg, state).await }
+					}
+
+					tokio::spawn(future(self.clone(), arg, state))
+						.await
+						.unwrap()?;
 				}
 			}
 
 			// Render the target.
-			let mut target: PathBuf = PathBuf::new();
+			let mut target = PathBuf::new();
 
 			// Get the artifact IDs.
-			let target_id = artifact.id(self).await?;
-			let root_id = root_artifact.id(self).await?;
-			let link_id = symlink.id(self).await?.into();
+			let target_id = target_artifact.id(self).await?;
 
-			if root_id == link_id || root_id != target_id {
+			if state.artifact == artifact.into() || state.artifact != target_id {
 				// If this symlink is the root item or the target artifact is different from the root, write a symlink relative to the cache directory.
-				let diff =
-					crate::util::path::diff(final_path.parent().unwrap(), cache_path).unwrap();
+				let diff = crate::util::path::diff(final_path.parent().unwrap(), &state.cache_path)
+					.unwrap();
 				target.push(diff.join(target_id.to_string()));
 			} else {
 				// Otherwise, write a relative path to the root.
+				let root_path = state
+					.arg
+					.path
+					.clone()
+					.unwrap_or_else(|| state.cache_path.join(target_id.to_string()));
+
 				let diff =
-					crate::util::path::diff(final_path.parent().unwrap(), root_path).unwrap();
+					crate::util::path::diff(final_path.parent().unwrap(), &root_path).unwrap();
 				target.push(diff);
 			}
 			if let Some(subpath) = subpath {
@@ -682,9 +625,10 @@ impl Server {
 		};
 
 		// Create the symlink.
-		tokio::fs::symlink(&target, &temp_path)
+		let _permit = self.file_descriptor_semaphore.acquire().await.unwrap();
+		tokio::fs::symlink(&target, &dest)
 			.await
-			.map_err(|source| tg::error!(!source, %src = target.display(), %dst = temp_path.display(), "failed to create the symlink"))?;
+			.map_err(|source| tg::error!(!source, %src = target.display(), %dst = dest.display(), "failed to create the symlink"))?;
 
 		Ok(())
 	}

--- a/packages/server/src/artifact/checkout/tests.rs
+++ b/packages/server/src/artifact/checkout/tests.rs
@@ -190,25 +190,6 @@ async fn cyclic_symlink() -> tg::Result<()> {
   {
     "kind": "directory",
     "entries": {
-      ".tangram": {
-        "kind": "directory",
-        "entries": {
-          "artifacts": {
-            "kind": "directory",
-            "entries": {
-              "dir_01jgpeycbs5s4yjr89jqf3kkvy1a0rmrk7j2fmedscvh495h5b3740": {
-                "kind": "directory",
-                "entries": {
-                  "link": {
-                    "kind": "symlink",
-                    "target": "link"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
       "link": {
         "kind": "symlink",
         "target": "link"


### PR DESCRIPTION
- remove check_out_with_files
- check for visited paths exactly once
- remove distinction between external and internal checkouts in check_out_inner
- don't attempt to hardlink internal checkouts, since the cache directory and destination path might be on different file systems
- only attempt to rename when the destination path and final path are different, which is reserved for internal checkouts
- split up InnerArg into server::checkout::InnerArg and server::checkout::State to distinguish between values that are only used by the checkout of a single artifact, and those that are shared for recursive checkouts
- use tokio::spawn for all recursion in checkout
