### PR TITLE
refactor(cli): swap condition

### DIFF
--- a/packages/cli/src/process/output.rs
+++ b/packages/cli/src/process/output.rs
@@ -15,12 +15,12 @@ impl Cli {
 		let handle = self.handle().await?;
 		let process = tg::Process::new(args.process, None, None, None, None);
 		let output = process.wait(&handle).await?;
-		let output = if output.status.is_finished() {
+		let output = if let Some(error) = output.error {
+			return Err(tg::error!(!error, "the process failed"));
+		} else if output.status.is_finished() {
 			output
 				.output
 				.ok_or_else(|| tg::error!("expected the output to be set"))?
-		} else if let Some(error) = output.error {
-			return Err(tg::error!(!error, "the process failed"));
 		} else {
 			return Err(tg::error!("the process failed"));
 		};


### PR DESCRIPTION
The `finished` status is now used even if an error occurred, so we need to check for the error presence first.