### PR TITLE
feat(runtime): add tagged template constructors for tg.File and tg.Blob

### DIFF
--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -483,6 +483,157 @@ async fn template_multiple_placeholders() {
 }
 
 #[tokio::test]
+async fn blob_template() {
+	let directory = temp::directory! {
+		"tangram.ts" => r"
+			export default () => tg.blob`\n\tHello, World!\n`.then((b) => b.text());
+		",
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout).unwrap();
+		assert_snapshot!(stdout, @r#""Hello, World!\n""#);
+	};
+	let path = "";
+	let command = "default";
+	let args = vec![];
+	test_build(directory, path, command, args, assertions).await;
+}
+
+#[tokio::test]
+async fn blob_template_two_placeholders() {
+	let directory = temp::directory! {
+		"tangram.ts" => r#"
+			export default () => {
+				let a = "string!";
+				return tg.blob`\n\tHello, World!\n\t${a}\n`.then((f) => f.text());
+			}
+		"#,
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout).unwrap();
+		assert_snapshot!(stdout, @r#""Hello, World!\nstring!\n""#);
+	};
+	let path = "";
+	let command = "default";
+	let args = vec![];
+	test_build(directory, path, command, args, assertions).await;
+}
+
+#[tokio::test]
+async fn blob_template_raw() {
+	let directory = temp::directory! {
+		"tangram.ts" => r"
+			export default () => tg.Blob.raw`\n\tHello, World!\n`.then((b) => b.text());
+		",
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout).unwrap();
+		assert_snapshot!(stdout, @r#""\n\tHello, World!\n""#);
+	};
+	let path = "";
+	let command = "default";
+	let args = vec![];
+	test_build(directory, path, command, args, assertions).await;
+}
+
+#[tokio::test]
+async fn file_template() {
+	let directory = temp::directory! {
+		"tangram.ts" => r"
+			export default () => tg.file`\n\tHello, World!\n`.then((f) => f.text());
+		",
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout).unwrap();
+		assert_snapshot!(stdout, @r#""Hello, World!\n""#);
+	};
+	let path = "";
+	let command = "default";
+	let args = vec![];
+	test_build(directory, path, command, args, assertions).await;
+}
+
+#[tokio::test]
+async fn file_template_two_placeholders() {
+	let directory = temp::directory! {
+		"tangram.ts" => r#"
+			export default () => {
+				let a = "string!";
+				return tg.file`\n\tHello, World!\n\t${a}\n`.then((f) => f.text());
+			}
+		"#,
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout).unwrap();
+		assert_snapshot!(stdout, @r#""Hello, World!\nstring!\n""#);
+	};
+	let path = "";
+	let command = "default";
+	let args = vec![];
+	test_build(directory, path, command, args, assertions).await;
+}
+
+#[tokio::test]
+async fn file_template_raw() {
+	let directory = temp::directory! {
+		"tangram.ts" => r"
+			export default () => tg.File.raw`\n\tHello, World!\n`.then((f) => f.text());
+		",
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_success!(output);
+		let stdout = std::str::from_utf8(&output.stdout).unwrap();
+		assert_snapshot!(stdout, @r#""\n\tHello, World!\n""#);
+	};
+	let path = "";
+	let command = "default";
+	let args = vec![];
+	test_build(directory, path, command, args, assertions).await;
+}
+
+// TODO - test_check
+// #[tokio::test]
+// async fn blob_rejects_non_strings() {
+// 	let directory = temp::directory! {
+// 		"tangram.ts" => r#"
+// 			import file from "./file.txt";
+// 			export default () => tg.blob`\n\t${file}\n`;
+// 		"#,
+// 		"file.txt" => "Hello, world!"
+// 	};
+// 	let assertions = |output: std::process::Output| async move {
+// 		assert_failure!(output);
+// 	};
+// 	let path = "";
+// 	let command = "default";
+// 	let args = vec![];
+// 	test_build(directory, path, command, args, assertions).await;
+// }
+
+// #[tokio::test]
+// async fn file_rejects_non_strings() {
+// 	let directory = temp::directory! {
+// 		"tangram.ts" => r#"
+// 			import file from "./file.txt";
+// 			export default () => tg.file`\n\t${file}\n`;
+// 		"#,
+// 		"file.txt" => "Hello, world!"
+// 	};
+// 	let assertions = |output: std::process::Output| async move {
+// 		assert_failure!(output);
+// 	};
+// 	let path = "";
+// 	let command = "default";
+// 	let args = vec![];
+// 	test_build(directory, path, command, args, assertions).await;
+// }
+
+#[tokio::test]
 async fn directory_get_follows_intermediate_component_symlinks() {
 	let directory = temp::directory! {
 		"tangram.ts" => indoc!(r#"

--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -597,38 +597,6 @@ async fn file_template_raw() {
 }
 
 #[tokio::test]
-async fn blob_rejects_non_strings() {
-	let directory = temp::directory! {
-		"tangram.ts" => r#"
-			import file from "./file.txt";
-			export default () => tg.blob`\n\t${file}\n`;
-		"#,
-		"file.txt" => "Hello, world!"
-	};
-	let assertions = |output: std::process::Output| async move {
-		assert_failure!(output);
-	};
-	let path = "";
-	test_check(directory, path, assertions).await;
-}
-
-#[tokio::test]
-async fn file_rejects_non_strings() {
-	let directory = temp::directory! {
-		"tangram.ts" => r#"
-			import file from "./file.txt";
-			export default () => tg.file`\n\t${file}\n`;
-		"#,
-		"file.txt" => "Hello, world!"
-	};
-	let assertions = |output: std::process::Output| async move {
-		assert_failure!(output);
-	};
-	let path = "";
-	test_check(directory, path, assertions).await;
-}
-
-#[tokio::test]
 async fn directory_get_follows_intermediate_component_symlinks() {
 	let directory = temp::directory! {
 		"tangram.ts" => indoc!(r#"
@@ -1152,34 +1120,6 @@ async fn test_build_remote<F, Fut>(
 		assert_success!(remote_output);
 
 		assertions(local_output, remote_output).await;
-	})
-	.await;
-}
-
-async fn test_check<F, Fut>(
-	artifact: impl Into<temp::Artifact> + Send + 'static,
-	path: &str,
-	assertions: F,
-) where
-	F: FnOnce(std::process::Output) -> Fut + Send + 'static,
-	Fut: Future<Output = ()> + Send,
-{
-	test(TG, async move |context| {
-		let server = context.spawn_server().await.unwrap();
-
-		let artifact: temp::Artifact = artifact.into();
-		let temp = Temp::new();
-		artifact.to_path(temp.as_ref()).await.unwrap();
-
-		let path = temp.path().join(path);
-		let command_ = format!("{path}", path = path.display());
-
-		// Build.
-		let mut command = server.tg();
-		command.arg("check").arg(command_);
-		let output = command.output().await.unwrap();
-
-		assertions(output).await;
 	})
 	.await;
 }

--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -596,42 +596,37 @@ async fn file_template_raw() {
 	test_build(directory, path, command, args, assertions).await;
 }
 
-// TODO - test_check
-// #[tokio::test]
-// async fn blob_rejects_non_strings() {
-// 	let directory = temp::directory! {
-// 		"tangram.ts" => r#"
-// 			import file from "./file.txt";
-// 			export default () => tg.blob`\n\t${file}\n`;
-// 		"#,
-// 		"file.txt" => "Hello, world!"
-// 	};
-// 	let assertions = |output: std::process::Output| async move {
-// 		assert_failure!(output);
-// 	};
-// 	let path = "";
-// 	let command = "default";
-// 	let args = vec![];
-// 	test_build(directory, path, command, args, assertions).await;
-// }
+#[tokio::test]
+async fn blob_rejects_non_strings() {
+	let directory = temp::directory! {
+		"tangram.ts" => r#"
+			import file from "./file.txt";
+			export default () => tg.blob`\n\t${file}\n`;
+		"#,
+		"file.txt" => "Hello, world!"
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_failure!(output);
+	};
+	let path = "";
+	test_check(directory, path, assertions).await;
+}
 
-// #[tokio::test]
-// async fn file_rejects_non_strings() {
-// 	let directory = temp::directory! {
-// 		"tangram.ts" => r#"
-// 			import file from "./file.txt";
-// 			export default () => tg.file`\n\t${file}\n`;
-// 		"#,
-// 		"file.txt" => "Hello, world!"
-// 	};
-// 	let assertions = |output: std::process::Output| async move {
-// 		assert_failure!(output);
-// 	};
-// 	let path = "";
-// 	let command = "default";
-// 	let args = vec![];
-// 	test_build(directory, path, command, args, assertions).await;
-// }
+#[tokio::test]
+async fn file_rejects_non_strings() {
+	let directory = temp::directory! {
+		"tangram.ts" => r#"
+			import file from "./file.txt";
+			export default () => tg.file`\n\t${file}\n`;
+		"#,
+		"file.txt" => "Hello, world!"
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_failure!(output);
+	};
+	let path = "";
+	test_check(directory, path, assertions).await;
+}
 
 #[tokio::test]
 async fn directory_get_follows_intermediate_component_symlinks() {
@@ -1157,6 +1152,34 @@ async fn test_build_remote<F, Fut>(
 		assert_success!(remote_output);
 
 		assertions(local_output, remote_output).await;
+	})
+	.await;
+}
+
+async fn test_check<F, Fut>(
+	artifact: impl Into<temp::Artifact> + Send + 'static,
+	path: &str,
+	assertions: F,
+) where
+	F: FnOnce(std::process::Output) -> Fut + Send + 'static,
+	Fut: Future<Output = ()> + Send,
+{
+	test(TG, async move |context| {
+		let server = context.spawn_server().await.unwrap();
+
+		let artifact: temp::Artifact = artifact.into();
+		let temp = Temp::new();
+		artifact.to_path(temp.as_ref()).await.unwrap();
+
+		let path = temp.path().join(path);
+		let command_ = format!("{path}", path = path.display());
+
+		// Build.
+		let mut command = server.tg();
+		command.arg("check").arg(command_);
+		let output = command.output().await.unwrap();
+
+		assertions(output).await;
 	})
 	.await;
 }

--- a/packages/cli/tests/check.rs
+++ b/packages/cli/tests/check.rs
@@ -6,50 +6,88 @@ const TG: &str = env!("CARGO_BIN_EXE_tangram");
 
 #[tokio::test]
 async fn hello_world() {
-	test(TG, async move |context| {
-		let server = context.spawn_server().await.unwrap();
-
-		let temp = Temp::new();
-		let package = temp::directory! {
+	let directory = temp::directory! {
 			"tangram.ts" => indoc!(r#"
 				export default () => "Hello, World!";
 			"#),
-		};
-		package.to_path(temp.as_ref()).await.unwrap();
-
-		let output = server
-			.tg()
-			.arg("check")
-			.arg(temp.path())
-			.output()
-			.await
-			.unwrap();
+	};
+	let assertions = |output: std::process::Output| async move {
 		assert_success!(output);
-	})
-	.await;
+	};
+	let path = "";
+	test_check(directory, path, assertions).await;
 }
 
 #[tokio::test]
 async fn nonexistent_function() {
-	test(TG, async move |context| {
-		let server = context.spawn_server().await.unwrap();
-
-		let temp = Temp::new();
-		let package = temp::directory! {
+	let directory = temp::directory! {
 			"tangram.ts" => indoc!(r"
 				export default () => foo();
 			"),
-		};
-		package.to_path(temp.as_ref()).await.unwrap();
-
-		let output = server
-			.tg()
-			.arg("check")
-			.arg(temp.path())
-			.output()
-			.await
-			.unwrap();
+	};
+	let assertions = |output: std::process::Output| async move {
 		assert_failure!(output);
+	};
+	let path = "";
+	test_check(directory, path, assertions).await;
+}
+
+#[tokio::test]
+async fn blob_template_rejects_non_strings() {
+	let directory = temp::directory! {
+		"tangram.ts" => r#"
+			import file from "./file.txt";
+			export default () => tg.blob`\n\t${file}\n`;
+		"#,
+		"file.txt" => "Hello, world!"
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_failure!(output);
+	};
+	let path = "";
+	test_check(directory, path, assertions).await;
+}
+
+#[tokio::test]
+async fn file_template_rejects_non_strings() {
+	let directory = temp::directory! {
+		"tangram.ts" => r#"
+			import file from "./file.txt";
+			export default () => tg.file`\n\t${file}\n`;
+		"#,
+		"file.txt" => "Hello, world!"
+	};
+	let assertions = |output: std::process::Output| async move {
+		assert_failure!(output);
+	};
+	let path = "";
+	test_check(directory, path, assertions).await;
+}
+
+async fn test_check<F, Fut>(
+	artifact: impl Into<temp::Artifact> + Send + 'static,
+	path: &str,
+	assertions: F,
+) where
+	F: FnOnce(std::process::Output) -> Fut + Send + 'static,
+	Fut: Future<Output = ()> + Send,
+{
+	test(TG, async move |context| {
+		let server = context.spawn_server().await.unwrap();
+
+		let artifact: temp::Artifact = artifact.into();
+		let temp = Temp::new();
+		artifact.to_path(temp.as_ref()).await.unwrap();
+
+		let path = temp.path().join(path);
+		let command_ = format!("{path}", path = path.display());
+
+		// Build.
+		let mut command = server.tg();
+		command.arg("check").arg(command_);
+		let output = command.output().await.unwrap();
+
+		assertions(output).await;
 	})
 	.await;
 }

--- a/packages/runtime/src/blob.ts
+++ b/packages/runtime/src/blob.ts
@@ -1,11 +1,11 @@
 import * as tg from "./index.ts";
 import { unindent } from "./template.ts";
 
-export async function blob(...args: tg.Args<Blob.Arg>): Promise<Blob>;
 export async function blob(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<string>
 ): Promise<Blob>;
+export async function blob(...args: tg.Args<Blob.Arg>): Promise<Blob>;
 export async function blob(
 	firstArg:
 		| TemplateStringsArray

--- a/packages/runtime/src/blob.ts
+++ b/packages/runtime/src/blob.ts
@@ -6,14 +6,25 @@ export async function blob(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<string>
 ): Promise<Blob>;
-export async function blob(...args: any): Promise<Blob> {
-	return await inner(false, ...args);
+export async function blob(
+	firstArg:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<Blob.Arg>>,
+	...args: tg.Args<Blob.Arg>
+): Promise<Blob> {
+	return await inner(false, firstArg, ...args);
 }
 
-async function inner(raw: boolean, ...args: any): Promise<tg.Blob> {
-	if (Array.isArray(args[0]) && "raw" in args[0]) {
-		let strings = args[0];
-		let placeholders = args.slice(1) as tg.Args<string>;
+async function inner(
+	raw: boolean,
+	firstArg:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<Blob.Arg>>,
+	...args: tg.Args<Blob.Arg>
+): Promise<tg.Blob> {
+	if (Array.isArray(firstArg) && "raw" in firstArg) {
+		let strings = firstArg;
+		let placeholders = args as tg.Args<string>;
 		let components = [];
 		for (let i = 0; i < strings.length - 1; i++) {
 			let string = strings[i]!;
@@ -28,7 +39,7 @@ async function inner(raw: boolean, ...args: any): Promise<tg.Blob> {
 		}
 		return await Blob.new(string);
 	} else {
-		return await Blob.new(...(args as tg.Args<tg.Blob.Arg>));
+		return await Blob.new(firstArg as tg.Blob.Arg, ...args);
 	}
 }
 
@@ -229,7 +240,10 @@ export namespace Blob {
 
 	export type State = tg.Object.State<tg.Blob.Id, tg.Blob.Object>;
 
-	export let raw = async (...args: any): Promise<Blob> => {
-		return await inner(true, ...args);
+	export let raw = async (
+		strings: TemplateStringsArray,
+		...placeholders: tg.Args<string>
+	): Promise<Blob> => {
+		return await inner(true, strings, ...placeholders);
 	};
 }

--- a/packages/runtime/src/file.ts
+++ b/packages/runtime/src/file.ts
@@ -1,7 +1,35 @@
 import * as tg from "./index.ts";
+import { unindent } from "./template.ts";
 
-export async function file(...args: tg.Args<File.Arg>) {
-	return await File.new(...args);
+export async function file(...args: tg.Args<File.Arg>): Promise<File>;
+export async function file(
+	strings: TemplateStringsArray,
+	...placeholders: tg.Args<string>
+): Promise<File>;
+export async function file(...args: any): Promise<File> {
+	return await inner(false, ...args);
+}
+
+async function inner(raw: boolean, ...args: any): Promise<tg.File> {
+	if (Array.isArray(args[0]) && "raw" in args[0]) {
+		let strings = args[0];
+		let placeholders = args.slice(1) as tg.Args<string>;
+		let components = [];
+		for (let i = 0; i < strings.length - 1; i++) {
+			let string = strings[i]!;
+			components.push(string);
+			let placeholder = placeholders[i]!;
+			components.push(placeholder);
+		}
+		components.push(strings[strings.length - 1]!);
+		let string = components.join("");
+		if (!raw) {
+			string = unindent([string]).join("");
+		}
+		return await File.new(string);
+	} else {
+		return await File.new(...(args as tg.Args<tg.File.Arg>));
+	}
 }
 
 export class File {
@@ -254,4 +282,8 @@ export namespace File {
 		| { graph: tg.Graph; node: number };
 
 	export type State = tg.Object.State<File.Id, File.Object>;
+
+	export let raw = async (...args: any): Promise<File> => {
+		return await inner(true, ...args);
+	};
 }

--- a/packages/runtime/src/file.ts
+++ b/packages/runtime/src/file.ts
@@ -6,14 +6,25 @@ export async function file(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<string>
 ): Promise<File>;
-export async function file(...args: any): Promise<File> {
-	return await inner(false, ...args);
+export async function file(
+	firstArg:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<File.Arg>>,
+	...args: tg.Args<File.Arg>
+): Promise<File> {
+	return await inner(false, firstArg, ...args);
 }
 
-async function inner(raw: boolean, ...args: any): Promise<tg.File> {
-	if (Array.isArray(args[0]) && "raw" in args[0]) {
-		let strings = args[0];
-		let placeholders = args.slice(1) as tg.Args<string>;
+async function inner(
+	raw: boolean,
+	firstArg:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<File.Arg>>,
+	...args: tg.Args<File.Arg>
+): Promise<tg.File> {
+	if (Array.isArray(firstArg) && "raw" in firstArg) {
+		let strings = firstArg;
+		let placeholders = args as tg.Args<string>;
 		let components = [];
 		for (let i = 0; i < strings.length - 1; i++) {
 			let string = strings[i]!;
@@ -28,7 +39,7 @@ async function inner(raw: boolean, ...args: any): Promise<tg.File> {
 		}
 		return await File.new(string);
 	} else {
-		return await File.new(...(args as tg.Args<tg.File.Arg>));
+		return await File.new(firstArg as tg.File.Arg, ...args);
 	}
 }
 
@@ -283,7 +294,10 @@ export namespace File {
 
 	export type State = tg.Object.State<File.Id, File.Object>;
 
-	export let raw = async (...args: any): Promise<File> => {
-		return await inner(true, ...args);
+	export let raw = async (
+		strings: TemplateStringsArray,
+		...placeholders: tg.Args<string>
+	): Promise<File> => {
+		return await inner(true, strings, ...placeholders);
 	};
 }

--- a/packages/runtime/src/file.ts
+++ b/packages/runtime/src/file.ts
@@ -1,11 +1,11 @@
 import * as tg from "./index.ts";
 import { unindent } from "./template.ts";
 
-export async function file(...args: tg.Args<File.Arg>): Promise<File>;
 export async function file(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<string>
 ): Promise<File>;
+export async function file(...args: tg.Args<File.Arg>): Promise<File>;
 export async function file(
 	firstArg:
 		| TemplateStringsArray

--- a/packages/runtime/src/template.ts
+++ b/packages/runtime/src/template.ts
@@ -115,7 +115,7 @@ export namespace Template {
 	};
 }
 
-let unindent = (strings: Array<string>): Array<string> => {
+export let unindent = (strings: Array<string>): Array<string> => {
 	// Concatenate the strings and collect the placeholder indices.
 	let placeholderIndices: Array<number> = [];
 	let string = strings[0]!;

--- a/packages/runtime/src/template.ts
+++ b/packages/runtime/src/template.ts
@@ -7,14 +7,25 @@ export async function template(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<Template.Arg>
 ): Promise<Template>;
-export async function template(...args: any): Promise<Template> {
-	return await inner(false, ...args);
+export async function template(
+	firstArg:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<Template.Arg>>,
+	...args: tg.Args<Template.Arg>
+): Promise<Template> {
+	return await inner(false, firstArg, ...args);
 }
 
-async function inner(raw: boolean, ...args: any): Promise<Template> {
-	if (Array.isArray(args[0]) && "raw" in args[0]) {
-		let strings = !raw ? unindent(args[0]) : args[0];
-		let placeholders = args.slice(1) as tg.Args<Template>;
+async function inner(
+	raw: boolean,
+	firstArg:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<Template.Arg>>,
+	...args: tg.Args<Template.Arg>
+): Promise<Template> {
+	if (Array.isArray(firstArg) && "raw" in firstArg) {
+		let strings = !raw ? unindent(firstArg) : firstArg;
+		let placeholders = args as tg.Args<Template>;
 		let components = [];
 		for (let i = 0; i < strings.length - 1; i++) {
 			let string = strings[i]!;
@@ -25,7 +36,7 @@ async function inner(raw: boolean, ...args: any): Promise<Template> {
 		components.push(strings[strings.length - 1]!);
 		return await Template.new(...components);
 	} else {
-		return await Template.new(...(args as tg.Args<Template>));
+		return await Template.new(firstArg as tg.Unresolved<Template.Arg>, ...args);
 	}
 }
 
@@ -110,8 +121,11 @@ export namespace Template {
 
 	export type Component = string | tg.Artifact;
 
-	export let raw = async (...args: any): Promise<Template> => {
-		return await inner(true, ...args);
+	export let raw = async (
+		strings: TemplateStringsArray,
+		...placeholders: tg.Args<Template.Arg>
+	): Promise<Template> => {
+		return await inner(true, strings, ...placeholders);
 	};
 }
 

--- a/packages/runtime/src/template.ts
+++ b/packages/runtime/src/template.ts
@@ -1,11 +1,11 @@
 import * as tg from "./index.ts";
 
 export async function template(
-	...args: tg.Args<Template.Arg>
-): Promise<Template>;
-export async function template(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<Template.Arg>
+): Promise<Template>;
+export async function template(
+	...args: tg.Args<Template.Arg>
 ): Promise<Template>;
 export async function template(
 	firstArg:

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -145,7 +145,11 @@ declare namespace tg {
 	}
 
 	/** Create a blob. */
-	export let blob: (...args: tg.Args<tg.Blob.Arg>) => Promise<tg.Blob>;
+	export function blob(...args: tg.Args<tg.Blob.Arg>): Promise<tg.Blob>;
+	export function blob(
+		strings: TemplateStringsArray,
+		...placeholders: tg.Args<string>
+	): Promise<tg.Blob>;
 
 	export class Blob {
 		/** Get a blob with an ID. */
@@ -186,6 +190,11 @@ declare namespace tg {
 		};
 
 		export type Child = { blob: Blob; size: number };
+
+		export let raw: (
+			strings: TemplateStringsArray,
+			...placeholders: tg.Args<string>
+		) => Promise<tg.Blob>;
 	}
 
 	/** Create a directory. */
@@ -247,7 +256,11 @@ declare namespace tg {
 	}
 
 	/** Create a file. */
-	export let file: (...args: tg.Args<tg.File.Arg>) => Promise<tg.File>;
+	export function file(...args: tg.Args<tg.File.Arg>): Promise<tg.File>;
+	export function file(
+		strings: TemplateStringsArray,
+		...placeholders: tg.Args<string>
+	): Promise<tg.File>;
 
 	/** A file. */
 	export class File {
@@ -310,6 +323,11 @@ declare namespace tg {
 					executable?: boolean | undefined;
 			  }
 			| { graph: tg.Graph; node: number };
+
+		export let raw: (
+			strings: TemplateStringsArray,
+			...placeholders: tg.Args<string>
+		) => Promise<tg.File>;
 	}
 
 	/** Create a symlink. */

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -18,11 +18,11 @@ declare let console: {
 	error: (...args: Array<unknown>) => void;
 };
 
-declare function tg(...args: tg.Args<tg.Template.Arg>): Promise<tg.Template>;
 declare function tg(
 	strings: TemplateStringsArray,
 	...placeholders: tg.Args<tg.Template.Arg>
 ): Promise<tg.Template>;
+declare function tg(...args: tg.Args<tg.Template.Arg>): Promise<tg.Template>;
 
 declare namespace tg {
 	export type ArchiveFormat = "tar" | "tgar" | "zip";
@@ -145,11 +145,11 @@ declare namespace tg {
 	}
 
 	/** Create a blob. */
-	export function blob(...args: tg.Args<tg.Blob.Arg>): Promise<tg.Blob>;
 	export function blob(
 		strings: TemplateStringsArray,
 		...placeholders: tg.Args<string>
 	): Promise<tg.Blob>;
+	export function blob(...args: tg.Args<tg.Blob.Arg>): Promise<tg.Blob>;
 
 	export class Blob {
 		/** Get a blob with an ID. */
@@ -256,11 +256,11 @@ declare namespace tg {
 	}
 
 	/** Create a file. */
-	export function file(...args: tg.Args<tg.File.Arg>): Promise<tg.File>;
 	export function file(
 		strings: TemplateStringsArray,
 		...placeholders: tg.Args<string>
 	): Promise<tg.File>;
+	export function file(...args: tg.Args<tg.File.Arg>): Promise<tg.File>;
 
 	/** A file. */
 	export class File {


### PR DESCRIPTION
Rejects templates which contain non-string components.

Closes #575.