### PR TITLE
Add support for acks, stream info, and other improvements to the memory messenger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,6 +6097,7 @@ dependencies = [
  "bytes",
  "crossbeam",
  "dashmap 6.1.0",
+ "derive_more",
  "fnv",
  "futures",
  "tangram_either",

--- a/packages/cli/src/process/run/stdio.rs
+++ b/packages/cli/src/process/run/stdio.rs
@@ -25,7 +25,7 @@ impl Cli {
 		let handle = self.handle().await?;
 
 		// If the process is detached, don't create any interactive stdio.
-		if options.detach || !options.spawn.tty {
+		if options.detach || options.spawn.no_tty {
 			let stdin = create(&handle, remote.clone(), None).await?;
 			let stdout = create(&handle, remote.clone(), None).await?;
 			let stderr = create(&handle, remote.clone(), None).await?;

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -76,8 +76,8 @@ pub struct Options {
 	pub tag: Option<tg::Tag>,
 
 	/// Allocate a terminal when running the process.
-	#[arg(short, long)]
-	pub tty: bool,
+	#[arg(long)]
+	pub no_tty: bool,
 }
 
 impl Cli {

--- a/packages/cli/tests/artifact_checkin.rs
+++ b/packages/cli/tests/artifact_checkin.rs
@@ -2388,6 +2388,14 @@ async fn test_artifact_checkin_inner(
 	}
 	let output = command.output().await.unwrap();
 
+	// Index
+	{
+		let mut command = server.tg();
+		command.arg("index");
+		let index_output = command.output().await.unwrap();
+		assert_success!(index_output);
+	}
+
 	// Get the object.
 	let id = std::str::from_utf8(&output.stdout)
 		.unwrap()

--- a/packages/messenger/Cargo.toml
+++ b/packages/messenger/Cargo.toml
@@ -20,6 +20,7 @@ crossbeam = { workspace = true }
 async-nats = { workspace = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
+derive_more = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }

--- a/packages/messenger/src/either.rs
+++ b/packages/messenger/src/either.rs
@@ -102,4 +102,14 @@ where
 				.right_future(),
 		}
 	}
+
+	fn stream_info(
+		&self,
+		name: String,
+	) -> impl Future<Output = Result<crate::StreamInfo, Self::Error>> + Send {
+		match self {
+			Either::Left(s) => s.stream_info(name).map_err(Either::Left).left_future(),
+			Either::Right(s) => s.stream_info(name).map_err(Either::Right).right_future(),
+		}
+	}
 }

--- a/packages/messenger/src/lib.rs
+++ b/packages/messenger/src/lib.rs
@@ -13,7 +13,10 @@ pub struct Message {
 
 #[derive(Clone, Debug)]
 pub struct StreamInfo {
-	pub first_sequence: u64,
+	/// The lowest sequence number in the stream. None if the stream is empty.
+	pub first_sequence: Option<u64>,
+
+	/// The most recently assigned sequence number.
 	pub last_sequence: u64,
 }
 

--- a/packages/messenger/src/lib.rs
+++ b/packages/messenger/src/lib.rs
@@ -1,12 +1,32 @@
 use bytes::Bytes;
-use futures::Stream;
+use futures::{FutureExt as _, Stream, future::BoxFuture};
 
 pub mod either;
 pub mod memory;
 pub mod nats;
 
+pub struct Message {
+	pub subject: String,
+	pub payload: Bytes,
+	pub acker: Acker,
+}
+
+#[derive(Clone, Debug)]
+pub struct StreamInfo {
+	pub first_sequence: u64,
+	pub last_sequence: u64,
+}
+
+pub struct Acker {
+	ack: Option<BoxFuture<'static, Result<(), StdError>>>,
+	acked: bool,
+	retry: Option<BoxFuture<'static, ()>>,
+}
+
+type StdError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 pub trait Messenger {
-	type Error: std::error::Error + Send + Sync + 'static;
+	type Error: std::error::Error + Send + 'static;
 
 	fn publish(
 		&self,
@@ -40,10 +60,55 @@ pub trait Messenger {
 			Self::Error,
 		>,
 	> + Send;
+
+	fn stream_info(
+		&self,
+		name: String,
+	) -> impl Future<Output = Result<StreamInfo, Self::Error>> + Send;
 }
 
-#[derive(Clone, Debug)]
-pub struct Message {
-	pub subject: String,
-	pub payload: Bytes,
+impl Default for Acker {
+	fn default() -> Self {
+		Self {
+			ack: None,
+			acked: true,
+			retry: None,
+		}
+	}
+}
+
+impl Acker {
+	pub fn new(
+		ack: impl Future<Output = Result<(), StdError>> + Send + 'static,
+		retry: impl Future<Output = ()> + Send + 'static,
+	) -> Self {
+		Self {
+			ack: Some(ack.boxed()),
+			acked: false,
+			retry: Some(retry.boxed()),
+		}
+	}
+
+	pub async fn ack(mut self) -> Result<(), StdError> {
+		if let Some(fut) = self.ack.take() {
+			fut.await?;
+		}
+		self.acked = true;
+		Ok(())
+	}
+}
+
+impl Drop for Acker {
+	fn drop(&mut self) {
+		drop(self.ack.take());
+		if let (false, Some(retry)) = (self.acked, self.retry.take()) {
+			tokio::spawn(retry);
+		}
+	}
+}
+
+impl Message {
+	pub fn split(self) -> (Bytes, Acker) {
+		(self.payload, self.acker)
+	}
 }

--- a/packages/messenger/src/memory.rs
+++ b/packages/messenger/src/memory.rs
@@ -6,7 +6,6 @@ use dashmap::DashMap;
 use futures::{StreamExt as _, TryFutureExt, future, stream::FuturesUnordered};
 use std::{
 	collections::BTreeSet,
-	fmt,
 	ops::Deref,
 	sync::{
 		Arc, Mutex,
@@ -16,25 +15,17 @@ use std::{
 use tokio::sync::RwLock;
 
 pub struct Messenger(Arc<Inner>);
-#[derive(Debug)]
+
+#[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum Error {
+	#[display("stream not found")]
 	NotFound,
+	#[display("stream closed")]
 	StreamClosed,
+	#[display("failed to publish to subject")]
 	SendError,
+	#[display("failed to publish to stream")]
 	StreamSendError,
-}
-
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			Error::NotFound => write!(f, "stream not found"),
-			Error::StreamClosed => write!(f, "stream closed"),
-			Error::SendError => write!(f, "failed to publish to subject"),
-			Error::StreamSendError => write!(f, "failed to publish to stream"),
-		}
-	}
 }
 
 pub struct Inner {

--- a/packages/messenger/src/memory.rs
+++ b/packages/messenger/src/memory.rs
@@ -309,7 +309,6 @@ impl Messenger {
 		&self,
 		name: String,
 	) -> Result<impl futures::Stream<Item = Message> + Send + 'static, Error> {
-		let mut last = None;
 		let receiver = self
 			.streams
 			.get(&name)

--- a/packages/messenger/src/nats.rs
+++ b/packages/messenger/src/nats.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use crate::{Acker, Message, StreamInfo};
 use async_nats as nats;
 use bytes::Bytes;
@@ -10,7 +8,7 @@ pub struct Messenger {
 	pub jetstream: nats::jetstream::Context,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum Error {
 	Publish(nats::PublishError),
 	Subscribe(nats::SubscribeError),
@@ -21,23 +19,6 @@ pub enum Error {
 	Stream(nats::jetstream::consumer::StreamError),
 	Messages(nats::jetstream::consumer::pull::MessagesError),
 	PublishStream(nats::jetstream::context::PublishError),
-}
-
-impl std::error::Error for Error {}
-impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match self {
-			Self::Publish(e) => write!(f, "{e}"),
-			Self::Subscribe(e) => write!(f, "{e}"),
-			Self::GetStream(e) => write!(f, "{e}"),
-			Self::Info(e) => write!(f, "{e}"),
-			Self::CreateStream(e) => write!(f, "{e}"),
-			Self::Consumer(e) => write!(f, "{e}"),
-			Self::Stream(e) => write!(f, "{e}"),
-			Self::Messages(e) => write!(f, "{e}"),
-			Self::PublishStream(e) => write!(f, "{e}"),
-		}
-	}
 }
 
 impl Messenger {

--- a/packages/messenger/src/nats.rs
+++ b/packages/messenger/src/nats.rs
@@ -106,7 +106,7 @@ impl Messenger {
 			.map_err(Error::GetStream)?;
 		let info = stream.info().await.map_err(Error::Info)?;
 		Ok(StreamInfo {
-			first_sequence: info.state.first_sequence,
+			first_sequence: Some(info.state.first_sequence),
 			last_sequence: info.state.last_sequence,
 		})
 	}

--- a/packages/messenger/src/nats.rs
+++ b/packages/messenger/src/nats.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::Message;
+use crate::{Acker, Message, StreamInfo};
 use async_nats as nats;
 use bytes::Bytes;
 use futures::prelude::*;
@@ -15,6 +15,7 @@ pub enum Error {
 	Publish(nats::PublishError),
 	Subscribe(nats::SubscribeError),
 	GetStream(nats::jetstream::context::GetStreamError),
+	Info(nats::jetstream::context::RequestError),
 	CreateStream(nats::jetstream::context::CreateStreamError),
 	Consumer(nats::jetstream::stream::ConsumerError),
 	Stream(nats::jetstream::consumer::StreamError),
@@ -29,6 +30,7 @@ impl fmt::Display for Error {
 			Self::Publish(e) => write!(f, "{e}"),
 			Self::Subscribe(e) => write!(f, "{e}"),
 			Self::GetStream(e) => write!(f, "{e}"),
+			Self::Info(e) => write!(f, "{e}"),
 			Self::CreateStream(e) => write!(f, "{e}"),
 			Self::Consumer(e) => write!(f, "{e}"),
 			Self::Stream(e) => write!(f, "{e}"),
@@ -94,9 +96,13 @@ impl Messenger {
 			.messages()
 			.await
 			.map_err(Error::Stream)?
-			.map_ok(|message| Message {
-				subject: message.subject.to_string(),
-				payload: message.payload.clone(),
+			.map_ok(|message| {
+				let (message, acker) = message.split();
+				Message {
+					subject: message.subject.to_string(),
+					payload: message.payload.clone(),
+					acker: acker.into(),
+				}
 			})
 			.map_err(Error::Messages);
 
@@ -107,10 +113,21 @@ impl Messenger {
 		self.jetstream
 			.publish(name, payload)
 			.await
-			.map_err(Error::PublishStream)?
-			.await
 			.map_err(Error::PublishStream)?;
 		Ok(())
+	}
+
+	async fn stream_info(&self, name: String) -> Result<StreamInfo, Error> {
+		let mut stream = self
+			.jetstream
+			.get_stream(name)
+			.await
+			.map_err(Error::GetStream)?;
+		let info = stream.info().await.map_err(Error::Info)?;
+		Ok(StreamInfo {
+			first_sequence: info.state.first_sequence,
+			last_sequence: info.state.last_sequence,
+		})
 	}
 }
 
@@ -141,6 +158,7 @@ impl crate::Messenger for Messenger {
 						.map(|message| Message {
 							subject: message.subject.to_string(),
 							payload: message.payload,
+							acker: Acker::default(),
 						})
 						.left_stream()
 				})
@@ -154,6 +172,7 @@ impl crate::Messenger for Messenger {
 						.map(|message| Message {
 							subject: message.subject.to_string(),
 							payload: message.payload,
+							acker: Acker::default(),
 						})
 						.right_stream()
 				})
@@ -189,5 +208,20 @@ impl crate::Messenger for Messenger {
 		>,
 	> + Send {
 		self.stream_subscribe(name, consumer_name)
+	}
+
+	fn stream_info(
+		&self,
+		name: String,
+	) -> impl Future<Output = Result<crate::StreamInfo, Self::Error>> + Send {
+		self.stream_info(name)
+	}
+}
+
+impl From<nats::jetstream::message::Acker> for Acker {
+	fn from(value: nats::jetstream::message::Acker) -> Self {
+		let ack = async move { value.ack().await };
+		let retry = future::ready(());
+		Acker::new(ack, retry)
 	}
 }

--- a/packages/sandbox/src/darwin.rs
+++ b/packages/sandbox/src/darwin.rs
@@ -96,7 +96,13 @@ pub(crate) async fn spawn(command: &Command) -> std::io::Result<Child> {
 		Either::Right(None) => None,
 	};
 	let stderr = match parent_stderr {
-		Either::Left(_) => Some(Either::Left(pty.as_ref().unwrap().get_reader()?)),
+		Either::Left(_) => {
+			if matches!(stdout, Some(Either::Left(_))) {
+				None
+			} else {
+				Some(Either::Left(pty.as_ref().unwrap().get_reader()?))
+			}
+		},
 		Either::Right(Some(io)) => Some(Either::Right(io)),
 		Either::Right(None) => None,
 	};

--- a/packages/sandbox/src/linux.rs
+++ b/packages/sandbox/src/linux.rs
@@ -160,7 +160,13 @@ pub async fn spawn(command: &Command) -> std::io::Result<Child> {
 		Either::Right(None) => None,
 	};
 	let stderr = match parent_stderr {
-		Either::Left(_) => Some(Either::Left(pty.as_ref().unwrap().get_reader()?)),
+		Either::Left(_) => {
+			if matches!(stdout, Some(Either::Left(_))) {
+				None
+			} else {
+				Some(Either::Left(pty.as_ref().unwrap().get_reader()?))
+			}
+		},
 		Either::Right(Some(io)) => Some(Either::Right(io)),
 		Either::Right(None) => None,
 	};

--- a/packages/sandbox/src/linux/guest.rs
+++ b/packages/sandbox/src/linux/guest.rs
@@ -129,6 +129,7 @@ fn mount_and_chroot(context: &mut Context) {
 	}
 }
 
+#[allow(clippy::cast_possible_wrap)]
 fn create_mountpoint_if_not_exists(source: &CString, target: &mut CString) {
 	unsafe {
 		const BACKSLASH: libc::c_char = b'\\' as _;

--- a/packages/server/src/artifact/cache.rs
+++ b/packages/server/src/artifact/cache.rs
@@ -8,6 +8,7 @@ use std::{
 };
 use tangram_client as tg;
 use tangram_either::Either;
+use tangram_futures::stream::TryExt;
 use tangram_messenger::Messenger as _;
 
 #[cfg(test)]
@@ -28,6 +29,42 @@ impl Server {
 		artifact: &tg::artifact::Id,
 		progress: &crate::progress::Handle<tg::artifact::checkout::Output>,
 	) -> tg::Result<()> {
+		// Check if this artifact is complete.
+		let complete = self
+			.try_get_object_complete_metadata_local(&artifact.clone().into())
+			.await?
+			.map(|metadata| metadata.complete)
+			.unwrap_or(false);
+		if !complete {
+			// Pull the object.
+			let stream = self
+				.pull(tg::pull::Arg {
+					items: vec![Either::Right(artifact.clone().into())],
+					..tg::pull::Arg::default()
+				})
+				.await
+				.map_err(|source| tg::error!(!source, %artifact, "failed to pull object"))?;
+			std::pin::pin!(stream)
+				.try_last()
+				.await
+				.map_err(|source| tg::error!(!source, "failed to await stream"))?;
+
+			// Wait for indexing to complete.
+			self.index()
+				.await
+				.map_err(|source| tg::error!(!source, "failed to index"))?;
+
+			// Verify that indexing has completed.
+			let complete = self
+				.try_get_object_complete_metadata_local(&artifact.clone().into())
+				.await?
+				.ok_or_else(|| tg::error!(%artifact, "expected the object to exist"))?
+				.complete;
+			if !complete {
+				return Err(tg::error!(%artifact, "failed to check if the artifact was complete"));
+			}
+		}
+
 		let server = self.clone();
 		let id = artifact.clone();
 		let artifact = Either::Right(artifact.clone());

--- a/packages/server/src/index.rs
+++ b/packages/server/src/index.rs
@@ -182,7 +182,7 @@ impl Server {
 				})
 			})
 			.filter_map(|result| future::ready(result.ok()))
-			.chunks(config.message_batch_size)
+			.ready_chunks(config.message_batch_size)
 			.map(Ok);
 		Ok(stream)
 	}

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -999,6 +999,9 @@ impl Server {
 				Self::handle_read_blob_request(handle, request, blob).boxed()
 			},
 
+			// Indexing.
+			(http::Method::POST, ["index"]) => Self::handle_index_request(handle, request).boxed(),
+
 			// Items.
 			(http::Method::POST, ["export"]) => {
 				Self::handle_export_request(handle, request).boxed()

--- a/packages/server/src/pipe/read.rs
+++ b/packages/server/src/pipe/read.rs
@@ -1,5 +1,5 @@
 use crate::Server;
-use futures::{Stream, StreamExt as _, TryFutureExt, TryStreamExt as _, future};
+use futures::{Stream, StreamExt as _, TryFutureExt, TryStreamExt as _};
 use tangram_client as tg;
 use tangram_futures::task::Stop;
 use tangram_http::{Body, request::Ext as _};

--- a/packages/server/src/pipe/read.rs
+++ b/packages/server/src/pipe/read.rs
@@ -26,11 +26,10 @@ impl Server {
 			.await
 			.map_err(|source| tg::error!(!source, "the pipe was closed or does not exist"))?
 			.map_err(|source| tg::error!(!source, "stream error"))
-			.and_then(|message| {
-				future::ready({
-					serde_json::from_slice::<tg::pipe::Event>(&message.payload)
-						.map_err(|source| tg::error!(!source, "failed to deserialize the event"))
-				})
+			.and_then(|message| async move {
+				message.acker.ack().await.ok();
+				serde_json::from_slice::<tg::pipe::Event>(&message.payload)
+					.map_err(|source| tg::error!(!source, "failed to deserialize the event"))
 			})
 			.boxed();
 

--- a/packages/server/src/pipe/write.rs
+++ b/packages/server/src/pipe/write.rs
@@ -1,9 +1,9 @@
 use crate::Server;
-use futures::{Stream, StreamExt as _, stream::TryStreamExt as _};
+use futures::{Stream, StreamExt as _, future, stream::TryStreamExt as _};
 use http_body_util::{BodyExt as _, BodyStream};
 use std::pin::pin;
 use tangram_client as tg;
-use tangram_futures::task::Stop;
+use tangram_futures::{stream::Ext as _, task::Stop};
 use tangram_http::{Body, request::Ext as _, response::builder::Ext};
 
 impl Server {
@@ -82,6 +82,7 @@ impl Server {
 					},
 				}
 			})
+			.take_while_inclusive(|event| future::ready(!matches!(event, Ok(tg::pipe::Event::End))))
 			.take_until(stop)
 			.boxed();
 

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -141,7 +141,7 @@ impl Server {
 			"
 				select command
 				from processes
-				where id = {p}1 
+				where id = {p}1
 			",
 		);
 		let params = db::params![id];

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -1,5 +1,5 @@
 use crate::Server;
-use futures::{Stream, StreamExt as _, TryFutureExt, TryStreamExt as _, future};
+use futures::{Stream, StreamExt as _, TryFutureExt, TryStreamExt as _};
 use indoc::formatdoc;
 use tangram_client::{self as tg};
 use tangram_database::{self as db, Database as _, Query as _};

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -81,14 +81,8 @@ impl Server {
 					.ack()
 					.await
 					.map_err(|source| tg::error!(!source, "failed to ack message"))?;
-				let event = serde_json::from_slice::<tg::pty::Event>(&message.payload)
-					.map_err(|source| tg::error!(!source, "failed to deserialize the event"))?;
-				match &event {
-					tg::pty::Event::Chunk(chunk) => eprintln!("recv {chunk:?}"),
-					tg::pty::Event::Size(sz) => eprintln!("recv {sz:?}"),
-					tg::pty::Event::End => eprintln!("recv END"),
-				};
-				Ok::<_, tg::Error>(event)
+				serde_json::from_slice::<tg::pty::Event>(&message.payload)
+					.map_err(|source| tg::error!(!source, "failed to deserialize the event"))
 			})
 			.boxed();
 

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -70,11 +70,10 @@ impl Server {
 			.await
 			.map_err(|source| tg::error!(!source, "the pty was closed or does not exist"))?
 			.map_err(|source| tg::error!(!source, "stream error"))
-			.and_then(|message| {
-				future::ready({
-					serde_json::from_slice::<tg::pty::Event>(&message.payload)
-						.map_err(|source| tg::error!(!source, "failed to deserialize the event"))
-				})
+			.and_then(|message| async move {
+				message.acker.ack().await.ok();
+				serde_json::from_slice::<tg::pty::Event>(&message.payload)
+					.map_err(|source| tg::error!(!source, "failed to deserialize the event"))
 			})
 			.boxed();
 

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -81,8 +81,9 @@ impl Server {
 					.ack()
 					.await
 					.map_err(|source| tg::error!(!source, "failed to ack message"))?;
-				serde_json::from_slice::<tg::pty::Event>(&message.payload)
-					.map_err(|source| tg::error!(!source, "failed to deserialize the event"))
+				let event = serde_json::from_slice::<tg::pty::Event>(&message.payload)
+					.map_err(|source| tg::error!(!source, "failed to deserialize the event"))?;
+				Ok::<_, tg::Error>(event)
 			})
 			.boxed();
 

--- a/packages/server/src/pty/write.rs
+++ b/packages/server/src/pty/write.rs
@@ -1,7 +1,7 @@
 use crate::Server;
 use futures::{
 	Stream, StreamExt as _,
-	future::{self, Inspect},
+	future,
 	stream::TryStreamExt as _,
 };
 use http_body_util::{BodyExt as _, BodyStream};

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -245,9 +245,9 @@ impl Runtime {
 		let stdio_task = Task::spawn(|stop| {
 			let server = self.server.clone();
 			let process = process.clone();
-			let stdin = child.stdin.take().unwrap();
-			let stdout = child.stdout.take().unwrap();
-			let stderr = child.stderr.take().unwrap();
+			let stdin = child.stdin.take();
+			let stdout = child.stdout.take();
+			let stderr = child.stderr.take();
 			async move { stdio_task(&server, &process, stop, stdin, stdout, stderr).await }
 		});
 

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -151,7 +151,7 @@ impl Runtime {
 					match message.level {
 						syscall::log::Level::Log => {
 							if matches!(&state.stdout, Some(tg::process::Stdio::Pty(_))) {
-								contents = contents.replace("\n", "\r\n");
+								contents = contents.replace('\n', "\r\n");
 							}
 							let bytes = Bytes::from(contents);
 							let arg = tg::process::log::post::Arg {
@@ -163,7 +163,7 @@ impl Runtime {
 						},
 						syscall::log::Level::Error => {
 							if matches!(&state.stderr, Some(tg::process::Stdio::Pty(_))) {
-								contents = contents.replace("\n", "\r\n");
+								contents = contents.replace('\n', "\r\n");
 							}
 							let bytes = Bytes::from(contents);
 							let arg = tg::process::log::post::Arg {

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -144,11 +144,16 @@ impl Runtime {
 			let server = self.server.clone();
 			let process = process.clone();
 			async move {
+				let state = process.load(&server).await?;
+
 				while let Some(message) = log_receiver.recv().await {
-					let syscall::log::Message { contents, .. } = message;
-					let bytes = Bytes::from(contents);
+					let syscall::log::Message { mut contents, .. } = message;
 					match message.level {
 						syscall::log::Level::Log => {
+							if matches!(&state.stdout, Some(tg::process::Stdio::Pty(_))) {
+								contents = contents.replace("\n", "\r\n");
+							}
+							let bytes = Bytes::from(contents);
 							let arg = tg::process::log::post::Arg {
 								bytes: bytes.clone(),
 								remote: process.remote().map(ToOwned::to_owned),
@@ -157,6 +162,10 @@ impl Runtime {
 							server.try_post_process_log(process.id(), arg).await.ok();
 						},
 						syscall::log::Level::Error => {
+							if matches!(&state.stderr, Some(tg::process::Stdio::Pty(_))) {
+								contents = contents.replace("\n", "\r\n");
+							}
+							let bytes = Bytes::from(contents);
 							let arg = tg::process::log::post::Arg {
 								bytes: bytes.clone(),
 								remote: process.remote().map(ToOwned::to_owned),

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -434,9 +434,9 @@ impl Runtime {
 		let stdio_task = Task::spawn(|stop| {
 			let server = self.server.clone();
 			let process = process.clone();
-			let stdin = child.stdin.take().unwrap();
-			let stdout = child.stdout.take().unwrap();
-			let stderr = child.stderr.take().unwrap();
+			let stdin = child.stdin.take();
+			let stdout = child.stdout.take();
+			let stderr = child.stderr.take();
 			async move { stdio_task(&server, &process, stop, stdin, stdout, stderr).await }
 		});
 


### PR DESCRIPTION
- Add `StreamInfo` to `Messenger` trait
- Add `Acker` to `Message`
- Support redelivery for unacknowledged messages in the memory messenger
- Ensure pty/pipe messages are acked
- Ensure index messages are acked in both memory/nats messengers
- Implement `server::index`
- Ensure artifacts are pulled/indexed in `cache`. 

