### PR TITLE
refactor(runtime): separate tg.build from tg.run/spawn

### DIFF
--- a/packages/runtime/src/command.ts
+++ b/packages/runtime/src/command.ts
@@ -47,12 +47,13 @@ export function command<
 		};
 		let cwd = undefined;
 		let mounts: Array<tg.Command.Mount> = [];
+		let env = {};
 		let stdin = undefined;
 		let user = undefined;
 		let object = {
 			args: args_,
 			cwd,
-			env: tg.Process.current.state!.command.state.object!.env,
+			env,
 			executable,
 			host: "js",
 			mounts,


### PR DESCRIPTION
Add a specific implementation for spawing processes with `tg.build`. Additionally, do not set any env in the macro form of `tg.command`.