### PR TITLE
feat: push or pull multiple references

### DIFF
--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1147,6 +1147,18 @@ impl Cli {
 		Ok(output)
 	}
 
+	async fn get_references(
+		&self,
+		references: &[tg::Reference],
+	) -> tg::Result<Vec<tg::Referent<Either<tg::Process, tg::Object>>>> {
+		let mut results = Vec::with_capacity(references.len());
+		for reference in references {
+			let result = self.get_reference(reference).await?;
+			results.push(result);
+		}
+		Ok(results)
+	}
+
 	/// Initialize V8.
 	fn initialize_v8() {
 		// Set the ICU data.

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1151,12 +1151,12 @@ impl Cli {
 		&self,
 		references: &[tg::Reference],
 	) -> tg::Result<Vec<tg::Referent<Either<tg::Process, tg::Object>>>> {
-		let mut results = Vec::with_capacity(references.len());
+		let mut referents = Vec::with_capacity(references.len());
 		for reference in references {
-			let result = self.get_reference(reference).await?;
-			results.push(result);
+			let referent = self.get_reference(reference).await?;
+			referents.push(referent);
 		}
-		Ok(results)
+		Ok(referents)
 	}
 
 	/// Initialize V8.

--- a/packages/cli/src/pull.rs
+++ b/packages/cli/src/pull.rs
@@ -12,14 +12,14 @@ pub struct Args {
 	#[arg(long)]
 	pub recursive: bool,
 
-	#[arg(index = 1)]
-	pub reference: tg::Reference,
-
 	#[arg(short, long)]
 	pub remote: Option<String>,
 
 	#[arg(long)]
 	pub commands: bool,
+
+	#[arg(required = true)]
+	pub references: Vec<tg::Reference>,
 }
 
 impl Cli {
@@ -29,31 +29,35 @@ impl Cli {
 		// Get the remote.
 		let remote = args.remote.unwrap_or_else(|| "default".to_owned());
 
-		// Get the reference.
-		let referent = self.get_reference(&args.reference).await?;
-		let item = match referent.item {
-			Either::Left(process) => Either::Left(process),
-			Either::Right(object) => {
-				let object = if let Some(subpath) = &referent.subpath {
-					let directory = object
-						.try_unwrap_directory()
-						.ok()
-						.ok_or_else(|| tg::error!("expected a directory"))?;
-					directory.get(&handle, subpath).await?.into()
-				} else {
-					object
-				};
-				Either::Right(object)
-			},
-		};
-		let item = match item {
-			Either::Left(process) => Either::Left(process.id().clone()),
-			Either::Right(object) => Either::Right(object.id(&handle).await?.clone()),
-		};
+		// Get the references.
+		let items = futures::future::try_join_all(args.references.iter().map(async |reference| {
+			let referent = self.get_reference(reference).await?;
+			let item = match referent.item {
+				Either::Left(process) => Either::Left(process),
+				Either::Right(object) => {
+					let object = if let Some(subpath) = &referent.subpath {
+						let directory = object
+							.try_unwrap_directory()
+							.ok()
+							.ok_or_else(|| tg::error!("expected a directory"))?;
+						directory.get(&handle, subpath).await?.into()
+					} else {
+						object
+					};
+					Either::Right(object)
+				},
+			};
+			let item = match item {
+				Either::Left(process) => Either::Left(process.id().clone()),
+				Either::Right(object) => Either::Right(object.id(&handle).await?.clone()),
+			};
+			Ok::<_, tg::Error>(item)
+		}))
+		.await?;
 
 		// Pull the item.
 		let arg = tg::pull::Arg {
-			items: vec![item.clone()],
+			items: items.clone(),
 			logs: args.logs,
 			outputs: true,
 			recursive: args.recursive,
@@ -63,17 +67,23 @@ impl Cli {
 		let stream = handle.pull(arg).await?;
 		self.render_progress_stream(stream).await?;
 
-		// If the reference has a tag, then put it.
-		if let tg::reference::Item::Tag(pattern) = args.reference.item() {
-			if let Ok(tag) = pattern.clone().try_into() {
-				let arg = tg::tag::put::Arg {
-					force: false,
-					item,
-					remote: None,
-				};
-				handle.put_tag(&tag, arg).await?;
-			}
-		}
+		// If any reference has a tag, then put it.
+		futures::future::try_join_all(args.references.iter().enumerate().map(
+			async |(idx, reference)| {
+				if let tg::reference::Item::Tag(pattern) = reference.item() {
+					if let Ok(tag) = pattern.clone().try_into() {
+						let arg = tg::tag::put::Arg {
+							force: false,
+							item: items[idx].clone(),
+							remote: Some(remote.clone()),
+						};
+						handle.put_tag(&tag, arg).await?;
+					}
+				}
+				Ok::<_, tg::Error>(())
+			},
+		))
+		.await?;
 
 		Ok(())
 	}

--- a/packages/cli/src/pull.rs
+++ b/packages/cli/src/pull.rs
@@ -7,19 +7,19 @@ use tangram_either::Either;
 #[group(skip)]
 pub struct Args {
 	#[arg(long)]
+	pub commands: bool,
+
+	#[arg(long)]
 	pub logs: bool,
 
 	#[arg(long)]
 	pub recursive: bool,
 
-	#[arg(short, long)]
-	pub remote: Option<String>,
-
-	#[arg(long)]
-	pub commands: bool,
-
 	#[arg(required = true)]
 	pub references: Vec<tg::Reference>,
+
+	#[arg(short, long)]
+	pub remote: Option<String>,
 }
 
 impl Cli {

--- a/packages/cli/src/pull.rs
+++ b/packages/cli/src/pull.rs
@@ -30,8 +30,8 @@ impl Cli {
 		let remote = args.remote.unwrap_or_else(|| "default".to_owned());
 
 		// Get the references.
-		let items = futures::future::try_join_all(args.references.iter().map(async |reference| {
-			let referent = self.get_reference(reference).await?;
+		let referents = self.get_references(&args.references).await?;
+		let items = futures::future::try_join_all(referents.into_iter().map(async |referent| {
 			let item = match referent.item {
 				Either::Left(process) => Either::Left(process),
 				Either::Right(object) => {

--- a/packages/cli/src/push.rs
+++ b/packages/cli/src/push.rs
@@ -33,8 +33,8 @@ impl Cli {
 		let remote = args.remote.unwrap_or_else(|| "default".to_owned());
 
 		// Get the references.
-		let items = futures::future::try_join_all(args.references.iter().map(async |reference| {
-			let referent = self.get_reference(reference).await?;
+		let referents = self.get_references(&args.references).await?;
+		let items = futures::future::try_join_all(referents.into_iter().map(async |referent| {
 			let item = match referent.item {
 				Either::Left(process) => Either::Left(process),
 				Either::Right(object) => {

--- a/packages/cli/src/push.rs
+++ b/packages/cli/src/push.rs
@@ -18,11 +18,11 @@ pub struct Args {
 	#[arg(long)]
 	pub recursive: bool,
 
-	#[arg(short, long)]
-	pub remote: Option<String>,
-
 	#[arg(required = true)]
 	pub references: Vec<tg::Reference>,
+
+	#[arg(short, long)]
+	pub remote: Option<String>,
 }
 
 impl Cli {

--- a/packages/client/src/util/serde.rs
+++ b/packages/client/src/util/serde.rs
@@ -1,7 +1,6 @@
-use std::borrow::Cow;
-
 use crate as tg;
 use bytes::Bytes;
+use std::borrow::Cow;
 
 pub struct BytesBase64;
 

--- a/packages/client/src/util/serde.rs
+++ b/packages/client/src/util/serde.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate as tg;
 use bytes::Bytes;
 
@@ -66,7 +68,7 @@ where
 	where
 		D: serde::Deserializer<'de>,
 	{
-		let s: &str = serde::Deserialize::deserialize(deserializer)?;
+		let s: Cow<'_, str> = serde::Deserialize::deserialize(deserializer)?;
 		if s.is_empty() {
 			return Ok(Vec::new());
 		}


### PR DESCRIPTION
Adds support for multiple references to push/pull.

Additionally, fixes the `CommaSeparatedString` serde helper to support unescaping strings.