### PR TITLE
fix: switch to our fork of `async-tar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,8 +445,7 @@ dependencies = [
 [[package]]
 name = "async-tar"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
+source = "git+https://github.com/tangramdotdev/async-tar?rev=3dfc3c8dd0#3dfc3c8dd0891db7f7c349be26ae832f7c65a605"
 dependencies = [
  "async-std",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,7 @@ zip = { version = "2", default-features = false, features = [
 zstd = "0.13"
 
 [patch.crates-io]
+async-tar = { git = "https://github.com/tangramdotdev/async-tar", rev = "3dfc3c8dd0" }
 async_zip = { git = "https://github.com/tangramdotdev/rs-async-zip", rev = "90e365c" }
 
 [profile.dev.package.blake3]


### PR DESCRIPTION
Closes #404