### PR TITLE
feat: checksum build outputs

### DIFF
--- a/packages/runtime/src/blob.ts
+++ b/packages/runtime/src/blob.ts
@@ -109,24 +109,11 @@ export namespace Blob {
 			await tg.target({
 				host: "builtin",
 				args: ["download", url],
-				checksum: "unsafe",
+				checksum: checksum,
 				env: undefined,
 			})
 		).output();
 		tg.assert(tg.Blob.is(value));
-		let algorithm = tg.Checksum.algorithm(checksum);
-		let actual = await (
-			await tg.target({
-				host: "builtin",
-				args: ["checksum", value, algorithm],
-				env: undefined,
-			})
-		).output();
-		if (actual !== checksum) {
-			throw new Error(
-				`invalid checksum, expected ${checksum} but got ${actual}`,
-			);
-		}
 		return value;
 	};
 

--- a/packages/runtime/src/checksum.ts
+++ b/packages/runtime/src/checksum.ts
@@ -18,7 +18,7 @@ export declare namespace Checksum {
 }
 
 export namespace Checksum {
-	export type Algorithm = "blake3" | "none" | "sha256" | "sha512" | "unsafe";
+	export type Algorithm = "none" | "unsafe" | "blake3" | "sha256" | "sha512";
 
 	export let new_ = async (
 		input: string | Uint8Array | tg.Blob | tg.Artifact,
@@ -37,14 +37,14 @@ export namespace Checksum {
 	Checksum.new = new_;
 
 	export let algorithm = (checksum: Checksum): Algorithm => {
-		if (checksum.includes(":")) {
-			return checksum.split(":")[0]! as Algorithm;
-		} else if (checksum.includes("-")) {
-			return checksum.split("-")[0]! as Algorithm;
-		} else if (checksum === "none") {
+		if (checksum === "none") {
 			return "none";
 		} else if (checksum === "unsafe") {
 			return "unsafe";
+		} else if (checksum.includes(":")) {
+			return checksum.split(":")[0]! as Algorithm;
+		} else if (checksum.includes("-")) {
+			return checksum.split("-")[0]! as Algorithm;
 		} else {
 			throw new Error("invalid checksum");
 		}

--- a/packages/runtime/src/checksum.ts
+++ b/packages/runtime/src/checksum.ts
@@ -18,7 +18,7 @@ export declare namespace Checksum {
 }
 
 export namespace Checksum {
-	export type Algorithm = "blake3" | "sha256" | "sha512" | "unsafe";
+	export type Algorithm = "blake3" | "none" | "sha256" | "sha512" | "unsafe";
 
 	export let new_ = async (
 		input: string | Uint8Array | tg.Blob | tg.Artifact,
@@ -41,6 +41,8 @@ export namespace Checksum {
 			return checksum.split(":")[0]! as Algorithm;
 		} else if (checksum.includes("-")) {
 			return checksum.split("-")[0]! as Algorithm;
+		} else if (checksum === "none") {
+			return "none";
 		} else if (checksum === "unsafe") {
 			return "unsafe";
 		} else {

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -848,7 +848,7 @@ declare namespace tg {
 	export type Checksum = string;
 
 	export namespace Checksum {
-		export type Algorithm = "blake3" | "sha256" | "sha512" | "unsafe";
+		export type Algorithm = "none" | "unsafe" | "blake3" | "sha256" | "sha512";
 
 		export let new_: (
 			input: string | Uint8Array | tg.Blob | tg.Artifact,

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -234,7 +234,7 @@ impl Server {
 		);
 		let status = tg::build::Status::Finished;
 		let finished_at = time::OffsetDateTime::now_utc().format(&Rfc3339).unwrap();
-		let params = db::params![log, outcome, status, finished_at, id];
+		let params = db::params![log, db::value::Json(outcome), status, finished_at, id];
 		connection
 			.execute(statement, params)
 			.await

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -326,7 +326,7 @@ impl Server {
 			Err(tg::error!("no checksum provided, expected {checksum}"))
 		} else if checksum != *expected {
 			Err(tg::error!(
-				"checksums do not match, expected {checksum}, actual {checksum}"
+				"checksums do not match, expected {expected}, actual {checksum}"
 			))
 		} else {
 			Ok(())

--- a/packages/server/src/runtime.rs
+++ b/packages/server/src/runtime.rs
@@ -1,4 +1,5 @@
 use crate::{compiler::Compiler, Server};
+use futures::FutureExt as _;
 use tangram_client as tg;
 use tangram_http::{outgoing::response::Ext as _, Incoming, Outgoing};
 
@@ -25,12 +26,12 @@ pub enum Runtime {
 impl Runtime {
 	pub async fn build(&self, build: &tg::Build, remote: Option<String>) -> tg::Result<tg::Value> {
 		match self {
-			Runtime::Builtin(runtime) => runtime.build(build, remote).await,
+			Runtime::Builtin(runtime) => runtime.build(build, remote).boxed().await,
 			#[cfg(target_os = "macos")]
-			Runtime::Darwin(runtime) => runtime.build(build, remote).await,
-			Runtime::Js(runtime) => runtime.build(build, remote).await,
+			Runtime::Darwin(runtime) => runtime.build(build, remote).boxed().await,
+			Runtime::Js(runtime) => runtime.build(build, remote).boxed().await,
 			#[cfg(target_os = "linux")]
-			Runtime::Linux(runtime) => runtime.build(build, remote).await,
+			Runtime::Linux(runtime) => runtime.build(build, remote).boxed().await,
 		}
 	}
 }

--- a/packages/server/src/runtime/builtin.rs
+++ b/packages/server/src/runtime/builtin.rs
@@ -1,4 +1,3 @@
-use super::util::spawn_checksum_build;
 use crate::Server;
 use futures::FutureExt as _;
 use tangram_client as tg;
@@ -54,10 +53,12 @@ impl Runtime {
 		}
 		.await?;
 
-		// Create a child build to calculate the checksum.
+		// Checksum the output if necessary.
 		let checksum = target.checksum(server).await?.clone();
 		if let Some(checksum) = checksum {
-			spawn_checksum_build(server, build.id().clone(), &output, &checksum).await?;
+			super::util::checksum(server, build, &output, &checksum)
+				.boxed()
+				.await?;
 		}
 
 		Ok(output)

--- a/packages/server/src/runtime/builtin.rs
+++ b/packages/server/src/runtime/builtin.rs
@@ -1,3 +1,4 @@
+use super::util::spawn_checksum_build;
 use crate::Server;
 use futures::FutureExt as _;
 use tangram_client as tg;
@@ -52,6 +53,12 @@ impl Runtime {
 			},
 		}
 		.await?;
+
+		// Create a child build to calculate the checksum.
+		let checksum = target.checksum(server).await?.clone();
+		if let Some(checksum) = checksum {
+			spawn_checksum_build(server, build.id().clone(), &output, &checksum).await?;
+		}
 
 		Ok(output)
 	}

--- a/packages/server/src/runtime/builtin/checksum.rs
+++ b/packages/server/src/runtime/builtin/checksum.rs
@@ -48,12 +48,18 @@ impl Runtime {
 
 	async fn checksum_artifact(
 		&self,
-		_artifact: &tg::Artifact,
+		artifact: &tg::Artifact,
 		algorithm: tg::checksum::Algorithm,
 	) -> tg::Result<tg::Checksum> {
 		match algorithm {
+			tg::checksum::Algorithm::None => Ok(tg::Checksum::None),
 			tg::checksum::Algorithm::Unsafe => Ok(tg::Checksum::Unsafe),
-			_ => Err(tg::error!("unimplemented")),
+			_ => {
+				let blob = artifact
+					.archive(&self.server, tg::artifact::archive::Format::Tgar)
+					.await?;
+				self.checksum_blob(&blob, algorithm).await
+			},
 		}
 	}
 

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -149,8 +149,11 @@ impl Runtime {
 			.try_collect()
 			.await?;
 
+		// Get the checksum.
+		let checksum = target.checksum(server).await?.clone();
+
 		// Enable the network if a checksum was provided.
-		let network_enabled = target.checksum(server).await?.is_some();
+		let network_enabled = checksum.is_some();
 
 		// Set `$HOME`.
 		env.insert(
@@ -484,6 +487,41 @@ impl Runtime {
 		} else {
 			tg::Value::Null
 		};
+
+		// Create a child build to calculate the checksum.
+		if let Some(checksum) = checksum {
+			let algorithm = checksum.algorithm();
+			let algorithm = if algorithm == tg::checksum::Algorithm::None {
+				tg::checksum::Algorithm::Sha256
+			} else {
+				algorithm
+			};
+			if algorithm == tg::checksum::Algorithm::Unsafe {
+				return Ok(value);
+			}
+			let host = "builtin";
+			let args = vec![
+				"checksum".into(),
+				value.clone(),
+				algorithm.to_string().into(),
+			];
+			let target = tg::Target::builder(host).args(args).build();
+			let target_id = target.id(server).await?;
+			let arg = tg::target::build::Arg {
+				create: true,
+				parent: Some(build.id().clone()),
+				..Default::default()
+			};
+			if let Some(output) = server.try_build_target(&target_id, arg).await? {
+				if let Some(future) = server.try_get_build_outcome_future(&output.build).await? {
+					future.await?;
+				} else {
+					return Err(tg::error!("could not find the checksum child build"));
+				}
+			} else {
+				return Err(tg::error!("could not get checksum build output"));
+			}
+		}
 
 		Ok(value)
 	}

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -1,4 +1,5 @@
 use self::syscall::syscall;
+use super::util::spawn_checksum_build;
 use crate::{compiler::Compiler, Server};
 use futures::{
 	future::{self, LocalBoxFuture},
@@ -378,6 +379,14 @@ impl Runtime {
 
 		// Stop the compiler.
 		state.compiler.stop().await;
+
+		// Create a child build to calculate the checksum.
+		if let Ok(ref value) = result {
+			let checksum = target.checksum(server).await?.clone();
+			if let Some(checksum) = checksum {
+				spawn_checksum_build(server, build.id().clone(), value, &checksum).await?;
+			}
+		}
 
 		result
 	}

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -1,6 +1,7 @@
 use super::{
 	proxy::{self, Proxy},
 	util::render,
+	util::spawn_checksum_build,
 };
 use crate::{temp::Temp, Server};
 use bytes::Bytes;
@@ -793,37 +794,7 @@ impl Runtime {
 
 		// Create a child build to calculate the checksum.
 		if let Some(checksum) = checksum {
-			let algorithm = checksum.algorithm();
-			let algorithm = if algorithm == tg::checksum::Algorithm::None {
-				tg::checksum::Algorithm::Sha256
-			} else {
-				algorithm
-			};
-			if algorithm == tg::checksum::Algorithm::Unsafe {
-				return Ok(value);
-			}
-			let host = "builtin";
-			let args = vec![
-				"checksum".into(),
-				value.clone(),
-				algorithm.to_string().into(),
-			];
-			let target = tg::Target::builder(host).args(args).build();
-			let target_id = target.id(server).await?;
-			let arg = tg::target::build::Arg {
-				create: true,
-				parent: Some(build.id().clone()),
-				..Default::default()
-			};
-			if let Some(output) = server.try_build_target(&target_id, arg).await? {
-				if let Some(future) = server.try_get_build_outcome_future(&output.build).await? {
-					future.await?;
-				} else {
-					return Err(tg::error!("could not find the checksum child build"));
-				}
-			} else {
-				return Err(tg::error!("could not get checksum build output"));
-			}
+			spawn_checksum_build(server, build.id().clone(), &value, &checksum).await?;
 		}
 
 		Ok(value)

--- a/packages/server/src/runtime/util.rs
+++ b/packages/server/src/runtime/util.rs
@@ -33,3 +33,46 @@ pub async fn render(
 		Ok("<tangram value>".to_owned())
 	}
 }
+
+pub async fn spawn_checksum_build(
+	server: &Server,
+	parent_build_id: tg::build::Id,
+	value: &tg::Value,
+	checksum: &tg::Checksum,
+) -> tg::Result<()> {
+	// Create a child build to calculate the checksum.
+	let algorithm = checksum.algorithm();
+	let algorithm = if algorithm == tg::checksum::Algorithm::None {
+		tg::checksum::Algorithm::Sha256
+	} else {
+		algorithm
+	};
+	if algorithm == tg::checksum::Algorithm::Unsafe {
+		return Ok(());
+	}
+	let host = "builtin";
+	let args = vec![
+		"checksum".into(),
+		value.clone(),
+		algorithm.to_string().into(),
+	];
+	let target = tg::Target::builder(host).args(args).build();
+	let target_id = target.id(server).await?;
+	let arg = tg::target::build::Arg {
+		create: true,
+		parent: Some(parent_build_id),
+		..Default::default()
+	};
+	if let Some(output) = server.try_build_target(&target_id, arg).await? {
+		if let Some(future) = server.try_get_build_outcome_future(&output.build).await? {
+			future
+				.await?
+				.map(|_| ())
+				.ok_or_else(|| tg::error!("checksum build failed"))
+		} else {
+			Err(tg::error!("could not find the checksum child build"))
+		}
+	} else {
+		Err(tg::error!("could not get checksum build output"))
+	}
+}

--- a/packages/server/tests/build.rs
+++ b/packages/server/tests/build.rs
@@ -812,7 +812,7 @@ async fn builtin_download_rejects_incorrect_checksum() -> tg::Result<()> {
 		vec![],
 		|_, outcome| async move {
 			let error = outcome.into_result().unwrap_err();
-			assert_snapshot!(error, @r"Uncaught Error: invalid checksum, expected sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa but got sha256:ea8fac7c65fb589b0d53560f5251f74f9e9b243478dcb6b3ea79b5e36449c8d9");
+			assert_snapshot!(error, @"failed to build the target");
 			Ok::<_, tg::Error>(())
 		},
 	)
@@ -837,7 +837,7 @@ async fn builtin_download_rejects_malformed_checksum() -> tg::Result<()> {
 		vec![],
 		|_, outcome| async move {
 			let error = outcome.into_result().unwrap_err();
-			assert_snapshot!(error, @r"Uncaught Error: invalid checksum");
+			assert_snapshot!(error, @"the syscall failed");
 			Ok::<_, tg::Error>(())
 		},
 	)


### PR DESCRIPTION
This PR adds a `None` variant to `Checksum`, which fails to verify, but provides a sha256 hash of the output to the user. The checksums are now calculated in a child build, and `finish_build` only verifies the output of the checksum build.

TODO:
- [x] test on Darwin
- [x] test with `std` working
- [x] rebase on #407 