### PR TITLE
feat: build checksum optimization

### DIFF
--- a/packages/client/src/artifact/checkin.rs
+++ b/packages/client/src/artifact/checkin.rs
@@ -2,7 +2,7 @@ use crate::{
 	self as tg,
 	util::serde::{is_false, is_true, return_true},
 };
-use futures::{Stream, TryStreamExt as _, future};
+use futures::{future, Stream, TryStreamExt as _};
 use std::{path::PathBuf, pin::pin};
 use tangram_futures::stream::TryStreamExt as _;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};

--- a/packages/client/src/artifact/checkout.rs
+++ b/packages/client/src/artifact/checkout.rs
@@ -2,7 +2,7 @@ use crate::{
 	self as tg,
 	util::serde::{is_false, is_true, return_true},
 };
-use futures::{Stream, TryStreamExt as _, future};
+use futures::{future, Stream, TryStreamExt as _};
 use std::{path::PathBuf, pin::pin};
 use tangram_futures::stream::TryStreamExt as _;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};

--- a/packages/client/src/build/children/get.rs
+++ b/packages/client/src/build/children/get.rs
@@ -1,5 +1,5 @@
 use crate::{self as tg, handle::Ext as _, util::serde::SeekFromString};
-use futures::{Stream, StreamExt as _, TryStreamExt as _, future, stream};
+use futures::{future, stream, Stream, StreamExt as _, TryStreamExt as _};
 use serde_with::serde_as;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 

--- a/packages/client/src/build/outcome.rs
+++ b/packages/client/src/build/outcome.rs
@@ -1,5 +1,5 @@
 use crate::{self as tg, handle::Ext as _};
-use futures::{Future, StreamExt as _, TryStreamExt as _, future};
+use futures::{future, Future, StreamExt as _, TryStreamExt as _};
 use tangram_futures::stream::TryStreamExt as _;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 
@@ -30,6 +30,7 @@ pub struct Cancelation {
 #[derive(Clone, Debug)]
 pub struct Failure {
 	pub error: tg::Error,
+	pub value: Option<tg::Value>,
 }
 
 #[derive(Clone, Debug)]
@@ -67,6 +68,8 @@ pub mod data {
 	#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 	pub struct Failure {
 		pub error: tg::Error,
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		pub value: Option<tg::value::Data>,
 	}
 
 	#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -96,7 +99,7 @@ impl Outcome {
 			Self::Cancelation(Cancelation { reason }) => {
 				Err(tg::error!(?reason, "the build was canceled"))
 			},
-			Self::Failure(Failure { error }) => Err(error),
+			Self::Failure(Failure { error, .. }) => Err(error),
 			Self::Success(Success { value }) => Ok(value),
 		}
 	}
@@ -114,6 +117,13 @@ impl Outcome {
 			Self::Failure(failure) => {
 				tg::build::outcome::Data::Failure(tg::build::outcome::data::Failure {
 					error: failure.error.clone(),
+					value: {
+						if let Some(ref value) = failure.value {
+							Some(value.data(handle).await?)
+						} else {
+							None
+						}
+					},
 				})
 			},
 			Self::Success(success) => {
@@ -169,7 +179,7 @@ impl tg::Build {
 			tg::build::Outcome::Cancelation(Cancelation { reason }) => {
 				Err(tg::error!(?reason, "the build was canceled"))
 			},
-			tg::build::Outcome::Failure(Failure { error }) => Err(error),
+			tg::build::Outcome::Failure(Failure { error, .. }) => Err(error),
 			tg::build::Outcome::Success(Success { value }) => Ok(value),
 		}
 	}
@@ -240,6 +250,13 @@ impl TryFrom<tg::build::outcome::Data> for Outcome {
 			},
 			tg::build::outcome::Data::Failure(failure) => Ok(Outcome::Failure(Failure {
 				error: failure.error,
+				value: {
+					if let Some(value) = failure.value {
+						Some(value.try_into()?)
+					} else {
+						None
+					}
+				},
 			})),
 			tg::build::outcome::Data::Success(success) => Ok(Outcome::Success(Success {
 				value: success.value.try_into()?,

--- a/packages/client/src/build/outcome.rs
+++ b/packages/client/src/build/outcome.rs
@@ -115,15 +115,14 @@ impl Outcome {
 				})
 			},
 			Self::Failure(failure) => {
+				let value = if let Some(ref value) = failure.value {
+					Some(value.data(handle).await?)
+				} else {
+					None
+				};
 				tg::build::outcome::Data::Failure(tg::build::outcome::data::Failure {
 					error: failure.error.clone(),
-					value: {
-						if let Some(ref value) = failure.value {
-							Some(value.data(handle).await?)
-						} else {
-							None
-						}
-					},
+					value,
 				})
 			},
 			Self::Success(success) => {
@@ -248,16 +247,17 @@ impl TryFrom<tg::build::outcome::Data> for Outcome {
 					reason: cancelation.reason,
 				}))
 			},
