### PR TITLE
fix(index): deduplicate index inserts

### DIFF
--- a/packages/server/src/export.rs
+++ b/packages/server/src/export.rs
@@ -949,19 +949,17 @@ impl Graph {
 				},
 			}
 		} else {
-			// Insert the node, and set it complete.
 			self.insert(None, &item.as_ref());
 			let Some(node) = self.nodes.get(&item) else {
 				tracing::error!(?item, "could not get node after insertion");
 				return;
 			};
 			match (&node.complete, new_complete) {
-				(Either::Left(old_complete), Either::Left(new_complete)) => {
-					let mut w = old_complete.write().unwrap();
-					*w = new_complete.clone();
+				(Either::Left(old), Either::Left(new)) => {
+					*old.write().unwrap() = new.clone();
 				},
-				(Either::Right(old_complete), Either::Right(value)) => {
-					old_complete.store(value, std::sync::atomic::Ordering::SeqCst);
+				(Either::Right(old), Either::Right(value)) => {
+					old.store(value, std::sync::atomic::Ordering::SeqCst);
 				},
 				_ => {
 					tracing::error!("attempted to update complete with mismatched type");

--- a/packages/server/src/export.rs
+++ b/packages/server/src/export.rs
@@ -949,7 +949,24 @@ impl Graph {
 				},
 			}
 		} else {
-			tracing::debug!("attempted to update complete for non-existent node");
+			// Insert the node, and set it complete.
+			self.insert(None, &item.as_ref());
+			let Some(node) = self.nodes.get(&item) else {
+				tracing::error!(?item, "could not get node after insertion");
+				return;
+			};
+			match (&node.complete, new_complete) {
+				(Either::Left(old_complete), Either::Left(new_complete)) => {
+					let mut w = old_complete.write().unwrap();
+					*w = new_complete.clone();
+				},
+				(Either::Right(old_complete), Either::Right(value)) => {
+					old_complete.store(value, std::sync::atomic::Ordering::SeqCst);
+				},
+				_ => {
+					tracing::error!("attempted to update complete with mismatched type");
+				},
+			}
 		}
 	}
 }

--- a/packages/server/src/import.rs
+++ b/packages/server/src/import.rs
@@ -380,19 +380,6 @@ impl Server {
 		event_sender: &tokio::sync::mpsc::Sender<tg::Result<tg::import::Event>>,
 		progress: &Arc<Progress>,
 	) -> tg::Result<()> {
-		// Ensure the stream exists.
-		if let Either::Right(messenger) = self.messenger.as_ref() {
-			messenger
-				.jetstream
-				.get_or_create_stream(async_nats::jetstream::stream::Config {
-					name: "index".to_string(),
-					max_messages: i64::MAX,
-					..Default::default()
-				})
-				.await
-				.map_err(|source| tg::error!(!source, "failed to ensure the stream exists"))?;
-		}
-
 		// Choose the parameters.
 		let (n_batch_tasks, max_objects_per_batch, max_bytes_per_batch) = match &self.store {
 			#[cfg(feature = "foundationdb")]

--- a/packages/server/src/index.rs
+++ b/packages/server/src/index.rs
@@ -264,7 +264,7 @@ impl Server {
 			.await?;
 
 		// Acknowledge the messages.
-		futures::future::try_join_all(ackers.into_iter().map(async |acker| {
+		future::try_join_all(ackers.into_iter().map(async |acker| {
 			if let Some(acker) = acker {
 				acker
 					.ack()
@@ -407,7 +407,7 @@ impl Server {
 				.map_err(|source| tg::error!(!source, "failed to commit the transaction"))?;
 
 			// Acknowledge the messages, including dropped duplicates.
-			futures::future::try_join_all(
+			future::try_join_all(
 				messages
 					.iter()
 					.filter_map(|(_, acker)| acker.as_ref())

--- a/packages/server/src/index.rs
+++ b/packages/server/src/index.rs
@@ -292,15 +292,6 @@ impl Server {
 		// Get list of unique message indices
 		let unique_indices: Vec<_> = unique_indices.values().copied().collect();
 
-		// Log summary of deduplication if any duplicates were found
-		if unique_indices.len() < messages.len() {
-			tracing::warn!(
-				"Found {} duplicate message(s) out of {} total messages",
-				messages.len() - unique_indices.len(),
-				messages.len()
-			);
-		}
-
 		// Get a database connection.
 		let options = db::ConnectionOptions {
 			kind: db::ConnectionKind::Write,

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -291,6 +291,20 @@ impl Server {
 				Messenger::Right(tangram_messenger::nats::Messenger::new(client))
 			},
 		};
+		if let Either::Right(messenger) = messenger.as_ref() {
+			let stream_config = async_nats::jetstream::stream::Config {
+				name: "index".to_string(),
+				max_messages: i64::MAX,
+				..Default::default()
+			};
+			messenger
+				.jetstream
+				.get_or_create_stream(stream_config)
+				.await
+				.map_err(|source| {
+					tg::error!(!source, "failed to ensure the index stream exists")
+				})?;
+		}
 
 		// Create the pipes.
 		let pipes = DashMap::default();

--- a/packages/server/src/process/put.rs
+++ b/packages/server/src/process/put.rs
@@ -307,31 +307,34 @@ impl Server {
 			"
 		);
 		transaction
-			.execute(statement, &[
-				&id.to_string(),
-				&i64::from(arg.data.cacheable),
-				&arg.data.checksum.map(|checksum| checksum.to_string()),
-				&arg.data.command.to_string(),
-				&arg.data.created_at.format(&Rfc3339).unwrap(),
-				&arg.data.cwd.map(|cwd| cwd.to_string_lossy().to_string()),
-				&arg.data.dequeued_at.map(|t| t.format(&Rfc3339).unwrap()),
-				&arg.data.enqueued_at.map(|t| t.format(&Rfc3339).unwrap()),
-				&serde_json::to_string(&arg.data.env.as_ref()).unwrap(),
-				&serde_json::to_string(&arg.data.error.as_ref()).unwrap(),
-				&serde_json::to_string(&arg.data.exit.as_ref()).unwrap(),
-				&arg.data.finished_at.map(|t| t.format(&Rfc3339).unwrap()),
-				&arg.data.host,
-				&arg.data
-					.log
-					.as_ref()
-					.map(|log| serde_json::to_string(&log).unwrap()),
-				&i64::from(arg.data.network),
-				&serde_json::to_string(&arg.data.output.as_ref()).unwrap(),
-				&i64::from(arg.data.retry),
-				&arg.data.started_at.map(|t| t.format(&Rfc3339).unwrap()),
-				&serde_json::to_string(&arg.data.status).unwrap(),
-				&time::OffsetDateTime::now_utc().format(&Rfc3339).unwrap(),
-			])
+			.execute(
+				statement,
+				&[
+					&id.to_string(),
+					&i64::from(arg.data.cacheable),
+					&arg.data.checksum.map(|checksum| checksum.to_string()),
+					&arg.data.command.to_string(),
+					&arg.data.created_at.format(&Rfc3339).unwrap(),
+					&arg.data.cwd.map(|cwd| cwd.to_string_lossy().to_string()),
+					&arg.data.dequeued_at.map(|t| t.format(&Rfc3339).unwrap()),
+					&arg.data.enqueued_at.map(|t| t.format(&Rfc3339).unwrap()),
+					&serde_json::to_string(&arg.data.env.as_ref()).unwrap(),
+					&serde_json::to_string(&arg.data.error.as_ref()).unwrap(),
+					&serde_json::to_string(&arg.data.exit.as_ref()).unwrap(),
+					&arg.data.finished_at.map(|t| t.format(&Rfc3339).unwrap()),
+					&arg.data.host,
+					&arg.data
+						.log
+						.as_ref()
+						.map(|log| serde_json::to_string(&log).unwrap()),
+					&i64::from(arg.data.network),
+					&serde_json::to_string(&arg.data.output.as_ref()).unwrap(),
+					&i64::from(arg.data.retry),
+					&arg.data.started_at.map(|t| t.format(&Rfc3339).unwrap()),
+					&serde_json::to_string(&arg.data.status).unwrap(),
+					&time::OffsetDateTime::now_utc().format(&Rfc3339).unwrap(),
+				],
+			)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
@@ -348,14 +351,17 @@ impl Server {
 				);
 
 				transaction
-					.execute(statement, &[
-						&id.to_string(),
-						&positions.as_slice(),
-						&children
-							.iter()
-							.map(|child| child.to_string())
-							.collect::<Vec<_>>(),
-					])
+					.execute(
+						statement,
+						&[
+							&id.to_string(),
+							&positions.as_slice(),
+							&children
+								.iter()
+								.map(|child| child.to_string())
+								.collect::<Vec<_>>(),
+						],
+					)
 					.await
 					.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 			}
@@ -388,13 +394,16 @@ impl Server {
 			);
 
 			transaction
-				.execute(statement, &[
-					&id.to_string(),
-					&objects
-						.iter()
-						.map(|object| object.to_string())
-						.collect::<Vec<_>>(),
-				])
+				.execute(
+					statement,
+					&[
+						&id.to_string(),
+						&objects
+							.iter()
+							.map(|object| object.to_string())
+							.collect::<Vec<_>>(),
+					],
+				)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 		}


### PR DESCRIPTION
- only insert unique ids in postgres batch inserts
- send index message in `put_object_inner`
- insert node in export graph if we try to set complete on a node we haven't seen