### PR TITLE
fix(client): inherit from current command

### DIFF
--- a/packages/cli/src/blob/download.rs
+++ b/packages/cli/src/blob/download.rs
@@ -17,8 +17,11 @@ impl Cli {
 	pub async fn command_blob_download(&self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
 		let host = "builtin";
-		let command_args = vec!["download".into(), args.url.to_string().into()];
-		let command = tg::Command::builder(host).args(command_args).build();
+		let executable = tg::command::Executable::Path("download".into());
+		let command_args = vec![args.url.to_string().into()];
+		let command = tg::Command::builder(host, executable)
+			.args(command_args)
+			.build();
 		let command = command.id(&handle).await?;
 		let reference = tg::Reference::with_object(&command.into());
 		self.build_process(args.build, reference, vec![]).await?;

--- a/packages/cli/src/process/build.rs
+++ b/packages/cli/src/process/build.rs
@@ -196,27 +196,10 @@ impl Cli {
 			result
 		};
 
-		// Handle the result.
-		let wait = result.map_err(|source| tg::error!(!source, "failed to await the process"))?;
-
-		// Return an error if necessary.
-		if let Some(error) = wait.error {
-			return Err(error);
-		}
-		match &wait.exit {
-			Some(tg::process::Exit::Code { code }) if *code != 0 => {
-				return Err(tg::error!("the process exited with code {code}"));
-			},
-			Some(tg::process::Exit::Signal { signal }) => {
-				return Err(tg::error!("the process exited with signal {signal}"));
-			},
-			_ => (),
-		}
-
 		// Get the output.
-		let output: tg::Value = wait
-			.output
-			.ok_or_else(|| tg::error!("expected the output to be set"))?;
+		let output = result
+			.map_err(|source| tg::error!(!source, "failed to await the process"))?
+			.into_output()?;
 
 		// Check out the output if requested.
 		if let Some(path) = options.checkout {

--- a/packages/cli/src/process/output.rs
+++ b/packages/cli/src/process/output.rs
@@ -17,27 +17,8 @@ impl Cli {
 		// Get the process.
 		let process = tg::Process::new(args.process, None, None, None, None);
 
-		// Await the process.
-		let wait = process.wait(&handle).await?;
-
-		// Return an error if necessary.
-		if let Some(error) = wait.error {
-			return Err(error);
-		}
-		match &wait.exit {
-			Some(tg::process::Exit::Code { code }) if *code != 0 => {
-				return Err(tg::error!("the process exited with code {code}"));
-			},
-			Some(tg::process::Exit::Signal { signal }) => {
-				return Err(tg::error!("the process exited with signal {signal}"));
-			},
-			_ => (),
-		}
-
 		// Get the output.
-		let output: tg::Value = wait
-			.output
-			.ok_or_else(|| tg::error!("expected the output to be set"))?;
+		let output = process.output(&handle).await?;
 
 		// Print the output.
 		let stdout = std::io::stdout();

--- a/packages/cli/src/process/run.rs
+++ b/packages/cli/src/process/run.rs
@@ -276,7 +276,7 @@ where
 		async move {
 			if stdout == stderr {
 				return Ok(());
-			};
+			}
 			stdio_task_inner(&handle, &stderr, remote, tokio::io::stderr()).await?;
 			Ok::<_, tg::Error>(())
 		}

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -165,10 +165,9 @@ impl Cli {
 		let mut command = if let tg::Object::Command(command) = object {
 			let object = command.object(&handle).await?;
 			command_env = Some(object.env.clone());
-			tg::Command::builder(object.host.clone())
+			tg::Command::builder(object.host.clone(), object.executable.clone())
 				.args(object.args.clone())
 				.cwd(object.cwd.clone())
-				.executable(object.executable.clone())
 				.mounts(object.mounts.clone())
 				.stdin(object.stdin.clone())
 		} else {
@@ -246,9 +245,7 @@ impl Cli {
 			let host = "js";
 
 			// Create the command.
-			tg::Command::builder(host)
-				.arg(target.into())
-				.executable(Some(executable))
+			tg::Command::builder(host, executable).arg(target.into())
 		};
 
 		// Get the args.

--- a/packages/client/src/artifact/archive.rs
+++ b/packages/client/src/artifact/archive.rs
@@ -45,7 +45,6 @@ impl tg::Artifact {
 				.map(|compression| compression.to_string())
 				.into(),
 		];
-		let executable = tg::command::Executable::Path("archive".into());
 		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/artifact/archive.rs
+++ b/packages/client/src/artifact/archive.rs
@@ -17,8 +17,15 @@ impl tg::Artifact {
 		H: tg::Handle,
 	{
 		let command = self.archive_command(format, compression);
-		let arg = tg::process::build::Arg::default();
-		let output = tg::Process::build(handle, &command, arg).await?;
+		let arg = tg::process::spawn::Arg {
+			command: Some(command.id(handle).await?),
+			..Default::default()
+		};
+		let output = tg::Process::spawn(handle, arg)
+			.await?
+			.wait(handle)
+			.await?
+			.into_output()?;
 		let blob = output.try_into()?;
 		Ok(blob)
 	}
@@ -38,6 +45,7 @@ impl tg::Artifact {
 				.map(|compression| compression.to_string())
 				.into(),
 		];
+		let executable = tg::command::Executable::Path("archive".into());
 		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/artifact/archive.rs
+++ b/packages/client/src/artifact/archive.rs
@@ -30,15 +30,15 @@ impl tg::Artifact {
 		compression: Option<tg::blob::compress::Format>,
 	) -> tg::Command {
 		let host = "builtin";
+		let executable = tg::command::Executable::Path("archive".into());
 		let args = vec![
-			"archive".into(),
 			self.clone().into(),
 			format.to_string().into(),
 			compression
 				.map(|compression| compression.to_string())
 				.into(),
 		];
-		tg::Command::builder(host).args(args).build()
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }
 

--- a/packages/client/src/artifact/bundle.rs
+++ b/packages/client/src/artifact/bundle.rs
@@ -16,7 +16,8 @@ impl tg::Artifact {
 	#[must_use]
 	pub fn bundle_command(&self) -> tg::Command {
 		let host = "builtin";
+		let executable = tg::command::Executable::Path("bundle".into());
 		let args = vec!["bundle".into(), self.clone().into()];
-		tg::Command::builder(host).args(args).build()
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/artifact/checksum.rs
+++ b/packages/client/src/artifact/checksum.rs
@@ -10,8 +10,15 @@ impl tg::Artifact {
 		H: tg::Handle,
 	{
 		let command = self.checksum_command(algorithm);
-		let arg = tg::process::build::Arg::default();
-		let output = tg::Process::build(handle, &command, arg).await?;
+		let arg = tg::process::spawn::Arg {
+			command: Some(command.id(handle).await?),
+			..Default::default()
+		};
+		let output = tg::Process::spawn(handle, arg)
+			.await?
+			.wait(handle)
+			.await?
+			.into_output()?;
 		let checksum = output
 			.try_unwrap_string()
 			.ok()

--- a/packages/client/src/artifact/checksum.rs
+++ b/packages/client/src/artifact/checksum.rs
@@ -23,11 +23,8 @@ impl tg::Artifact {
 	#[must_use]
 	pub fn checksum_command(&self, algorithm: tg::checksum::Algorithm) -> tg::Command {
 		let host = "builtin";
-		let args = vec![
-			"checksum".into(),
-			self.clone().into(),
-			algorithm.to_string().into(),
-		];
-		tg::Command::builder(host).args(args).build()
+		let executable = tg::command::Executable::Path("checksum".into());
+		let args = vec![self.clone().into(), algorithm.to_string().into()];
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/artifact/extract.rs
+++ b/packages/client/src/artifact/extract.rs
@@ -6,8 +6,15 @@ impl tg::Artifact {
 		H: tg::Handle,
 	{
 		let command = Self::extract_command(blob);
-		let arg = tg::process::build::Arg::default();
-		let output = tg::Process::build(handle, &command, arg).await?;
+		let arg = tg::process::spawn::Arg {
+			command: Some(command.id(handle).await?),
+			..Default::default()
+		};
+		let output = tg::Process::spawn(handle, arg)
+			.await?
+			.wait(handle)
+			.await?
+			.into_output()?;
 		let artifact = output.try_into()?;
 		Ok(artifact)
 	}
@@ -15,8 +22,8 @@ impl tg::Artifact {
 	#[must_use]
 	pub fn extract_command(blob: &tg::Blob) -> tg::Command {
 		let host = "builtin";
-		let executable = tg::command::Executable::Path("extract".into());
 		let args = vec![blob.clone().into()];
+		let executable = tg::command::Executable::Path("extract".into());
 		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/artifact/extract.rs
+++ b/packages/client/src/artifact/extract.rs
@@ -15,7 +15,8 @@ impl tg::Artifact {
 	#[must_use]
 	pub fn extract_command(blob: &tg::Blob) -> tg::Command {
 		let host = "builtin";
-		let args = vec!["extract".into(), blob.clone().into()];
-		tg::Command::builder(host).args(args).build()
+		let executable = tg::command::Executable::Path("extract".into());
+		let args = vec![blob.clone().into()];
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/blob/checksum.rs
+++ b/packages/client/src/blob/checksum.rs
@@ -23,11 +23,8 @@ impl tg::Blob {
 	#[must_use]
 	pub fn checksum_command(&self, algorithm: tg::checksum::Algorithm) -> tg::Command {
 		let host = "builtin";
-		let args = vec![
-			"checksum".into(),
-			self.clone().into(),
-			algorithm.to_string().into(),
-		];
-		tg::Command::builder(host).args(args).build()
+		let executable = tg::command::Executable::Path("checksum".into());
+		let args = vec![self.clone().into(), algorithm.to_string().into()];
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/blob/checksum.rs
+++ b/packages/client/src/blob/checksum.rs
@@ -10,8 +10,15 @@ impl tg::Blob {
 		H: tg::Handle,
 	{
 		let command = self.checksum_command(algorithm);
-		let arg = tg::process::build::Arg::default();
-		let output = tg::Process::build(handle, &command, arg).await?;
+		let arg = tg::process::spawn::Arg {
+			command: Some(command.id(handle).await?),
+			..Default::default()
+		};
+		let output = tg::Process::spawn(handle, arg)
+			.await?
+			.wait(handle)
+			.await?
+			.into_output()?;
 		let checksum = output
 			.try_unwrap_string()
 			.ok()
@@ -23,8 +30,8 @@ impl tg::Blob {
 	#[must_use]
 	pub fn checksum_command(&self, algorithm: tg::checksum::Algorithm) -> tg::Command {
 		let host = "builtin";
-		let executable = tg::command::Executable::Path("checksum".into());
 		let args = vec![self.clone().into(), algorithm.to_string().into()];
+		let executable = tg::command::Executable::Path("checksum".into());
 		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/blob/compress.rs
+++ b/packages/client/src/blob/compress.rs
@@ -27,12 +27,9 @@ impl tg::Blob {
 	#[must_use]
 	pub fn compress_command(&self, format: tg::blob::compress::Format) -> tg::Command {
 		let host = "builtin";
-		let args = vec![
-			"compress".into(),
-			self.clone().into(),
-			format.to_string().into(),
-		];
-		tg::Command::builder(host).args(args).build()
+		let executable = tg::command::Executable::Path("compress".into());
+		let args = vec![self.clone().into(), format.to_string().into()];
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }
 

--- a/packages/client/src/blob/decompress.rs
+++ b/packages/client/src/blob/decompress.rs
@@ -15,7 +15,8 @@ impl tg::Blob {
 	#[must_use]
 	pub fn decompress_command(&self) -> tg::Command {
 		let host = "builtin";
-		let args = vec!["decompress".into(), self.clone().into()];
-		tg::Command::builder(host).args(args).build()
+		let executable = tg::command::Executable::Path("decompress".into());
+		let args = vec![self.clone().into()];
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/blob/decompress.rs
+++ b/packages/client/src/blob/decompress.rs
@@ -6,8 +6,15 @@ impl tg::Blob {
 		H: tg::Handle,
 	{
 		let command = self.decompress_command();
-		let arg = tg::process::build::Arg::default();
-		let output = tg::Process::build(handle, &command, arg).await?;
+		let arg = tg::process::spawn::Arg {
+			command: Some(command.id(handle).await?),
+			..Default::default()
+		};
+		let output = tg::Process::spawn(handle, arg)
+			.await?
+			.wait(handle)
+			.await?
+			.into_output()?;
 		let blob = output.try_into()?;
 		Ok(blob)
 	}
@@ -15,8 +22,8 @@ impl tg::Blob {
 	#[must_use]
 	pub fn decompress_command(&self) -> tg::Command {
 		let host = "builtin";
-		let executable = tg::command::Executable::Path("decompress".into());
 		let args = vec![self.clone().into()];
+		let executable = tg::command::Executable::Path("decompress".into());
 		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/blob/download.rs
+++ b/packages/client/src/blob/download.rs
@@ -7,11 +7,16 @@ impl tg::Blob {
 		H: tg::Handle,
 	{
 		let command = Self::download_command(url);
-		let arg = tg::process::build::Arg {
+		let arg = tg::process::spawn::Arg {
 			checksum: Some(checksum.clone()),
+			command: Some(command.id(handle).await?),
 			..Default::default()
 		};
-		let output = tg::Process::build(handle, &command, arg).await?;
+		let output = tg::Process::spawn(handle, arg)
+			.await?
+			.wait(handle)
+			.await?
+			.into_output()?;
 		let blob = output
 			.try_unwrap_object()
 			.ok()
@@ -23,8 +28,8 @@ impl tg::Blob {
 	#[must_use]
 	pub fn download_command(url: &Url) -> tg::Command {
 		let host = "builtin";
+		let args = vec![url.to_string().into()];
 		let executable = tg::command::Executable::Path("download".into());
-		let args = vec!["download".into(), url.to_string().into()];
 		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/blob/download.rs
+++ b/packages/client/src/blob/download.rs
@@ -23,7 +23,8 @@ impl tg::Blob {
 	#[must_use]
 	pub fn download_command(url: &Url) -> tg::Command {
 		let host = "builtin";
+		let executable = tg::command::Executable::Path("download".into());
 		let args = vec!["download".into(), url.to_string().into()];
-		tg::Command::builder(host).args(args).build()
+		tg::Command::builder(host, executable).args(args).build()
 	}
 }

--- a/packages/client/src/command/builder.rs
+++ b/packages/client/src/command/builder.rs
@@ -6,7 +6,7 @@ pub struct Builder {
 	args: Vec<tg::Value>,
 	cwd: Option<PathBuf>,
 	env: BTreeMap<String, tg::Value>,
-	executable: Option<tg::command::Executable>,
+	executable: tg::command::Executable,
 	host: String,
 	mounts: Vec<tg::command::Mount>,
 	stdin: Option<tg::Blob>,
@@ -15,12 +15,12 @@ pub struct Builder {
 
 impl Builder {
 	#[must_use]
-	pub fn new(host: impl Into<String>) -> Self {
+	pub fn new(host: impl Into<String>, executable: impl Into<tg::command::Executable>) -> Self {
 		Self {
 			args: Vec::new(),
 			cwd: None,
 			env: BTreeMap::new(),
-			executable: None,
+			executable: executable.into(),
 			host: host.into(),
 			mounts: Vec::new(),
 			stdin: None,
@@ -67,7 +67,7 @@ impl Builder {
 	}
 
 	#[must_use]
-	pub fn executable(mut self, executable: impl Into<Option<tg::command::Executable>>) -> Self {
+	pub fn executable(mut self, executable: impl Into<tg::command::Executable>) -> Self {
 		self.executable = executable.into();
 		self
 	}

--- a/packages/client/src/command/data.rs
+++ b/packages/client/src/command/data.rs
@@ -16,8 +16,7 @@ pub struct Command {
 	#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
 	pub env: tg::value::data::Map,
 
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub executable: Option<tg::command::data::Executable>,
+	pub executable: tg::command::data::Executable,
 
 	pub host: String,
 
@@ -65,10 +64,7 @@ impl Command {
 
 	#[must_use]
 	pub fn children(&self) -> BTreeSet<tg::object::Id> {
-		let executable = self
-			.executable
-			.iter()
-			.flat_map(tg::command::data::Executable::children);
+		let executable = self.executable.children();
 		let args = self.args.iter().flat_map(tg::value::Data::children);
 		let env = self.env.values().flat_map(tg::value::Data::children);
 		let mounts = self

--- a/packages/client/src/command/object.rs
+++ b/packages/client/src/command/object.rs
@@ -8,7 +8,7 @@ pub struct Command {
 	pub args: tg::value::Array,
 	pub cwd: Option<PathBuf>,
 	pub env: tg::value::Map,
-	pub executable: Option<tg::command::Executable>,
+	pub executable: tg::command::Executable,
 	pub host: String,
 	pub mounts: Vec<tg::command::Mount>,
 	pub stdin: Option<tg::Blob>,
@@ -39,11 +39,7 @@ impl Command {
 	#[must_use]
 	pub fn children(&self) -> Vec<tg::Object> {
 		std::iter::empty()
-			.chain(
-				self.executable
-					.iter()
-					.flat_map(tg::command::Executable::object),
-			)
+			.chain(self.executable.object())
 			.chain(self.args.iter().flat_map(tg::Value::objects))
 			.chain(self.env.values().flat_map(tg::Value::objects))
 			.chain(self.mounts.iter().flat_map(tg::command::Mount::object))
@@ -99,7 +95,7 @@ impl TryFrom<Data> for Command {
 			.into_iter()
 			.map(|(key, data)| Ok::<_, tg::Error>((key, data.try_into()?)))
 			.try_collect()?;
-		let executable = data.executable.map(Into::into);
+		let executable = data.executable.into();
 		let host = data.host;
 		let mounts = data.mounts.into_iter().map(Into::into).collect();
 		let stdin = data.stdin.map(tg::Blob::with_id);

--- a/packages/client/src/process.rs
+++ b/packages/client/src/process.rs
@@ -167,6 +167,15 @@ impl Process {
 	{
 		handle.wait_process(&self.id).await?.try_into()
 	}
+
+	pub async fn output<H>(&self, handle: &H) -> tg::Result<tg::Value>
+	where
+		H: tg::Handle,
+	{
+		let wait = self.wait(handle).await?;
+		let output = wait.into_output()?;
+		Ok(output)
+	}
 }
 
 impl Deref for Process {

--- a/packages/client/src/process/run.rs
+++ b/packages/client/src/process/run.rs
@@ -58,23 +58,20 @@ impl tg::Process {
 		}
 		builder = builder.env(env);
 		let mut command_mounts = vec![];
-		let mut process_mount_data = vec![];
-		// If there are mounts in the arg, use those and only those.
+		let mut process_mounts = vec![];
 		if let Some(mounts) = arg.mounts {
 			for mount in mounts {
 				match mount {
-					Either::Left(process_mount) => process_mount_data.push(process_mount.data()),
-					Either::Right(command_mount) => command_mounts.push(command_mount),
+					Either::Left(mount) => process_mounts.push(mount.data()),
+					Either::Right(mount) => command_mounts.push(mount),
 				}
 			}
 		} else {
-			// If the arg mounts were None, check if there are command mounts.
 			if let Some(mounts) = command.as_ref().map(|command| command.mounts.clone()) {
 				command_mounts = mounts;
 			}
-			// Check if there are process mounts.
 			if let Some(mounts) = state.as_ref().map(|state| state.mounts.clone()) {
-				process_mount_data = mounts.iter().map(super::mount::Mount::data).collect();
+				process_mounts = mounts.iter().map(super::mount::Mount::data).collect();
 			}
 		}
 		builder = builder.mounts(command_mounts);
@@ -126,7 +123,7 @@ impl tg::Process {
 			cached: arg.cached,
 			checksum,
 			command: Some(command_id),
-			mounts: process_mount_data,
+			mounts: process_mounts,
 			network,
 			parent: arg.parent,
 			remote: arg.remote,

--- a/packages/client/src/process/run.rs
+++ b/packages/client/src/process/run.rs
@@ -30,7 +30,7 @@ impl tg::Process {
 			None
 		};
 		let command = command.object(handle).await?;
-		let mut builder = tg::Command::builder(command.host.clone());
+		let mut builder = tg::Command::builder(command.host.clone(), command.executable.clone());
 		builder = builder.args(command.args.clone());
 		let cwd = std::env::current_dir()
 			.map_err(|source| tg::error!(!source, "failed to get the current directory"))?;
@@ -48,7 +48,6 @@ impl tg::Process {
 			builder = builder.mounts(object.mounts.clone());
 		}
 		builder = builder.env(env);
-		builder = builder.executable(command.executable.clone());
 		builder = builder.host(command.host.clone());
 		builder = builder.mounts(command.mounts.clone());
 		let stdin = if arg.stdin.is_none() {

--- a/packages/client/src/process/run.rs
+++ b/packages/client/src/process/run.rs
@@ -40,39 +40,21 @@ impl tg::Process {
 		for (key, value) in std::env::vars() {
 			tg::mutation::mutate(&mut env, key, value.into())?;
 		}
-		// Inherit from current command.
-		let mut current_command_stdin = None;
+		for (key, value) in command.env.clone() {
+			tg::mutation::mutate(&mut env, key, value)?;
+		}
 		if let Some(current) = state.as_ref().map(|state| state.command.clone()) {
 			let object = current.object(handle).await?;
 			if !object.mounts.is_empty() {
 				builder = builder.mounts(object.mounts.clone());
 			}
-			if !object.env.is_empty() {
-				for (key, value) in object.env.clone() {
-					tg::mutation::mutate(&mut env, key, value)?;
-				}
-			}
-			if let Some(stdin) = &object.stdin {
-				current_command_stdin = Some(stdin.clone());
-			}
 		}
-		// Inherit from arg after current command.
-		for (key, value) in command.env.clone() {
-			tg::mutation::mutate(&mut env, key, value)?;
-		}
-		// Inherit from arg.
 		builder = builder.env(env);
 		builder = builder.executable(command.executable.clone());
 		builder = builder.host(command.host.clone());
 		builder = builder.mounts(command.mounts.clone());
 		let stdin = if arg.stdin.is_none() {
-			if command.stdin.is_some() {
-				command.stdin.clone()
-			} else if current_command_stdin.is_some() {
-				current_command_stdin.clone()
-			} else {
-				None
-			}
+			command.stdin.clone()
 		} else {
 			None
 		};

--- a/packages/client/src/process/run.rs
+++ b/packages/client/src/process/run.rs
@@ -45,9 +45,7 @@ impl tg::Process {
 		}
 		if let Some(current) = state.as_ref().map(|state| state.command.clone()) {
 			let object = current.object(handle).await?;
-			if !object.mounts.is_empty() {
-				builder = builder.mounts(object.mounts.clone());
-			}
+			builder = builder.mounts(object.mounts.clone());
 		}
 		builder = builder.env(env);
 		builder = builder.executable(command.executable.clone());

--- a/packages/client/src/value/print.rs
+++ b/packages/client/src/value/print.rs
@@ -534,13 +534,11 @@ where
 		if !object.env.is_empty() {
 			self.map_entry("env", |s| s.map(&object.env))?;
 		}
-		if let Some(executable) = &object.executable {
-			self.map_entry("executable", |s| match executable {
-				tg::command::Executable::Artifact(artifact) => s.artifact(artifact),
-				tg::command::Executable::Module(module) => s.command_module(module),
-				tg::command::Executable::Path(path) => s.string(path.to_string_lossy().as_ref()),
-			})?;
-		}
+		self.map_entry("executable", |s| match &object.executable {
+			tg::command::Executable::Artifact(artifact) => s.artifact(artifact),
+			tg::command::Executable::Module(module) => s.command_module(module),
+			tg::command::Executable::Path(path) => s.string(path.to_string_lossy().as_ref()),
+		})?;
 		self.map_entry("host", |s| s.string(&object.host))?;
 		if !object.mounts.is_empty() {
 			self.map_entry("mounts", |s| {

--- a/packages/runtime/src/artifact.ts
+++ b/packages/runtime/src/artifact.ts
@@ -42,7 +42,7 @@ export namespace Artifact {
 		format: ArchiveFormat,
 		compression?: tg.Blob.CompressionFormat,
 	): Promise<tg.Blob> => {
-		const args = ["archive", artifact, format];
+		const args: Array<tg.Value> = [artifact, format];
 		if (compression !== undefined) {
 			if (format === "zip") {
 				throw new Error("compression is not supported for zip archives");
@@ -52,6 +52,7 @@ export namespace Artifact {
 		let value = await tg.build({
 			args,
 			env: undefined,
+			executable: "archive",
 			host: "builtin",
 		});
 		tg.assert(tg.Blob.is(value));
@@ -60,8 +61,9 @@ export namespace Artifact {
 
 	export let extract = async (blob: tg.Blob): Promise<Artifact> => {
 		let value = await tg.build({
-			args: ["extract", blob],
+			args: [blob],
 			env: undefined,
+			executable: "extract",
 			host: "builtin",
 		});
 		tg.assert(Artifact.is(value));
@@ -70,8 +72,9 @@ export namespace Artifact {
 
 	export let bundle = async (artifact: Artifact): Promise<Artifact> => {
 		let value = await tg.build({
-			args: ["bundle", artifact],
+			args: [artifact],
 			env: undefined,
+			executable: "bundle",
 			host: "builtin",
 		});
 		tg.assert(Artifact.is(value));
@@ -83,8 +86,9 @@ export namespace Artifact {
 		algorithm: tg.Checksum.Algorithm,
 	): Promise<tg.Checksum> => {
 		let value = await tg.build({
-			args: ["checksum", artifact, algorithm],
+			args: [artifact, algorithm],
 			env: undefined,
+			executable: "checksum",
 			host: "builtin",
 		});
 		return value as tg.Checksum;

--- a/packages/runtime/src/blob.ts
+++ b/packages/runtime/src/blob.ts
@@ -74,8 +74,9 @@ export namespace Blob {
 		format: CompressionFormat,
 	): Promise<Blob> => {
 		let value = await tg.build({
-			args: ["compress", blob, format],
+			args: [blob, format],
 			env: undefined,
+			executable: "compress",
 			host: "builtin",
 		});
 		tg.assert(tg.Blob.is(value));
@@ -84,8 +85,9 @@ export namespace Blob {
 
 	export let decompress = async (blob: Blob): Promise<Blob> => {
 		let value = await tg.build({
-			args: ["decompress", blob],
+			args: [blob],
 			env: undefined,
+			executable: "decompress",
 			host: "builtin",
 		});
 		tg.assert(tg.Blob.is(value));
@@ -97,9 +99,10 @@ export namespace Blob {
 		checksum: tg.Checksum,
 	): Promise<Blob> => {
 		let value = await tg.build({
-			args: ["download", url],
+			args: [url],
 			checksum,
 			env: undefined,
+			executable: "download",
 			host: "builtin",
 		});
 		tg.assert(tg.Blob.is(value));
@@ -111,8 +114,9 @@ export namespace Blob {
 		algorithm: tg.Checksum.Algorithm,
 	): Promise<tg.Checksum> => {
 		let value = await tg.build({
-			args: ["checksum", blob, algorithm],
+			args: [blob, algorithm],
 			env: undefined,
+			executable: "checksum",
 			host: "builtin",
 		});
 		return value as tg.Checksum;

--- a/packages/runtime/src/command.ts
+++ b/packages/runtime/src/command.ts
@@ -137,6 +137,9 @@ export class Command<
 		if (!host) {
 			throw new Error("cannot create a command without a host");
 		}
+		if (!executable) {
+			throw new Error("cannot create an executable without a host");
+		}
 		let stdin = arg.stdin !== undefined ? await tg.blob(arg.stdin) : undefined;
 		let user = arg.user;
 		let object = {

--- a/packages/runtime/src/command.ts
+++ b/packages/runtime/src/command.ts
@@ -138,7 +138,7 @@ export class Command<
 			throw new Error("cannot create a command without a host");
 		}
 		if (!executable) {
-			throw new Error("cannot create an executable without a host");
+			throw new Error("cannot create an command without an executable");
 		}
 		let stdin = arg.stdin !== undefined ? await tg.blob(arg.stdin) : undefined;
 		let user = arg.user;

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -121,6 +121,7 @@ export class Process {
 
 	static async run(...args: tg.Args<tg.Process.RunArg>): Promise<tg.Value> {
 		let state = tg.Process.current.#state!;
+		let currentCommand = await Process.current.command();
 		let arg = await Process.runArg(...args);
 		let checksum = arg.checksum;
 		let processMounts: Array<tg.Process.Mount> = [];
@@ -151,6 +152,7 @@ export class Process {
 				}
 			}
 		} else {
+			commandMounts = await currentCommand.mounts();
 			processMounts = state.mounts;
 		}
 		let processStdin = state.stdin;
@@ -160,6 +162,8 @@ export class Process {
 			if (arg.stdin !== undefined) {
 				commandStdin = arg.stdin;
 			}
+		} else {
+			commandStdin = await currentCommand.stdin();
 		}
 		let stderr = state.stdout;
 		if ("stderr" in arg) {
@@ -169,7 +173,6 @@ export class Process {
 		if ("stdout" in arg) {
 			stdout = arg.stdout;
 		}
-		let currentCommand = await Process.current.command();
 		let command = await tg.command(
 			{
 				cwd: currentCommand.cwd(),
@@ -452,6 +455,7 @@ export namespace Process {
 		stderr?: undefined;
 		stdin?: tg.Blob.Arg | undefined;
 		stdout?: undefined;
+		user?: string | undefined;
 	};
 
 	export type State = {

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -37,7 +37,6 @@ export class Process {
 			commandStdin = arg.stdin;
 		}
 		let command = await tg.command(
-			arg.command,
 			"args" in arg ? { args: arg.args } : undefined,
 			"cwd" in arg ? { cwd: arg.cwd } : undefined,
 			"env" in arg ? { env: arg.env } : undefined,
@@ -176,7 +175,6 @@ export class Process {
 				cwd: currentCommand.cwd(),
 				env: currentCommand.env(),
 			},
-			arg.command,
 			"args" in arg ? { args: arg.args } : undefined,
 			"cwd" in arg ? { cwd: arg.cwd } : undefined,
 			"env" in arg ? { env: arg.env } : undefined,
@@ -423,7 +421,6 @@ export namespace Process {
 	export type BuildArgObject = {
 		args?: Array<tg.Value> | undefined;
 		checksum?: tg.Checksum | undefined;
-		command?: tg.Command.Arg | undefined;
 		cwd?: string | undefined;
 		env?: tg.MaybeNestedArray<tg.MaybeMutationMap> | undefined;
 		executable?: tg.Command.ExecutableArg | undefined;
@@ -444,7 +441,6 @@ export namespace Process {
 	export type RunArgObject = {
 		args?: Array<tg.Value> | undefined;
 		checksum?: tg.Checksum | undefined;
-		command?: tg.Command.Arg | undefined;
 		cwd?: string | undefined;
 		env?: tg.MaybeNestedArray<tg.MaybeMutationMap> | undefined;
 		executable?: tg.Command.ExecutableArg | undefined;

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -42,6 +42,7 @@ export class Process {
 			"env" in arg ? { env: arg.env } : undefined,
 			"executable" in arg ? { executable: arg.executable } : undefined,
 			"host" in arg ? { host: arg.host } : undefined,
+			"user" in arg ? { user: arg.user } : undefined,
 			commandMounts !== undefined ? { mounts: commandMounts } : undefined,
 			commandStdin !== undefined ? { stdin: commandStdin } : undefined,
 		);
@@ -183,6 +184,7 @@ export class Process {
 			"env" in arg ? { env: arg.env } : undefined,
 			"executable" in arg ? { executable: arg.executable } : undefined,
 			"host" in arg ? { host: arg.host } : undefined,
+			"user" in arg ? { user: arg.user } : undefined,
 			commandMounts !== undefined ? { mounts: commandMounts } : undefined,
 			commandStdin !== undefined ? { stdin: commandStdin } : undefined,
 		);
@@ -431,6 +433,7 @@ export namespace Process {
 		mounts?: Array<string | tg.Template | tg.Command.Mount> | undefined;
 		network?: boolean | undefined;
 		stdin?: tg.Blob.Arg | undefined;
+		user?: string | undefined;
 	};
 
 	export type RunArg =

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -106,7 +106,7 @@ export class Process {
 						executable: await tg.symlink("/bin/sh"),
 					};
 				} else if (arg instanceof tg.Command) {
-					return { command: await arg.object() };
+					return { ...(await arg.object()) };
 				} else {
 					return arg;
 				}
@@ -244,7 +244,7 @@ export class Process {
 						executable: await tg.symlink("/bin/sh"),
 					};
 				} else if (arg instanceof tg.Command) {
-					return { command: await arg.object() };
+					return { ...(await arg.object()) };
 				} else {
 					return arg;
 				}

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -1016,6 +1016,47 @@ declare namespace tg {
 	export namespace Process {
 		export type Id = string;
 
+		export type BuildArg =
+			| undefined
+			| string
+			| tg.Artifact
+			| tg.Template
+			| tg.Command
+			| BuildArgObject;
+
+		
+		export type BuildArgObject = {
+			/** The command's arguments. */
+			args?: Array<tg.Value> | undefined;
+
+			/** If a checksum of the process's output is provided, then the process can be cached even if it is not sandboxed. */
+			checksum?: tg.Checksum | undefined;
+
+			/** The command's working directory. **/
+			cwd?: string | undefined;
+			
+			/** The command's environment. */
+			env?: tg.MaybeNestedArray<tg.MaybeMutationMap> | undefined;
+			
+			/** The command's executable. */
+			executable?: tg.Command.ExecutableArg | undefined;
+			
+			/** The command's host. */
+			host?: string | undefined;
+			
+			/** The command's mounts. */
+			mounts?: Array<string | tg.Template | tg.Command.Mount> | undefined;
+			
+			/** Configure whether the process has access to the network. **/
+			network?: boolean | undefined;
+			
+			/** Ignore stdin, or set it to a blob. */
+			stdin?: tg.Blob.Arg | undefined;
+			
+			/** The command's user. */
+			user?: string | undefined;
+		};
+
 		export type RunArg =
 			| undefined
 			| string
@@ -1030,9 +1071,6 @@ declare namespace tg {
 
 			/** If a checksum of the process's output is provided, then the process can be cached even if it is not sandboxed. */
 			checksum?: tg.Checksum | undefined;
-
-			/** The command to spawn. **/
-			command?: tg.Command.Arg | undefined;
 
 			/** The command's working directory. **/
 			cwd?: string | undefined;

--- a/packages/sandbox/src/darwin.rs
+++ b/packages/sandbox/src/darwin.rs
@@ -156,7 +156,7 @@ pub(crate) async fn wait(child: &mut Child) -> std::io::Result<ExitStatus> {
 		let mut status = 0;
 		if libc::waitpid(pid, std::ptr::addr_of_mut!(status), 0) == -1 {
 			return Err(std::io::Error::last_os_error());
-		};
+		}
 		if libc::WIFEXITED(status) {
 			let code = libc::WEXITSTATUS(status);
 			Ok(ExitStatus::Code(code))

--- a/packages/server/src/artifact/cache.rs
+++ b/packages/server/src/artifact/cache.rs
@@ -187,7 +187,7 @@ impl Server {
 					.try_into()
 					.map_err(|_| tg::error!("expected a graph"))?;
 					state.graphs.insert(graph.clone(), data);
-				};
+				}
 				Either::Left((graph, node))
 			},
 

--- a/packages/server/src/artifact/checkout.rs
+++ b/packages/server/src/artifact/checkout.rs
@@ -226,7 +226,7 @@ impl Server {
 					.try_into()
 					.map_err(|_| tg::error!("expected a graph"))?;
 					state.graphs.insert(graph.clone(), data);
-				};
+				}
 				Either::Left((graph, node))
 			},
 

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -255,12 +255,9 @@ impl Server {
 		} else {
 			expected.algorithm()
 		};
-		let args = vec![
-			"checksum".into(),
-			value.clone(),
-			algorithm.to_string().into(),
-		];
-		let command = tg::Command::builder(host).args(args).build();
+		let executable = tg::command::Executable::Path("checksum".into());
+		let args = vec![value.clone(), algorithm.to_string().into()];
+		let command = tg::Command::builder(host, executable).args(args).build();
 		let command_id = command
 			.id(self)
 			.await

--- a/packages/server/src/process/put.rs
+++ b/packages/server/src/process/put.rs
@@ -55,7 +55,7 @@ impl Server {
 				Self::put_process_postgres(database, id, arg, &now.format(&Rfc3339).unwrap())
 					.await?;
 			},
-		};
+		}
 
 		Ok(())
 	}

--- a/packages/server/src/runtime/builtin/archive.rs
+++ b/packages/server/src/runtime/builtin/archive.rs
@@ -16,7 +16,7 @@ impl Runtime {
 
 		// Get the artifact.
 		let artifact: tg::Artifact = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.clone()
 			.try_into()
@@ -25,7 +25,7 @@ impl Runtime {
 
 		// Get the format.
 		let format = args
-			.get(2)
+			.get(1)
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.try_unwrap_string_ref()
 			.ok()

--- a/packages/server/src/runtime/builtin/bundle.rs
+++ b/packages/server/src/runtime/builtin/bundle.rs
@@ -16,7 +16,7 @@ impl Runtime {
 
 		// Get the artifact.
 		let artifact: tg::Artifact = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.clone()
 			.try_into()

--- a/packages/server/src/runtime/builtin/checksum.rs
+++ b/packages/server/src/runtime/builtin/checksum.rs
@@ -11,7 +11,7 @@ impl Runtime {
 
 		// Get the object.
 		let object = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.clone()
 			.try_unwrap_object()
@@ -20,7 +20,7 @@ impl Runtime {
 
 		// Get the algorithm.
 		let algorithm = args
-			.get(2)
+			.get(1)
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.try_unwrap_string_ref()
 			.ok()

--- a/packages/server/src/runtime/builtin/compress.rs
+++ b/packages/server/src/runtime/builtin/compress.rs
@@ -14,7 +14,7 @@ impl Runtime {
 
 		// Get the blob.
 		let blob: tg::Blob = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.clone()
 			.try_into()
@@ -23,7 +23,7 @@ impl Runtime {
 
 		// Get the format.
 		let format = args
-			.get(2)
+			.get(1)
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.try_unwrap_string_ref()
 			.ok()

--- a/packages/server/src/runtime/builtin/decompress.rs
+++ b/packages/server/src/runtime/builtin/decompress.rs
@@ -15,7 +15,7 @@ impl Runtime {
 
 		// Get the blob.
 		let blob: tg::Blob = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.clone()
 			.try_into()

--- a/packages/server/src/runtime/builtin/download.rs
+++ b/packages/server/src/runtime/builtin/download.rs
@@ -25,7 +25,7 @@ impl Runtime {
 
 		// Get the URL.
 		let url = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.try_unwrap_string_ref()
 			.ok()

--- a/packages/server/src/runtime/builtin/extract.rs
+++ b/packages/server/src/runtime/builtin/extract.rs
@@ -23,7 +23,7 @@ impl Runtime {
 
 		// Get the blob.
 		let blob: tg::Blob = args
-			.get(1)
+			.first()
 			.ok_or_else(|| tg::error!("invalid number of arguments"))?
 			.clone()
 			.try_into()
@@ -88,7 +88,7 @@ impl Runtime {
 			tg::artifact::archive::Format::Zip => {
 				self.extract_zip(&temp, reader).await?;
 			},
-		};
+		}
 
 		// Check in the temp.
 		let stream = self

--- a/packages/server/src/runtime/darwin.rs
+++ b/packages/server/src/runtime/darwin.rs
@@ -125,9 +125,7 @@ impl Runtime {
 		let mut env = render_env(&artifacts_path, &command.env)?;
 
 		// Render the executable.
-		let Some(executable) = command.executable else {
-			return Err(tg::error!("missing executable"));
-		};
+		let executable = command.executable;
 		let executable = match executable {
 			tg::command::data::Executable::Artifact(artifact) => {
 				render_value(&artifacts_path, &tg::object::Id::from(artifact).into())

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -120,8 +120,6 @@ impl Runtime {
 		let root = command
 			.executable(&self.server)
 			.await?
-			.as_ref()
-			.ok_or_else(|| tg::error!("expected the command to have an executable"))?
 			.try_unwrap_module_ref()
 			.ok()
 			.ok_or_else(|| tg::error!("expected the executable to be a module"))?

--- a/packages/server/src/runtime/linux.rs
+++ b/packages/server/src/runtime/linux.rs
@@ -316,10 +316,7 @@ impl Runtime {
 		let mut env = render_env(&artifacts_path, &command.env)?;
 
 		// Render the executable.
-		let Some(executable) = command.executable else {
-			return Err(tg::error!("missing executable"));
-		};
-		let executable = match executable {
+		let executable = match command.executable {
 			tg::command::data::Executable::Artifact(artifact) => {
 				render_value(&artifacts_path, &tg::object::Id::from(artifact).into())
 			},

--- a/packages/server/src/runtime/util.rs
+++ b/packages/server/src/runtime/util.rs
@@ -82,12 +82,9 @@ pub async fn compute_checksum(
 	}
 
 	let host = "builtin";
-	let args = vec![
-		"checksum".into(),
-		value.clone(),
-		algorithm.to_string().into(),
-	];
-	let command = tg::Command::builder(host).args(args).build();
+	let executable = tg::command::Executable::Path("checksum".into());
+	let args = vec![value.clone(), algorithm.to_string().into()];
+	let command = tg::Command::builder(host, executable).args(args).build();
 
 	// If the process is remote, push the command.
 	let remote = process.remote();

--- a/packages/server/src/runtime/util.rs
+++ b/packages/server/src/runtime/util.rs
@@ -130,12 +130,14 @@ pub async fn compute_checksum(
 		}
 	}
 
-	let arg = tg::process::build::Arg {
+	let arg = tg::process::spawn::Arg {
+		command: Some(command.id(runtime.server()).await?),
 		parent: Some(process.id().clone()),
 		remote: remote.cloned(),
 		..Default::default()
 	};
-	let output = tg::Process::build(runtime.server(), &command, arg).await?;
+	let process = tg::Process::spawn(runtime.server(), arg).await?;
+	let output = process.output(runtime.server()).await?;
 	let output = output
 		.try_unwrap_string()
 		.map_err(|source| tg::error!(!source, "expected a string"))?;


### PR DESCRIPTION
`tg::Process::run` must inherit mounts/env/stdin from the current command and the command passed in the args. The current implementation only inherits process mounts, not command mounts.