### PR TITLE
feat: add tg::SourceMap and integrate with try_get_reference, tangram…

### DIFF
--- a/packages/cli/src/artifact/checkout.rs
+++ b/packages/cli/src/artifact/checkout.rs
@@ -42,7 +42,7 @@ impl Cli {
 		};
 
 		// Get the artifact.
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		let Either::Right(object) = referent.item else {
 			return Err(tg::error!("expected an object"));
 		};

--- a/packages/cli/src/cat.rs
+++ b/packages/cli/src/cat.rs
@@ -14,7 +14,7 @@ impl Cli {
 	pub async fn command_cat(&self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
 		for reference in &args.references {
-			let referent = self.get_reference(reference).await?;
+			let (referent, _) = self.get_reference(reference).await?;
 			let Either::Right(object) = referent.item else {
 				return Err(tg::error!("expected an object"));
 			};

--- a/packages/cli/src/checksum.rs
+++ b/packages/cli/src/checksum.rs
@@ -21,7 +21,7 @@ pub struct Args {
 impl Cli {
 	pub async fn command_checksum(&self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		let Either::Right(object) = referent.item else {
 			return Err(tg::error!("expected an object"));
 		};

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -202,6 +202,10 @@ pub struct Build {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub max_depth: Option<u64>,
 
+	/// Configure if path and tag are set for builds.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub set_path_and_tag: Option<bool>,
+
 	/// The remotes to build for.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub remotes: Option<Vec<String>>,

--- a/packages/cli/src/get.rs
+++ b/packages/cli/src/get.rs
@@ -23,7 +23,7 @@ pub struct Args {
 impl Cli {
 	pub async fn command_get(&self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		eprintln!("{} item {}", "info".blue().bold(), referent.item);
 		if let Some(path) = &referent.path {
 			let path = path.display();

--- a/packages/cli/src/package/document.rs
+++ b/packages/cli/src/package/document.rs
@@ -43,7 +43,7 @@ impl Cli {
 		}
 
 		// Get the reference.
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		let Either::Right(object) = referent.item else {
 			return Err(tg::error!("expected an object"));
 		};

--- a/packages/cli/src/progress.rs
+++ b/packages/cli/src/progress.rs
@@ -72,7 +72,7 @@ impl Cli {
 				},
 
 				tg::progress::Event::Diagnostic(diagnostic) => {
-					Self::print_diagnostic(&diagnostic);
+					Self::print_diagnostic(&diagnostic, None);
 				},
 
 				tg::progress::Event::Start(indicator) | tg::progress::Event::Update(indicator) => {

--- a/packages/cli/src/pull.rs
+++ b/packages/cli/src/pull.rs
@@ -27,7 +27,7 @@ impl Cli {
 		let handle = self.handle().await?;
 
 		// Get the reference.
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		let item = match referent.item {
 			Either::Left(build) => Either::Left(build),
 			Either::Right(object) => {

--- a/packages/cli/src/push.rs
+++ b/packages/cli/src/push.rs
@@ -34,7 +34,7 @@ impl Cli {
 		let remote = args.remote.unwrap_or_else(|| "default".to_owned());
 
 		// Get the reference.
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		let item = match referent.item {
 			Either::Left(build) => Either::Left(build),
 			Either::Right(object) => {

--- a/packages/cli/src/tag/put.rs
+++ b/packages/cli/src/tag/put.rs
@@ -30,7 +30,7 @@ impl Cli {
 			.map(|option| option.unwrap_or_else(|| "default".to_owned()));
 
 		// Get the reference.
-		let referent = self.get_reference(&args.reference).await?;
+		let (referent, _) = self.get_reference(&args.reference).await?;
 		let item = match referent.item {
 			Either::Left(build) => Either::Left(build),
 			Either::Right(object) => {

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -145,7 +145,12 @@ where
 		}
 	}
 
-	pub fn new(handle: &H, item: Item, options: Options) -> Self {
+	pub fn new(
+		handle: &H,
+		item: Item,
+		options: Options,
+		source_map: Option<tg::SourceMap>,
+	) -> Self {
 		let (update_sender, update_receiver) = std::sync::mpsc::channel();
 		let data = Data::new();
 		let tree = Tree::new(
@@ -154,6 +159,7 @@ where
 			options,
 			data.update_sender(),
 			update_sender.clone(),
+			source_map,
 		);
 		Self {
 			data,

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -38,6 +38,7 @@ struct Node {
 	log_task: Option<Task<()>>,
 	options: Rc<Options>,
 	parent: Option<Weak<RefCell<Self>>>,
+	source_map: Option<Rc<tg::SourceMap>>,
 	title: String,
 	update_receiver: NodeUpdateReceiver,
 	update_sender: NodeUpdateSender,
@@ -217,6 +218,7 @@ where
 		let depth = parent.borrow().depth + 1;
 		let (update_sender, update_receiver) = std::sync::mpsc::channel();
 		let options = parent.borrow().options.clone();
+		let source_map = parent.borrow().source_map.clone();
 		let parent = Rc::downgrade(parent);
 		let title = item.map_or(String::new(), |item| Self::item_title(item));
 
@@ -258,6 +260,7 @@ where
 			log_task: None,
 			options,
 			parent: Some(parent),
+			source_map,
 			title,
 			update_receiver,
 			update_sender,
@@ -1323,8 +1326,11 @@ where
 		options: Options,
 		data: data::UpdateSender,
 		viewer: super::UpdateSender<H>,
+		source_map: Option<tg::SourceMap>,
 	) -> Self {
 		let options = Rc::new(options);
+		let source_map = source_map.map(Rc::new);
+
 		let (update_sender, update_receiver) = std::sync::mpsc::channel();
 		let title = Self::item_title(&item);
 		let expand_task = if options.expand_on_create {
@@ -1367,6 +1373,7 @@ where
 			log_task: None,
 			options: options.clone(),
 			parent: None,
+			source_map,
 			title,
 			update_receiver,
 			update_sender,

--- a/packages/client/src/artifact/checkin.rs
+++ b/packages/client/src/artifact/checkin.rs
@@ -34,6 +34,7 @@ pub struct Arg {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Output {
 	pub artifact: tg::artifact::Id,
+	pub lockfile: Option<PathBuf>,
 }
 
 impl tg::Artifact {

--- a/packages/client/src/build/get.rs
+++ b/packages/client/src/build/get.rs
@@ -19,6 +19,9 @@ pub struct Output {
 	pub host: String,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub lock: Option<tg::Lockfile>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub log: Option<tg::blob::Id>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -1,6 +1,5 @@
 use crate as tg;
 use futures::{Future, Stream};
-use tangram_either::Either;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite};
 
 mod either;
@@ -204,8 +203,7 @@ pub trait Handle: Clone + Unpin + Send + Sync + 'static {
 	fn try_get_reference(
 		&self,
 		reference: &tg::Reference,
-	) -> impl Future<Output = tg::Result<Option<tg::Referent<Either<tg::build::Id, tg::object::Id>>>>>
-	       + Send;
+	) -> impl Future<Output = tg::Result<Option<tg::reference::get::Output>>> + Send;
 
 	fn list_remotes(
 		&self,

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -391,8 +391,7 @@ where
 	fn try_get_reference(
 		&self,
 		reference: &tg::Reference,
-	) -> impl Future<Output = tg::Result<Option<tg::Referent<Either<tg::build::Id, tg::object::Id>>>>>
-	       + Send {
+	) -> impl Future<Output = tg::Result<Option<tg::reference::get::Output>>> + Send {
 		match self {
 			Either::Left(s) => s.try_get_reference(reference).left_future(),
 			Either::Right(s) => s.try_get_reference(reference).right_future(),

--- a/packages/client/src/handle/ext.rs
+++ b/packages/client/src/handle/ext.rs
@@ -9,7 +9,6 @@ use std::{
 	io::SeekFrom,
 	sync::{Arc, Mutex},
 };
-use tangram_either::Either;
 
 pub trait Ext: tg::Handle {
 	fn try_read_blob(
@@ -400,8 +399,7 @@ pub trait Ext: tg::Handle {
 	fn get_reference(
 		&self,
 		reference: &tg::Reference,
-	) -> impl Future<Output = tg::Result<tg::Referent<Either<tg::build::Id, tg::object::Id>>>> + Send
-	{
+	) -> impl Future<Output = tg::Result<tg::reference::get::Output>> + Send {
 		self.try_get_reference(reference).map(|result| {
 			result
 				.and_then(|option| option.ok_or_else(|| tg::error!("failed to get the reference")))

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -40,6 +40,7 @@ pub use self::{
 	range::Range,
 	reference::Reference,
 	referent::Referent,
+	sourcemap::SourceMap,
 	symlink::Handle as Symlink,
 	tag::Tag,
 	target::Handle as Target,
@@ -78,6 +79,7 @@ pub mod reference;
 pub mod referent;
 pub mod remote;
 pub mod runtime;
+pub mod sourcemap;
 pub mod symlink;
 pub mod tag;
 pub mod target;
@@ -816,8 +818,7 @@ impl tg::Handle for Client {
 	fn try_get_reference(
 		&self,
 		reference: &tg::Reference,
-	) -> impl Future<Output = tg::Result<Option<tg::Referent<Either<tg::build::Id, tg::object::Id>>>>>
-	       + Send {
+	) -> impl Future<Output = tg::Result<Option<tg::reference::get::Output>>> + Send {
 		self.try_get_reference(reference)
 	}
 

--- a/packages/client/src/reference.rs
+++ b/packages/client/src/reference.rs
@@ -140,10 +140,9 @@ impl Reference {
 	where
 		H: tg::Handle,
 	{
-		handle
-			.get_reference(self)
-			.await
-			.map(|referent| tg::Referent {
+		handle.get_reference(self).await.map(|output| {
+			let referent = output.referent;
+			tg::Referent {
 				item: referent
 					.item
 					.map_left(tg::Build::with_id)
@@ -151,7 +150,8 @@ impl Reference {
 				path: referent.path,
 				subpath: referent.subpath,
 				tag: referent.tag,
-			})
+			}
+		})
 	}
 }
 

--- a/packages/client/src/reference/get.rs
+++ b/packages/client/src/reference/get.rs
@@ -1,12 +1,17 @@
 use crate as tg;
+use std::path::PathBuf;
 use tangram_either::Either;
 use tangram_http::{incoming::response::Ext as _, outgoing::request::Ext as _};
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Output {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub lockfile: Option<PathBuf>,
+	pub referent: tg::Referent<Either<tg::build::Id, tg::object::Id>>,
+}
+
 impl tg::Client {
-	pub async fn try_get_reference(
-		&self,
-		reference: &tg::Reference,
-	) -> tg::Result<Option<tg::Referent<Either<tg::build::Id, tg::object::Id>>>> {
+	pub async fn try_get_reference(&self, reference: &tg::Reference) -> tg::Result<Option<Output>> {
 		let method = http::Method::GET;
 		let path = reference.uri().path();
 		let query = reference.uri().query().unwrap_or_default();

--- a/packages/client/src/sourcemap.rs
+++ b/packages/client/src/sourcemap.rs
@@ -1,0 +1,149 @@
+use crate as tg;
+use std::{collections::BTreeMap, sync::Arc};
+
+pub struct SourceMap {
+	objects: BTreeMap<tg::object::Id, tg::Referent<tg::Object>>,
+}
+
+impl SourceMap {
+	pub async fn new<H>(handle: &H, lockfile: &tg::Lockfile, object: tg::Object) -> tg::Result<Self>
+	where
+		H: tg::Handle,
+	{
+		let edge = tg::Referent {
+			item: object.clone(),
+			path: Some(".".into()),
+			subpath: None,
+			tag: None,
+		};
+		let mut stack = vec![(edge, 0)];
+		let mut visited = vec![false; lockfile.nodes.len()];
+		let mut objects = BTreeMap::new();
+		while let Some((edge, node)) = stack.pop() {
+			if visited[node] {
+				continue;
+			}
+			visited[node] = true;
+			objects.insert(edge.item.id(handle).await?, edge.clone());
+
+			let edges = get_edges(handle, &edge.item, node, lockfile).await?;
+			stack.extend(edges);
+		}
+		Ok(Self { objects })
+	}
+
+	pub fn lookup(&self, object: &tg::object::Id) -> Option<tg::Referent<tg::Object>> {
+		self.objects.get(object).cloned()
+	}
+
+	pub fn convert_diagnostic(&self, mut diagnostic: tg::Diagnostic) -> tg::Diagnostic {
+		diagnostic.location = diagnostic.location.map(|mut location| {
+			location.module = self.convert_module(location.module);
+			location
+		});
+		diagnostic
+	}
+
+	pub fn convert_error(&self, mut error: tg::Error) -> tg::Error {
+		if let Some(location) = error.location.as_mut() {
+			if let tg::error::Source::Module(module) = &mut location.source {
+				*module = self.convert_module(module.clone());
+			}
+		}
+		if let Some(source) = error.source.as_ref() {
+			let source = self.convert_error(source.as_ref().clone());
+			error.source.replace(Arc::new(source));
+		}
+		error
+	}
+
+	pub fn convert_module(&self, mut module: tg::Module) -> tg::Module {
+		let tg::module::Item::Object(object) = &module.referent.item else {
+			return module;
+		};
+		let Some(referent) = self.lookup(object) else {
+			return module;
+		};
+		module.referent.path = referent.path;
+		module.referent.tag = referent.tag;
+		module
+	}
+}
+
+async fn get_edges(
+	handle: &impl tg::Handle,
+	object: &tg::Object,
+	node: usize,
+	lockfile: &tg::Lockfile,
+) -> tg::Result<Vec<(tg::Referent<tg::Object>, usize)>> {
+	match (&lockfile.nodes[node], object) {
+		(tg::lockfile::Node::Directory(node), tg::Object::Directory(object)) => {
+			let entries = object.entries(handle).await?;
+			let edges = node
+				.entries
+				.iter()
+				.filter_map(|(name, value)| {
+					let node = value.as_ref().left().copied()?;
+					let item = entries.get(name)?.clone().into();
+					let path = None;
+					let subpath = None;
+					let tag = None;
+					let referent = tg::Referent {
+						item,
+						path,
+						tag,
+						subpath,
+					};
+					Some((referent, node))
+				})
+				.collect();
+			Ok(edges)
+		},
+		(tg::lockfile::Node::File(node), tg::Object::File(object)) => {
+			let dependencies = object.dependencies(handle).await?;
+			let edges = node
+				.dependencies
+				.iter()
+				.filter_map(|(reference, referent)| {
+					let node = referent.item.as_ref().left().copied()?;
+					let item = dependencies.get(reference)?.item.clone();
+					let path = referent.path.clone();
+					let subpath = referent.subpath.clone();
+					let tag = referent.tag.clone();
+					let referent = tg::Referent {
+						item,
+						path,
+						subpath,
+						tag,
+					};
+					Some((referent, node))
+				})
+				.collect();
+			Ok(edges)
+		},
+		(
+			tg::lockfile::Node::Symlink(tg::lockfile::Symlink::Artifact { artifact, .. }),
+			tg::Object::Symlink(object),
+		) => {
+			let Some(node) = artifact.as_ref().left().copied() else {
+				return Ok(Vec::new());
+			};
+			let item = object
+				.artifact(handle)
+				.await?
+				.ok_or_else(|| tg::error!("expected an artifact"))?
+				.into();
+			let path = None;
+			let subpath = None;
+			let tag = None;
+			let referent = tg::Referent {
+				item,
+				path,
+				tag,
+				subpath,
+			};
+			Ok(vec![(referent, node)])
+		},
+		_ => Ok(Vec::new()),
+	}
+}

--- a/packages/client/src/target/build.rs
+++ b/packages/client/src/target/build.rs
@@ -11,6 +11,9 @@ pub struct Arg {
 	pub create: bool,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub lock: Option<tg::Lockfile>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub parent: Option<tg::build::Id>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -76,6 +79,7 @@ impl Default for Arg {
 	fn default() -> Self {
 		Self {
 			create: true,
+			lock: None,
 			parent: None,
 			remote: None,
 			retry: tg::build::Retry::default(),

--- a/packages/server/src/artifact/checkin/lockfile.rs
+++ b/packages/server/src/artifact/checkin/lockfile.rs
@@ -13,7 +13,7 @@ impl Server {
 		&self,
 		input: &input::Graph,
 		object: &object::Graph,
-	) -> tg::Result<()> {
+	) -> tg::Result<Option<PathBuf>> {
 		// Create the lockfile.
 		let lockfile = self
 			.create_lockfile(object, &input.nodes[0].arg.path)
@@ -22,7 +22,7 @@ impl Server {
 
 		// Skip empty lockfiles.
 		if lockfile.nodes.is_empty() {
-			return Ok(());
+			return Ok(None);
 		};
 
 		// Get the path to the root of the input graph.
@@ -57,7 +57,7 @@ impl Server {
 			},
 		}
 
-		Ok(())
+		Ok(Some(lockfile_path))
 	}
 
 	async fn create_lockfile(

--- a/packages/server/src/build/get.rs
+++ b/packages/server/src/build/get.rs
@@ -44,6 +44,8 @@ impl Server {
 			pub error: Option<db::value::Json<tg::Error>>,
 			pub host: String,
 			#[serde(default)]
+			pub lock: Option<tg::Lockfile>,
+			#[serde(default)]
 			pub log: Option<tg::blob::Id>,
 			#[serde(default)]
 			pub logs_count: Option<u64>,
@@ -92,6 +94,7 @@ impl Server {
 					depth,
 					error,
 					host,
+					lock,
 					log,
 					logs_complete,
 					logs_count,
@@ -126,6 +129,7 @@ impl Server {
 			depth: row.depth,
 			error: row.error.map(|error| error.0),
 			host: row.host,
+			lock: row.lock,
 			log: row.log,
 			logs_count: row.logs_count,
 			logs_depth: row.logs_depth,

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -58,6 +58,7 @@ pub struct Build {
 	pub concurrency: usize,
 	pub heartbeat_interval: Duration,
 	pub max_depth: u64,
+	pub set_path_and_tag: bool,
 	pub remotes: Vec<String>,
 }
 
@@ -194,6 +195,7 @@ impl Default for Build {
 			concurrency: n.into(),
 			heartbeat_interval: Duration::from_secs(1),
 			max_depth: 4096,
+			set_path_and_tag: false,
 			remotes: Vec::new(),
 		}
 	}

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -1221,8 +1221,7 @@ impl tg::Handle for Server {
 	fn try_get_reference(
 		&self,
 		reference: &tg::Reference,
-	) -> impl Future<Output = tg::Result<Option<tg::Referent<Either<tg::build::Id, tg::object::Id>>>>>
-	{
+	) -> impl Future<Output = tg::Result<Option<tg::reference::get::Output>>> {
 		self.try_get_reference(reference)
 	}
 

--- a/packages/server/src/runtime/js/syscall/target.rs
+++ b/packages/server/src/runtime/js/syscall/target.rs
@@ -14,6 +14,7 @@ pub async fn output(state: Rc<State>, args: (tg::Target,)) -> tg::Result<tg::Val
 			let retry = parent.retry(&server).await?;
 			let arg = tg::target::build::Arg {
 				create: true,
+				lock: None,
 				parent: Some(parent.id().clone()),
 				remote,
 				retry,

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -2,7 +2,6 @@ use crate::Server;
 use futures::{stream, Future, Stream, TryStreamExt as _};
 use std::{path::PathBuf, sync::Arc};
 use tangram_client as tg;
-use tangram_either::Either;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite};
 
 #[derive(Clone)]
@@ -338,7 +337,7 @@ impl tg::Handle for Proxy {
 	async fn try_get_reference(
 		&self,
 		_reference: &tg::Reference,
-	) -> tg::Result<Option<tg::Referent<Either<tg::build::Id, tg::object::Id>>>> {
+	) -> tg::Result<Option<tg::reference::get::Output>> {
 		Err(tg::error!("forbidden"))
 	}
 


### PR DESCRIPTION
…_cli

- created tg::reference::get::Output
- added lockfile: Option<PathBuf> to tg::reference::get::Output
- added tg::SourceMap which can be constructed from a lockfile and root object
- use tg::SourceMap to remap module referent IDs to paths/tags in diagnostics, errors, and viewer titles