### PR TITLE
fix(server/runtime): don't remap temp paths in proxy

### DIFF
--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -40,7 +40,8 @@ impl Proxy {
 
 	fn host_path_for_guest_path(&self, path: PathBuf) -> PathBuf {
 		// If the path is a tempdir, don't remap.
-		if path.starts_with(std::env::temp_dir()) {
+		#[cfg(target_os = "linux")]
+		if path.starts_with("/tmp") {
 			return path;
 		}
 

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -39,6 +39,11 @@ impl Proxy {
 	}
 
 	fn host_path_for_guest_path(&self, path: PathBuf) -> PathBuf {
+		// If the path is a tempdir, don't remap.
+		if path.starts_with(std::env::temp_dir()) {
+			return path;
+		}
+
 		// Get the path map. If there is no path map, then the guest path is the host path.
 		let Some(path_map) = &self.path_map else {
 			return path;


### PR DESCRIPTION
On Linux, `/tmp` is bind-mounted into the chroot, so we shouldn't remap this path. There is no remapping on Darwin, but this logic remains correct.