### PR TITLE
feat: combined compress/decompress and tar archive/extract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,26 +194,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65152cbda42e8ab5ecff69e8811e8333d69188c7d5c41e3eedb8d127e3f23b27"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.1",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -246,64 +251,6 @@ dependencies = [
  "xz2",
  "zstd",
  "zstd-safe",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener 5.4.0",
- "event-listener-strategy",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -343,25 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel 2.3.1",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.4.0",
- "futures-lite",
- "rustix",
- "tracing",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,51 +298,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c634475f29802fde2b8f0b505b1bd00dfe4df7d4a000f0b36f7671197d5c3615"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -438,25 +321,6 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
-
-[[package]]
-name = "async-tar"
-version = "0.5.0"
-source = "git+https://github.com/tangramdotdev/async-tar#3dfc3c8dd0891db7f7c349be26ae832f7c65a605"
-dependencies = [
- "async-std",
- "filetime",
- "libc",
- "pin-project",
- "redox_syscall 0.2.16",
- "xattr 0.2.3",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1170,19 +1034,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -2143,12 +1994,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -2164,7 +2009,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2555,18 +2400,6 @@ dependencies = [
  "log",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3318,15 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy-bytes-cast"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,7 +3192,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3426,9 +3250,6 @@ name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "loom"
@@ -3971,7 +3792,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4153,17 +3974,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs8"
@@ -4588,15 +4398,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6171,10 +5972,10 @@ dependencies = [
 name = "tangram_server"
 version = "0.0.0"
 dependencies = [
- "async-channel 2.3.1",
+ "astral-tokio-tar",
+ "async-channel",
  "async-compression",
  "async-nats",
- "async-tar",
  "async_zip",
  "aws-credential-types",
  "aws-sigv4",
@@ -6255,7 +6056,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "v8",
- "xattr 1.4.0",
+ "xattr",
  "zstd",
 ]
 
@@ -6269,7 +6070,7 @@ dependencies = [
  "serde",
  "tangram_client",
  "tokio",
- "xattr 1.4.0",
+ "xattr",
 ]
 
 [[package]]
@@ -6308,7 +6109,7 @@ dependencies = [
 name = "tangram_vfs"
 version = "0.0.0"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "bytes",
  "clap",
  "dashmap 6.1.0",
@@ -6338,7 +6139,7 @@ checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
 dependencies = [
  "filetime",
  "libc",
- "xattr 1.4.0",
+ "xattr",
 ]
 
 [[package]]
@@ -7050,12 +6851,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7405,7 +7200,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.9",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]
@@ -7807,15 +7602,6 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
-
-[[package]]
-name = "xattr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,11 @@ type_complexity = "allow"
 unused_async = "allow"
 
 [workspace.dependencies]
+astral-tokio-tar = "0.5"
 async-broadcast = "0.7"
 async-channel = "2"
 async-compression = { version = "0.4", features = ["all"] }
 async-nats = "0.39"
-async-tar = "0.5"
 async_zip = { version = "0.0.17", features = ["full"] }
 aws-credential-types = "1"
 aws-sigv4 = "1"
@@ -182,7 +182,6 @@ zerocopy = { version = "0.8", features = ["derive"] }
 zstd = "0.13"
 
 [patch.crates-io]
-async-tar = { git = "https://github.com/tangramdotdev/async-tar" }
 async_zip = { git = "https://github.com/tangramdotdev/rs-async-zip" }
 biome_js_formatter = { git = "https://github.com/biomejs/biome" }
 biome_js_parser = { git = "https://github.com/biomejs/biome" }

--- a/packages/cli/build.rs
+++ b/packages/cli/build.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
-use std::process::Command;
+#[cfg(feature = "foundationdb")]
+use std::{path::Path, process::Command};
 
 fn main() {
 	println!("cargo:rerun-if-changed=build.rs");

--- a/packages/cli/src/artifact/archive.rs
+++ b/packages/cli/src/artifact/archive.rs
@@ -13,6 +13,9 @@ pub struct Args {
 
 	#[arg(long)]
 	pub format: tg::artifact::archive::Format,
+
+	#[arg(long)]
+	pub compression_format: Option<tg::blob::compress::Format>,
 }
 
 impl Cli {
@@ -20,7 +23,8 @@ impl Cli {
 		let handle = self.handle().await?;
 		let artifact = tg::Artifact::with_id(args.artifact);
 		let format = args.format;
-		let command = artifact.archive_command(format);
+		let compression_format = args.compression_format;
+		let command = artifact.archive_command(format, compression_format);
 		let command = command.id(&handle).await?;
 		let reference = tg::Reference::with_object(&command.into());
 		self.build_process(args.build, reference, vec![]).await?;

--- a/packages/cli/src/artifact/archive.rs
+++ b/packages/cli/src/artifact/archive.rs
@@ -15,7 +15,7 @@ pub struct Args {
 	pub format: tg::artifact::archive::Format,
 
 	#[arg(long)]
-	pub compression_format: Option<tg::blob::compress::Format>,
+	pub compression: Option<tg::blob::compress::Format>,
 }
 
 impl Cli {
@@ -23,8 +23,8 @@ impl Cli {
 		let handle = self.handle().await?;
 		let artifact = tg::Artifact::with_id(args.artifact);
 		let format = args.format;
-		let compression_format = args.compression_format;
-		let command = artifact.archive_command(format, compression_format);
+		let compression = args.compression;
+		let command = artifact.archive_command(format, compression);
 		let command = command.id(&handle).await?;
 		let reference = tg::Reference::with_object(&command.into());
 		self.build_process(args.build, reference, vec![]).await?;

--- a/packages/cli/src/artifact/extract.rs
+++ b/packages/cli/src/artifact/extract.rs
@@ -13,6 +13,9 @@ pub struct Args {
 
 	#[arg(long)]
 	pub format: Option<tg::artifact::archive::Format>,
+
+	#[arg(long)]
+	pub compression_format: Option<tg::blob::compress::Format>,
 }
 
 impl Cli {
@@ -20,7 +23,8 @@ impl Cli {
 		let handle = self.handle().await?;
 		let blob = tg::Blob::with_id(args.blob);
 		let format = args.format;
-		let command = tg::Artifact::extract_command(&blob, format);
+		let compression_format = args.compression_format;
+		let command = tg::Artifact::extract_command(&blob, format, compression_format);
 		let command = command.id(&handle).await?;
 		let reference = tg::Reference::with_object(&command.into());
 		self.build_process(args.build, reference, vec![]).await?;

--- a/packages/cli/src/artifact/extract.rs
+++ b/packages/cli/src/artifact/extract.rs
@@ -10,21 +10,13 @@ pub struct Args {
 
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
-
-	#[arg(long)]
-	pub format: Option<tg::artifact::archive::Format>,
-
-	#[arg(long)]
-	pub compression_format: Option<tg::blob::compress::Format>,
 }
 
 impl Cli {
 	pub async fn command_artifact_extract(&self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
 		let blob = tg::Blob::with_id(args.blob);
-		let format = args.format;
-		let compression_format = args.compression_format;
-		let command = tg::Artifact::extract_command(&blob, format, compression_format);
+		let command = tg::Artifact::extract_command(&blob);
 		let command = command.id(&handle).await?;
 		let reference = tg::Reference::with_object(&command.into());
 		self.build_process(args.build, reference, vec![]).await?;

--- a/packages/cli/src/blob/decompress.rs
+++ b/packages/cli/src/blob/decompress.rs
@@ -10,17 +10,13 @@ pub struct Args {
 
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
-
-	#[arg(short, long)]
-	pub format: tg::blob::compress::Format,
 }
 
 impl Cli {
 	pub async fn command_blob_decompress(&self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
 		let blob = tg::Blob::with_id(args.blob);
-		let format = args.format;
-		let command = blob.decompress_command(format);
+		let command = blob.decompress_command();
 		let command = command.id(&handle).await?;
 		let reference = tg::Reference::with_object(&command.into());
 		self.build_process(args.build, reference, vec![]).await?;

--- a/packages/client/src/artifact/archive.rs
+++ b/packages/client/src/artifact/archive.rs
@@ -7,11 +7,16 @@ pub enum Format {
 }
 
 impl tg::Artifact {
-	pub async fn archive<H>(&self, handle: &H, format: Format) -> tg::Result<tg::Blob>
+	pub async fn archive<H>(
+		&self,
+		handle: &H,
+		format: Format,
+		compression_format: Option<tg::blob::compress::Format>,
+	) -> tg::Result<tg::Blob>
 	where
 		H: tg::Handle,
 	{
-		let command = self.archive_command(format);
+		let command = self.archive_command(format, compression_format);
 		let arg = tg::process::spawn::Arg {
 			command: Some(command.id(handle).await?),
 			..Default::default()
@@ -22,12 +27,19 @@ impl tg::Artifact {
 	}
 
 	#[must_use]
-	pub fn archive_command(&self, format: Format) -> tg::Command {
+	pub fn archive_command(
+		&self,
+		format: Format,
+		compression_format: Option<tg::blob::compress::Format>,
+	) -> tg::Command {
 		let host = "builtin";
 		let args = vec![
 			"archive".into(),
 			self.clone().into(),
 			format.to_string().into(),
+			compression_format
+				.map(|compression_format| compression_format.to_string())
+				.into(),
 		];
 		tg::Command::builder(host).args(args).build()
 	}

--- a/packages/client/src/artifact/archive.rs
+++ b/packages/client/src/artifact/archive.rs
@@ -11,12 +11,12 @@ impl tg::Artifact {
 		&self,
 		handle: &H,
 		format: Format,
-		compression_format: Option<tg::blob::compress::Format>,
+		compression: Option<tg::blob::compress::Format>,
 	) -> tg::Result<tg::Blob>
 	where
 		H: tg::Handle,
 	{
-		let command = self.archive_command(format, compression_format);
+		let command = self.archive_command(format, compression);
 		let arg = tg::process::spawn::Arg {
 			command: Some(command.id(handle).await?),
 			..Default::default()
@@ -30,15 +30,15 @@ impl tg::Artifact {
 	pub fn archive_command(
 		&self,
 		format: Format,
-		compression_format: Option<tg::blob::compress::Format>,
+		compression: Option<tg::blob::compress::Format>,
 	) -> tg::Command {
 		let host = "builtin";
 		let args = vec![
 			"archive".into(),
 			self.clone().into(),
 			format.to_string().into(),
-			compression_format
-				.map(|compression_format| compression_format.to_string())
+			compression
+				.map(|compression| compression.to_string())
 				.into(),
 		];
 		tg::Command::builder(host).args(args).build()

--- a/packages/client/src/artifact/extract.rs
+++ b/packages/client/src/artifact/extract.rs
@@ -1,16 +1,11 @@
 use crate as tg;
 
 impl tg::Artifact {
-	pub async fn extract<H>(
-		handle: &H,
-		blob: &tg::Blob,
-		format: Option<tg::artifact::archive::Format>,
-		compression_format: Option<tg::blob::compress::Format>,
-	) -> tg::Result<Self>
+	pub async fn extract<H>(handle: &H, blob: &tg::Blob) -> tg::Result<Self>
 	where
 		H: tg::Handle,
 	{
-		let command = Self::extract_command(blob, format, compression_format);
+		let command = Self::extract_command(blob);
 		let arg = tg::process::spawn::Arg {
 			command: Some(command.id(handle).await?),
 			..Default::default()
@@ -21,20 +16,9 @@ impl tg::Artifact {
 	}
 
 	#[must_use]
-	pub fn extract_command(
-		blob: &tg::Blob,
-		format: Option<tg::artifact::archive::Format>,
-		compression_format: Option<tg::blob::compress::Format>,
-	) -> tg::Command {
+	pub fn extract_command(blob: &tg::Blob) -> tg::Command {
 		let host = "builtin";
-		let args = vec![
-			"extract".into(),
-			blob.clone().into(),
-			format.map(|format| format.to_string()).into(),
-			compression_format
-				.map(|compression_format| compression_format.to_string())
-				.into(),
-		];
+		let args = vec!["extract".into(), blob.clone().into()];
 		tg::Command::builder(host).args(args).build()
 	}
 }

--- a/packages/client/src/artifact/extract.rs
+++ b/packages/client/src/artifact/extract.rs
@@ -5,11 +5,12 @@ impl tg::Artifact {
 		handle: &H,
 		blob: &tg::Blob,
 		format: Option<tg::artifact::archive::Format>,
+		compression_format: Option<tg::blob::compress::Format>,
 	) -> tg::Result<Self>
 	where
 		H: tg::Handle,
 	{
-		let command = Self::extract_command(blob, format);
+		let command = Self::extract_command(blob, format, compression_format);
 		let arg = tg::process::spawn::Arg {
 			command: Some(command.id(handle).await?),
 			..Default::default()
@@ -23,12 +24,16 @@ impl tg::Artifact {
 	pub fn extract_command(
 		blob: &tg::Blob,
 		format: Option<tg::artifact::archive::Format>,
+		compression_format: Option<tg::blob::compress::Format>,
 	) -> tg::Command {
 		let host = "builtin";
 		let args = vec![
 			"extract".into(),
 			blob.clone().into(),
 			format.map(|format| format.to_string()).into(),
+			compression_format
+				.map(|compression_format| compression_format.to_string())
+				.into(),
 		];
 		tg::Command::builder(host).args(args).build()
 	}

--- a/packages/client/src/blob/compress.rs
+++ b/packages/client/src/blob/compress.rs
@@ -39,6 +39,46 @@ impl tg::Blob {
 	}
 }
 
+impl Format {
+	#[must_use]
+	pub fn from_magic(bytes: &[u8]) -> Option<Self> {
+		let len = bytes.len();
+		if len < 2 {
+			return None;
+		}
+
+		// Gz
+		if bytes[0] == 0x1F && bytes[1] == 0x8B {
+			return Some(tg::blob::compress::Format::Gz);
+		}
+
+		// Zstd
+		if len >= 4 && bytes[0] == 0x28 && bytes[1] == 0xB5 && bytes[2] == 0x2F && bytes[3] == 0xFD
+		{
+			return Some(tg::blob::compress::Format::Zstd);
+		}
+
+		// Bz2
+		if len >= 3 && bytes[0] == 0x42 && bytes[1] == 0x5A && bytes[2] == 0x68 {
+			return Some(tg::blob::compress::Format::Bz2);
+		}
+
+		// Xz
+		if len >= 6
+			&& bytes[0] == 0xFD
+			&& bytes[1] == 0x37
+			&& bytes[2] == 0x7A
+			&& bytes[3] == 0x58
+			&& bytes[4] == 0x5A
+			&& bytes[5] == 0x00
+		{
+			return Some(tg::blob::compress::Format::Xz);
+		}
+
+		None
+	}
+}
+
 impl std::fmt::Display for Format {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		let s = match self {

--- a/packages/client/src/blob/decompress.rs
+++ b/packages/client/src/blob/decompress.rs
@@ -1,15 +1,11 @@
 use crate as tg;
 
 impl tg::Blob {
-	pub async fn decompress<H>(
-		&self,
-		handle: &H,
-		format: tg::blob::compress::Format,
-	) -> tg::Result<Self>
+	pub async fn decompress<H>(&self, handle: &H) -> tg::Result<Self>
 	where
 		H: tg::Handle,
 	{
-		let command = self.decompress_command(format);
+		let command = self.decompress_command();
 		let arg = tg::process::spawn::Arg {
 			command: Some(command.id(handle).await?),
 			..Default::default()
@@ -20,13 +16,9 @@ impl tg::Blob {
 	}
 
 	#[must_use]
-	pub fn decompress_command(&self, format: tg::blob::compress::Format) -> tg::Command {
+	pub fn decompress_command(&self) -> tg::Command {
 		let host = "builtin";
-		let args = vec![
-			"decompress".into(),
-			self.clone().into(),
-			format.to_string().into(),
-		];
+		let args = vec!["decompress".into(), self.clone().into()];
 		tg::Command::builder(host).args(args).build()
 	}
 }

--- a/packages/runtime/src/artifact.ts
+++ b/packages/runtime/src/artifact.ts
@@ -58,20 +58,9 @@ export namespace Artifact {
 		return value;
 	};
 
-	export let extract = async (
-		blob: tg.Blob,
-		format: ArchiveFormat,
-		compressionFormat?: tg.Blob.CompressionFormat,
-	): Promise<Artifact> => {
-		const args = ["extract", blob, format];
-		if (compressionFormat !== undefined) {
-			if (format === "zip") {
-				throw new Error("compressionFormat is not supported for zip archives");
-			}
-			args.push(compressionFormat);
-		}
+	export let extract = async (blob: tg.Blob): Promise<Artifact> => {
 		let value = await tg.build({
-			args,
+			args: ["extract", blob],
 			env: undefined,
 			host: "builtin",
 		});

--- a/packages/runtime/src/artifact.ts
+++ b/packages/runtime/src/artifact.ts
@@ -40,14 +40,14 @@ export namespace Artifact {
 	export let archive = async (
 		artifact: Artifact,
 		format: ArchiveFormat,
-		compressionFormat?: tg.Blob.CompressionFormat,
+		compression?: tg.Blob.CompressionFormat,
 	): Promise<tg.Blob> => {
 		const args = ["archive", artifact, format];
-		if (compressionFormat !== undefined) {
+		if (compression !== undefined) {
 			if (format === "zip") {
 				throw new Error("compressionFormat is not supported for zip archives");
 			}
-			args.push(compressionFormat);
+			args.push(compression);
 		}
 		let value = await tg.build({
 			args,

--- a/packages/runtime/src/artifact.ts
+++ b/packages/runtime/src/artifact.ts
@@ -40,9 +40,18 @@ export namespace Artifact {
 	export let archive = async (
 		artifact: Artifact,
 		format: ArchiveFormat,
+		compressionFormat?: tg.Blob.CompressionFormat,
 	): Promise<tg.Blob> => {
+		const args = ["archive", artifact, format];
+		if (compressionFormat !== undefined) {
+			if (format === "zip") {
+				throw new Error("compressionFormat is not supported for zip archives");
+			}
+			args.push(compressionFormat);
+		}
 		let value = await tg.build({
-			args: ["archive", artifact, format],
+			args,
+			env: undefined,
 			host: "builtin",
 		});
 		tg.assert(tg.Blob.is(value));
@@ -52,9 +61,17 @@ export namespace Artifact {
 	export let extract = async (
 		blob: tg.Blob,
 		format: ArchiveFormat,
+		compressionFormat?: tg.Blob.CompressionFormat,
 	): Promise<Artifact> => {
+		const args = ["extract", blob, format];
+		if (compressionFormat !== undefined) {
+			if (format === "zip") {
+				throw new Error("compressionFormat is not supported for zip archives");
+			}
+			args.push(compressionFormat);
+		}
 		let value = await tg.build({
-			args: ["extract", blob, format],
+			args,
 			env: undefined,
 			host: "builtin",
 		});

--- a/packages/runtime/src/artifact.ts
+++ b/packages/runtime/src/artifact.ts
@@ -45,7 +45,7 @@ export namespace Artifact {
 		const args = ["archive", artifact, format];
 		if (compression !== undefined) {
 			if (format === "zip") {
-				throw new Error("compressionFormat is not supported for zip archives");
+				throw new Error("compression is not supported for zip archives");
 			}
 			args.push(compression);
 		}

--- a/packages/runtime/src/blob.ts
+++ b/packages/runtime/src/blob.ts
@@ -82,12 +82,9 @@ export namespace Blob {
 		return value;
 	};
 
-	export let decompress = async (
-		blob: Blob,
-		format: CompressionFormat,
-	): Promise<Blob> => {
+	export let decompress = async (blob: Blob): Promise<Blob> => {
 		let value = await tg.build({
-			args: ["decompress", blob, format],
+			args: ["decompress", blob],
 			env: undefined,
 			host: "builtin",
 		});

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -235,12 +235,14 @@ declare namespace tg {
 	export let archive: (
 		artifact: tg.Artifact,
 		format: tg.Artifact.ArchiveFormat,
+		compressionFormat?: tg.Blob.CompressionFormat,
 	) => Promise<tg.Blob>;
 
 	/** Extract an artifact from an archive. **/
 	export let extract: (
 		blob: tg.Blob,
 		format: tg.Artifact.ArchiveFormat,
+		compressionFormat?: tg.Blob.CompressionFormat,
 	) => Promise<tg.Artifact>;
 
 	/** Bundle an artifact. **/
@@ -268,12 +270,14 @@ declare namespace tg {
 		export let archive: (
 			artifact: tg.Artifact,
 			format: tg.Artifact.ArchiveFormat,
+			compressionFormat?: tg.Blob.CompressionFormat,
 		) => Promise<tg.Blob>;
 
 		/** Extract an artifact from an archive. **/
 		export let extract: (
 			blob: tg.Blob,
 			format: tg.Artifact.ArchiveFormat,
+			compressionFormat?: tg.Blob.CompressionFormat,
 		) => Promise<tg.Artifact>;
 
 		/** Bundle an artifact. **/

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -99,7 +99,6 @@ declare namespace tg {
 	/** Decompress a blob. **/
 	export let decompress: (
 		blob: tg.Blob,
-		format: tg.Blob.CompressionFormat,
 	) => Promise<tg.Blob>;
 
 	/** Download the contents of a URL. */
@@ -133,7 +132,6 @@ declare namespace tg {
 		/** Decompress a blob. **/
 		export let decompress: (
 			blob: tg.Blob,
-			format: tg.Blob.CompressionFormat,
 		) => Promise<tg.Blob>;
 
 		/** Download a blob. **/
@@ -235,7 +233,7 @@ declare namespace tg {
 	export let archive: (
 		artifact: tg.Artifact,
 		format: tg.Artifact.ArchiveFormat,
-		compressionFormat?: tg.Blob.CompressionFormat,
+		compression?: tg.Blob.CompressionFormat,
 	) => Promise<tg.Blob>;
 
 	/** Extract an artifact from an archive. **/
@@ -268,7 +266,7 @@ declare namespace tg {
 		export let archive: (
 			artifact: tg.Artifact,
 			format: tg.Artifact.ArchiveFormat,
-			compressionFormat?: tg.Blob.CompressionFormat,
+			compression?: tg.Blob.CompressionFormat,
 		) => Promise<tg.Blob>;
 
 		/** Extract an artifact from an archive. **/

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -241,8 +241,6 @@ declare namespace tg {
 	/** Extract an artifact from an archive. **/
 	export let extract: (
 		blob: tg.Blob,
-		format: tg.Artifact.ArchiveFormat,
-		compressionFormat?: tg.Blob.CompressionFormat,
 	) => Promise<tg.Artifact>;
 
 	/** Bundle an artifact. **/
@@ -276,8 +274,6 @@ declare namespace tg {
 		/** Extract an artifact from an archive. **/
 		export let extract: (
 			blob: tg.Blob,
-			format: tg.Artifact.ArchiveFormat,
-			compressionFormat?: tg.Blob.CompressionFormat,
 		) => Promise<tg.Artifact>;
 
 		/** Bundle an artifact. **/

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -28,10 +28,10 @@ pretty_assertions = { workspace = true }
 insta = { workspace = true }
 
 [dependencies]
+astral-tokio-tar = { workspace = true }
 async-channel = { workspace = true }
 async-compression = { workspace = true }
 async-nats = { workspace = true }
-async-tar = { workspace = true }
 async_zip = { workspace = true }
 aws-credential-types = { workspace = true }
 aws-sigv4 = { workspace = true }

--- a/packages/server/src/runtime/builtin/archive.rs
+++ b/packages/server/src/runtime/builtin/archive.rs
@@ -48,9 +48,7 @@ impl Runtime {
 		if compression_format.is_some()
 			&& matches!(format, tangram_client::artifact::archive::Format::Zip)
 		{
-			return Err(tg::error!(
-				"compression_format is not supported for zip archives"
-			));
+			return Err(tg::error!("compression is not supported for zip archives"));
 		}
 
 		// Create the archive task.

--- a/packages/server/src/runtime/builtin/extract.rs
+++ b/packages/server/src/runtime/builtin/extract.rs
@@ -59,7 +59,9 @@ impl Runtime {
 
 		// If there is a compression format, make sure the format is tar.
 		if compression_format.is_some() && matches!(format, tg::artifact::archive::Format::Zip) {
-			return Err(tg::error!("compression is only supported for tar archives"));
+			return Err(tg::error!(
+				"compression_format is not supported for zip archives"
+			));
 		}
 
 		// Create the reader.

--- a/packages/server/src/runtime/builtin/extract.rs
+++ b/packages/server/src/runtime/builtin/extract.rs
@@ -29,7 +29,7 @@ impl Runtime {
 			.ok_or_else(|| tg::error!("expected a blob"))?;
 
 		// Detect archive format.
-		let (format, compression_format) = detect_archive_format(server, &blob).await?;
+		let (format, compression) = detect_archive_format(server, &blob).await?;
 
 		// Create the reader.
 		let reader = crate::blob::Reader::new(&self.server, blob.clone()).await?;
@@ -78,7 +78,7 @@ impl Runtime {
 		let artifact = match format {
 			tg::artifact::archive::Format::Tar => {
 				// If there is a compression format, wrap the reader.
-				let reader: Pin<Box<dyn AsyncRead + Send + 'static>> = match compression_format {
+				let reader: Pin<Box<dyn AsyncRead + Send + 'static>> = match compression {
 					Some(tg::blob::compress::Format::Bz2) => {
 						Box::pin(async_compression::tokio::bufread::BzDecoder::new(reader))
 					},


### PR DESCRIPTION
Adds an optional compression format to `tg.archive`/`tg.extract` to avoid requiring a separate compression step when handling tar archives.

Closes #458.

TODO:
- [x] switch `async-tar` to `astral-tokio-tar`
- [x] update `std.download` to use combined extraction when possible
- [x] remove extract args, detect magic numbers
- [x] remove decompress args, detect magic numbers