### PR TITLE
Template placeholder inserted in wrong position

### DIFF
--- a/packages/runtime/src/template.ts
+++ b/packages/runtime/src/template.ts
@@ -199,24 +199,27 @@ let unindent = (strings: Array<string>): Array<string> => {
 			}
 		}
 		let firstPlaceholderIndex = placeholderIndices.find(
-			(index) => index >= position && index < position + line.length + 1,
+			(index) => index >= position && index < position + line.length,
 		);
 		if (firstPlaceholderIndex !== undefined) {
 			firstPlaceholderIndex -= position;
 		}
-		let count = Math.min(
+		let remove = Math.min(
+			indentation,
+			line.length,
 			firstNonWhitespaceIndex ?? Number.POSITIVE_INFINITY,
 			firstPlaceholderIndex ?? Number.POSITIVE_INFINITY,
 		);
-		let remove = Math.min(indentation, count);
 		lines[i] = lines[i]!.slice(remove);
-		for (let j = 0; j < placeholderIndices.length; j++) {
-			if (placeholderIndices[j]! > position) {
-				placeholderIndices[j]! -= remove;
+		for (let i = 0; i < placeholderIndices.length; i++) {
+			if (placeholderIndices[i]! >= position) {
+				placeholderIndices[i]! -= remove;
 			}
 		}
 		position += lines[i]!.length + 1;
 	}
+
+	// Join the lines.
 	string = lines.join("\n");
 
 	// Split the string at the placeholder indices.

--- a/packages/server/tests/build.rs
+++ b/packages/server/tests/build.rs
@@ -385,6 +385,38 @@ async fn template_single_line() -> tg::Result<()> {
 }
 
 #[tokio::test]
+async fn template_with_quote() -> tg::Result<()> {
+	test(
+		temp::directory! {
+			"foo" => temp::directory! {
+				"tangram.ts" => r##"
+					import file from "./hello.txt";
+					export default tg.target(() => tg`
+						other_command
+
+						other_command
+					
+						other_command
+					
+						echo 'exec ${file} "$@"' >> script.sh
+					`);
+				"##,
+				"hello.txt" => "Hello, World!",
+			},
+		},
+		"foo",
+		"default",
+		vec![],
+		|_, outcome| async move {
+			let output = outcome.into_result()?;
+			assert_snapshot!(output, @r#"tg.template(["other_command\n\nother_command\n\nother_command\n\nech",fil_01tvcqmbbf8dkkejz6y69ywvgfsh9gyn1xjweyb9zgv0sf4752446g,"o 'exec  \"$@\"' >> script.sh\n"])"#);
+			Ok::<_, tg::Error>(())
+		},
+	)
+	.await
+}
+
+#[tokio::test]
 async fn template_single_line_two_artifacts() -> tg::Result<()> {
 	test(
 		temp::directory! {

--- a/packages/server/tests/build.rs
+++ b/packages/server/tests/build.rs
@@ -389,7 +389,7 @@ async fn template_with_quote() -> tg::Result<()> {
 	test(
 		temp::directory! {
 			"foo" => temp::directory! {
-				"tangram.ts" => r##"
+				"tangram.ts" => r#"
 					import file from "./hello.txt";
 					export default tg.target(() => tg`
 						other_command
@@ -400,7 +400,7 @@ async fn template_with_quote() -> tg::Result<()> {
 					
 						echo 'exec ${file} "$@"' >> script.sh
 					`);
-				"##,
+				"#,
 				"hello.txt" => "Hello, World!",
 			},
 		},
@@ -409,7 +409,7 @@ async fn template_with_quote() -> tg::Result<()> {
 		vec![],
 		|_, outcome| async move {
 			let output = outcome.into_result()?;
-			assert_snapshot!(output, @r#"tg.template(["other_command\n\nother_command\n\nother_command\n\nech",fil_01tvcqmbbf8dkkejz6y69ywvgfsh9gyn1xjweyb9zgv0sf4752446g,"o 'exec  \"$@\"' >> script.sh\n"])"#);
+			assert_snapshot!(output, @r#"tg.template(["other_command\n\nother_command\n\nother_command\n\necho 'exec ",fil_01tvcqmbbf8dkkejz6y69ywvgfsh9gyn1xjweyb9zgv0sf4752446g," \"$@\"' >> script.sh\n"])"#);
 			Ok::<_, tg::Error>(())
 		},
 	)


### PR DESCRIPTION
The test here fails in odd ways as I add and remove lines above the `echo` line at the end - in the pushed iteration, the artifact component is placed inside the word `echo`.

In-context, the offending template:
```
	const prepare = tg`
		export CARGO_HOME=$PWD/cargo_home
		mkdir -p $CARGO_HOME

		export TARGET=$PWD/target
		mkdir -p "$TARGET"

		echo "#!/usr/bin/env sh" > rustc.sh
		echo 'set -eu' >> rustc.sh
		echo 'exec ${rustc} "$@"' >> rustc.sh
		chmod +x rustc.sh
		export RUSTC=$PWD/rustc.sh
		`;
```
This bug manifests as `/home/tangram/work/rustc.sh: line 3: e/.tangram/artifacts/fil_01e0717fmehcb44sahkb5tmmwcendc00vjky7w5gryptys3z9zzggg: not found` - the word `exec` and following space got truncated, and the rendered artifact path got tacked onto the letter `e`.