### PR TITLE
fix(runtime): fill in default mode

### DIFF
--- a/packages/runtime/src/builtin.ts
+++ b/packages/runtime/src/builtin.ts
@@ -74,7 +74,7 @@ export let download = async (
 	options?: DownloadOptions,
 ): Promise<tg.Blob | tg.Artifact> => {
 	let value = await tg.build({
-		args: [url, options],
+		args: [url, options ?? { mode: "raw" }],
 		checksum,
 		executable: "download",
 		host: "builtin",


### PR DESCRIPTION
Provides the default download mode if user did not specify this arg.