-			tg::build::outcome::Data::Failure(failure) => Ok(Outcome::Failure(Failure {
-				error: failure.error,
-				value: {
-					if let Some(value) = failure.value {
-						Some(value.try_into()?)
-					} else {
-						None
-					}
-				},
-			})),
+			tg::build::outcome::Data::Failure(failure) => {
+				let value = if let Some(value) = failure.value {
+					Some(value.try_into()?)
+				} else {
+					None
+				};
+				Ok(Outcome::Failure(Failure {
+					error: failure.error,
+					value,
+				}))
+			},
 			tg::build::outcome::Data::Success(success) => Ok(Outcome::Success(Success {
 				value: success.value.try_into()?,
 			})),

--- a/packages/client/src/handle/ext.rs
+++ b/packages/client/src/handle/ext.rs
@@ -1,7 +1,8 @@
 use crate as tg;
 use futures::{
-	Future, FutureExt as _, Stream, StreamExt as _, TryStreamExt as _, future,
+	future,
 	stream::{self, BoxStream},
+	Future, FutureExt as _, Stream, StreamExt as _, TryStreamExt as _,
 };
 use num::ToPrimitive as _;
 use std::{

--- a/packages/client/src/target/builder.rs
+++ b/packages/client/src/target/builder.rs
@@ -23,6 +23,17 @@ impl Builder {
 	}
 
 	#[must_use]
+	pub fn with_object(object: &tg::target::Object) -> Self {
+		Self {
+			args: object.args.clone(),
+			checksum: object.checksum.clone(),
+			env: object.env.clone(),
+			executable: object.executable.clone(),
+			host: object.host.clone(),
+		}
+	}
+
+	#[must_use]
 	pub fn args(mut self, args: Vec<tg::Value>) -> Self {
 		self.args = args;
 		self
@@ -61,17 +72,5 @@ impl Builder {
 			executable: self.executable,
 			host: self.host,
 		})
-	}
-}
-
-impl From<&tg::target::Object> for Builder {
-	fn from(value: &tg::target::Object) -> Self {
-		Self {
-			args: value.args.clone(),
-			checksum: value.checksum.clone(),
-			env: value.env.clone(),
-			executable: value.executable.clone(),
-			host: value.host.clone(),
-		}
 	}
 }

--- a/packages/client/src/target/builder.rs
+++ b/packages/client/src/target/builder.rs
@@ -63,3 +63,15 @@ impl Builder {
 		})
 	}
 }
+
+impl From<&tg::target::Object> for Builder {
+	fn from(value: &tg::target::Object) -> Self {
+		Self {
+			args: value.args.clone(),
+			checksum: value.checksum.clone(),
+			env: value.env.clone(),
+			executable: value.executable.clone(),
+			host: value.host.clone(),
+		}
+	}
+}

