### PR TITLE
fix: JS runtime error, logging, and signal handling

### DIFF
--- a/packages/messenger/src/either.rs
+++ b/packages/messenger/src/either.rs
@@ -1,6 +1,6 @@
 use crate::{BatchConfig, Error, Message, Messenger, StreamConfig, StreamPublishInfo};
 use bytes::Bytes;
-use futures::{FutureExt, Stream, TryFutureExt as _};
+use futures::{FutureExt as _, Stream, TryFutureExt as _};
 use tangram_either::Either;
 
 impl<L, R> Messenger for Either<L, R>

--- a/packages/messenger/src/memory.rs
+++ b/packages/messenger/src/memory.rs
@@ -2,7 +2,9 @@ use crate::{Acker, BatchConfig, Error, Message, StreamConfig, StreamInfo, Stream
 use async_broadcast as broadcast;
 use bytes::Bytes;
 use dashmap::DashMap;
-use futures::{FutureExt, StreamExt as _, TryFutureExt, TryStreamExt, future, stream};
+use futures::{
+	FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _, future, stream,
+};
 use num::ToPrimitive;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{Notify, RwLock};

--- a/packages/messenger/src/nats.rs
+++ b/packages/messenger/src/nats.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_nats as nats;
 use bytes::Bytes;
-use futures::{FutureExt, TryFutureExt, prelude::*};
+use futures::{FutureExt as _, TryFutureExt as _, prelude::*};
 use num::ToPrimitive;
 use std::error::Error as _;
 

--- a/packages/server/src/runtime.rs
+++ b/packages/server/src/runtime.rs
@@ -55,15 +55,13 @@ impl Runtime {
 
 		// If there is an error, then add it to the process's log.
 		if let Some(error) = &output.error {
-			let arg = tg::process::log::post::Arg {
-				bytes: error.to_string().into(),
-				remote: process.remote().cloned(),
-				stream: tg::process::log::Stream::Stderr,
-			};
-			self.server()
-				.try_post_process_log(process.id(), arg)
-				.await
-				.ok();
+			util::log(
+				self.server(),
+				process,
+				tg::process::log::Stream::Stderr,
+				format!("{error}\n"),
+			)
+			.await;
 		}
 
 		output

--- a/packages/server/src/runtime/builtin/compress.rs
+++ b/packages/server/src/runtime/builtin/compress.rs
@@ -1,6 +1,5 @@
-use crate::runtime::util;
-
 use super::Runtime;
+use crate::runtime::util;
 use std::{pin::Pin, time::Duration};
 use tangram_client as tg;
 use tangram_futures::read::shared_position_reader::SharedPositionReader;

--- a/packages/server/src/runtime/builtin/compress.rs
+++ b/packages/server/src/runtime/builtin/compress.rs
@@ -1,3 +1,5 @@
+use crate::runtime::util;
+
 use super::Runtime;
 use std::{pin::Pin, time::Duration};
 use tangram_client as tg;
@@ -54,15 +56,7 @@ impl Runtime {
 						total: Some(size),
 					};
 					let message = format!("{indicator}\n");
-					let arg = tg::process::log::post::Arg {
-						bytes: message.into(),
-						remote: process.remote().cloned(),
-						stream: tg::process::log::Stream::Stderr,
-					};
-					let result = server.try_post_process_log(process.id(), arg).await;
-					if let Err(error) = result {
-						tracing::error!(?error, "failed to post process log");
-					}
+					util::log(&server, &process, tg::process::log::Stream::Stderr, message).await;
 					tokio::time::sleep(Duration::from_secs(1)).await;
 				}
 			}
@@ -93,12 +87,14 @@ impl Runtime {
 
 		// Log that the compression finished.
 		let message = "finished compressing\n";
-		let arg = tg::process::log::post::Arg {
-			bytes: message.into(),
-			remote: process.remote().cloned(),
-			stream: tg::process::log::Stream::Stderr,
-		};
-		server.try_post_process_log(process.id(), arg).await.ok();
+		util::log(
+			server,
+			process,
+			tg::process::log::Stream::Stderr,
+			message.to_owned(),
+		)
+		.await;
+
 		Ok(blob.into())
 	}
 }

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -1,8 +1,7 @@
 use self::syscall::syscall;
-use crate::{Server, compiler::Compiler};
-use bytes::Bytes;
+use crate::{Server, compiler::Compiler, runtime::util};
 use futures::{
-	FutureExt as _, StreamExt as _, TryFutureExt as _,
+	FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt,
 	future::{self, LocalBoxFuture},
 	stream::FuturesUnordered,
 };
@@ -97,19 +96,26 @@ impl Runtime {
 		};
 
 		// Get the output.
