### PR TITLE
refactor(cli/init): add env target to default package

### DIFF
--- a/packages/cli/src/package/init.rs
+++ b/packages/cli/src/package/init.rs
@@ -53,9 +53,11 @@ impl Cli {
 			path.join("tangram.ts"),
 			formatdoc!(
 				r#"
-					import autobuild from "{autobuild_reference}";
+					import * as autobuild from "{autobuild_reference}";
+					import * as std from "std";
 					import source from "." with {{ type: "directory" }};
-					export default tg.target(() => autobuild({{ source }}));
+					export default tg.target(() => autobuild.build({{ env: env(), source }}));
+					export const env = tg.target(() => std.env(autobuild.env({{ source }})));
 				"#,
 			),
 		));


### PR DESCRIPTION
Instead of just a single target calling the default target of `autobuild`, add a second `env` target that flows into `autobuild.build`, wrapped with `std.env`.