--- a/packages/database/src/postgres.rs
+++ b/packages/database/src/postgres.rs
@@ -1,8 +1,8 @@
 use crate::{
-	Row, Value,
 	pool::{self, Pool},
+	Row, Value,
 };
-use futures::{Future, Stream, TryStreamExt as _, future};
+use futures::{future, Future, Stream, TryStreamExt as _};
 use indexmap::IndexMap;
 use itertools::Itertools as _;
 use std::collections::HashMap;

--- a/packages/database/src/sqlite.rs
+++ b/packages/database/src/sqlite.rs
@@ -1,8 +1,8 @@
 use crate::{
-	Error as _, Row, Value,
 	pool::{self, Pool},
+	Error as _, Row, Value,
 };
-use futures::{Future, Stream, stream};
+use futures::{stream, Future, Stream};
 use indexmap::IndexMap;
 use itertools::Itertools as _;
 use num::ToPrimitive as _;

--- a/packages/server/src/build/finish.rs
+++ b/packages/server/src/build/finish.rs
@@ -202,20 +202,20 @@ impl Server {
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
 		// Add the outcome's children to the build objects.
-		let value = if let tg::build::outcome::Data::Success(tg::build::outcome::data::Success {
-			ref value,
-		}) = outcome
-		{
-			Some(value.clone())
-		} else if let tg::build::outcome::Data::Failure(tg::build::outcome::data::Failure {
-			value: Some(ref value),
-			..
-		}) = outcome
-		{
-			Some(value.clone())
-		} else {
-			None
-		};
+		let value =
+			if let tg::build::outcome::Data::Success(tg::build::outcome::data::Success { value }) =
+				&outcome
+			{
+				Some(value.clone())
+			} else if let tg::build::outcome::Data::Failure(tg::build::outcome::data::Failure {
+				value: Some(ref value),
+				..
+			}) = outcome
+			{
+				Some(value.clone())
+			} else {
+				None
+			};
 
 		let objects = value.map(|value| value.children()).into_iter().flatten();
 		for object in objects {

--- a/packages/server/src/build/spawn.rs
+++ b/packages/server/src/build/spawn.rs
@@ -117,7 +117,9 @@ impl Server {
 		let result = self.build_task_inner(build.clone(), remote.clone()).await;
 		let outcome = match result {
 			Ok(outcome) => outcome,
-			Err(error) => tg::build::Outcome::Failure(tg::build::outcome::Failure { error }),
+			Err(error) => {
+				tg::build::Outcome::Failure(tg::build::outcome::Failure { error, value: None })
+			},
 		};
 		let outcome = outcome.data(self).await?;
 
@@ -184,7 +186,9 @@ impl Server {
 		// Create the outcome.
 		let outcome = match result {
 			Ok(value) => tg::build::Outcome::Success(tg::build::outcome::Success { value }),
-			Err(error) => tg::build::Outcome::Failure(tg::build::outcome::Failure { error }),
+			Err(error) => {
+				tg::build::Outcome::Failure(tg::build::outcome::Failure { error, value: None })
+			},
 		};
 
 		Ok(outcome)

--- a/packages/server/src/runtime/builtin.rs
+++ b/packages/server/src/runtime/builtin.rs
@@ -31,6 +31,15 @@ impl Runtime {
 		// Get the args.
 		let args = target.args(server).await?;
 
+		// Get the checksum.
+		let checksum = target.checksum(server).await?;
+
+		// Check if a similar build with a checksum failure exists.
+		let value = super::util::maybe_reuse_build(server, &target, checksum.as_ref()).await;
+		if value.is_ok() {
+			return value;
+		}
+
 		// Get the name.
 		let name = args
 			.first()
@@ -54,9 +63,8 @@ impl Runtime {
 		.await?;
 
 		// Checksum the output if necessary.
-		let checksum = target.checksum(server).await?.clone();
-		if let Some(checksum) = checksum {
-			super::util::checksum(server, build, &output, &checksum)
+		if let Some(checksum) = checksum.as_ref() {
+			super::util::checksum(server, build, &output, checksum)
 				.boxed()
 				.await?;
 		}

--- a/packages/server/src/runtime/builtin.rs
+++ b/packages/server/src/runtime/builtin.rs
@@ -34,11 +34,10 @@ impl Runtime {
 		// Get the checksum.
 		let checksum = target.checksum(server).await?;
 
-		// Check if a similar build with a checksum failure exists.
-		let value = super::util::maybe_reuse_build(server, &target, checksum.as_ref()).await;
-		if value.is_ok() {
-			return value;
-		}
+		// Try to reuse a build whose checksum is `None` or `Unsafe`.
+		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+			return Ok(value);
+		};
 
 		// Get the name.
 		let name = args

--- a/packages/server/src/runtime/builtin.rs
+++ b/packages/server/src/runtime/builtin.rs
@@ -35,7 +35,9 @@ impl Runtime {
 		let checksum = target.checksum(server).await?;
 
 		// Try to reuse a build whose checksum is `None` or `Unsafe`.
-		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+		if let Ok(value) =
+			super::util::try_reuse_build(server, build.id(), &target, checksum.as_ref()).await
+		{
 			return Ok(value);
 		};
 

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -40,11 +40,10 @@ impl Runtime {
 		// Get the checksum.
 		let checksum = target.checksum(server).await?;
 
-		// Check if a similar build with a checksum failure exists.
-		let value = super::util::try_reuse_build(server, &target, checksum.as_ref()).await;
-		if value.is_ok() {
-			return value;
-		}
+		// Try to reuse a build whose checksum is `None` or `Unsafe`.
+		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+			return Ok(value);
+		};
 
 		// If the VFS is disabled, then check out the target's children.
 		if server.vfs.lock().unwrap().is_none() {

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -41,7 +41,9 @@ impl Runtime {
 		let checksum = target.checksum(server).await?;
 
 		// Try to reuse a build whose checksum is `None` or `Unsafe`.
-		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+		if let Ok(value) =
+			super::util::try_reuse_build(server, build.id(), &target, checksum.as_ref()).await
+		{
 			return Ok(value);
 		};
 

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -41,7 +41,7 @@ impl Runtime {
 		let checksum = target.checksum(server).await?;
 
 		// Check if a similar build with a checksum failure exists.
-		let value = super::util::maybe_reuse_build(server, &target, checksum.as_ref()).await;
+		let value = super::util::try_reuse_build(server, &target, checksum.as_ref()).await;
 		if value.is_ok() {
 			return value;
 		}

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -79,15 +79,14 @@ impl Runtime {
 			let server = server.clone();
 			let build = build.clone();
 			move || async move {
-				runtime
-					.run_inner(
-						&server,
-						&build,
-						remote,
-						main_runtime_handle.clone(),
-						isolate_handle_sender,
-					)
-					.await
+				Box::pin(runtime.run_inner(
+					&server,
+					&build,
+					remote,
+					main_runtime_handle.clone(),
+					isolate_handle_sender,
+				))
+				.await
 			}
 		});
 		let abort_handle = task.abort_handle();

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -115,11 +115,10 @@ impl Runtime {
 		// Get the checksum.
 		let checksum = target.checksum(server).await?;
 
-		// Check if a similar build with a checksum failure exists.
-		let value = super::util::try_reuse_build(server, &target, checksum.as_ref()).await;
-		if value.is_ok() {
-			return value;
-		}
+		// Try to reuse a build whose checksum is `None` or `Unsafe`.
+		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+			return Ok(value);
+		};
 
 		// Get the root module.
 		let root = target

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -79,14 +79,16 @@ impl Runtime {
 			let server = server.clone();
 			let build = build.clone();
 			move || async move {
-				Box::pin(runtime.run_inner(
-					&server,
-					&build,
-					remote,
-					main_runtime_handle.clone(),
-					isolate_handle_sender,
-				))
-				.await
+				runtime
+					.run_inner(
+						&server,
+						&build,
+						remote,
+						main_runtime_handle.clone(),
+						isolate_handle_sender,
+					)
+					.boxed_local()
+					.await
 			}
 		});
 		let abort_handle = task.abort_handle();

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -116,7 +116,7 @@ impl Runtime {
 		let checksum = target.checksum(server).await?;
 
 		// Check if a similar build with a checksum failure exists.
-		let value = super::util::maybe_reuse_build(server, &target, checksum.as_ref()).await;
+		let value = super::util::try_reuse_build(server, &target, checksum.as_ref()).await;
 		if value.is_ok() {
 			return value;
 		}

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -116,7 +116,9 @@ impl Runtime {
 		let checksum = target.checksum(server).await?;
 
 		// Try to reuse a build whose checksum is `None` or `Unsafe`.
-		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+		if let Ok(value) =
+			super::util::try_reuse_build(server, build.id(), &target, checksum.as_ref()).await
+		{
 			return Ok(value);
 		};
 

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -77,11 +77,10 @@ impl Runtime {
 		// Get the checksum.
 		let checksum = target.checksum(server).await?;
 
-		// Check if a similar build with a checksum failure exists.
-		let value = super::util::maybe_reuse_build(server, &target, checksum.as_ref()).await;
-		if value.is_ok() {
-			return value;
-		}
+		// Try to reuse a build whose checksum is `None` or `Unsafe`.
+		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+			return Ok(value);
+		};
 
 		// If the VFS is disabled, then check out the target's children.
 		if server.vfs.lock().unwrap().is_none() {

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -77,47 +77,10 @@ impl Runtime {
 		let target = build.target(server).await?;
 
 		// Get the checksum.
-		let checksum = target.checksum(server).await?.clone();
+		let checksum = target.checksum(server).await?;
 
-		'a: {
-			// Unwrap checksum.
-			let Some(ref checksum) = checksum else {
-				break 'a;
-			};
-
-			// Break if checksum type is `None` or `Unsafe`.
-			if let tg::Checksum::None | tg::Checksum::Unsafe = checksum {
-				break 'a;
-			}
-
-			// Search for a previous build with a `None` or `Unsafe` checksum.
-			let Ok(Some(matching_build)) = find_matching_build(server, &target).await else {
-				break 'a;
-			};
-			let matching_build = tg::Build::with_id(matching_build);
-
-			// Get the matching build outcome.
-			let Ok(Some(future)) = server.try_get_build_outcome(matching_build.id()).await else {
-				break 'a;
-			};
-			let outcome = future.await;
-
-			// Get the value out of the build's outcome.
-			let Ok(Some(
-				tg::build::Outcome::Success(tg::build::outcome::Success { value })
-				| tg::build::Outcome::Failure(tg::build::outcome::Failure {
-					value: Some(value), ..
-				}),
-			)) = outcome
-			else {
-				break 'a;
-			};
-
-			// Launch a child build to checksum the value.
-			if let Ok(()) = super::util::checksum(server, &matching_build, &value, checksum).await {
-				return Ok(value);
-			}
-		}
+		// Check if a similar build with a checksum failure exists.
+		super::util::maybe_reuse_build(&checksum);
 
 		// If the VFS is disabled, then check out the target's children.
 		if server.vfs.lock().unwrap().is_none() {

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -78,7 +78,9 @@ impl Runtime {
 		let checksum = target.checksum(server).await?;
 
 		// Try to reuse a build whose checksum is `None` or `Unsafe`.
-		if let Ok(value) = super::util::try_reuse_build(server, &target, checksum.as_ref()).await {
+		if let Ok(value) =
+			super::util::try_reuse_build(server, build.id(), &target, checksum.as_ref()).await
+		{
 			return Ok(value);
 		};
 


### PR DESCRIPTION
This PR saves the output of builds that failed due to a checksum verification. When rerunning a similar target, we reuse this output and simply checksum it.

TODO:

- [x] all runtimes