### PR TITLE
Add `tangram_http::Idle` and use it when serving `Response`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5614,6 +5614,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "pin-project",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5618,6 +5618,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "tangram_futures",
  "tokio",
  "tokio-util",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5618,7 +5618,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tangram_futures",
  "tokio",
  "tokio-util",
 ]

--- a/packages/http/Cargo.toml
+++ b/packages/http/Cargo.toml
@@ -26,6 +26,5 @@ pin-project = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
-tangram_futures = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/packages/http/Cargo.toml
+++ b/packages/http/Cargo.toml
@@ -26,5 +26,6 @@ pin-project = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
+tangram_futures = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/packages/http/Cargo.toml
+++ b/packages/http/Cargo.toml
@@ -22,6 +22,7 @@ http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
+pin-project = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }

--- a/packages/http/src/idle.rs
+++ b/packages/http/src/idle.rs
@@ -1,19 +1,28 @@
+use crate::Error;
 use bytes::Bytes;
-use futures::{
-	future::{self, BoxFuture},
-	FutureExt, TryFutureExt as _,
-};
 use pin_project::pin_project;
 use std::{
 	pin::pin,
-	sync::{
-		atomic::{AtomicUsize, Ordering},
-		Arc,
-	},
+	sync::{Arc, Mutex},
 	time::Duration,
 };
 
