### PR TITLE
repro(cli): fail to build package with remote tag import

### DIFF
--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -1,0 +1,126 @@
+use indoc::indoc;
+use insta::assert_snapshot;
+use serde_json::json;
+use tangram_temp::{self as temp, Temp};
+
+mod common;
+use common::Server;
+
+#[tokio::test]
+async fn import_from_remote_tag() -> std::io::Result<()> {
+	// Create a remote
+	let remote_config = json!({
+		"build": null,
+		"remotes": null,
+		"vfs": null
+	});
+	let mut remote = Server::start(remote_config).await?;
+
+	// Create a local server
+	let local_config = json!({
+		"remotes": {
+			"default": {
+				"url": remote.url()
+			},
+			"vfs": null
+		}
+	});
+	let mut local = Server::start(local_config.clone()).await?;
+
+	// Create a package foo
+	let foo_temp = Temp::new();
+	let foo = temp::directory! {
+			"tangram.ts" => indoc!(r#"
+				export default tg.target(() => "foo");
+			"#),
+	};
+	let foo: temp::Artifact = foo.into();
+	foo.to_path(foo_temp.as_ref()).await?;
+
+	// Tag foo
+	let foo_tag_output = local
+		.tg()
+		.args(["tag", "foo", foo_temp.path().to_str().unwrap()])
+		.output()
+		.await?;
+	assert!(foo_tag_output.stdout.is_empty());
+	assert!(foo_tag_output.stderr.is_empty());
+
+	// Push the tag.
+	let push_foo_tag_output = local.tg().args(["push", "foo"]).output().await?;
+	assert!(push_foo_tag_output.stderr.is_empty());
+
+	// Does the remote have the tag?
+	let remote_foo_get_output = remote.tg().args(["get", "foo"]).output().await?;
+	let remote_foo_get_output_stdout = String::from_utf8(remote_foo_get_output.stdout).unwrap();
+	assert_snapshot!(remote_foo_get_output_stdout, @r#"{"entries":{"tangram.ts":"fil_010crryhp6zqjp0fsx9kyds5jmhq5zb5akvwbd579gexkyhr3kcmk0"}}"#);
+
+	// Create a package bar that imports foo
+	let bar_temp = Temp::new();
+	let bar = temp::directory! {
+			"tangram.ts" => indoc!(r#"
+				import foo from "foo";
+				export default tg.target(() => foo());
+			"#),
+	};
+	let bar: temp::Artifact = bar.into();
+	bar.to_path(bar_temp.as_ref()).await?;
+
+	// Build bar.
+	let first_build_bar_output = local
+		.tg()
+		.args(["build", bar_temp.path().to_str().unwrap(), "--detach"])
+		.output()
+		.await?;
+	let first_build_bar_id = String::from_utf8(first_build_bar_output.stdout).unwrap();
+	let first_build_bar_id = first_build_bar_id.trim().to_string();
+	assert!(!first_build_bar_id.is_empty());
+
+	// Push the build
+	let push_bar_output = local
+		.tg()
+		.args(["push", &first_build_bar_id])
+		.output()
+		.await?;
+	let push_bar_output_stderr = String::from_utf8(push_bar_output.stderr).unwrap();
+	assert!(push_bar_output_stderr.is_empty());
+
+	// The remote should have this build
+	let remote_get_build_output = remote
+		.tg()
+		.args(["get", &first_build_bar_id])
+		.output()
+		.await?;
+	let remote_get_build_output_stdout = String::from_utf8(remote_get_build_output.stdout).unwrap();
+	assert!(!remote_get_build_output_stdout.is_empty());
+
+	// Create a fresh server with the same config.
+	let mut fresh = Server::start(local_config).await?;
+
+	// Build bar.
+	let fresh_build_bar_output = fresh
+		.tg()
+		.args(["build", bar_temp.path().to_str().unwrap(), "--detach"])
+		.output()
+		.await?;
+	let fresh_build_bar_id = String::from_utf8(fresh_build_bar_output.stdout).unwrap();
+	let fresh_build_bar_id = fresh_build_bar_id.trim().to_string();
+	assert!(!fresh_build_bar_id.is_empty());
+
+	let fresh_build_bar_outcome = fresh
+		.tg()
+		.args(["build", "output", &fresh_build_bar_id])
+		.output()
+		.await?;
+	let fresh_build_bar_output_stdout = String::from_utf8(fresh_build_bar_outcome.stdout).unwrap();
+	let fresh_build_bar_output_stdout = fresh_build_bar_output_stdout.trim().to_string();
+	assert_eq!(fresh_build_bar_output_stdout, r#""foo""#.to_string());
+
+	// Assert the build ID is the same.
+	assert_eq!(first_build_bar_id, fresh_build_bar_id);
+
+	local.cleanup().await?;
+	fresh.cleanup().await?;
+	remote.cleanup().await?;
+	Ok(())
+}

--- a/packages/cli/tests/common.rs
+++ b/packages/cli/tests/common.rs
@@ -1,6 +1,7 @@
 use futures::{Future, FutureExt as _};
 use std::{panic::AssertUnwindSafe, path::PathBuf};
 use tangram_temp::Temp;
+use url::Url;
 
 pub async fn test<F, Fut>(
 	config: serde_json::Value,
@@ -67,6 +68,13 @@ impl Server {
 		let mut command = tokio::process::Command::new(TG);
 		command.args(["--config", config, "--path", path, "--mode", "client"]);
 		command
+	}
+
+	pub fn url(&self) -> Url {
+		let path = self.data_path.join("socket");
+		let path = path.to_str().unwrap();
+		let path = urlencoding::encode(path);
+		format!("http+unix://{path}").parse().unwrap()
 	}
 
 	pub fn stop(&mut self) -> std::io::Result<()> {


### PR DESCRIPTION
Adds a CLI integration test that fails after taking these steps:

1. Builds a basic package `foo`
2. Tags `foo`.
3. Pushes the `foo` tag.
4. Builds a package `bar` that imports `foo` by tag.
5. Pushes the build of `bar`.
6. Clears the original server.
7. Attempts to build `bar` using a new server.

I expect this build to work and to have the same build ID as the first build. I instead get this error:
```
  2024-12-12T21:43:13.877684Z ERROR tangram_server: error: Error { message: Some("failed to construct the object graph"), location: Some(Location { symbol: Some("tangram_server::artifact::checkin::<impl tangram_server::Server>::check_in_artifact_inner::{{closure}}::{{closure}}"), source: Internal("./packages/server/src/artifact/checkin.rs"), line: 101, column: 21 }), stack: None, source: Some(Error { message: Some("could not resolve dependency with lockfile, missing artifact"), location: Some(Location { symbol: Some("tangram_server::lockfile::ParsedLockfile::try_resolve_dependency::{{closure}}"), source: Internal("./packages/server/src/lockfile.rs"), line: 300, column: 8 }), stack: None, source: None, values: {"reference": "foo"} }), values: {} }
    at packages/server/src/lib.rs:943

// ..

---- import_from_remote_tag stdout ----
thread 'import_from_remote_tag' panicked at packages/cli/tests/build.rs:112:5:
assertion failed: !fresh_build_bar_id.is_empty()
```

Notably, this test sometimes succeeds. However, the failure message matches the failure I see attempting a similar build using `std` and `jq` , which fails consistently.

Another failure mode I see in the real-world context but was unable to replicate in a test thus far:
```
thread 'tokio-runtime-worker' panicked at /Users/benlovy/code/tangram/packages/server/src/artifact/checkin/unify.rs:724:78:
called `Option::unwrap()` on a `None` value
  2024-12-12T21:24:24.556851Z ERROR tangram_server: error: Error { message: Some("the task panicked"), location: Some(Location { symbol: Some("tangram_server::artifact::checkin::<impl tangram_server::Server>::check_in_artifact::{{closure}}:
:{{closure}}"), source: Internal("./packages/server/src/artifact/checkin.rs"), line: 40, column: 21 }), stack: None, source: Some(Error { message: Some("task 52159 panicked with message \"called `Option::unwrap()` on a `None` value\""), loc
ation: None, stack: None, source: None, values: {} }), values: {} }
    at packages/server/src/lib.rs:943
```

I'm not sure how to trigger this reliably.