### PR TITLE
repro(checkout): reproduce checkout failure

### DIFF
--- a/packages/cli/tests/artifact_checkout.rs
+++ b/packages/cli/tests/artifact_checkout.rs
@@ -196,7 +196,7 @@ async fn shared_dependency_on_symlink() {
 			export default tg.target(async () => {
 				let depDir = await tg.directory({
 					"file.txt": "contents",
-					"link": tg.symlink("dir"),
+					"link": tg.symlink("file.txt"),
 				});
 				let depDirId = await depDir.id();
 				return tg.directory({

--- a/packages/server/src/artifact/checkout.rs
+++ b/packages/server/src/artifact/checkout.rs
@@ -596,9 +596,9 @@ impl Server {
 		};
 
 		// Create the symlink.
-		tokio::fs::symlink(target, &arg.path)
+		tokio::fs::symlink(&target, &arg.path)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to create the symlink"))?;
+			.map_err(|source| tg::error!(!source, %src = target.display(), %dst = arg.path.display(), "failed to create the symlink"))?;
 
 		Ok(output)
 	}


### PR DESCRIPTION
This test demonstrates a checkout failure in which two files in a directory share a dependency on a third directory which contains a symlink. While creating the `.tangram/artifacts` directory, the second dependency fails because the symlink already exists:
```
error failed to run the command
-> File exists (os error 17)
-> failed to create the symlink
   internal:./packages/server/src/artifact/checkout.rs:601:22 tangram_server::artifact::checkout::<impl tangram_server::Server>::check_out_symlink::{{closure}}
::{{closure}}
   dst = /tmp/4G2PLpqrD7DJvivE/.tangram/artifacts/dir_01f3a7p72672yg5ztdzte7qz85g0xkx7rt9m6hhcyx1yss6csdf5kg/link
   src = dir
thread 'shared_dependency_on_symlink' panicked at packages/cli/tests/artifact_checkout.rs:516:9:
assertion failed: output.status.success()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```