### PR TITLE
refactor: remove .tangram/run

### DIFF
--- a/packages/cli/src/process/exec.rs
+++ b/packages/cli/src/process/exec.rs
@@ -43,6 +43,17 @@ impl Cli {
 			let artifact: tg::Artifact = output
 				.try_into()
 				.map_err(|source| tg::error!(!source, "expected the output to be an artifact"))?;
+			artifact
+				.check_out(
+					&handle,
+					tg::artifact::checkout::Arg {
+						dependencies: false,
+						force: false,
+						lockfile: false,
+						path: None,
+					},
+				)
+				.await?;
 			let path = self
 				.config
 				.as_ref()
@@ -60,7 +71,7 @@ impl Cli {
 			// Ensure the path is not a directory.
 			let metadata = tokio::fs::metadata(&artifact_path)
 				.await
-				.map_err(|source| tg::error!(!source, "failed to stat the artifact"))?;
+				.map_err(|source| tg::error!(!source, %artifact_path  = artifact_path.display(), "failed to stat the artifact"))?;
 			if metadata.is_dir() {
 				return Err(
 					tg::error!(%artifact_path = artifact_path.display(), "cannot execute a directory"),

--- a/packages/cli/src/process/exec.rs
+++ b/packages/cli/src/process/exec.rs
@@ -39,7 +39,7 @@ impl Cli {
 			.unwrap();
 
 		// Get the path to the artifact.
-		let mut artifact_path = {
+		let artifact_path = {
 			let artifact: tg::Artifact = output
 				.try_into()
 				.map_err(|source| tg::error!(!source, "expected the output to be an artifact"))?;
@@ -57,12 +57,14 @@ impl Cli {
 			// Resolve the argument as a path relative to the artifact.
 			artifact_path.join(executable_path)
 		} else {
-			// If the artifact is a directory, then the executable path should be `.tangram/run`.
+			// Ensure the path is not a directory.
 			let metadata = tokio::fs::metadata(&artifact_path)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to stat the artifact"))?;
 			if metadata.is_dir() {
-				artifact_path = artifact_path.join(".tangram/run");
+				return Err(
+					tg::error!(%artifact_path = artifact_path.display(), "cannot execute a directory"),
+				);
 			}
 			artifact_path
 		};

--- a/packages/server/src/runtime/builtin/bundle.rs
+++ b/packages/server/src/runtime/builtin/bundle.rs
@@ -6,8 +6,6 @@ use tangram_client as tg;
 
 static TANGRAM_ARTIFACTS_PATH: &str = ".tangram/artifacts";
 
-static TANGRAM_RUN_PATH: &str = ".tangram/run";
-
 impl Runtime {
 	pub async fn bundle(&self, process: &tg::Process) -> tg::Result<tg::Value> {
 		let server = &self.server;
@@ -51,21 +49,9 @@ impl Runtime {
 			// If the artifact is a directory, use it as is.
 			tg::Artifact::Directory(directory) => directory.clone().into(),
 
-			// If the artifact is an executable file, then create a directory and place the executable at `.tangram/run`.
-			tg::Artifact::File(file) if file.executable(server).await? => {
-				tg::directory::Builder::default()
-					.add(server, TANGRAM_RUN_PATH.as_ref(), file.clone().into())
-					.await?
-					.build()
-					.into()
-			},
-
 			// Otherwise, return an error.
 			artifact => {
-				return Err(tg::error!(
-					?artifact,
-					"the artifact must be a directory or an executable file"
-				));
+				return Err(tg::error!(?artifact, "the artifact must be a directory"));
 			},
 		};
 


### PR DESCRIPTION
This change restricts `Artifact::bundle` to directories only and removes logic to look for `.tangram/run` in `tg exec`.