### PR TITLE
fix(server): rollup remote build fixes

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -229,6 +229,7 @@ pub enum Store {
 	Lmdb(LmdbStore),
 	#[default]
 	Memory,
+	Lmdb(LmdbStore),
 	S3(S3Store),
 }
 
@@ -243,6 +244,13 @@ pub struct FdbStore {
 #[serde(deny_unknown_fields)]
 pub struct LmdbStore {
 	pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct LmdbStore {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -229,7 +229,6 @@ pub enum Store {
 	Lmdb(LmdbStore),
 	#[default]
 	Memory,
-	Lmdb(LmdbStore),
 	S3(S3Store),
 }
 
@@ -238,12 +237,6 @@ pub enum Store {
 #[serde(deny_unknown_fields)]
 pub struct FdbStore {
 	pub path: Option<PathBuf>,
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct LmdbStore {
-	pub path: PathBuf,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -736,6 +736,11 @@ impl Cli {
 						})
 					},
 					config::Store::Memory => tangram_server::config::Store::Memory,
+					config::Store::Lmdb(lmdb) => {
+						tangram_server::config::Store::Lmdb(tangram_server::config::LmdbStore {
+							path: lmdb.path.unwrap_or_else(|| config.path.join("store")),
+						})
+					},
 					config::Store::S3(s3) => {
 						tangram_server::config::Store::S3(tangram_server::config::S3Store {
 							access_key: s3.access_key,

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -732,15 +732,10 @@ impl Cli {
 					},
 					config::Store::Lmdb(lmdb) => {
 						tangram_server::config::Store::Lmdb(tangram_server::config::LmdbStore {
-							path: lmdb.path,
-						})
-					},
-					config::Store::Memory => tangram_server::config::Store::Memory,
-					config::Store::Lmdb(lmdb) => {
-						tangram_server::config::Store::Lmdb(tangram_server::config::LmdbStore {
 							path: lmdb.path.unwrap_or_else(|| config.path.join("store")),
 						})
 					},
+					config::Store::Memory => tangram_server::config::Store::Memory,
 					config::Store::S3(s3) => {
 						tangram_server::config::Store::S3(tangram_server::config::S3Store {
 							access_key: s3.access_key,

--- a/packages/server/src/export.rs
+++ b/packages/server/src/export.rs
@@ -638,17 +638,25 @@ impl Server {
 		let p = connection.p();
 		let statement = formatdoc!(
 			"
-				select id, count, commands_count, commands_weight, logs_count, logs_weight, outputs_count, outputs_weight
+				select
+					commands_count,
+					commands_weight,
+					count,
+					id,
+					logs_count,
+					logs_weight,
+					outputs_count,
+					outputs_weight
 				from processes
 				where id = {p}1;
 			",
 		);
 		let params = db::params![id];
-		let result = connection
+		let output = connection
 			.query_optional_into(statement.into(), params)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
-		let output = match result {
+		let output = match output {
 			Some(output) => output,
 			None => tg::export::ProcessComplete {
 				commands_count: None,

--- a/packages/server/src/export.rs
+++ b/packages/server/src/export.rs
@@ -604,12 +604,11 @@ impl Server {
 			",
 		);
 		let params = db::params![id];
-		let result = connection
+		let output = connection
 			.query_optional_into(statement.into(), params)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
-		// If we couldn't find the object in the objects table, it hasn't been indexed.
-		let output = match result {
+		let output = match output {
 			Some(output) => output,
 			None => tg::export::ObjectComplete {
 				id: id.clone(),

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -292,6 +292,7 @@ impl Server {
 				from processes
 				join process_children on processes.id = process_children.child
 				where processes.command = {p}1 and process_children.process = {p}2
+				limit 1
 			"
 		);
 		let params = db::params![command_id.to_string(), parent_process_id.to_string()];

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -278,8 +278,6 @@ impl Server {
 			.id(self)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get command id"))?;
-
-		// Get the output.
 		let connection = self
 			.database
 			.connection()
@@ -288,10 +286,9 @@ impl Server {
 		let p = connection.p();
 		let statement = formatdoc!(
 			"
-				select processes.output
+				select output
 				from processes
-				join process_children on processes.id = process_children.child
-				where processes.command = {p}1 and process_children.process = {p}2
+				where processes.command = {p}1
 				limit 1
 			"
 		);

--- a/packages/server/src/process/log.rs
+++ b/packages/server/src/process/log.rs
@@ -767,8 +767,8 @@ impl Server {
 	{
 		let id = id.parse()?;
 		let arg = request.json().await?;
-		handle.try_post_process_log(&id, arg).await?;
-		let response = http::Response::builder().empty().unwrap();
+		let output = handle.try_post_process_log(&id, arg).await?;
+		let response = http::Response::builder().json(output).unwrap();
 		Ok(response)
 	}
 }

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -40,9 +40,12 @@ impl Server {
 		if !cacheable {
 			let id = self.spawn_local_process(&arg).await?;
 			if let Some(parent) = arg.parent.as_ref() {
-				self.try_add_process_child(parent, &id).await.map_err(
+				let added = self.try_add_process_child(parent, &id).await.map_err(
 					|source| tg::error!(!source, %parent, %child = id, "failed to add the process as a child"),
 				)?;
+				if !added {
+					return Err(tg::error!(%parent, %id, "failed to add child to parent"));
+				}
 			}
 			let output = tg::process::spawn::Output {
 				process: id,
@@ -53,11 +56,6 @@ impl Server {
 
 		// Return a matching local process if one exists.
 		if let Some(id) = self.try_get_cached_process_local(&arg).await? {
-			if let Some(parent) = arg.parent.as_ref() {
-				self.try_add_process_child(parent, &id).await.map_err(
-					|source| tg::error!(!source, %parent, %child = id, "failed to add the process as a child"),
-				)?;
-			}
 			let output = tg::process::spawn::Output {
 				process: id,
 				remote: None,
@@ -71,9 +69,12 @@ impl Server {
 				return Ok(None);
 			};
 			if let Some(parent) = arg.parent.as_ref() {
-				self.try_add_process_child(parent, &id).await.map_err(
+				let added = self.try_add_process_child(parent, &id).await.map_err(
 					|source| tg::error!(!source, %parent, %child = id, "failed to add the process as a child"),
 				)?;
+				if !added {
+					return Err(tg::error!(%parent, %id, "failed to add child to parent"));
+				}
 			}
 			let output = tg::process::spawn::Output {
 				process: id,
@@ -119,9 +120,12 @@ impl Server {
 
 		// Add the process to the parent.
 		if let Some(parent) = arg.parent.as_ref() {
-			self.try_add_process_child(parent, &id).await.map_err(
+			let added = self.try_add_process_child(parent, &id).await.map_err(
 				|source| tg::error!(!source, %parent, %child = id, "failed to add the process as a child"),
 			)?;
+			if !added {
+				return Err(tg::error!(%parent, %id, "failed to add child to parent"));
+			}
 		}
 
 		// Create the output.
@@ -187,9 +191,12 @@ impl Server {
 
 		// Attempt to add the process as a child of the parent.
 		if let Some(parent) = arg.parent.as_ref() {
-			self.try_add_process_child(parent, &id).await.map_err(
+			let added = self.try_add_process_child(parent, &id).await.map_err(
 				|source| tg::error!(!source, %parent, %child = id, "failed to add the process as a child"),
 			)?;
+			if !added {
+				return Err(tg::error!(%parent, %id, "failed to add child to parent"));
+			}
 		}
 
 		// Touch the process.

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -159,12 +159,7 @@ impl Runtime {
 						bytes: bytes.clone(),
 						remote: process.remote().map(ToOwned::to_owned),
 					};
-					if let Some(remote) = process.remote() {
-						let client = server.get_remote_client(remote.to_string()).await?;
-						client.try_post_process_log(process.id(), arg).await.ok();
-					} else {
-						server.try_post_process_log(process.id(), arg).await.ok();
-					}
+					server.try_post_process_log(process.id(), arg).await.ok();
 				}
 				Ok::<(), tg::Error>(())
 			}


### PR DESCRIPTION
- handle lmdb store config option

- fix js log task

- add path to lmdb init error

- fix post log response body

- don't fail exporting if object/process not yet in table

- check for successful add child to parent

- push checksum command

- don't spawn in finish to verify checksum

- don't create blobs from logs in process finish