### PR TITLE
feat(http): define compress/decompress middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6332,7 +6332,6 @@ dependencies = [
 name = "tangram_client"
 version = "0.0.0"
 dependencies = [
- "async-compression",
  "blake3",
  "byte-unit",
  "bytes",
@@ -6421,6 +6420,7 @@ dependencies = [
 name = "tangram_http"
 version = "0.0.0"
 dependencies = [
+ "async-compression",
  "bytes",
  "derive_more",
  "erased-serde",
@@ -6438,6 +6438,7 @@ dependencies = [
  "tokio-util",
  "tower 0.5.2",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]

--- a/packages/client/Cargo.toml
+++ b/packages/client/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 proptest = { workspace = true }
 
 [dependencies]
-async-compression = { workspace = true }
 blake3 = { workspace = true }
 byte-unit = { workspace = true }
 bytes = { workspace = true }

--- a/packages/client/src/lib.rs
+++ b/packages/client/src/lib.rs
@@ -170,6 +170,13 @@ impl Client {
 				HeaderName::from_str("x-tg-version").unwrap(),
 				HeaderValue::from_str(&Self::version()).unwrap(),
 			)
+			.layer(tangram_http::middleware::request_compression_layer(
+				tangram_http::middleware::CompressionPredicate::default(),
+			))
+			.layer(tangram_http::middleware::response_decompression_layer())
+			.layer(tangram_http::middleware::trace_layer(
+				&tangram_http::middleware::TraceLayerArg::default(),
+			))
 			.service(service);
 		let service = Service::new(service);
 

--- a/packages/http/Cargo.toml
+++ b/packages/http/Cargo.toml
@@ -14,6 +14,7 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
+async-compression = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true }
 erased-serde = { workspace = true }
@@ -27,6 +28,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }
 sync_wrapper = { workspace = true }
+tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true }

--- a/packages/http/src/lib.rs
+++ b/packages/http/src/lib.rs
@@ -2,6 +2,7 @@ pub use self::{body::Body, request::Request, response::Response};
 
 pub mod body;
 pub mod idle;
+pub mod middleware;
 pub mod request;
 pub mod response;
 pub mod service;

--- a/packages/http/src/middleware.rs
+++ b/packages/http/src/middleware.rs
@@ -1,0 +1,203 @@
+use crate::{
+	service::{middleware, BoxLayer, Service},
+	Body, Request, Response,
+};
+use async_compression::tokio::bufread::{ZstdDecoder, ZstdEncoder};
+use http::{header, HeaderMap, HeaderValue};
+use http_body::Body as _;
+use tower::{Service as _, ServiceExt as _};
+
+#[derive(Clone, Copy, Debug)]
+pub struct CompressionPredicate {
+	minimum_size_bytes: u16,
+}
+
+impl CompressionPredicate {
+	pub fn should_compress(&self, headers: &HeaderMap<HeaderValue>, body: &Body) -> bool {
+		// Try to get the size hint from the body, and if not available, try to read CONTENT_LENGTH.
+		let content_size = body.size_hint().exact().or_else(|| {
+			headers
+				.get(header::CONTENT_LENGTH)
+				.and_then(|h| h.to_str().ok())
+				.and_then(|val| val.parse().ok())
+		});
+
+		match content_size {
+			Some(size) => size >= u64::from(self.minimum_size_bytes),
+			_ => true,
+		}
+	}
+}
+
+impl Default for CompressionPredicate {
+	fn default() -> Self {
+		Self {
+			minimum_size_bytes: 32,
+		}
+	}
+}
+
+/// Compress requests with zstd.
+#[must_use]
+pub fn request_compression_layer<S, E>(predicate: CompressionPredicate) -> BoxLayer<S, E>
+where
+	S: Service<E>,
+	S::Future: Send + 'static,
+	E: Send + 'static,
+{
+	middleware::<S, E, _, _>(move |mut service, request| async move {
+		// Don't recompress requests that are already compressed.
+		let should_compress = !request.headers().contains_key(header::CONTENT_ENCODING)
+			&& !request.headers().contains_key(header::CONTENT_RANGE)
+			&& predicate.should_compress(request.headers(), request.body());
+
+		let (mut parts, mut body) = request.into_parts();
+		if should_compress {
+			// The CONTENT_LENGTH has changed.
+			parts.headers.remove(header::CONTENT_LENGTH);
+			// The CONTENT_ENCODING has changed.
+			parts.headers.insert(
+				header::CONTENT_ENCODING,
+				HeaderValue::from_str("zstd").unwrap(),
+			);
+
+			body = Body::with_reader(ZstdEncoder::new(body.into_reader()));
+		}
+
+		let request = Request::from_parts(parts, body);
+		let response = service.ready().await?.call(request).await?;
+		Ok(response)
+	})
+}
+
+/// Decompress zstd-compressed requests.
+#[must_use]
+pub fn request_decompression_layer<S, E>() -> BoxLayer<S, E>
+where
+	S: Service<E>,
+	S::Future: Send + 'static,
+	E: Send + 'static,
+{
+	middleware::<S, E, _, _>(move |mut service, request| async move {
+		let (mut parts, mut body) = request.into_parts();
+		if let header::Entry::Occupied(entry) = parts.headers.entry(header::CONTENT_ENCODING) {
+			let encoding = entry.get().as_bytes();
+			if encoding == b"zstd" {
+				body = Body::with_reader(ZstdDecoder::new(body.into_reader()));
+				// The content encoding is no longer applicable.
+				entry.remove();
+				// The content length changed.
+				parts.headers.remove(header::CONTENT_LENGTH);
+			} else {
+				tracing::warn!(?encoding, "unexpected content-encoding");
+			}
+		}
+		let request = Request::from_parts(parts, body);
+		let response = service.ready().await?.call(request).await?;
+		Ok(response)
+	})
+}
+
+/// Compress responses with zstd.
+#[must_use]
+pub fn response_compression_layer<S, E>(predicate: CompressionPredicate) -> BoxLayer<S, E>
+where
+	S: Service<E>,
+	S::Future: Send + 'static,
+	E: Send + 'static,
+{
+	middleware::<S, E, _, _>(move |mut service, request| async move {
+		let response = service.ready().await?.call(request).await?;
+
+		// Don't recompress responses that are already compressed.
+		let should_compress = !response.headers().contains_key(header::CONTENT_ENCODING)
+			&& !response.headers().contains_key(header::CONTENT_RANGE)
+			&& predicate.should_compress(response.headers(), response.body());
+
+		if !should_compress {
+			return Ok(response);
+		}
+
+		let (mut parts, body) = response.into_parts();
+
+		// This response does not accept ranges.
+		parts.headers.remove(header::ACCEPT_RANGES);
+		// The CONTENT_LENGTH has changed.
+		parts.headers.remove(header::CONTENT_LENGTH);
+		// The CONTENT_ENCODING has changed.
+		parts.headers.insert(
+			header::CONTENT_ENCODING,
+			HeaderValue::from_str("zstd").unwrap(),
+		);
+
+		let body = Body::with_reader(ZstdEncoder::new(body.into_reader()));
+
+		let response = Response::from_parts(parts, body);
+		Ok(response)
+	})
+}
+
+/// Decompress zstd-compressed responses.
+#[must_use]
+pub fn response_decompression_layer<S, E>() -> BoxLayer<S, E>
+where
+	S: Service<E>,
+	S::Future: Send + 'static,
+	E: Send + 'static,
+{
+	middleware::<S, E, _, _>(move |mut service, request| async move {
+		let response = service.ready().await?.call(request).await?;
+
+		let (mut parts, mut body) = response.into_parts();
+		if let header::Entry::Occupied(entry) = parts.headers.entry(header::CONTENT_ENCODING) {
+			let encoding = entry.get().as_bytes();
+			if encoding == b"zstd" {
+				body = Body::with_reader(ZstdDecoder::new(body.into_reader()));
+				// The content encoding is no longer applicable.
+				entry.remove();
+				// The content length changed.
+				parts.headers.remove(header::CONTENT_LENGTH);
+			} else {
+				tracing::warn!(?encoding, "unexpected content-encoding");
+			}
+		}
+		let response = Response::from_parts(parts, body);
+		Ok(response)
+	})
+}
+
+#[derive(Clone, Debug)]
+pub struct TraceLayerArg {
+	request: bool,
+	response: bool,
+}
+
+impl Default for TraceLayerArg {
+	fn default() -> Self {
+		Self {
+			request: true,
+			response: true,
+		}
+	}
+}
+
+/// Add tracing.
+#[must_use]
+pub fn trace_layer<S, E>(arg: &TraceLayerArg) -> BoxLayer<S, E>
+where
+	S: Service<E>,
+	S::Future: Send + 'static,
+	E: Send + 'static,
+{
+	let arg = arg.clone();
+	middleware::<S, E, _, _>(move |mut service, request| async move {
+		if arg.request {
+			tracing::trace!(headers = ?request.headers(), method = ?request.method(), path = ?request.uri().path(), "request");
+		}
+		let response = service.ready().await?.call(request).await?;
+		if arg.response {
+			tracing::trace!(headers = ?response.headers(), status = ?response.status(), "response");
+		}
+		Ok(response)
+	})
+}


### PR DESCRIPTION
Closes #456.

- [x] Client compresses requests
- [x] Client decompresses responses
- [x] Server decompresses requests
- [x] Server compresses responses

TODO:

- [ ] Determine useful tracing options
- [ ] Determine additional compression predicates
- [ ] Use middleware for request ID