### PR TITLE
feat: improved error traces

### DIFF
--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -145,12 +145,8 @@ impl Cli {
 								expand_on_create: true,
 							};
 							let item = crate::viewer::Item::Process(process);
-							let mut viewer = crate::viewer::Viewer::new(
-								&handle,
-								Some(referent),
-								item,
-								viewer_options,
-							);
+							let mut viewer =
+								crate::viewer::Viewer::new(&handle, referent, item, viewer_options);
 							match options.view {
 								View::None => (),
 								View::Inline => {

--- a/packages/cli/src/checkin.rs
+++ b/packages/cli/src/checkin.rs
@@ -55,7 +55,14 @@ impl Cli {
 		let output = self.render_progress_stream(stream).await?;
 
 		// Print the artifact.
-		println!("{}", output.artifact);
+		match (output.referent.item, output.referent.subpath) {
+			(tg::artifact::Id::Directory(directory), Some(subpath)) => {
+				let directory = tg::Directory::with_id(directory);
+				let item = directory.get(&handle, subpath).await?.id(&handle).await?;
+				println!("{item}");
+			},
+			(id, _) => println!("{id}"),
+		}
 
 		Ok(())
 	}

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1137,7 +1137,6 @@ impl Cli {
 
 	fn print_error(error: &tg::Error, config: Option<&Config>) {
 		let error = Self::fix_error_locations(error, None);
-		let mut current_source = error.source.as_ref();
 		let options = config
 			.as_ref()
 			.and_then(|config| config.advanced.as_ref())
@@ -1152,9 +1151,6 @@ impl Cli {
 			errors.reverse();
 		}
 		for error in errors {
-			if let Some(new_source) = &error.source {
-				current_source.replace(new_source);
-			}
 			let message = error.message.as_deref().unwrap_or("an error occurred");
 			eprintln!("{} {message}", "->".red());
 			if let Some(location) = &error.location {

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1142,19 +1142,18 @@ impl Cli {
 			.and_then(|config| config.advanced.as_ref())
 			.and_then(|advanced| advanced.error_trace_options.clone())
 			.unwrap_or_default();
-		let trace = error.trace(&options);
-		let mut errors = vec![trace.error];
+		let mut errors = vec![&error];
 		while let Some(next) = errors.last().unwrap().source.as_ref() {
-			errors.push(next.error.as_ref());
+			errors.push(&next.error);
 		}
-		if trace.options.reverse {
+		if options.reverse {
 			errors.reverse();
 		}
 		for error in errors {
 			let message = error.message.as_deref().unwrap_or("an error occurred");
 			eprintln!("{} {message}", "->".red());
 			if let Some(location) = &error.location {
-				if !location.file.is_internal() || trace.options.internal {
+				if !location.file.is_internal() || options.internal {
 					let mut string = String::new();
 					write!(string, "{location}").unwrap();
 					eprintln!("   {}", string.yellow());
@@ -1166,11 +1165,11 @@ impl Cli {
 				eprintln!("   {name} = {value}");
 			}
 			let mut stack = error.stack.iter().flatten().collect::<Vec<_>>();
-			if trace.options.reverse {
+			if options.reverse {
 				stack.reverse();
 			}
 			for location in stack {
-				if !location.file.is_internal() || trace.options.internal {
+				if !location.file.is_internal() || options.internal {
 					let mut string = String::new();
 					write!(string, "{location}").unwrap();
 					eprintln!("   {}", string.yellow());

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1246,7 +1246,13 @@ impl Cli {
 
 		// Recurse.
 		if let Some(tg::error::Source { error, referent }) = error.source.as_mut() {
-			let new_error = Self::fix_error_locations(error.as_ref(), referent.as_ref());
+			let source = match (source, referent.as_ref()) {
+				(Some(parent), Some(child)) if parent.item == child.item => Some(parent),
+				(_, Some(child)) => Some(child),
+				(Some(parent), None) => Some(parent),
+				(None, None) => None,
+			};
+			let new_error = Self::fix_error_locations(error.as_ref(), source);
 			*error = Arc::new(new_error);
 		}
 

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1147,7 +1147,7 @@ impl Cli {
 		while let Some(next) = errors.last().unwrap().source.as_ref() {
 			errors.push(next.error.as_ref());
 		}
-		if !trace.options.reverse {
+		if trace.options.reverse {
 			errors.reverse();
 		}
 		for error in errors {
@@ -1166,7 +1166,7 @@ impl Cli {
 				eprintln!("   {name} = {value}");
 			}
 			let mut stack = error.stack.iter().flatten().collect::<Vec<_>>();
-			if !trace.options.reverse {
+			if trace.options.reverse {
 				stack.reverse();
 			}
 			for location in stack {

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -125,7 +125,7 @@ impl Cli {
 
 		// If the detach flag is set, then spawn without stdio and return.
 		if options.detach {
-			let process = self
+			let (_, process) = self
 				.spawn(options.spawn, reference, trailing, None, None, None)
 				.boxed()
 				.await?;
@@ -140,7 +140,7 @@ impl Cli {
 			.map_err(|source| tg::error!(!source, "failed to create stdio"))?;
 
 		// Spawn the process.
-		let process = self
+		let (referent, process) = self
 			.spawn(
 				options.spawn,
 				reference,
@@ -199,7 +199,9 @@ impl Cli {
 		let wait = result.map_err(|source| tg::error!(!source, "failed to await the process"))?;
 
 		// Print the error.
-		if let Some(error) = wait.error {
+		if let Some(source) = wait.error {
+			let mut error = tg::error!(!source, "the process failed");
+			error.source.as_mut().unwrap().referent.replace(referent);
 			Self::print_error(&error, self.config.as_ref());
 		}
 

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -42,7 +42,7 @@ impl Cli {
 
 		// Get the reference.
 		let referent = self.get_reference(&args.reference).await?;
-		let item = match referent.item {
+		let item = match referent.item.clone() {
 			Either::Left(process) => Either::Left(process),
 			Either::Right(object) => {
 				let object = if let Some(subpath) = &referent.subpath {
@@ -78,7 +78,8 @@ impl Cli {
 						condensed_processes: false,
 						expand_on_create: matches!(kind, Kind::Inline),
 					};
-					let mut viewer = crate::viewer::Viewer::new(&handle, item, options);
+					let mut viewer =
+						crate::viewer::Viewer::new(&handle, Some(referent), item, options);
 					match kind {
 						Kind::Inline => {
 							viewer.run_inline(stop).await?;

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -78,8 +78,7 @@ impl Cli {
 						condensed_processes: false,
 						expand_on_create: matches!(kind, Kind::Inline),
 					};
-					let mut viewer =
-						crate::viewer::Viewer::new(&handle, Some(referent), item, options);
+					let mut viewer = crate::viewer::Viewer::new(&handle, referent, item, options);
 					match kind {
 						Kind::Inline => {
 							viewer.run_inline(stop).await?;

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -149,7 +149,7 @@ where
 
 	pub fn new(
 		handle: &H,
-		root: Option<tg::Referent<Either<tg::Process, tg::Object>>>,
+		root: tg::Referent<Either<tg::Process, tg::Object>>,
 		item: Item,
 		options: Options,
 	) -> Self {

--- a/packages/client/src/checkin.rs
+++ b/packages/client/src/checkin.rs
@@ -29,7 +29,7 @@ pub struct Arg {
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Output {
-	pub artifact: tg::artifact::Id,
+	pub referent: tg::Referent<tg::artifact::Id>,
 }
 
 pub async fn checkin<H>(handle: &H, arg: tg::checkin::Arg) -> tg::Result<tg::Artifact>
@@ -42,7 +42,7 @@ where
 		.await?
 		.and_then(|event| event.try_unwrap_output().ok())
 		.ok_or_else(|| tg::error!("stream ended without output"))?;
-	let artifact = tg::Artifact::with_id(output.artifact);
+	let artifact = tg::Artifact::with_id(output.referent.item);
 	Ok(artifact)
 }
 

--- a/packages/client/src/error.rs
+++ b/packages/client/src/error.rs
@@ -176,7 +176,6 @@ impl std::fmt::Display for Trace<'_> {
 		if self.options.reverse {
 			errors.reverse();
 		}
-
 		for error in errors {
 			let message = error.message.as_deref().unwrap_or("an error occurred");
 			writeln!(f, "-> {message}")?;
@@ -185,13 +184,11 @@ impl std::fmt::Display for Trace<'_> {
 					writeln!(f, "   {location}")?;
 				}
 			}
-
 			for (name, value) in &error.values {
 				let name = name.as_str();
 				let value = value.as_str();
 				writeln!(f, "   {name} = {value}")?;
 			}
-
 			let mut stack = error.stack.iter().flatten().collect::<Vec<_>>();
 			if self.options.reverse {
 				stack.reverse();
@@ -202,7 +199,6 @@ impl std::fmt::Display for Trace<'_> {
 				}
 			}
 		}
-
 		Ok(())
 	}
 }
@@ -221,7 +217,7 @@ impl std::fmt::Display for File {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			File::Internal(path) => {
-				write!(f, "(internal) {}", path.display())?;
+				write!(f, "internal {}", path.display())?;
 			},
 			File::Module(module) => {
 				write!(f, "{module}")?;

--- a/packages/client/src/handle/ext.rs
+++ b/packages/client/src/handle/ext.rs
@@ -463,7 +463,8 @@ pub trait Ext: tg::Handle {
 	> + Send {
 		self.try_get(reference).map(|result| {
 			result.map(|stream| {
-				stream.map(|event_result| {
+				let reference = reference.clone();
+				stream.map(move |event_result| {
 					event_result.and_then(|event| match event {
 						crate::progress::Event::Log(log) => Ok(tg::progress::Event::Log(log)),
 						crate::progress::Event::Diagnostic(diagnostic) => {
@@ -493,7 +494,7 @@ pub trait Ext: tg::Handle {
 								};
 								crate::progress::Event::Output(referent)
 							})
-							.ok_or_else(|| tg::error!("failed to get reference")),
+							.ok_or_else(|| tg::error!(%reference, "failed to get reference")),
 					})
 				})
 			})

--- a/packages/client/src/module/data.rs
+++ b/packages/client/src/module/data.rs
@@ -34,27 +34,26 @@ pub enum Item {
 
 impl std::fmt::Display for Module {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "({})", self.kind)?;
 		if let Some(tag) = &self.referent.tag {
-			write!(f, " {tag}")?;
+			write!(f, "{tag}")?;
 			if let Some(subpath) = &self.referent.subpath {
 				write!(f, ":{}", subpath.display())?;
 			}
 		} else if let Some(path) = &self.referent.path {
-			write!(f, " {}", path.display())?;
+			write!(f, "{}", path.display())?;
 			if let Some(subpath) = &self.referent.subpath {
 				write!(f, "/{}", subpath.display())?;
 			}
 		} else {
 			match &self.referent.item {
 				Item::Path(path) => {
-					write!(f, " {}", path.display())?;
+					write!(f, "{}", path.display())?;
 					if let Some(subpath) = &self.referent.subpath {
 						write!(f, "/{}", subpath.display())?;
 					}
 				},
 				Item::Object(object) => {
-					write!(f, " {object}")?;
+					write!(f, "{object}")?;
 					if let Some(subpath) = &self.referent.subpath {
 						write!(f, ":{}", subpath.display())?;
 					}

--- a/packages/client/src/module/data.rs
+++ b/packages/client/src/module/data.rs
@@ -34,23 +34,32 @@ pub enum Item {
 
 impl std::fmt::Display for Module {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{}", self.kind)?;
+		write!(f, "({})", self.kind)?;
 		if let Some(tag) = &self.referent.tag {
-			write!(f, ":{tag}")?;
+			write!(f, " {tag}")?;
+			if let Some(subpath) = &self.referent.subpath {
+				write!(f, ":{}", subpath.display())?;
+			}
 		} else if let Some(path) = &self.referent.path {
-			write!(f, ":{}", path.display())?;
+			write!(f, " {}", path.display())?;
+			if let Some(subpath) = &self.referent.subpath {
+				write!(f, "/{}", subpath.display())?;
+			}
 		} else {
 			match &self.referent.item {
 				Item::Path(path) => {
-					write!(f, ":{}", path.display())?;
+					write!(f, " {}", path.display())?;
+					if let Some(subpath) = &self.referent.subpath {
+						write!(f, "/{}", subpath.display())?;
+					}
 				},
 				Item::Object(object) => {
-					write!(f, ":{object}")?;
+					write!(f, " {object}")?;
+					if let Some(subpath) = &self.referent.subpath {
+						write!(f, ":{}", subpath.display())?;
+					}
 				},
 			}
-		}
-		if let Some(subpath) = &self.referent.subpath {
-			write!(f, ":{}", subpath.display())?;
 		}
 		Ok(())
 	}

--- a/packages/runtime/src/error.ts
+++ b/packages/runtime/src/error.ts
@@ -35,4 +35,5 @@ type File =
 
 type Source = {
 	error: Error_;
+	referent: tg.Referent<tg.Object.Id> | undefined;
 };

--- a/packages/runtime/src/run.ts
+++ b/packages/runtime/src/run.ts
@@ -43,6 +43,26 @@ async function inner(...args: tg.Args<tg.Process.RunArg>): Promise<tg.Value> {
 		},
 		...args,
 	);
+
+	// Get the source for error reporting and clear path/tag from the executable.
+	let source: tg.Referent<tg.Object.Id> | undefined = undefined;
+	if (
+		"executable" in arg &&
+		typeof arg.executable === "object" &&
+		"module" in arg.executable
+	) {
+		let item =
+			typeof arg.executable.module.referent.item === "object"
+				? await arg.executable.module.referent.item.id()
+				: arg.executable.module.referent.item;
+		source = {
+			...arg.executable.module.referent,
+			item,
+		};
+		arg.executable.module.referent.path = undefined;
+		arg.executable.module.referent.tag = undefined;
+	}
+
 	let checksum = arg.checksum;
 	let processMounts: Array<tg.Process.Mount> = [];
 	let commandMounts: Array<tg.Command.Mount> | undefined;
@@ -124,8 +144,15 @@ async function inner(...args: tg.Args<tg.Process.RunArg>): Promise<tg.Value> {
 		state: undefined,
 	});
 	let wait = await process.wait();
+
+	// Update or wrap underlying errors.
 	if (wait.error) {
-		throw wait.error;
+		throw new Error("the process failed", {
+			cause: {
+				error: wait.error,
+				referent: source,
+			},
+		});
 	}
 	if (wait.exit >= 1 && wait.exit < 128) {
 		throw new Error(`the process exited with code ${wait.exit}`);

--- a/packages/server/src/checkin/input.rs
+++ b/packages/server/src/checkin/input.rs
@@ -1,6 +1,4 @@
-use super::{
-	Directory, File, FileDependency, Node, State, Symlink, Variant,
-};
+use super::{Directory, File, FileDependency, Node, State, Symlink, Variant};
 use crate::Server;
 use std::{
 	os::unix::fs::PermissionsExt as _,

--- a/packages/server/src/compiler/error.rs
+++ b/packages/server/src/compiler/error.rs
@@ -102,6 +102,7 @@ pub(super) fn from_exception<'s>(
 		.map(|cause| from_exception(scope, cause.into()))
 		.map(|error| tg::error::Source {
 			error: Arc::new(error),
+			referent: None,
 		});
 	let values = BTreeMap::new();
 
@@ -121,12 +122,12 @@ fn get_location(line: u32, column: u32) -> Option<tg::error::Location> {
 	let token = source_map.lookup_token(line, column)?;
 	let symbol = token.get_name().map(String::from);
 	let path = token.get_source().unwrap().parse().unwrap();
-	let source = tg::error::File::Internal(path);
+	let file = tg::error::File::Internal(path);
 	let line = token.get_src_line();
 	let column = token.get_src_col();
 	let location = tg::error::Location {
 		symbol,
-		file: source,
+		file,
 		line,
 		column,
 	};

--- a/packages/server/src/compiler/resolve.rs
+++ b/packages/server/src/compiler/resolve.rs
@@ -16,7 +16,7 @@ impl Compiler {
 		let kind = import.kind;
 
 		// Get the referent.
-		let referent = match referrer {
+		let mut referent = match referrer {
 			// Handle a path referrer.
 			tg::module::Data {
 				referent:
@@ -126,6 +126,11 @@ impl Compiler {
 				},
 			}
 		};
+
+		if referent.item == referrer.referent.item {
+			referent.path = referrer.referent.path.clone();
+			referent.tag = referrer.referent.tag.clone();
+		}
 
 		// Create the module.
 		let module = tg::module::Data { kind, referent };

--- a/packages/server/src/runtime/builtin/extract.rs
+++ b/packages/server/src/runtime/builtin/extract.rs
@@ -102,7 +102,7 @@ impl Runtime {
 			.await?
 			.and_then(|event| event.try_unwrap_output().ok())
 			.ok_or_else(|| tg::error!("stream ended without output"))?;
-		let artifact = tg::Artifact::with_id(output.artifact);
+		let artifact = tg::Artifact::with_id(output.referent.item);
 
 		// Abort and await the log task.
 		log_task.abort();

--- a/packages/v8/src/convert/error.rs
+++ b/packages/v8/src/convert/error.rs
@@ -216,8 +216,16 @@ impl FromV8 for tg::error::Source {
 		let error = value.get(scope, error.into()).unwrap();
 		let error = <_>::from_v8(scope, error)
 			.map_err(|source| tg::error!(!source, "failed to deserialize the error"))?;
+
+		let referent =
+			v8::String::new_external_onebyte_static(scope, "referent".as_bytes()).unwrap();
+		let referent = value.get(scope, referent.into()).unwrap();
+		let referent = <_>::from_v8(scope, referent)
+			.map_err(|source| tg::error!(!source, "failed to deserialize the referent"))?;
+
 		Ok(tg::error::Source {
 			error: Arc::new(error),
+			referent,
 		})
 	}
 }


### PR DESCRIPTION
- (fix) return tg::Referent from checkin
- (fix) correctly lookup path/subpath in checkin
- (fix) correctly report tag/path in try_get_reference
- (feat) add `referent` field to `tg::error::Source`
- (feat) use referent field in `Source` when formatting errors in the CLI
- (feat) re-throw errors in tg.build/tg.run with `cause: { error: wait.error, referent }` set.