### PR TITLE
fix: `tar` header handling, relative paths

### DIFF
--- a/packages/server/src/runtime/builtin/extract.rs
+++ b/packages/server/src/runtime/builtin/extract.rs
@@ -193,7 +193,16 @@ where
 	// Build the directory.
 	let mut builder = tg::directory::Builder::default();
 	for (path, artifact) in processed_entries {
-		builder = builder.add(server, &path, artifact).await?;
+		let path = if path.starts_with("./") {
+			path.strip_prefix("./")
+				.map_err(|source| tg::error!(!source, "could not strip the path prefix"))?
+		} else {
+			&path
+		};
+		if path.as_os_str().is_empty() {
+			continue;
+		}
+		builder = builder.add(server, path, artifact).await?;
 	}
 	let directory = builder.build();
 


### PR DESCRIPTION
- [x] make tar extract a for loop
- [x] handle the hardlink case just like the tar crate does
- [x] posix-compliant treats unrecognized as a file
- [x] skip xglobalarray
- [x] check zip against the zip crate as well
  - no such thing as a hardlink in zip, it just stores copies
- [x] handle relative paths