### PR TITLE
repro(checkin): checkin mismatch

### DIFF
--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -17,7 +17,7 @@ mod build;
 mod cat;
 mod checksum;
 mod clean;
-mod config;
+pub mod config;
 mod get;
 mod health;
 mod lsp;

--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -14,7 +14,7 @@ async fn build_module_without_package() {
 
 		// Start the server.
 		let config = Config {
-			remotes: None,
+			remotes: Some(None),
 			..Default::default()
 		};
 		let server = context.spawn_server_with_config(config).await.unwrap();

--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -1,6 +1,6 @@
 use indoc::indoc;
 use insta::assert_snapshot;
-use tangram_cli::{assert_output_success, test::test};
+use tangram_cli::{assert_output_success, config::Config, test::test};
 use tangram_temp::{self as temp, Temp};
 use tokio::io::AsyncWriteExt as _;
 
@@ -13,7 +13,11 @@ async fn build_module_without_package() {
 		let mut context = context.lock().await;
 
 		// Start the server.
-		let server = context.spawn_server().await.unwrap();
+		let config = Config {
+			remotes: None,
+			..Default::default()
+		};
+		let server = context.spawn_server_with_config(config).await.unwrap();
 
 		// Create a directory with a module.
 		let temp = Temp::new();

--- a/packages/cli/tests/checkin.rs
+++ b/packages/cli/tests/checkin.rs
@@ -1,0 +1,72 @@
+use indoc::indoc;
+use tangram_cli::{assert_output_success, config::Config, test::test};
+use tangram_client as tg;
+use tangram_temp::{self as temp, Temp};
+use tokio::io::AsyncWriteExt as _;
+
+const TG: &str = env!("CARGO_BIN_EXE_tangram");
+
+/// Test checking in a file with a lockfile in its xattrs.
+#[tokio::test]
+async fn checkin_locked_file() {
+	test(TG, |context| async move {
+		let mut context = context.lock().await;
+
+		// Start the server.
+		let config = Config {
+			remotes: None,
+			..Default::default()
+		};
+		let server = context.spawn_server_with_config(config).await.unwrap();
+
+		// Create a file with dependencies.
+		let temp = Temp::new();
+		let package = temp::directory! {
+			"tangram.ts" => indoc!(r#"
+				export default tg.target(async () => {
+					const d = await tg.directory({
+						entry: tg.file("inner")
+					});
+					const d_id = await d.id();
+					const f = await tg.file("contents");
+					return await f.id();
+				});
+			"#),
+		};
+		package.to_path(temp.as_ref()).await.unwrap();
+
+		let output = server
+			.tg()
+			.arg("build")
+			.arg("--quiet")
+			.arg(temp.path())
+			.output()
+			.await
+			.unwrap();
+		assert_output_success!(output);
+		// let id: tg::file::Id = String::from_utf8(output.stdout).unwrap().parse().unwrap();
+
+		// Check out the file with dependencies=false, lockfile=true.
+		let checkout_temp = Temp::new();
+		tokio::fs::create_dir_all(checkout_temp.path())
+			.await
+			.unwrap();
+		// let checkout_output = server
+		// 	.tg()
+		// 	.arg("checkout")
+		// 	.arg("--dependencies=false")
+		// 	.arg("--lockfile=true")
+		// 	.arg(id.to_string())
+		// 	.arg(checkout_temp.path().join("orig"))
+		// 	.output()
+		// 	.await
+		// 	.unwrap();
+		// assert_output_success!(checkout_output);
+
+		//
+		// Check in the file
+		//
+		// Assert the contents and dependencies match the original.
+	})
+	.await;
+}

--- a/packages/cli/tests/checkin.rs
+++ b/packages/cli/tests/checkin.rs
@@ -111,3 +111,111 @@ async fn checkin_locked_file() {
 	})
 	.await;
 }
+
+/// Test checking in a file with a lockfile in its xattrs that has transitive dependencies.
+#[tokio::test]
+async fn checkin_locked_file_with_transitive_dependency() {
+	test(TG, |context| async move {
+		let mut context = context.lock().await;
+
+		// Start the server.
+		let config = Config {
+			remotes: Some(None),
+			..Default::default()
+		};
+		let server = context.spawn_server_with_config(config).await.unwrap();
+
+		// Create a file with dependencies.
+		let temp = Temp::new();
+		let package = temp::directory! {
+			"tangram.ts" => indoc!(r#"
+				export default tg.target(async () => {
+					const inner_dep = await tg.file("transive dep");
+					const inner_dep_id = await inner_dep.id();
+					const d = await tg.directory({
+						entry: tg.file("inner", { dependencies: { [inner_dep_id]: { item: inner_dep }}}),
+					});
+					const d_id = await d.id();
+					const f = await tg.file("contents", { dependencies: { [d_id]: { item: d }}});
+					return await f.id();
+				});
+			"#),
+		};
+		package.to_path(temp.as_ref()).await.unwrap();
+
+		let output = server
+			.tg()
+			.arg("build")
+			.arg("--quiet")
+			.arg(temp.path())
+			.output()
+			.await
+			.unwrap();
+		assert_output_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout)
+			.unwrap()
+			.trim()
+			.trim_matches('"');
+		let orig_id: tg::file::Id = stdout.parse().unwrap();
+
+		// Store the output of `tg get`.
+		let orig_get_output = server
+			.tg()
+			.arg("get")
+			.arg(orig_id.to_string())
+			.output()
+			.await
+			.unwrap();
+		let orig_get_stdout = std::str::from_utf8(&orig_get_output.stdout).unwrap().trim();
+
+		// Check out the file with dependencies=false, lockfile=true.
+		let checkout_temp = Temp::new();
+		tokio::fs::create_dir_all(checkout_temp.path())
+			.await
+			.unwrap();
+		let checkout_output = server
+			.tg()
+			.arg("checkout")
+			.arg("--dependencies=false")
+			.arg("--lockfile=true")
+			.arg(orig_id.to_string())
+			.arg(checkout_temp.path().join("orig"))
+			.output()
+			.await
+			.unwrap();
+		assert_output_success!(checkout_output);
+
+		// Check in the file
+		let checkin_output = server
+			.tg()
+			.arg("checkin")
+			.arg(checkout_temp.path().join("orig"))
+			.output()
+			.await
+			.unwrap();
+		assert_output_success!(checkin_output);
+		let checkin_stdout = std::str::from_utf8(&checkin_output.stdout)
+			.unwrap()
+			.trim()
+			.trim_matches('"');
+		let checkin_id: tg::file::Id = checkin_stdout.parse().unwrap();
+
+		// The checked in file should match the original file.
+		assert_eq!(orig_id, checkin_id);
+
+		// The `tg get` output of each should be identical.
+		let checkin_get_output = server
+			.tg()
+			.arg("get")
+			.arg(checkin_id.to_string())
+			.output()
+			.await
+			.unwrap();
+		let checkin_get_stdout = std::str::from_utf8(&checkin_get_output.stdout)
+			.unwrap()
+			.trim();
+		assert_eq!(orig_get_stdout, checkin_get_stdout);
+		// assert_eq!("a", checkin_get_stdout);
+	})
+	.await;
+}

--- a/packages/cli/tests/checkin.rs
+++ b/packages/cli/tests/checkin.rs
@@ -29,7 +29,7 @@ async fn checkin_locked_file() {
 					});
 					const d_id = await d.id();
 					const f = await tg.file("contents", { dependencies: { [d_id]: { item: d }}});
