### PR TITLE
refactor: add `Target` variant to `Symlink`

### DIFF
--- a/packages/cli/src/view/info.rs
+++ b/packages/cli/src/view/info.rs
@@ -339,13 +339,14 @@ impl InfoViewExt for tg::symlink::Data {
 			tg::symlink::Data::Graph { graph, .. } => {
 				vec![("graph", graph.to_string())]
 			},
-			tg::symlink::Data::Normal {
+			tg::symlink::Data::Target { target } => {
+				vec![("target", target.to_string_lossy().into_owned())]
+			},
+			tg::symlink::Data::Artifact {
 				artifact, subpath, ..
 			} => {
 				let mut rows = vec![];
-				if let Some(artifact) = artifact {
-					rows.push(("artifact", artifact.to_string()));
-				}
+				rows.push(("artifact", artifact.to_string()));
 				if let Some(subpath) = subpath {
 					rows.push(("subpath", subpath.to_string_lossy().into_owned()));
 				}

--- a/packages/cli/src/view/tree/provider.rs
+++ b/packages/cli/src/view/tree/provider.rs
@@ -491,12 +491,17 @@ impl Provider {
 						}
 						(Some(index.to_string()), tg::Value::Map(value))
 					},
-					tg::graph::Node::Symlink(tg::graph::object::Symlink::Target { .. }) => {
-						(Some(index.to_string()), tg::Value::Map(BTreeMap::new()))
+					tg::graph::Node::Symlink(tg::graph::object::Symlink::Target { target }) => {
+						let mut value = BTreeMap::new();
+						value.insert(
+							"target".into(),
+							tg::Value::String(target.to_str().unwrap().to_owned()),
+						);
+						(Some(index.to_string()), tg::Value::Map(value))
 					},
 					tg::graph::Node::Symlink(tg::graph::object::Symlink::Artifact {
 						artifact,
-						..
+						subpath,
 					}) => {
 						let mut value = BTreeMap::new();
 						let object = match artifact {
@@ -504,6 +509,12 @@ impl Provider {
 							Either::Right(artifact) => tg::Value::Object(artifact.clone().into()),
 						};
 						value.insert("artifact".into(), object);
+						if let Some(subpath) = subpath {
+							value.insert(
+								"subpath".into(),
+								tg::Value::String(subpath.to_str().unwrap().to_owned()),
+							);
+						}
 						(Some(index.to_string()), tg::Value::Map(value))
 					},
 				})

--- a/packages/client/src/directory/data.rs
+++ b/packages/client/src/directory/data.rs
@@ -30,7 +30,7 @@ impl Directory {
 	#[must_use]
 	pub fn children(&self) -> BTreeSet<tg::object::Id> {
 		match self {
-			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
+			Self::Graph { graph, .. } => std::iter::once(graph.clone()).map_into().collect(),
 			Self::Normal { entries } => entries.values().cloned().map(Into::into).collect(),
 		}
 	}

--- a/packages/client/src/directory/object.rs
+++ b/packages/client/src/directory/object.rs
@@ -18,7 +18,7 @@ impl Directory {
 	#[must_use]
 	pub fn children(&self) -> Vec<tg::Object> {
 		match self {
-			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
+			Self::Graph { graph, .. } => std::iter::once(graph.clone()).map_into().collect(),
 			Self::Normal { entries } => entries.values().cloned().map(Into::into).collect(),
 		}
 	}

--- a/packages/client/src/file/data.rs
+++ b/packages/client/src/file/data.rs
@@ -37,7 +37,7 @@ impl File {
 	#[must_use]
 	pub fn children(&self) -> BTreeSet<tg::object::Id> {
 		match self {
-			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
+			Self::Graph { graph, .. } => std::iter::once(graph.clone()).map_into().collect(),
 			Self::Normal {
 				contents,
 				dependencies,

--- a/packages/client/src/file/object.rs
+++ b/packages/client/src/file/object.rs
@@ -20,7 +20,7 @@ impl File {
 	#[must_use]
 	pub fn children(&self) -> Vec<tg::Object> {
 		match self {
-			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
+			Self::Graph { graph, .. } => std::iter::once(graph.clone()).map_into().collect(),
 			Self::Normal {
 				contents,
 				dependencies,

--- a/packages/client/src/graph/data.rs
+++ b/packages/client/src/graph/data.rs
@@ -36,12 +36,16 @@ pub struct File {
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub struct Symlink {
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub artifact: Option<Either<usize, tg::artifact::Id>>,
+pub enum Symlink {
+	Target {
+		target: PathBuf,
+	},
+	Artifact {
+		artifact: Either<usize, tg::artifact::Id>,
 
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub subpath: Option<PathBuf>,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		subpath: Option<PathBuf>,
+	},
 }
 
 impl Graph {
@@ -80,8 +84,12 @@ impl Graph {
 						}
 					}
 				},
-				tg::graph::data::Node::Symlink(tg::graph::data::Symlink { artifact, .. }) => {
-					if let Some(Either::Right(id)) = artifact {
+				tg::graph::data::Node::Symlink(symlink) => {
+					if let tg::graph::data::Symlink::Artifact {
+						artifact: Either::Right(id),
+						..
+					} = symlink
+					{
 						children.insert(id.clone().into());
 					}
 				},

--- a/packages/client/src/graph/object.rs
+++ b/packages/client/src/graph/object.rs
@@ -145,6 +145,11 @@ impl Node {
 			},
 
 			Self::Symlink(symlink) => match symlink {
+				tg::graph::object::Symlink::Target { target } => Ok(
+					tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target {
+						target: target.clone(),
+					}),
+				),
 				tg::graph::object::Symlink::Artifact { artifact, subpath } => {
 					let artifact = match artifact {
 						Either::Left(index) => Either::Left(*index),
@@ -155,11 +160,6 @@ impl Node {
 						tg::graph::data::Symlink::Artifact { artifact, subpath },
 					))
 				},
-				tg::graph::object::Symlink::Target { target } => Ok(
-					tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target {
-						target: target.clone(),
-					}),
-				),
 			},
 		}
 	}
@@ -227,6 +227,9 @@ impl TryFrom<tg::graph::data::Node> for Node {
 				let node = Node::File(file);
 				Ok(node)
 			},
+			tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target { target }) => {
+				Ok(Node::Symlink(tg::graph::object::Symlink::Target { target }))
+			},
 			tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Artifact {
 				artifact,
 				subpath,
@@ -235,9 +238,6 @@ impl TryFrom<tg::graph::data::Node> for Node {
 				let symlink = tg::graph::object::Symlink::Artifact { artifact, subpath };
 				let node = Node::Symlink(symlink);
 				Ok(node)
-			},
-			tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target { target }) => {
-				Ok(Node::Symlink(tg::graph::object::Symlink::Target { target }))
 			},
 		}
 	}

--- a/packages/client/src/lockfile.rs
+++ b/packages/client/src/lockfile.rs
@@ -28,9 +28,16 @@ pub enum Node {
 		executable: bool,
 	},
 
-	Symlink {
-		#[serde(default, skip_serializing_if = "Option::is_none")]
-		artifact: Option<Entry>,
+	Symlink(Symlink),
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum Symlink {
+	Target {
+		target: PathBuf,
+	},
+	Artifact {
+		artifact: Entry,
 
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		subpath: Option<PathBuf>,

--- a/packages/client/src/symlink/data.rs
+++ b/packages/client/src/symlink/data.rs
@@ -11,9 +11,12 @@ pub enum Symlink {
 		node: usize,
 	},
 
-	Normal {
-		#[serde(default, skip_serializing_if = "Option::is_none")]
-		artifact: Option<tg::artifact::Id>,
+	Target {
+		target: PathBuf,
+	},
+
+	Artifact {
+		artifact: tg::artifact::Id,
 
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		subpath: Option<PathBuf>,
@@ -36,7 +39,8 @@ impl Symlink {
 	pub fn children(&self) -> BTreeSet<tg::object::Id> {
 		match self {
 			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
-			Self::Normal { artifact, .. } => artifact.clone().into_iter().map_into().collect(),
+			Self::Target { .. } => BTreeSet::new(),
+			Self::Artifact { artifact, .. } => [artifact.clone()].into_iter().map_into().collect(),
 		}
 	}
 }

--- a/packages/client/src/symlink/data.rs
+++ b/packages/client/src/symlink/data.rs
@@ -38,9 +38,11 @@ impl Symlink {
 	#[must_use]
 	pub fn children(&self) -> BTreeSet<tg::object::Id> {
 		match self {
-			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
+			Self::Graph { graph, .. } => std::iter::once(graph.clone()).map_into().collect(),
 			Self::Target { .. } => BTreeSet::new(),
-			Self::Artifact { artifact, .. } => [artifact.clone()].into_iter().map_into().collect(),
+			Self::Artifact { artifact, .. } => {
+				std::iter::once(artifact.clone()).map_into().collect()
+			},
 		}
 	}
 }

--- a/packages/client/src/symlink/object.rs
+++ b/packages/client/src/symlink/object.rs
@@ -9,8 +9,11 @@ pub enum Symlink {
 		graph: tg::Graph,
 		node: usize,
 	},
-	Normal {
-		artifact: Option<tg::Artifact>,
+	Target {
+		target: PathBuf,
+	},
+	Artifact {
+		artifact: tg::Artifact,
 		subpath: Option<PathBuf>,
 	},
 }
@@ -20,7 +23,8 @@ impl Symlink {
 	pub fn children(&self) -> Vec<tg::Object> {
 		match self {
 			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
-			Self::Normal { artifact, .. } => artifact.clone().into_iter().map_into().collect(),
+			Self::Target { .. } => vec![],
+			Self::Artifact { artifact, .. } => [artifact.clone()].into_iter().map_into().collect(),
 		}
 	}
 }
@@ -34,9 +38,10 @@ impl TryFrom<Data> for Symlink {
 				let graph = tg::Graph::with_id(graph);
 				Ok(Self::Graph { graph, node })
 			},
-			Data::Normal { artifact, subpath } => {
-				let artifact = artifact.map(tg::Artifact::with_id);
-				Ok(Self::Normal { artifact, subpath })
+			Data::Target { target } => Ok(Self::Target { target }),
+			Data::Artifact { artifact, subpath } => {
+				let artifact = tg::Artifact::with_id(artifact);
+				Ok(Self::Artifact { artifact, subpath })
 			},
 		}
 	}

--- a/packages/client/src/symlink/object.rs
+++ b/packages/client/src/symlink/object.rs
@@ -22,9 +22,11 @@ impl Symlink {
 	#[must_use]
 	pub fn children(&self) -> Vec<tg::Object> {
 		match self {
-			Self::Graph { graph, .. } => [graph.clone()].into_iter().map_into().collect(),
+			Self::Graph { graph, .. } => std::iter::once(graph.clone()).map_into().collect(),
 			Self::Target { .. } => vec![],
-			Self::Artifact { artifact, .. } => [artifact.clone()].into_iter().map_into().collect(),
+			Self::Artifact { artifact, .. } => {
+				std::iter::once(artifact.clone()).map_into().collect()
+			},
 		}
 	}
 }

--- a/packages/client/src/value/print.rs
+++ b/packages/client/src/value/print.rs
@@ -473,6 +473,11 @@ where
 							s.start_map()?;
 							s.map_entry("kind", |s| s.string("symlink"))?;
 							match symlink {
+								tg::graph::object::Symlink::Target { target } => {
+									s.map_entry("target", |s| {
+										s.string(target.to_string_lossy().as_ref())
+									})?;
+								},
 								tg::graph::object::Symlink::Artifact { artifact, subpath } => {
 									s.map_entry("artifact", |s| {
 										match &artifact {
@@ -490,11 +495,6 @@ where
 											s.string(subpath.to_string_lossy().as_ref())
 										})?;
 									}
-								},
-								tg::graph::object::Symlink::Target { target } => {
-									s.map_entry("target", |s| {
-										s.string(target.to_string_lossy().as_ref())
-									})?;
 								},
 							}
 							s.finish_map()

--- a/packages/client/src/value/print.rs
+++ b/packages/client/src/value/print.rs
@@ -362,10 +362,11 @@ where
 				self.map_entry("graph", |s| s.graph(graph))?;
 				self.map_entry("node", |s| s.number(node.to_f64().unwrap()))?;
 			},
-			tg::symlink::Object::Normal { artifact, subpath } => {
-				if let Some(artifact) = &artifact {
-					self.map_entry("artifact", |s| s.artifact(artifact))?;
-				}
+			tg::symlink::Object::Target { target } => {
+				self.map_entry("target", |s| s.string(target.to_string_lossy().as_ref()))?;
+			},
+			tg::symlink::Object::Artifact { artifact, subpath } => {
+				self.map_entry("artifact", |s| s.artifact(artifact))?;
 				if let Some(subpath) = &subpath {
 					self.map_entry("subpath", |s| s.string(subpath.to_string_lossy().as_ref()))?;
 				}
@@ -471,23 +472,30 @@ where
 						tg::graph::Node::Symlink(symlink) => {
 							s.start_map()?;
 							s.map_entry("kind", |s| s.string("symlink"))?;
-							if let Some(artifact) = &symlink.artifact {
-								s.map_entry("artifact", |s| {
-									match &artifact {
-										Either::Left(index) => {
-											s.number(index.to_f64().unwrap())?;
-										},
-										Either::Right(artifact) => {
-											s.artifact(artifact)?;
-										},
+							match symlink {
+								tg::graph::object::Symlink::Artifact { artifact, subpath } => {
+									s.map_entry("artifact", |s| {
+										match &artifact {
+											Either::Left(index) => {
+												s.number(index.to_f64().unwrap())?;
+											},
+											Either::Right(artifact) => {
+												s.artifact(artifact)?;
+											},
+										}
+										Ok(())
+									})?;
+									if let Some(subpath) = subpath {
+										s.map_entry("subpath", |s| {
+											s.string(subpath.to_string_lossy().as_ref())
+										})?;
 									}
-									Ok(())
-								})?;
-							}
-							if let Some(subpath) = &symlink.subpath {
-								s.map_entry("subpath", |s| {
-									s.string(subpath.to_string_lossy().as_ref())
-								})?;
+								},
+								tg::graph::object::Symlink::Target { target } => {
+									s.map_entry("target", |s| {
+										s.string(target.to_string_lossy().as_ref())
+									})?;
+								},
 							}
 							s.finish_map()
 						},

--- a/packages/runtime/src/checksum.ts
+++ b/packages/runtime/src/checksum.ts
@@ -1,4 +1,3 @@
-import { unreachable } from "./assert";
 import * as tg from "./index.ts";
 
 export let checksum = (
@@ -32,7 +31,7 @@ export namespace Checksum {
 		} else if (tg.Artifact.is(input)) {
 			return await tg.Artifact.checksum(input, algorithm);
 		} else {
-			return unreachable();
+			return tg.unreachable();
 		}
 	};
 	Checksum.new = new_;

--- a/packages/runtime/src/directory.ts
+++ b/packages/runtime/src/directory.ts
@@ -197,15 +197,16 @@ export class Directory {
 			parents.push(artifact);
 			artifact = entry;
 			if (entry instanceof tg.Symlink) {
+				let target = await entry.target();
 				let artifact_ = await entry.artifact();
 				let subpath = await entry.subpath();
-				if (artifact_ === undefined && subpath !== undefined) {
+				if (target !== undefined) {
 					let parent = parents.pop();
 					if (!parent) {
 						throw new Error("path is external");
 					}
 					artifact = parent;
-					components.unshift(...tg.path.components(subpath));
+					components.unshift(...tg.path.components(target));
 				} else if (artifact_ !== undefined && subpath === undefined) {
 					return artifact_;
 				} else if (artifact_ instanceof tg.Directory && subpath !== undefined) {

--- a/packages/runtime/src/symlink.ts
+++ b/packages/runtime/src/symlink.ts
@@ -1,10 +1,8 @@
+import { unreachable } from "./assert";
 import * as tg from "./index.ts";
-import { flatten } from "./util.ts";
 
-export let symlink = async (
-	...args: tg.Args<Symlink.Arg>
-): Promise<Symlink> => {
-	return await Symlink.new(...args);
+export let symlink = async (arg: Symlink.Arg): Promise<Symlink> => {
+	return await Symlink.new(arg);
 };
 
 export class Symlink {
@@ -22,76 +20,67 @@ export class Symlink {
 		return new Symlink({ id });
 	}
 
-	static async new(...args: tg.Args<Symlink.Arg>): Promise<Symlink> {
-		let arg = await Symlink.arg(...args);
-		if ("graph" in arg) {
-			return new Symlink({ object: arg });
+	static async new(arg: Symlink.Arg): Promise<Symlink> {
+		let resolved = await Symlink.arg(arg);
+		if ("graph" in resolved && "node" in resolved) {
+			return new Symlink({ object: resolved });
+		} else if ("target" in resolved) {
+			let symlink = new Symlink({ object: resolved });
+			return symlink;
+		} else if ("artifact" in resolved) {
+			return new Symlink({
+				object: {
+					artifact: resolved.artifact,
+					subpath: resolved.subpath,
+				},
+			});
 		}
-		let artifact = arg.artifact;
-		let subpath = arg.subpath !== undefined ? arg.subpath : undefined;
-		let object = { artifact, subpath };
-		return new Symlink({ object });
+		return unreachable("invalid symlink arguments");
 	}
 
-	static async arg(...args: tg.Args<Symlink.Arg>): Promise<Symlink.ArgObject> {
-		let resolved = await Promise.all(args.map(tg.resolve));
-		if (resolved.length === 1) {
-			const arg = resolved[0];
-			if (typeof arg === "object" && "graph" in arg) {
-				return arg;
+	static async arg(arg: Symlink.Arg): Promise<Symlink.ArgObject> {
+		let resolved = await tg.resolve(arg);
+		if (typeof resolved === "object" && "graph" in resolved) {
+			return resolved;
+		}
+		if (typeof resolved === "string") {
+			return { target: resolved };
+		} else if (tg.Artifact.is(resolved)) {
+			return { artifact: resolved, subpath: undefined };
+		} else if (resolved instanceof tg.Template) {
+			tg.assert(resolved.components.length <= 2);
+			let [firstComponent, secondComponent] = resolved.components;
+			if (typeof firstComponent === "string" && secondComponent === undefined) {
+				return { target: firstComponent };
+			} else if (
+				tg.Artifact.is(firstComponent) &&
+				secondComponent === undefined
+			) {
+				return { artifact: firstComponent, subpath: undefined };
+			} else if (
+				tg.Artifact.is(firstComponent) &&
+				typeof secondComponent === "string"
+			) {
+				tg.assert(secondComponent.startsWith("/"));
+				return {
+					artifact: firstComponent,
+					subpath: secondComponent.slice(1),
+				};
+			} else {
+				throw new Error("invalid template");
 			}
+		} else if (resolved instanceof Symlink) {
+			if ("target" in resolved) {
+				return { target: resolved.target };
+			} else if ("artifact" in resolved) {
+				let subpath = await resolved.subpath();
+				let artifact = resolved.artifact;
+				return { artifact, subpath };
+			}
+		} else {
+			return resolved;
 		}
-		if (resolved.some((arg) => typeof arg === "object" && "graph" in arg)) {
-			throw new Error("only a single graph arg is supported");
-		}
-		let flattened = flatten(resolved);
-		let objects = await Promise.all(
-			flattened.map(async (arg) => {
-				if (arg === undefined) {
-					return {};
-				} else if (typeof arg === "string") {
-					return { subpath: arg };
-				} else if (tg.Artifact.is(arg)) {
-					return { artifact: arg, subpath: tg.Mutation.unset() };
-				} else if (arg instanceof tg.Template) {
-					tg.assert(arg.components.length <= 2);
-					let [firstComponent, secondComponent] = arg.components;
-					if (
-						typeof firstComponent === "string" &&
-						secondComponent === undefined
-					) {
-						return { subpath: firstComponent };
-					} else if (
-						tg.Artifact.is(firstComponent) &&
-						secondComponent === undefined
-					) {
-						return { artifact: firstComponent, subpath: tg.Mutation.unset() };
-					} else if (
-						tg.Artifact.is(firstComponent) &&
-						typeof secondComponent === "string"
-					) {
-						tg.assert(secondComponent.startsWith("/"));
-						return {
-							artifact: firstComponent,
-							subpath: secondComponent.slice(1),
-						};
-					} else {
-						throw new Error("invalid template");
-					}
-				} else if (arg instanceof Symlink) {
-					let subpath = await arg.subpath();
-					return { artifact: await arg.artifact(), subpath };
-				} else {
-					return arg;
-				}
-			}),
-		);
-		let mutations = await tg.Args.createMutations(objects, {
-			artifact: "set",
-			subpath: "set",
-		});
-		let arg = await tg.Args.applyMutations(mutations);
-		return arg;
+		return unreachable();
 	}
 
 	static expect(value: unknown): Symlink {
@@ -132,9 +121,9 @@ export class Symlink {
 
 	async artifact(): Promise<tg.Artifact | undefined> {
 		const object = await this.object();
-		if (!("graph" in object)) {
+		if ("artifact" in object) {
 			return object.artifact;
-		} else {
+		} else if ("graph" in object) {
 			const nodes = await object.graph.nodes();
 			const node = nodes[object.node];
 			tg.assert(node !== undefined, `invalid index ${object.node}`);
@@ -171,9 +160,9 @@ export class Symlink {
 
 	async subpath(): Promise<string | undefined> {
 		const object = await this.object();
-		if (!("graph" in object)) {
+		if ("artifact" in object) {
 			return object.subpath;
-		} else {
+		} else if ("graph" in object) {
 			const nodes = await object.graph.nodes();
 			const node = nodes[object.node];
 			tg.assert(node !== undefined, `invalid index ${object.node}`);
@@ -182,6 +171,8 @@ export class Symlink {
 				`expected a symlink node, got ${node}`,
 			);
 			return node.subpath;
+		} else if ("target" in object) {
+			return object.target;
 		}
 	}
 
@@ -204,29 +195,25 @@ export class Symlink {
 }
 
 export namespace Symlink {
-	export type Arg =
-		| undefined
-		| string
-		| tg.Artifact
-		| tg.Template
-		| Symlink
-		| ArgObject;
+	export type Arg = string | tg.Artifact | tg.Template | Symlink | ArgObject;
 
 	export type ArgObject =
+		| { graph: tg.Graph; node: number }
+		| { target: string }
 		| {
-				artifact?: tg.Artifact | undefined;
+				artifact: tg.Artifact;
 				subpath?: string | undefined;
-		  }
-		| { graph: tg.Graph; node: number };
+		  };
 
 	export type Id = string;
 
 	export type Object =
+		| { graph: tg.Graph; node: number }
+		| { target: string }
 		| {
-				artifact: tg.Artifact | undefined;
+				artifact: tg.Artifact;
 				subpath: string | undefined;
-		  }
-		| { graph: tg.Graph; node: number };
+		  };
 
 	export type State = tg.Object.State<Symlink.Id, Symlink.Object>;
 }

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -408,7 +408,7 @@ declare namespace tg {
 	}
 
 	/** Create a symlink. */
-	export let symlink: (...args: tg.Args<tg.Symlink.Arg>) => Promise<tg.Symlink>;
+	export let symlink: (arg: tg.Symlink.Arg) => Promise<tg.Symlink>;
 
 	/** A symlink. */
 	export class Symlink {
@@ -435,25 +435,23 @@ declare namespace tg {
 
 		/** Resolve this symlink to the artifact it refers to, or return undefined if none is found. */
 		resolve(): Promise<tg.Artifact | undefined>;
+
+		/** Get this symlink's target. */
+		target(): Promise<string | undefined>;
 	}
 
 	export namespace Symlink {
 		export type Id = string;
 
-		export type Arg =
-			| undefined
-			| string
-			| tg.Artifact
-			| tg.Template
-			| tg.Symlink
-			| ArgObject;
+		export type Arg = string | tg.Artifact | tg.Template | Symlink | ArgObject;
 
 		type ArgObject =
+			| { graph: tg.Graph; node: number }
+			| { target: string }
 			| {
-					artifact?: tg.Artifact | undefined;
+					artifact: tg.Artifact;
 					subpath?: string | undefined;
-			  }
-			| { graph: tg.Graph; node: number };
+			  };
 	}
 
 	/** Create a graph. */
@@ -506,11 +504,16 @@ declare namespace tg {
 			executable?: boolean | undefined;
 		};
 
-		type SymlinkNodeArg = {
-			kind: "symlink";
-			artifact?: number | tg.Artifact | undefined;
-			subpath?: string | undefined;
-		};
+		type SymlinkNodeArg =
+			| {
+					kind: "symlink";
+					target: string;
+			  }
+			| {
+					kind: "symlink";
+					artifact: number | tg.Artifact;
+					subpath?: string | undefined;
+			  };
 
 		type Node = DirectoryNode | FileNode | SymlinkNode;
 
@@ -528,11 +531,16 @@ declare namespace tg {
 			executable: boolean;
 		};
 
-		type SymlinkNode = {
-			kind: "symlink";
-			artifact: number | tg.Artifact | undefined;
-			subpath: string | undefined;
-		};
+		type SymlinkNode =
+			| {
+					kind: "symlink";
+					target: string;
+			  }
+			| {
+					kind: "symlink";
+					artifact: number | tg.Artifact;
+					subpath: string | undefined;
+			  };
 	}
 
 	/** Create a target. */

--- a/packages/server/src/artifact/checkin/lockfile.rs
+++ b/packages/server/src/artifact/checkin/lockfile.rs
@@ -437,7 +437,7 @@ fn strip_nodes_inner(
 					if let Some(subpath) = subpath {
 						tg::lockfile::Symlink::Target { target: subpath }
 					} else {
-						todo!()
+						return None;
 					},
 				));
 			}

--- a/packages/server/src/artifact/checkin/lockfile.rs
+++ b/packages/server/src/artifact/checkin/lockfile.rs
@@ -187,15 +187,38 @@ impl Server {
 					.clone()
 					.try_unwrap_symlink()
 					.unwrap();
-				symlink.subpath.map(PathBuf::from)
+				match symlink {
+					tg::graph::object::Symlink::Artifact {
+						artifact: _,
+						subpath,
+					} => subpath.map(PathBuf::from),
+					tg::graph::object::Symlink::Target { target } => Some(target),
+				}
 			},
-			tg::symlink::Data::Normal { subpath, .. } => subpath.as_ref().map(PathBuf::from),
+			tg::symlink::Data::Target { target } => Some(PathBuf::from(target)),
+			tg::symlink::Data::Artifact {
+				artifact: _,
+				subpath,
+			} => subpath.clone().map(PathBuf::from),
 		};
 		let artifact = graph.nodes[node]
 			.edges
 			.first()
 			.map(|edge| self.get_lockfile_entry(graph, edge.index));
-		Ok(tg::lockfile::Node::Symlink { artifact, subpath })
+		match artifact {
+			Some(artifact) => Ok(tg::lockfile::Node::Symlink(
+				tg::lockfile::Symlink::Artifact { artifact, subpath },
+			)),
+			None => {
+				if let Some(subpath) = subpath {
+					Ok(tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target {
+						target: subpath,
+					}))
+				} else {
+					Err(tg::error!("unable to determine subpath for lockfile"))
+				}
+			},
+		}
 	}
 
 	#[allow(clippy::unused_self)]
@@ -279,10 +302,10 @@ fn check_if_references_module(
 							check_if_references_module(nodes, path, *child_node, visited)?;
 					}
 				},
-				tg::lockfile::Node::Symlink {
-					artifact: Some(artifact),
+				tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Artifact {
+					artifact,
 					subpath,
-				} => {
+				}) => {
 					let retain = subpath
 						.as_ref()
 						.map_or(false, |subpath| tg::package::is_module_path(subpath));
@@ -295,7 +318,7 @@ fn check_if_references_module(
 							check_if_references_module(nodes, path, child_node, visited)?;
 					}
 				},
-				tg::lockfile::Node::Symlink { .. } => {
+				tg::lockfile::Node::Symlink(_) => {
 					visited[node].replace(false);
 				},
 			}
@@ -387,19 +410,37 @@ fn strip_nodes_inner(
 			});
 		},
 
-		tg::lockfile::Node::Symlink { artifact, subpath } => {
+		tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target { target }) => {
+			new_nodes[new_node].replace(tg::lockfile::Node::Symlink(
+				tg::lockfile::Symlink::Target {
+					target: target.clone(),
+				},
+			));
+		},
+		tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Artifact { artifact, subpath }) => {
 			// Remap the artifact if necessary.
 			let artifact = match artifact {
-				Some(Either::Left(node)) => {
+				Either::Left(node) => {
 					strip_nodes_inner(old_nodes, node, visited, new_nodes, should_retain)
 						.map(Either::Left)
 				},
-				Some(Either::Right(id)) => Some(Either::Right(id)),
-				None => None,
+				Either::Right(id) => Some(Either::Right(id)),
 			};
 
 			// Create the node.
-			new_nodes[new_node].replace(tg::lockfile::Node::Symlink { artifact, subpath });
+			if let Some(artifact) = artifact {
+				new_nodes[new_node].replace(tg::lockfile::Node::Symlink(
+					tg::lockfile::Symlink::Artifact { artifact, subpath },
+				));
+			} else {
+				new_nodes[new_node].replace(tg::lockfile::Node::Symlink(
+					if let Some(subpath) = subpath {
+						tg::lockfile::Symlink::Target { target: subpath }
+					} else {
+						todo!()
+					},
+				));
+			}
 		},
 	}
 

--- a/packages/server/src/artifact/checkin/object.rs
+++ b/packages/server/src/artifact/checkin/object.rs
@@ -501,12 +501,12 @@ impl Server {
 				.into()
 			},
 			tg::graph::data::Node::Symlink(symlink) => match symlink {
+				tg::graph::data::Symlink::Target { target } => {
+					tg::symlink::Data::Target { target }.into()
+				},
 				tg::graph::data::Symlink::Artifact { artifact, subpath } => {
 					let artifact = Either::unwrap_right(artifact);
 					tg::symlink::Data::Artifact { artifact, subpath }.into()
-				},
-				tg::graph::data::Symlink::Target { target } => {
-					tg::symlink::Data::Target { target }.into()
 				},
 			},
 		}
@@ -549,6 +549,7 @@ impl Server {
 						}
 					}
 				},
+				tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target { .. }) => (),
 				tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Artifact {
 					artifact,
 					..
@@ -562,7 +563,6 @@ impl Server {
 						weight += metadata.weight.unwrap_or(0);
 					}
 				},
-				tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target { .. }) => (),
 			}
 		}
 

--- a/packages/server/src/artifact/checkin/object.rs
+++ b/packages/server/src/artifact/checkin/object.rs
@@ -335,10 +335,7 @@ impl Server {
 				let subpath = edge
 					.subpath
 					.map(|path| path.strip_prefix("./").unwrap_or(&path).to_owned());
-				let symlink = tg::graph::data::Symlink {
-					artifact: Some(artifact),
-					subpath,
-				};
+				let symlink = tg::graph::data::Symlink::Artifact { artifact, subpath };
 				tg::graph::data::Node::Symlink(symlink)
 			} else {
 				let target = input.nodes[input_index]
@@ -349,9 +346,8 @@ impl Server {
 					.item()
 					.try_unwrap_path_ref()
 					.map_err(|_| tg::error!("expected a path item"))?;
-				let symlink = tg::graph::data::Symlink {
-					artifact: None,
-					subpath: Some(target.clone()),
+				let symlink = tg::graph::data::Symlink::Target {
+					target: target.clone(),
 				};
 				tg::graph::data::Node::Symlink(symlink)
 			}
@@ -504,10 +500,14 @@ impl Server {
 				}
 				.into()
 			},
-			tg::graph::data::Node::Symlink(symlink) => {
-				let tg::graph::data::Symlink { artifact, subpath } = symlink;
-				let artifact = artifact.map(Either::unwrap_right);
-				tg::symlink::Data::Normal { artifact, subpath }.into()
+			tg::graph::data::Node::Symlink(symlink) => match symlink {
+				tg::graph::data::Symlink::Artifact { artifact, subpath } => {
+					let artifact = Either::unwrap_right(artifact);
+					tg::symlink::Data::Artifact { artifact, subpath }.into()
+				},
+				tg::graph::data::Symlink::Target { target } => {
+					tg::symlink::Data::Target { target }.into()
+				},
 			},
 		}
 	}
@@ -549,8 +549,11 @@ impl Server {
 						}
 					}
 				},
-				tg::graph::data::Node::Symlink(symlink) => {
-					if let Some(Either::Right(id)) = &symlink.artifact {
+				tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Artifact {
+					artifact,
+					..
+				}) => {
+					if let Either::Right(id) = artifact {
 						let node = graph.objects.get(&id.clone().into()).unwrap();
 						let metadata = graph.nodes[*node].metadata.clone().unwrap();
 						complete &= metadata.complete;
@@ -559,6 +562,7 @@ impl Server {
 						weight += metadata.weight.unwrap_or(0);
 					}
 				},
+				tg::graph::data::Node::Symlink(tg::graph::data::Symlink::Target { .. }) => (),
 			}
 		}
 

--- a/packages/server/src/artifact/checkin/output.rs
+++ b/packages/server/src/artifact/checkin/output.rs
@@ -415,13 +415,13 @@ impl<'a> petgraph::visit::IntoNeighbors for GraphImpl<'a> {
 					.values()
 					.filter_map(|referent| referent.item.as_ref().left().copied()),
 			),
+			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target { target: _ }) => {
+				Box::new(std::iter::empty())
+			},
 			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Artifact { artifact, .. }) => {
 				Box::new(
 					std::iter::once(artifact).filter_map(|entry| entry.as_ref().left().copied()),
 				)
-			},
-			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target { target: _ }) => {
-				Box::new(std::iter::empty())
 			},
 		}
 	}

--- a/packages/server/src/artifact/checkin/tests.rs
+++ b/packages/server/src/artifact/checkin/tests.rs
@@ -68,7 +68,7 @@ async fn external_symlink() -> tg::Result<()> {
    		"dependencies": {
    			"../b/c": {
    				"item": tg.symlink({
-   					"subpath": "e",
+   					"target": "e",
    				}),
    				"path": "../b/c",
    			},
@@ -318,7 +318,7 @@ async fn symlink() -> tg::Result<()> {
 			assert_snapshot!(output, @r#"
    tg.directory({
    	"link": tg.symlink({
-   		"subpath": ".",
+   		"target": ".",
    	}),
    })
    "#);
@@ -414,11 +414,11 @@ async fn directory() -> tg::Result<()> {
    		"contents": tg.leaf("Hello, world!"),
    	}),
    	"link": tg.symlink({
-   		"subpath": "hello.txt",
+   		"target": "hello.txt",
    	}),
    	"subdirectory": tg.directory({
    		"sublink": tg.symlink({
-   			"subpath": "../link",
+   			"target": "../link",
    		}),
    	}),
    })
@@ -566,12 +566,12 @@ async fn directory_destructive() -> tg::Result<()> {
    	"a": tg.directory({
    		"b": tg.directory({
    			"c": tg.symlink({
-   				"subpath": "../../a/d/e",
+   				"target": "../../a/d/e",
    			}),
    		}),
    		"d": tg.directory({
    			"e": tg.symlink({
-   				"subpath": "../../a/f/g",
+   				"target": "../../a/f/g",
    			}),
    		}),
    		"f": tg.directory({

--- a/packages/server/src/artifact/checkin/tests.rs
+++ b/packages/server/src/artifact/checkin/tests.rs
@@ -642,7 +642,7 @@ async fn external_symlink_roundtrip() -> tg::Result<()> {
 		let directory = tg::directory! {
 			"file" => "contents",
 		};
-		let symlink = tg::symlink_artifact!(directory, Some(PathBuf::from("file")));
+		let symlink = tg::symlink!(artifact = directory, subpath = Some(PathBuf::from("file")));
 
 		// Check out the artifact.
 		let temp = Temp::new();

--- a/packages/server/src/artifact/checkin/tests.rs
+++ b/packages/server/src/artifact/checkin/tests.rs
@@ -641,9 +641,8 @@ async fn external_symlink_roundtrip() -> tg::Result<()> {
 	let result = AssertUnwindSafe(async {
 		let directory = tg::directory! {
 			"file" => "contents",
-		}
-		.into();
-		let symlink = tg::symlink!(Some(directory), Some(PathBuf::from("file")));
+		};
+		let symlink = tg::symlink_artifact!(directory, Some(PathBuf::from("file")));
 
 		// Check out the artifact.
 		let temp = Temp::new();

--- a/packages/server/src/artifact/checkout/tests.rs
+++ b/packages/server/src/artifact/checkout/tests.rs
@@ -46,7 +46,7 @@ async fn symlink() -> tg::Result<()> {
 		tg::directory! {
 			"directory" => tg::directory! {
 				"hello.txt" => "Hello, World!",
-				"link" => tg::symlink_target!(PathBuf::from("hello.txt")),
+				"link" => tg::symlink!(PathBuf::from("hello.txt")),
 			}
 		},
 		|_, artifact| async move {
@@ -84,8 +84,8 @@ async fn symlink_shared_target() -> tg::Result<()> {
 		tg::directory! {
 			"directory" => tg::directory! {
 				"hello.txt" => "Hello, World!",
-				"link1" => tg::symlink_target!(PathBuf::from("hello.txt")),
-				"link2" => tg::symlink_target!(PathBuf::from("hello.txt")),
+				"link1" => tg::symlink!(PathBuf::from("hello.txt")),
+				"link2" => tg::symlink!(PathBuf::from("hello.txt")),
 			}
 		},
 		|_, artifact| async move {
@@ -232,7 +232,7 @@ async fn shared_directory_dependency() -> tg::Result<()> {
 			"bin" => tg::directory! {
 				"a" => "",
 			},
-			"usr" => tg::symlink_target!(PathBuf::from(".")),
+			"usr" => tg::symlink!(PathBuf::from(".")),
 		};
 		let b = tg::Symlink::with_artifact_and_subpath(a.clone().into(), Some("bin/a".into()));
 		let c = tg::File::with_object(tg::file::Object::Normal {

--- a/packages/server/src/artifact/checkout/tests.rs
+++ b/packages/server/src/artifact/checkout/tests.rs
@@ -46,7 +46,7 @@ async fn symlink() -> tg::Result<()> {
 		tg::directory! {
 			"directory" => tg::directory! {
 				"hello.txt" => "Hello, World!",
-				"link" => tg::symlink!(None, Some(PathBuf::from("hello.txt"))),
+				"link" => tg::symlink_target!(PathBuf::from("hello.txt")),
 			}
 		},
 		|_, artifact| async move {
@@ -84,8 +84,8 @@ async fn symlink_shared_target() -> tg::Result<()> {
 		tg::directory! {
 			"directory" => tg::directory! {
 				"hello.txt" => "Hello, World!",
-				"link1" => tg::symlink!(None, Some(PathBuf::from("hello.txt"))),
-				"link2" => tg::symlink!(None, Some(PathBuf::from("hello.txt"))),
+				"link1" => tg::symlink_target!(PathBuf::from("hello.txt")),
+				"link2" => tg::symlink_target!(PathBuf::from("hello.txt")),
 			}
 		},
 		|_, artifact| async move {
@@ -178,8 +178,8 @@ async fn cyclic_symlink() -> tg::Result<()> {
 			tg::graph::object::Node::Directory(tg::graph::object::Directory {
 				entries: [("link".to_owned(), Either::Left(1))].into(),
 			}),
-			tg::graph::object::Node::Symlink(tg::graph::object::Symlink {
-				artifact: Some(Either::Left(0)),
+			tg::graph::object::Node::Symlink(tg::graph::object::Symlink::Artifact {
+				artifact: Either::Left(0),
 				subpath: Some("link".into()),
 			}),
 		],
@@ -196,7 +196,7 @@ async fn cyclic_symlink() -> tg::Result<()> {
           "artifacts": {
             "kind": "directory",
             "entries": {
-              "dir_014yyvsnfgj1dsd3s7dctta79hmjm3rq6sya1t7hymygjm97ynqhng": {
+              "dir_01jgpeycbs5s4yjr89jqf3kkvy1a0rmrk7j2fmedscvh495h5b3740": {
                 "kind": "directory",
                 "entries": {
                   "link": {
@@ -232,10 +232,9 @@ async fn shared_directory_dependency() -> tg::Result<()> {
 			"bin" => tg::directory! {
 				"a" => "",
 			},
-			"usr" => tg::symlink!(None, Some(PathBuf::from("."))),
+			"usr" => tg::symlink_target!(PathBuf::from(".")),
 		};
-		let b =
-			tg::Symlink::with_artifact_and_subpath(Some(a.clone().into()), Some("bin/a".into()));
+		let b = tg::Symlink::with_artifact_and_subpath(a.clone().into(), Some("bin/a".into()));
 		let c = tg::File::with_object(tg::file::Object::Normal {
 			contents: tg::Blob::with_reader(&server, b"c".as_slice()).await?,
 			dependencies: [

--- a/packages/server/src/lockfile.rs
+++ b/packages/server/src/lockfile.rs
@@ -278,9 +278,9 @@ impl Server {
 					}
 				}
 			},
-			tg::lockfile::Node::Symlink { artifact, subpath } => {
+			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Artifact { artifact, subpath }) => {
 				// Get the referent artifact.
-				let Some(Either::Left(artifact)) = artifact else {
+				let Either::Left(artifact) = artifact else {
 					return Ok(None);
 				};
 
@@ -315,6 +315,9 @@ impl Server {
 				if let Some(result) = result {
 					return Ok(Some(result));
 				}
+			},
+			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target { .. }) => {
+				return Ok(None);
 			},
 		}
 

--- a/packages/server/src/lockfile.rs
+++ b/packages/server/src/lockfile.rs
@@ -231,6 +231,7 @@ impl Server {
 					}
 				}
 			},
+
 			tg::lockfile::Node::File { dependencies, .. } => {
 				for (reference, dependency) in dependencies {
 					// Skip dependencies that are not contained in the lockfile.
@@ -278,6 +279,11 @@ impl Server {
 					}
 				}
 			},
+
+			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target { .. }) => {
+				return Ok(None);
+			},
+
 			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Artifact { artifact, subpath }) => {
 				// Get the referent artifact.
 				let Either::Left(artifact) = artifact else {
@@ -315,9 +321,6 @@ impl Server {
 				if let Some(result) = result {
 					return Ok(Some(result));
 				}
-			},
-			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Target { .. }) => {
-				return Ok(None);
 			},
 		}
 

--- a/packages/server/src/runtime/builtin/bundle.rs
+++ b/packages/server/src/runtime/builtin/bundle.rs
@@ -154,7 +154,7 @@ impl Runtime {
 				if let Some(path) = path.as_ref() {
 					target.push(path);
 				}
-				let symlink = tg::Symlink::with_artifact_and_subpath(None, Some(target));
+				let symlink = tg::Symlink::with_target(target);
 				Ok(symlink.into())
 			},
 		}

--- a/packages/server/src/runtime/js/error.rs
+++ b/packages/server/src/runtime/js/error.rs
@@ -191,7 +191,7 @@ fn get_location(
 		Some(id) => {
 			// Get the module.
 			let modules = state.modules.borrow();
-			let module = modules.get(id - 1)?;
+			let module = modules.get(id - 1).unwrap();
 
 			// Get the source.
 			let source = tg::error::Source::Module(module.module.clone());

--- a/packages/server/src/runtime/js/error.rs
+++ b/packages/server/src/runtime/js/error.rs
@@ -191,7 +191,7 @@ fn get_location(
 		Some(id) => {
 			// Get the module.
 			let modules = state.modules.borrow();
-			let module = modules.get(id - 1).unwrap();
+			let module = modules.get(id - 1)?;
 
 			// Get the source.
 			let source = tg::error::Source::Module(module.module.clone());

--- a/packages/server/tests/directory.rs
+++ b/packages/server/tests/directory.rs
@@ -12,7 +12,7 @@ async fn get_symlink() -> tg::Result<()> {
 	let result = AssertUnwindSafe(async {
 		let directory = tg::directory! {
 			"file.txt" => "Hello, World!",
-			"link" => tg::symlink_target!("file.txt"),
+			"link" => tg::symlink!("file.txt"),
 		};
 		let artifact = directory.get(&server, "link").await?;
 		assert!(artifact.is_file());
@@ -37,7 +37,7 @@ async fn get_file_through_symlink() -> tg::Result<()> {
 			"directory" => tg::directory! {
 				"file.txt" => "Hello, World!",
 			},
-			"link" => tg::symlink_target!("directory"),
+			"link" => tg::symlink!("directory"),
 		};
 		let artifact = directory.get(&server, "link/file.txt").await?;
 		assert!(artifact.is_file());

--- a/packages/server/tests/directory.rs
+++ b/packages/server/tests/directory.rs
@@ -12,7 +12,7 @@ async fn get_symlink() -> tg::Result<()> {
 	let result = AssertUnwindSafe(async {
 		let directory = tg::directory! {
 			"file.txt" => "Hello, World!",
-			"link" => tg::symlink!(None, Some("file.txt".into())),
+			"link" => tg::symlink_target!("file.txt"),
 		};
 		let artifact = directory.get(&server, "link").await?;
 		assert!(artifact.is_file());
@@ -37,7 +37,7 @@ async fn get_file_through_symlink() -> tg::Result<()> {
 			"directory" => tg::directory! {
 				"file.txt" => "Hello, World!",
 			},
-			"link" => tg::symlink!(None, Some("directory".into())),
+			"link" => tg::symlink_target!("directory"),
 		};
 		let artifact = directory.get(&server, "link/file.txt").await?;
 		assert!(artifact.is_file());

--- a/packages/v8/src/convert/graph.rs
+++ b/packages/v8/src/convert/graph.rs
@@ -141,6 +141,19 @@ impl ToV8 for tg::graph::Node {
 				object.set(scope, key.into(), value);
 			},
 
+			tg::graph::Node::Symlink(tg::graph::object::Symlink::Target { target }) => {
+				let key =
+					v8::String::new_external_onebyte_static(scope, "kind".as_bytes()).unwrap();
+				let value =
+					v8::String::new_external_onebyte_static(scope, "symlink".as_bytes()).unwrap();
+				object.set(scope, key.into(), value.into());
+
+				let key =
+					v8::String::new_external_onebyte_static(scope, "target".as_bytes()).unwrap();
+				let value = target.to_v8(scope)?;
+				object.set(scope, key.into(), value);
+			},
+
 			tg::graph::Node::Symlink(tg::graph::object::Symlink::Artifact {
 				artifact,
 				subpath,
@@ -159,18 +172,6 @@ impl ToV8 for tg::graph::Node {
 				let key =
 					v8::String::new_external_onebyte_static(scope, "subpath".as_bytes()).unwrap();
 				let value = subpath.to_v8(scope)?;
-				object.set(scope, key.into(), value);
-			},
-			tg::graph::Node::Symlink(tg::graph::object::Symlink::Target { target }) => {
-				let key =
-					v8::String::new_external_onebyte_static(scope, "kind".as_bytes()).unwrap();
-				let value =
-					v8::String::new_external_onebyte_static(scope, "symlink".as_bytes()).unwrap();
-				object.set(scope, key.into(), value.into());
-
-				let key =
-					v8::String::new_external_onebyte_static(scope, "target".as_bytes()).unwrap();
-				let value = target.to_v8(scope)?;
 				object.set(scope, key.into(), value);
 			},
 		}


### PR DESCRIPTION
This PR adds a `Target` variant to `Symlink` types, which will hopefully help with type safety. Now, we are guaranteed an artifact in the `Artifact` variant, and a path (`target`) in the `Target` variant.