-		let (error, exit, output) = match task.await.unwrap() {
+		let (exit, output) = match task.await.unwrap() {
 			Ok(output) => {
 				let exit = tg::process::Exit::SUCCESS;
-				(None, Some(exit), Some(output))
+				(Some(exit), Some(output))
 			},
 			Err(error) => {
 				let exit = tg::process::Exit::FAILURE;
-				(Some(error), Some(exit), None)
+				util::log(
+					&self.server,
+					process,
+					tg::process::log::Stream::Stderr,
+					format!("{error}\n"),
+				)
+				.await;
+				(Some(exit), None)
 			},
 		};
 
 		super::Output {
-			error,
+			error: None,
 			exit,
 			output,
 		}
@@ -148,34 +154,26 @@ impl Runtime {
 			let server = self.server.clone();
 			let process = process.clone();
 			async move {
-				let state = process.load(&server).await?;
-
 				while let Some(message) = log_receiver.recv().await {
-					let syscall::log::Message { mut contents, .. } = message;
-					match message.level {
+					let syscall::log::Message { contents, level } = message;
+					match level {
 						syscall::log::Level::Log => {
-							if matches!(&state.stdout, Some(tg::process::Stdio::Pty(_))) {
-								contents = contents.replace('\n', "\r\n");
-							}
-							let bytes = Bytes::from(contents);
-							let arg = tg::process::log::post::Arg {
-								bytes: bytes.clone(),
-								remote: process.remote().map(ToOwned::to_owned),
-								stream: tg::process::log::Stream::Stdout,
-							};
-							server.try_post_process_log(process.id(), arg).await.ok();
+							util::log(
+								&server,
+								&process,
+								tg::process::log::Stream::Stdout,
+								contents,
+							)
+							.await;
 						},
 						syscall::log::Level::Error => {
-							if matches!(&state.stderr, Some(tg::process::Stdio::Pty(_))) {
-								contents = contents.replace('\n', "\r\n");
-							}
-							let bytes = Bytes::from(contents);
-							let arg = tg::process::log::post::Arg {
-								bytes: bytes.clone(),
-								remote: process.remote().map(ToOwned::to_owned),
-								stream: tg::process::log::Stream::Stderr,
-							};
-							server.try_post_process_log(process.id(), arg).await.ok();
+							util::log(
+								&server,
+								&process,
+								tg::process::log::Stream::Stderr,
+								contents,
+							)
+							.await;
 						},
 					}
 				}
@@ -187,6 +185,36 @@ impl Runtime {
 			log_task_abort_handle.abort();
 		}
 
+		// Create the signal task.
+		let (rejection, _) = tokio::sync::watch::channel(None);
+		let signal_task = tokio::spawn({
+			let rejection = rejection.clone();
+			let server = self.server.clone();
+			let process = process.clone();
+			async move {
+				let arg = tg::process::signal::get::Arg {
+					remote: process.remote().cloned(),
+				};
+				let Ok(Some(stream)) = server
+					.try_get_process_signal_stream(process.id(), arg)
+					.await
+					.inspect_err(|error| tracing::error!(?error, "failed to get signal stream"))
+				else {
+					return;
+				};
+				let mut stream = pin!(stream);
+				if let Ok(Some(tg::process::signal::get::Event::Signal(signal))) =
+					stream.try_next().await
+				{
+					rejection
+						.send_replace(Some(tg::error!("process terminated with signal {signal}")));
+				}
+			}
+		});
+		scopeguard::defer! {
+			signal_task.abort();
+		}
+
 		// Create the state.
 		let state = Rc::new(State {
 			process: process.clone(),
@@ -196,7 +224,7 @@ impl Runtime {
 			log_sender: RefCell::new(Some(log_sender)),
 			main_runtime_handle,
 			modules: RefCell::new(Vec::new()),
-			rejection: tokio::sync::watch::channel(None).0,
+			rejection,
 			root,
 			server: self.server.clone(),
 		});
@@ -393,10 +421,7 @@ impl Runtime {
 			.map(Result::unwrap);
 		let result = match future::select(pin!(future), pin!(rejection)).await {
 			future::Either::Left((result, _)) => result,
-			future::Either::Right((error, _)) => Err(tg::error!(
-				source = error,
-				"an unhandled promise rejection occurred"
-			)),
+			future::Either::Right((error, _)) => Err(error),
 		};
 
 		// Stop and await the log task.

--- a/packages/server/src/runtime/js.rs
+++ b/packages/server/src/runtime/js.rs
@@ -1,7 +1,7 @@
 use self::syscall::syscall;
 use crate::{Server, compiler::Compiler, runtime::util};
 use futures::{
-	FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt,
+	FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
 	future::{self, LocalBoxFuture},
 	stream::FuturesUnordered,
 };

--- a/packages/server/src/runtime/js/syscall/process.rs
+++ b/packages/server/src/runtime/js/syscall/process.rs
@@ -1,3 +1,5 @@
+use crate::runtime::util;
+
 use super::State;
 use futures::TryStreamExt as _;
 use std::{pin::pin, rc::Rc, sync::Arc};
@@ -51,12 +53,13 @@ pub async fn spawn(
 							| tg::progress::Event::Update(indicator) => {
 								if indicator.name == "bytes" {
 									let message = format!("{indicator}\n");
-									let arg = tg::process::log::post::Arg {
-										bytes: message.into(),
-										remote: Some(remote.to_owned()),
-										stream: tg::process::log::Stream::Stderr,
-									};
-									server.try_post_process_log(parent.id(), arg).await.ok();
+									util::log(
+										&server,
+										&parent,
+										tg::process::log::Stream::Stderr,
+										message,
+									)
+									.await;
 								}
 							},
 							tg::progress::Event::Output(()) => {

--- a/packages/server/src/runtime/js/syscall/process.rs
+++ b/packages/server/src/runtime/js/syscall/process.rs
@@ -1,6 +1,5 @@
-use crate::runtime::util;
-
 use super::State;
+use crate::runtime::util;
 use futures::TryStreamExt as _;
 use std::{pin::pin, rc::Rc, sync::Arc};
 use tangram_client::{self as tg, handle::Ext as _};


### PR DESCRIPTION
- unify logging in JS and Builtin runtimes
- handle CRLF replacement when stdout/stderr are PTYs (#549)
- remove ctrl+c task in `tg process run` implementation
- treat signals as errors in JS processes
- do not set process error when a JS process fails, instead log the error and mark the exit status FAILED