-					return await f.id();
+					return f;
 				});
 			"#),
 		};
@@ -44,10 +44,7 @@ async fn checkin_locked_file() {
 			.await
 			.unwrap();
 		assert_output_success!(output);
-		let stdout = std::str::from_utf8(&output.stdout)
-			.unwrap()
-			.trim()
-			.trim_matches('"');
+		let stdout = std::str::from_utf8(&output.stdout).unwrap().trim();
 		let orig_id: tg::file::Id = stdout.parse().unwrap();
 
 		// Store the output of `tg get`.
@@ -86,10 +83,7 @@ async fn checkin_locked_file() {
 			.await
 			.unwrap();
 		assert_output_success!(checkin_output);
-		let checkin_stdout = std::str::from_utf8(&checkin_output.stdout)
-			.unwrap()
-			.trim()
-			.trim_matches('"');
+		let checkin_stdout = std::str::from_utf8(&checkin_output.stdout).unwrap().trim();
 		let checkin_id: tg::file::Id = checkin_stdout.parse().unwrap();
 
 		// The checked in file should match the original file.
@@ -107,7 +101,6 @@ async fn checkin_locked_file() {
 			.unwrap()
 			.trim();
 		assert_eq!(orig_get_stdout, checkin_get_stdout);
-		// assert_eq!("a", checkin_get_stdout);
 	})
 	.await;
 }
