### PR TITLE
fix: add output types and swallow errors to some build methods

### DIFF
--- a/packages/cli/src/build/cancel.rs
+++ b/packages/cli/src/build/cancel.rs
@@ -29,7 +29,7 @@ impl Cli {
 			remote,
 			status: tg::build::Status::Canceled,
 		};
-		handle.finish_build(&args.build, arg).await?;
+		handle.try_finish_build(&args.build, arg).await?;
 
 		Ok(())
 	}

--- a/packages/client/src/build/finish.rs
+++ b/packages/client/src/build/finish.rs
@@ -15,23 +15,28 @@ pub struct Arg {
 	pub status: tg::build::Status,
 }
 
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct Output {
+	pub finished: bool,
+}
+
 impl tg::Build {
-	pub async fn finish<H>(&self, handle: &H, arg: tg::build::finish::Arg) -> tg::Result<()>
+	pub async fn finish<H>(&self, handle: &H, arg: tg::build::finish::Arg) -> tg::Result<bool>
 	where
 		H: tg::Handle,
 	{
 		let id = self.id();
-		handle.finish_build(id, arg).await?;
-		Ok(())
+		let output = handle.try_finish_build(id, arg).await?;
+		Ok(output.finished)
 	}
 }
 
 impl tg::Client {
-	pub async fn finish_build(
+	pub async fn try_finish_build(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::finish::Arg,
-	) -> tg::Result<bool> {
+	) -> tg::Result<Output> {
 		let method = http::Method::POST;
 		let uri = format!("/builds/{id}/finish");
 		let request = http::request::Builder::default()

--- a/packages/client/src/build/start.rs
+++ b/packages/client/src/build/start.rs
@@ -7,12 +7,17 @@ pub struct Arg {
 	pub remote: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct Output {
+	pub started: bool,
+}
+
 impl tg::Client {
 	pub async fn try_start_build(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::start::Arg,
-	) -> tg::Result<bool> {
+	) -> tg::Result<Output> {
 		let method = http::Method::POST;
 		let uri = format!("/builds/{id}/start");
 		let request = http::request::Builder::default()

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -87,7 +87,7 @@ pub trait Handle: Clone + Unpin + Send + Sync + 'static {
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::start::Arg,
-	) -> impl Future<Output = tg::Result<bool>> + Send;
+	) -> impl Future<Output = tg::Result<tg::build::start::Output>> + Send;
 
 	fn try_get_build_status_stream(
 		&self,
@@ -120,17 +120,17 @@ pub trait Handle: Clone + Unpin + Send + Sync + 'static {
 		>,
 	> + Send;
 
-	fn add_build_log(
+	fn try_add_build_log(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::post::Arg,
-	) -> impl Future<Output = tg::Result<()>> + Send;
+	) -> impl Future<Output = tg::Result<tg::build::log::post::Output>> + Send;
 
-	fn finish_build(
+	fn try_finish_build(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::finish::Arg,
-	) -> impl Future<Output = tg::Result<bool>> + Send;
+	) -> impl Future<Output = tg::Result<tg::build::finish::Output>> + Send;
 
 	fn touch_build(
 		&self,

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -161,7 +161,7 @@ where
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::start::Arg,
-	) -> impl Future<Output = tg::Result<bool>> + Send {
+	) -> impl Future<Output = tg::Result<tg::build::start::Output>> + Send {
 		match self {
 			Either::Left(s) => s.try_start_build(id, arg).left_future(),
 			Either::Right(s) => s.try_start_build(id, arg).right_future(),
@@ -230,25 +230,25 @@ where
 		}
 	}
 
-	fn add_build_log(
+	fn try_add_build_log(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::post::Arg,
-	) -> impl Future<Output = tg::Result<()>> {
+	) -> impl Future<Output = tg::Result<tg::build::log::post::Output>> {
 		match self {
-			Either::Left(s) => s.add_build_log(id, arg).left_future(),
-			Either::Right(s) => s.add_build_log(id, arg).right_future(),
+			Either::Left(s) => s.try_add_build_log(id, arg).left_future(),
+			Either::Right(s) => s.try_add_build_log(id, arg).right_future(),
 		}
 	}
 
-	fn finish_build(
+	fn try_finish_build(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::finish::Arg,
-	) -> impl Future<Output = tg::Result<bool>> {
+	) -> impl Future<Output = tg::Result<tg::build::finish::Output>> {
 		match self {
-			Either::Left(s) => s.finish_build(id, arg).left_future(),
-			Either::Right(s) => s.finish_build(id, arg).right_future(),
+			Either::Left(s) => s.try_finish_build(id, arg).left_future(),
+			Either::Right(s) => s.try_finish_build(id, arg).right_future(),
 		}
 	}
 

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -667,7 +667,7 @@ impl tg::Handle for Client {
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::start::Arg,
-	) -> impl Future<Output = tg::Result<bool>> {
+	) -> impl Future<Output = tg::Result<tg::build::start::Output>> {
 		self.try_start_build(id, arg)
 	}
 
@@ -714,20 +714,20 @@ impl tg::Handle for Client {
 		self.try_get_build_log_stream(id, arg)
 	}
 
-	fn add_build_log(
+	fn try_add_build_log(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::post::Arg,
-	) -> impl Future<Output = tg::Result<()>> {
-		self.add_build_log(id, arg)
+	) -> impl Future<Output = tg::Result<tg::build::log::post::Output>> {
+		self.try_add_build_log(id, arg)
 	}
 
-	fn finish_build(
+	fn try_finish_build(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::finish::Arg,
-	) -> impl Future<Output = tg::Result<bool>> {
-		self.finish_build(id, arg)
+	) -> impl Future<Output = tg::Result<tg::build::finish::Output>> {
+		self.try_finish_build(id, arg)
 	}
 
 	fn touch_build(

--- a/packages/server/src/build/children.rs
+++ b/packages/server/src/build/children.rs
@@ -286,14 +286,14 @@ impl Server {
 		Ok(Some(stream))
 	}
 
-	pub(crate) async fn add_build_child(
+	pub(crate) async fn try_add_build_child(
 		&self,
 		parent: &tg::build::Id,
 		child: &tg::build::Id,
-	) -> tg::Result<()> {
+	) -> tg::Result<bool> {
 		// Verify the build is local and started.
 		if self.get_current_build_status_local(parent).await? != tg::build::Status::Started {
-			return Err(tg::error!("the build is not started"));
+			return Ok(false);
 		}
 
 		// Get a database connection.
@@ -337,7 +337,7 @@ impl Server {
 			}
 		});
 
-		Ok(())
+		Ok(true)
 	}
 }
 

--- a/packages/server/src/build/log.rs
+++ b/packages/server/src/build/log.rs
@@ -286,14 +286,14 @@ impl Server {
 		Ok(Some(stream))
 	}
 
-	pub async fn add_build_log(
+	pub async fn try_add_build_log(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::post::Arg,
-	) -> tg::Result<()> {
+	) -> tg::Result<tg::build::log::post::Output> {
 		// Verify the build is local and started.
 		if self.get_current_build_status_local(id).await? != tg::build::Status::Started {
-			return Err(tg::error!("the build is not started"));
+			return Ok(tg::build::log::post::Output { added: false });
 		}
 
 		// Log.
@@ -317,7 +317,7 @@ impl Server {
 			}
 		});
 
-		Ok(())
+		Ok(tg::build::log::post::Output { added: true })
 	}
 
 	async fn try_add_build_log_to_database(
@@ -751,7 +751,7 @@ impl Server {
 	{
 		let id = id.parse()?;
 		let arg = request.json().await?;
-		handle.add_build_log(&id, arg).await?;
+		handle.try_add_build_log(&id, arg).await?;
 		let response = http::Response::builder().empty().unwrap();
 		Ok(response)
 	}

--- a/packages/server/src/build/spawn.rs
+++ b/packages/server/src/build/spawn.rs
@@ -68,7 +68,7 @@ impl Server {
 			let arg = tg::build::start::Arg {
 				remote: remote.clone(),
 			};
-			let started = server.try_start_build(build.id(), arg).await?;
+			let started = server.try_start_build(build.id(), arg).await?.started;
 			if !started {
 				return Ok(());
 			}

--- a/packages/server/src/build/start.rs
+++ b/packages/server/src/build/start.rs
@@ -11,7 +11,7 @@ impl Server {
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::start::Arg,
-	) -> tg::Result<bool> {
+	) -> tg::Result<tg::build::start::Output> {
 		// If the remote arg is set, then forward the request.
 		let remote = arg.remote.as_ref();
 		if let Some(remote) = remote {
@@ -71,7 +71,7 @@ impl Server {
 			}
 		});
 
-		Ok(started)
+		Ok(tg::build::start::Output { started })
 	}
 }
 

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -1105,7 +1105,7 @@ impl tg::Handle for Server {
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::start::Arg,
-	) -> impl Future<Output = tg::Result<bool>> {
+	) -> impl Future<Output = tg::Result<tg::build::start::Output>> {
 		self.try_start_build(id, arg)
 	}
 
@@ -1146,20 +1146,20 @@ impl tg::Handle for Server {
 		self.try_get_build_log_stream(id, arg)
 	}
 
-	fn add_build_log(
+	fn try_add_build_log(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::log::post::Arg,
-	) -> impl Future<Output = tg::Result<()>> {
-		self.add_build_log(id, arg)
+	) -> impl Future<Output = tg::Result<tg::build::log::post::Output>> {
+		self.try_add_build_log(id, arg)
 	}
 
-	fn finish_build(
+	fn try_finish_build(
 		&self,
 		id: &tg::build::Id,
 		arg: tg::build::finish::Arg,
-	) -> impl Future<Output = tg::Result<bool>> {
-		self.finish_build(id, arg)
+	) -> impl Future<Output = tg::Result<tg::build::finish::Output>> {
+		self.try_finish_build(id, arg)
 	}
 
 	fn touch_build(

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -214,7 +214,7 @@ impl tg::Handle for Proxy {
 		&self,
 		_id: &tg::build::Id,
 		_arg: tg::build::start::Arg,
-	) -> tg::Result<bool> {
+	) -> tg::Result<tg::build::start::Output> {
 		Err(tg::error!("forbidden"))
 	}
 
@@ -257,19 +257,19 @@ impl tg::Handle for Proxy {
 		self.server.try_get_build_log_stream(id, arg)
 	}
 
-	async fn add_build_log(
+	async fn try_add_build_log(
 		&self,
 		_id: &tg::build::Id,
 		_arg: tg::build::log::post::Arg,
-	) -> tg::Result<()> {
+	) -> tg::Result<tg::build::log::post::Output> {
 		Err(tg::error!("forbidden"))
 	}
 
-	async fn finish_build(
+	async fn try_finish_build(
 		&self,
 		_id: &tg::build::Id,
 		_arg: tg::build::finish::Arg,
-	) -> tg::Result<bool> {
+	) -> tg::Result<tg::build::finish::Output> {
 		Err(tg::error!("forbidden"))
 	}
 

--- a/packages/server/src/target/build.rs
+++ b/packages/server/src/target/build.rs
@@ -93,7 +93,7 @@ impl Server {
 
 			// Add the build as a child of the parent.
 			if let Some(parent) = arg.parent.as_ref() {
-				self.add_build_child(parent, build.id()).await.map_err(
+				self.try_add_build_child(parent, build.id()).await.map_err(
 					|source| tg::error!(!source, %parent, %child = build.id(), "failed to add the build as a child"),
 				)?;
 			}
@@ -151,7 +151,7 @@ impl Server {
 
 			// Add the build as a child of the parent.
 			if let Some(parent) = arg.parent.as_ref() {
-				self.add_build_child(parent, build.id()).await.map_err(
+				self.try_add_build_child(parent, build.id()).await.map_err(
 					|source| tg::error!(!source, %parent, %child = build.id(), "failed to add build as a child"),
 				)?;
 			}
@@ -219,7 +219,7 @@ impl Server {
 
 		// Add the build to the parent.
 		if let Some(parent) = arg.parent.as_ref() {
-			self.add_build_child(parent, build.id()).await.map_err(
+			self.try_add_build_child(parent, build.id()).await.map_err(
 				|source| tg::error!(!source, %parent, %child = build.id(), "failed to add build as a child"),
 			)?;
 		}


### PR DESCRIPTION
- rename server::add_build_child to try_add_build child
- rename tg::Handle::finish_build to try_finish_build
- rename tg::Handle::start_build to try_start_build
- rename tg::Handle::add_build_log to try_add_build_log
- add output structs to try_finish_build, try_start_build, and try_add_log
- swallow errors caused by adding build logs/children/etc after builds have finished