### PR TITLE
fix: replace tabs with spaces before rendering Data

### DIFF
--- a/packages/cli/src/view/data.rs
+++ b/packages/cli/src/view/data.rs
@@ -55,6 +55,7 @@ where
 		let lines = state
 			.text
 			.lines()
+			.map(|line| line.replace('\t', "  "))
 			.skip(state.scroll)
 			.map(Line::raw)
 			.collect::<Vec<_>>();


### PR DESCRIPTION
This is a workaround for https://github.com/ratatui/ratatui/issues/876 where ratatui's dependency calculates the width of a tab as zero, which seems [intended](https://github.com/unicode-rs/unicode-width/issues/6#issuecomment-1859217112).

Closes #332