### PR TITLE
chore(runtime): remove superfluous symlink, expose tg.Args.apply

### DIFF
--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -125,11 +125,11 @@ export class Process {
 				) {
 					return {
 						args: ["-c", arg],
-						executable: await tg.symlink("/bin/sh"),
+						executable: "/bin/sh",
 					};
 				} else if (arg instanceof tg.Command) {
 					let object = await arg.object();
-					let ret: tg.Process.RunArgObject = {
+					let ret: tg.Process.BuildArgObject = {
 						args: object.args,
 						env: object.env,
 						executable: object.executable,
@@ -304,7 +304,7 @@ export class Process {
 				) {
 					return {
 						args: ["-c", arg],
-						executable: await tg.symlink("/bin/sh"),
+						executable: "/bin/sh",
 					};
 				} else if (arg instanceof tg.Command) {
 					let object = await arg.object();

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -914,6 +914,20 @@ declare namespace tg {
 		tg.Unresolved<tg.MaybeNestedArray<tg.ValueOrMaybeMutationMap<T>>>
 	>;
 
+	export namespace Args {
+		export type Rules<
+			T extends { [key: string]: tg.Value } = { [key: string]: tg.Value },
+		> = {
+			[K in keyof T]:
+				| tg.Mutation.Kind
+				| ((arg: T[K]) => tg.MaybePromise<tg.Mutation<T[K]>>);
+		};
+
+		export function apply<
+			T extends { [key: string]: tg.Value } = { [key: string]: tg.Value },
+		>(args: Array<tg.MaybeMutationMap<T>>, rules?: Rules<T>): Promise<T>;
+	}
+
 	/* Compute a checksum. */
 	export let checksum: (
 		input: string | Uint8Array | tg.Blob | tg.Artifact,


### PR DESCRIPTION
Fixes small errors in the process runArg code, and adds the tg.Args namespace to the `d.ts`.