@@ -137,7 +130,7 @@ async fn checkin_locked_file_with_transitive_dependency() {
 					});
 					const d_id = await d.id();
 					const f = await tg.file("contents", { dependencies: { [d_id]: { item: d }}});
-					return await f.id();
+					return f;
 				});
 			"#),
 		};
@@ -152,10 +145,7 @@ async fn checkin_locked_file_with_transitive_dependency() {
 			.await
 			.unwrap();
 		assert_output_success!(output);
-		let stdout = std::str::from_utf8(&output.stdout)
-			.unwrap()
-			.trim()
-			.trim_matches('"');
+		let stdout = std::str::from_utf8(&output.stdout).unwrap().trim();
 		let orig_id: tg::file::Id = stdout.parse().unwrap();
 
 		// Store the output of `tg get`.
@@ -194,10 +184,7 @@ async fn checkin_locked_file_with_transitive_dependency() {
 			.await
 			.unwrap();
 		assert_output_success!(checkin_output);
-		let checkin_stdout = std::str::from_utf8(&checkin_output.stdout)
-			.unwrap()
-			.trim()
-			.trim_matches('"');
+		let checkin_stdout = std::str::from_utf8(&checkin_output.stdout).unwrap().trim();
 		let checkin_id: tg::file::Id = checkin_stdout.parse().unwrap();
 
 		// The checked in file should match the original file.
@@ -215,7 +202,6 @@ async fn checkin_locked_file_with_transitive_dependency() {
 			.unwrap()
 			.trim();
 		assert_eq!(orig_get_stdout, checkin_get_stdout);
-		// assert_eq!("a", checkin_get_stdout);
 	})
 	.await;
 }

--- a/packages/server/src/artifact/tests.rs
+++ b/packages/server/src/artifact/tests.rs
@@ -672,7 +672,7 @@ async fn file_with_transitive_object_dependencies() -> tg::Result<()> {
     "contents": "hello",
     "executable": false,
     "xattrs": {
-      "user.tangram.lock": "{\"nodes\":[{\"kind\":\"file\",\"dependencies\":{\"fil_010ahk1drre093nerbycshqfpb5vzcjptq94jyfw5r5y9j7jhfx1mg\":{\"item\":\"fil_010ahk1drre093nerbycshqfpb5vzcjptq94jyfw5r5y9j7jhfx1mg\"}},\"id\":\"fil_01jwz4z27dcyft5q87egvz5r7mh1k67v7q0sey4ffb63nqbpdhj21g\"}]}"
+      "user.tangram.lock": "{\"nodes\":[{\"kind\":\"file\",\"dependencies\":{\"dir_01s8c95696nppdhy29sdjqxbzdmhyw53g807z2ddm47dt9w5xbts9g\":{\"item\":1}},\"id\":\"fil_015g2z6mnxhe1wtz6f9vgv1cjxpxvvmmph32a7n18153n74hrj33n0\"},{\"kind\":\"directory\",\"entries\":{\"entry\":2},\"id\":\"dir_01s8c95696nppdhy29sdjqxbzdmhyw53g807z2ddm47dt9w5xbts9g\"},{\"kind\":\"file\",\"dependencies\":{\"fil_010ahk1drre093nerbycshqfpb5vzcjptq94jyfw5r5y9j7jhfx1mg\":{\"item\":\"fil_010ahk1drre093nerbycshqfpb5vzcjptq94jyfw5r5y9j7jhfx1mg\"}},\"id\":\"fil_01jwz4z27dcyft5q87egvz5r7mh1k67v7q0sey4ffb63nqbpdhj21g\"}]}"
     }
   }
   "#);