-use crate::Error;
+#[derive(Clone)]
+pub struct Idle {
+	receiver: tokio::sync::watch::Receiver<bool>,
+	sender: tokio::sync::watch::Sender<bool>,
+	state: Arc<Mutex<State>>,
+	timeout: Duration,
+}
+
+pub struct State {
+	count: usize,
+	task: Option<tokio::task::JoinHandle<()>>,
+}
+
+pub struct Token {
+	idle: Idle,
+}
 
 #[pin_project]
 pub struct Body<T: hyper::body::Body<Data = Bytes, Error = Error>> {
@@ -22,7 +31,70 @@ pub struct Body<T: hyper::body::Body<Data = Bytes, Error = Error>> {
 	token: Token,
 }
 
-impl<T: hyper::body::Body<Data = Bytes, Error = Error>> Body<T> {
+impl Idle {
+	#[must_use]
+	pub fn new(timeout: Duration) -> Self {
+		let (sender, receiver) = tokio::sync::watch::channel(false);
+		let task = tokio::spawn({
+			let sender = sender.clone();
+			async move {
+				tokio::time::sleep(timeout).await;
+				sender.send_replace(true);
+			}
+		});
+		let state = Arc::new(Mutex::new(State {
+			count: 0,
+			task: Some(task),
+		}));
+		Self {
+			receiver,
+			sender,
+			state,
+			timeout,
+		}
+	}
+
+	pub async fn wait(&self) {
+		self.receiver
+			.clone()
+			.wait_for(|value| *value)
+			.await
+			.unwrap();
+	}
+
+	#[must_use]
+	pub fn token(&self) -> Token {
+		let mut state = self.state.lock().unwrap();
+		if let Some(task) = state.task.take() {
+			task.abort();
+		}
+		state.count += 1;
+		Token { idle: self.clone() }
+	}
+}
+
+impl Drop for Token {
+	fn drop(&mut self) {
+		let mut state = self.idle.state.lock().unwrap();
+		state.count -= 1;
+		if state.count == 0 {
+			let task = tokio::spawn({
+				let timeout = self.idle.timeout;
+				let sender = self.idle.sender.clone();
+				async move {
+					tokio::time::sleep(timeout).await;
+					sender.send_replace(true);
+				}
+			});
+			state.task.replace(task);
+		}
+	}
+}
+
+impl<T> Body<T>
+where
+	T: hyper::body::Body<Data = Bytes, Error = Error>,
+{
 	#[must_use]
 	pub fn new(token: Token, body: T) -> Self
 	where
@@ -32,7 +104,10 @@ impl<T: hyper::body::Body<Data = Bytes, Error = Error>> Body<T> {
 	}
 }
 
-impl<T: hyper::body::Body<Data = Bytes, Error = Error>> hyper::body::Body for Body<T> {
+impl<T> hyper::body::Body for Body<T>
+where
+	T: hyper::body::Body<Data = Bytes, Error = Error>,
+{
 	type Data = Bytes;
 
 	type Error = Error;
@@ -43,113 +118,5 @@ impl<T: hyper::body::Body<Data = Bytes, Error = Error>> hyper::body::Body for Bo
 	) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
 		let this = self.project();
 		this.body.poll_frame(cx)
-	}
-}
-
-pub struct Token {
-	idle: Idle,
-}
-
-impl Drop for Token {
-	fn drop(&mut self) {
-		self.idle.inner.drop_token();
-	}
-}
-
-#[derive(Clone)]
-pub struct Idle {
-	inner: Arc<Inner>,
-}
-
-impl Idle {
-	#[must_use]
-	pub fn new(duration: Duration) -> Self {
-		Self {
-			inner: Arc::new(Inner::new(duration)),
-		}
-	}
-
-	pub async fn wait(&self) -> Result<(), Arc<tokio::task::JoinError>> {
-		self.inner.wait().await
-	}
-
-	#[must_use]
-	pub fn token(&self) -> Token {
-		self.inner.new_token();
-		Token { idle: self.clone() }
-	}
-}
-
-pub struct Inner {
-	abort: Arc<tokio::task::AbortHandle>,
-	count: AtomicUsize,
-	duration: Duration,
-	future: future::Shared<BoxFuture<'static, Result<(), Arc<tokio::task::JoinError>>>>,
-	tx: tokio::sync::watch::Sender<Option<Duration>>,
-}
-
-impl Inner {
-	#[must_use]
-	fn new(duration: Duration) -> Self {
-		let (tx, mut rx) = tokio::sync::watch::channel(None);
-		let task = tokio::spawn({
-			async move {
-				loop {
-					let sleep = if let Some(duration) = *rx.borrow_and_update() {
-						tokio::time::sleep(duration).boxed()
-					} else {
-						future::pending().boxed()
-					};
-					match future::select(pin!(sleep), pin!(rx.clone().changed())).await {
-						future::Either::Left(_) => break,
-						future::Either::Right((result, _)) => {
-							if result.is_err() {
-								break;
-							}
-							continue;
-						},
-					}
-				}
-			}
-		});
-		let abort = Arc::new(task.abort_handle());
-		let future = task.map_err(Arc::new).boxed().shared();
-		let count = AtomicUsize::new(0);
-
-		Self {
-			abort,
-			count,
-			duration,
-			future,
-			tx,
-		}
-	}
-
-	async fn wait(&self) -> Result<(), Arc<tokio::task::JoinError>> {
-		self.future.clone().await
-	}
-
-	fn abort(&self) {
-		self.abort.abort();
-	}
-
-	fn new_token(&self) {
-		let count = self.count.fetch_add(1, Ordering::Relaxed);
-		if count == 0 {
-			let _ = self.tx.send(None);
-		}
-	}
-
-	fn drop_token(&self) {
-		let count = self.count.fetch_sub(1, Ordering::Release);
-		if count == 1 {
-			let _ = self.tx.send(Some(self.duration));
-		}
-	}
-}
-
-impl Drop for Inner {
-	fn drop(&mut self) {
-		self.abort();
 	}
 }

--- a/packages/http/src/idle.rs
+++ b/packages/http/src/idle.rs
@@ -1,0 +1,155 @@
+use bytes::Bytes;
+use futures::{
+	future::{self, BoxFuture},
+	FutureExt, TryFutureExt as _,
+};
+use pin_project::pin_project;
+use std::{
+	pin::pin,
+	sync::{
+		atomic::{AtomicUsize, Ordering},
+		Arc,
+	},
+	time::Duration,
+};
+
+use crate::Error;
+
+#[pin_project]
+pub struct Body<T: hyper::body::Body<Data = Bytes, Error = Error>> {
+	#[pin]
+	body: T,
+	token: Token,
+}
+
+impl<T: hyper::body::Body<Data = Bytes, Error = Error>> Body<T> {
+	#[must_use]
+	pub fn new(token: Token, body: T) -> Self
+	where
+		T: hyper::body::Body,
+	{
+		Self { body, token }
+	}
+}
+
+impl<T: hyper::body::Body<Data = Bytes, Error = Error>> hyper::body::Body for Body<T> {
+	type Data = Bytes;
+
+	type Error = Error;
+
+	fn poll_frame(
+		self: std::pin::Pin<&mut Self>,
+		cx: &mut std::task::Context<'_>,
+	) -> std::task::Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+		let this = self.project();
+		this.body.poll_frame(cx)
+	}
+}
+
+pub struct Token {
+	idle: Idle,
+}
+
+impl Drop for Token {
+	fn drop(&mut self) {
+		self.idle.inner.drop_token();
+	}
+}
+
+#[derive(Clone)]
+pub struct Idle {
+	inner: Arc<Inner>,
+}
+
+impl Idle {
+	#[must_use]
+	pub fn new(duration: Duration) -> Self {
+		Self {
+			inner: Arc::new(Inner::new(duration)),
+		}
+	}
+
+	pub async fn wait(&self) -> Result<(), Arc<tokio::task::JoinError>> {
+		self.inner.wait().await
+	}
+
+	#[must_use]
+	pub fn token(&self) -> Token {
+		self.inner.new_token();
+		Token { idle: self.clone() }
+	}
+}
+
+pub struct Inner {
+	abort: Arc<tokio::task::AbortHandle>,
+	count: AtomicUsize,
+	duration: Duration,
+	future: future::Shared<BoxFuture<'static, Result<(), Arc<tokio::task::JoinError>>>>,
+	tx: tokio::sync::watch::Sender<Option<Duration>>,
+}
+
+impl Inner {
+	#[must_use]
+	fn new(duration: Duration) -> Self {
+		let (tx, mut rx) = tokio::sync::watch::channel(None);
+		let task = tokio::spawn({
+			async move {
+				loop {
+					let sleep = if let Some(duration) = *rx.borrow_and_update() {
+						tokio::time::sleep(duration).boxed()
+					} else {
+						future::pending().boxed()
+					};
+					match future::select(pin!(sleep), pin!(rx.clone().changed())).await {
+						future::Either::Left(_) => break,
+						future::Either::Right((result, _)) => {
+							if result.is_err() {
+								break;
+							}
+							continue;
+						},
+					}
+				}
+			}
+		});
+		let abort = Arc::new(task.abort_handle());
+		let future = task.map_err(Arc::new).boxed().shared();
+		let count = AtomicUsize::new(0);
+
+		Self {
+			abort,
+			count,
+			duration,
+			future,
+			tx,
+		}
+	}
+
+	async fn wait(&self) -> Result<(), Arc<tokio::task::JoinError>> {
+		self.future.clone().await
+	}
+
+	fn abort(&self) {
+		self.abort.abort();
+	}
+
+	fn new_token(&self) {
+		let count = self.count.fetch_add(1, Ordering::Relaxed);
+		if count == 0 {
+			let _ = self.tx.send(None);
+		}
+	}
+
+	fn drop_token(&self) {
+		let count = self.count.fetch_sub(1, Ordering::Release);
+		if count == 1 {
+			let _ = self.tx.send(Some(self.duration));
+		}
+	}
+}
+
+impl Drop for Inner {
+	fn drop(&mut self) {
+		self.abort();
+	}
+}

--- a/packages/http/src/lib.rs
+++ b/packages/http/src/lib.rs
@@ -1,5 +1,6 @@
 pub use self::{incoming::Incoming, outgoing::Outgoing};
 
+pub mod idle;
 pub mod incoming;
 pub mod outgoing;
 pub mod sse;


### PR DESCRIPTION
This change creates a new `Idle` class that issues `Token`s which get attached to the `Response` bodies. Once all `Token`s are dropped, we stop serving, after a delay.

Closes #316 