### PR TITLE
fix(runtime/linux): correct root, output paths

### DIFF
--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -131,7 +131,7 @@ impl Runtime {
 			};
 
 			// Create the proxy server guest URL.
-			let socket = Path::new(HOME_DIRECTORY_GUEST_PATH).join(".tangram/socket");
+			let socket = Path::new(SERVER_DIRECTORY_GUEST_PATH).join("socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -130,7 +130,7 @@ impl Runtime {
 			};
 
 			// Create the proxy server guest URL.
-			let socket = Path::new(SERVER_DIRECTORY_GUEST_PATH).join("socket");
+			let socket = Path::new(HOME_DIRECTORY_GUEST_PATH).join(".tangram/socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()
@@ -139,7 +139,7 @@ impl Runtime {
 			let guest_url = format!("http+unix://{socket}").parse::<Url>().unwrap();
 
 			// Create the proxy server host URL.
-			let socket = chroot.temp.path().join(".tangram/socket");
+			let socket = chroot.temp.path().join("home/tangram/.tangram/socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()
@@ -160,6 +160,7 @@ impl Runtime {
 		} else {
 			None
 		};
+		dbg!(&proxy.is_some());
 
 		// Get the artifacts path.
 		let artifacts_path = if chroot.is_some() {
@@ -238,6 +239,7 @@ impl Runtime {
 				let path = urlencoding::encode(&path);
 				format!("http+unix://{path}")
 			});
+		dbg!(&url);
 		env.insert("TANGRAM_URL".to_owned(), url.to_string());
 
 		// Spawn the child.

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -122,12 +122,11 @@ impl Runtime {
 
 		// Create the proxy for the chroot.
 		let proxy = if let Some(chroot) = &chroot {
-			let root_host = std::path::PathBuf::from(chroot.root.clone().into_string().unwrap());
 			// Create the path map.
 			let path_map = proxy::PathMap {
 				output_host: output_parent.path().to_owned(),
 				output_guest: OUTPUT_PARENT_DIRECTORY_GUEST_PATH.into(),
-				root_host: root_host.to_owned(),
+				root_host: chroot.temp.path().to_owned(),
 			};
 
 			// Create the proxy server guest URL.
@@ -140,7 +139,7 @@ impl Runtime {
 			let guest_url = format!("http+unix://{socket}").parse::<Url>().unwrap();
 
 			// Create the proxy server host URL.
-			let socket = root_host.join(".tangram/socket");
+			let socket = chroot.temp.path().join(".tangram/socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -122,14 +122,15 @@ impl Runtime {
 
 		// Create the proxy for the chroot.
 		let proxy = if let Some(chroot) = &chroot {
+			let root_host = std::path::PathBuf::from(chroot.root.clone().into_string().unwrap());
 			// Create the path map.
 			let path_map = proxy::PathMap {
 				output_host: output_parent.path().to_owned(),
 				output_guest: OUTPUT_PARENT_DIRECTORY_GUEST_PATH.into(),
-				root_host: chroot.temp.path().to_owned(),
+				root_host: root_host.to_owned(),
 			};
 
-			// Create the proxy server host URL.
+			// Create the proxy server guest URL.
 			let socket = Path::new(HOME_DIRECTORY_GUEST_PATH).join(".tangram/socket");
 			let socket = urlencoding::encode(
 				socket
@@ -138,8 +139,8 @@ impl Runtime {
 			);
 			let guest_url = format!("http+unix://{socket}").parse::<Url>().unwrap();
 
-			// Create the proxy server guest URL.
-			let socket = chroot.temp.path().join(".tangram/socket");
+			// Create the proxy server host URL.
+			let socket = root_host.join(".tangram/socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -139,7 +139,7 @@ impl Runtime {
 			let guest_url = format!("http+unix://{socket}").parse::<Url>().unwrap();
 
 			// Create the proxy server guest URL.
-			let socket = chroot.home.join(".tangram/socket");
+			let socket = chroot.temp.path().join(".tangram/socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()
@@ -210,9 +210,11 @@ impl Runtime {
 			// Set `$HOME`.
 			env.insert("HOME".to_owned(), HOME_DIRECTORY_GUEST_PATH.to_owned());
 			// Set `$OUTPUT`.
+			let output_guest_path =
+				std::path::PathBuf::from(OUTPUT_PARENT_DIRECTORY_GUEST_PATH).join("output");
 			env.insert(
 				"OUTPUT".to_owned(),
-				OUTPUT_PARENT_DIRECTORY_GUEST_PATH.to_owned(),
+				output_guest_path.to_str().unwrap().to_owned(),
 			);
 		} else {
 			// Set OUTPUT to the host path.

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -130,7 +130,7 @@ impl Runtime {
 			};
 
 			// Create the proxy server guest URL.
-			let socket = Path::new(HOME_DIRECTORY_GUEST_PATH).join(".tangram/socket");
+			let socket = Path::new(SERVER_DIRECTORY_GUEST_PATH).join("socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()
@@ -139,7 +139,7 @@ impl Runtime {
 			let guest_url = format!("http+unix://{socket}").parse::<Url>().unwrap();
 
 			// Create the proxy server host URL.
-			let socket = chroot.temp.path().join("home/tangram/.tangram/socket");
+			let socket = chroot.temp.path().join(".tangram/socket");
 			let socket = urlencoding::encode(
 				socket
 					.to_str()
@@ -160,7 +160,6 @@ impl Runtime {
 		} else {
 			None
 		};
-		dbg!(&proxy.is_some());
 
 		// Get the artifacts path.
 		let artifacts_path = if chroot.is_some() {
@@ -239,7 +238,6 @@ impl Runtime {
 				let path = urlencoding::encode(&path);
 				format!("http+unix://{path}")
 			});
-		dbg!(&url);
 		env.insert("TANGRAM_URL".to_owned(), url.to_string());
 
 		// Spawn the child.

--- a/packages/server/src/runtime/linux/chroot.rs
+++ b/packages/server/src/runtime/linux/chroot.rs
@@ -198,12 +198,16 @@ impl Chroot {
 			readonly: false,
 		});
 
-		// Add the &runtime.server directory to the mounts.
-		let server_directory_source_path = &runtime.server.path;
-		let server_directory_guest_path = Path::new(SERVER_DIRECTORY_GUEST_PATH);
-		let server_directory_target_path =
-			root.join(server_directory_guest_path.strip_prefix("/").unwrap());
-		tokio::fs::create_dir_all(&server_directory_target_path)
+		// Add the &runtime.server artifacts directory to the mounts.
+		let server_artifacts_directory_source_path = &runtime.server.path.join("artifacts");
+		let server_artifacts_directory_guest_path =
+			Path::new(SERVER_DIRECTORY_GUEST_PATH).join("artifacts");
+		let server_artifacts_directory_target_path = root.join(
+			server_artifacts_directory_guest_path
+				.strip_prefix("/")
+				.unwrap(),
+		);
+		tokio::fs::create_dir_all(&server_artifacts_directory_target_path)
 			.await
 			.map_err(|error| {
 				tg::error!(
@@ -211,13 +215,21 @@ impl Chroot {
 					"failed to create the mount point for the tangram directory"
 				)
 			})?;
-		let server_directory_source_path =
-			CString::new(server_directory_source_path.as_os_str().as_bytes()).unwrap();
-		let server_directory_target_path =
-			CString::new(server_directory_target_path.as_os_str().as_bytes()).unwrap();
+		let server_artifacts_directory_source_path = CString::new(
+			server_artifacts_directory_source_path
+				.as_os_str()
+				.as_bytes(),
+		)
+		.unwrap();
+		let server_artifacts_directory_target_path = CString::new(
+			server_artifacts_directory_target_path
+				.as_os_str()
+				.as_bytes(),
+		)
+		.unwrap();
 		mounts.push(Mount {
-			source: server_directory_source_path,
-			target: server_directory_target_path,
+			source: server_artifacts_directory_source_path,
+			target: server_artifacts_directory_target_path,
 			fstype: None,
 			flags: libc::MS_BIND | libc::MS_REC,
 			data: None,

--- a/packages/server/src/runtime/linux/chroot.rs
+++ b/packages/server/src/runtime/linux/chroot.rs
@@ -4,16 +4,11 @@ use super::{
 };
 use crate::temp::Temp;
 use indoc::formatdoc;
-use std::{
-	ffi::CString,
-	os::unix::ffi::OsStrExt as _,
-	path::{Path, PathBuf},
-};
+use std::{ffi::CString, os::unix::ffi::OsStrExt as _, path::Path};
 use tangram_client as tg;
 
 pub struct Chroot {
-	pub home: PathBuf,
-	pub temp: Temp,
+	_temp: Temp,
 	pub mounts: Vec<Mount>,
 	pub root: CString,
 }
@@ -117,7 +112,6 @@ impl Chroot {
 		// Create the host and guest paths for the home directory, with inner .tangram directory.
 		let home_directory_host_path =
 			root.join(HOME_DIRECTORY_GUEST_PATH.strip_prefix('/').unwrap());
-		let home_directory_guest_path = PathBuf::from(HOME_DIRECTORY_GUEST_PATH);
 		tokio::fs::create_dir_all(&home_directory_host_path.join(".tangram"))
 			.await
 			.map_err(|source| tg::error!(!source, "failed to create the home directory"))?;
@@ -284,8 +278,7 @@ impl Chroot {
 		})?;
 
 		Ok(Self {
-			home: home_directory_guest_path,
-			temp,
+			_temp: temp,
 			root,
 			mounts,
 		})

--- a/packages/server/src/runtime/linux/chroot.rs
+++ b/packages/server/src/runtime/linux/chroot.rs
@@ -8,7 +8,7 @@ use std::{ffi::CString, os::unix::ffi::OsStrExt as _, path::Path};
 use tangram_client as tg;
 
 pub struct Chroot {
-	_temp: Temp,
+	pub temp: Temp,
 	pub mounts: Vec<Mount>,
 	pub root: CString,
 }
@@ -277,10 +277,6 @@ impl Chroot {
 			)
 		})?;
 
-		Ok(Self {
-			_temp: temp,
-			root,
-			mounts,
-		})
+		Ok(Self { temp, root, mounts })
 	}
 }

--- a/packages/server/src/runtime/linux/process.rs
+++ b/packages/server/src/runtime/linux/process.rs
@@ -308,7 +308,7 @@ unsafe fn root(context: &Context) -> ! {
 
 	// Fork.
 	let mut clone_args = libc::clone_args {
-		flags: dbg!(flags.try_into().unwrap()),
+		flags: flags.try_into().unwrap(),
 		stack: 0,
 		stack_size: 0,
 		pidfd: 0,

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -94,6 +94,7 @@ impl tg::Handle for Proxy {
 	> {
 		// Replace the path with the host path.
 		arg.path = self.host_path_for_guest_path(arg.path.clone());
+		dbg!(&arg.path);
 
 		// Perform the checkin.
 		let stream = self.server.check_in_artifact(arg).await?;

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -92,6 +92,7 @@ impl tg::Handle for Proxy {
 			+ Send
 			+ 'static,
 	> {
+		dbg!("proxy check in artifact");
 		// Replace the path with the host path.
 		arg.path = self.host_path_for_guest_path(arg.path.clone());
 		dbg!(&arg.path);

--- a/packages/server/src/runtime/proxy.rs
+++ b/packages/server/src/runtime/proxy.rs
@@ -92,10 +92,8 @@ impl tg::Handle for Proxy {
 			+ Send
 			+ 'static,
 	> {
-		dbg!("proxy check in artifact");
 		// Replace the path with the host path.
 		arg.path = self.host_path_for_guest_path(arg.path.clone());
-		dbg!(&arg.path);
 
 		// Perform the checkin.
 		let stream = self.server.check_in_artifact(arg).await?;


### PR DESCRIPTION
Two fixes to the linux chroot setup:

- Set `$OUTPUT` to `/output/output`, instead of the parent path `/output`.
- Set the guest socket path to the `<root_temp>/.tangram/socket` instead of `<root_temp>/home/tangram/.tangram/socket`
- only mount the server artifacts directory instead of the whole server directory.