### PR TITLE
feat: init with autobuild

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -113,6 +113,10 @@ pub struct Advanced {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub file_descriptor_semaphore_size: Option<usize>,
 
+	/// The path to the preferred autobuild package for `tangram init`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub init_autobuild_reference: Option<tg::Reference>,
+
 	/// Whether to preserve temporary directories.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub preserve_temp_directories: Option<bool>,

--- a/packages/cli/src/package/init.rs
+++ b/packages/cli/src/package/init.rs
@@ -25,7 +25,10 @@ impl Cli {
 		// Check if there is already a root module for the path.
 		for name in tg::package::ROOT_MODULE_FILE_NAMES {
 			let module_path = path.join(name);
-			if tokio::fs::try_exists(&module_path).await.unwrap_or(false) {
+			let exists = tokio::fs::try_exists(&module_path)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to check if the path exists"))?;
+			if exists {
 				return Err(
 					tg::error!(%module_path = module_path.display(), "found existing root module"),
 				);


### PR DESCRIPTION
Augment the default package produced by `tangram init` to use autobuild.

- error if path already contains a root module
- add config option to change the reference used to import the package
- have `tangram target build` perform an init if it detects a directory without a root module