--- a/packages/server/src/artifact/tests.rs
+++ b/packages/server/src/artifact/tests.rs
@@ -606,6 +606,101 @@ async fn file_with_object_dependencies() -> tg::Result<()> {
 	result.unwrap()
 }
 
+#[tokio::test]
+async fn file_with_transitive_object_dependencies() -> tg::Result<()> {
+	// Create the first server.
+	let temp1 = Temp::new();
+	let config = Config::with_path(temp1.path().to_owned());
+	let server = Server::start(config.clone()).await?;
+
+	// Run the test.
+	let result = AssertUnwindSafe(async {
+		let transitive_dep = tg::file!("transitive");
+		
+		// Create the dependency artifact and object.
+		let file_dep = tg::File::with_object(tg::file::Object::Normal {
+			contents: "hello".into(),
+			dependencies: [(
+				tg::Reference::with_object(&transitive_dep.id(&server).await?.into()),
+				tg::Referent {
+					item: transitive_dep.clone().into(),
+					path: None,
+					subpath: None,
+					tag: None,
+				},
+			)]
+			.into_iter()
+			.collect(),
+			executable: false,
+		});
+
+		let dep_dir = tg::directory!{ "entry" => file_dep };
+		let orig = tg::File::with_object(tg::file::Object::Normal {
+			contents: "hello".into(),
+			dependencies: [(
+				tg::Reference::with_object(&dep_dir.id(&server).await?.into()),
+				tg::Referent {
+					item: dep_dir.clone().into(),
+					path: None,
+					subpath: None,
+					tag: None,
+				},
+			)]
+			.into_iter()
+			.collect(),
+			executable: false,
+		});
+		
+		let orig_id = orig.id(&server).await?;
+
+  		// Check out the file within the artifact.
+		let temp = Temp::new();
+		let arg = tg::artifact::checkout::Arg {
+			dependencies: false,
+			force: false,
+			lockfile: true,
+			path: Some(temp.path().to_owned()),
+		};
+		let path = tg::Artifact::from(orig).check_out(&server, arg).await?;
+
+		// Get the result.
+		let artifact = temp::Artifact::with_path(&path).await.map_err(|source| tg::error!(!source, "failed to get the artifact"))?;
+
+		assert_json_snapshot!(artifact, @r#"
+  {
+    "kind": "file",
+    "contents": "hello",
+    "executable": false,
+    "xattrs": {
+      "user.tangram.lock": "{\"nodes\":[{\"kind\":\"file\",\"dependencies\":{\"fil_010ahk1drre093nerbycshqfpb5vzcjptq94jyfw5r5y9j7jhfx1mg\":{\"item\":\"fil_010ahk1drre093nerbycshqfpb5vzcjptq94jyfw5r5y9j7jhfx1mg\"}},\"id\":\"fil_01jwz4z27dcyft5q87egvz5r7mh1k67v7q0sey4ffb63nqbpdhj21g\"}]}"
+    }
+  }
+  "#);
+
+	// Check back in the file.
+		let arg = tg::artifact::checkin::Arg {
+			cache: false,
+			destructive: false,
+			deterministic: false,
+			ignore: false,
+			locked: false,
+			lockfile: false,
+			path: temp.path().to_owned(),
+		};
+		let roundtrip = tg::Artifact::check_in(&server, arg).await?.try_unwrap_file().unwrap();
+		let roundtrip_id = roundtrip.id(&server).await?;
+		assert_eq!(orig_id, roundtrip_id);
+	
+
+		Ok::<_, tg::Error>(())
+	})
+	.catch_unwind()
+	.await;
+
+	cleanup(temp1, server).await;
+	result.unwrap()
+}
+
 async fn test<F, Fut>(
 	checkin: impl Into<temp::Artifact>,
 	path: &Path,


### PR DESCRIPTION
Adds a failing test to `tangram_cli`: `checkin_locked_file_with_transitive_dependency`.