### PR TITLE
refactor(runtime): remove tg.Command.Mount.parse

### DIFF
--- a/packages/runtime/src/build.ts
+++ b/packages/runtime/src/build.ts
@@ -57,13 +57,7 @@ async function inner(...args: tg.Args<tg.Process.BuildArg>): Promise<tg.Value> {
 	}
 	let commandMounts: Array<tg.Command.Mount> | undefined;
 	if ("mounts" in arg && arg.mounts !== undefined) {
-		commandMounts = arg.mounts.map((mount) => {
-			if (typeof mount === "string" || mount instanceof tg.Template) {
-				return tg.Command.Mount.parse(mount);
-			} else {
-				return mount;
-			}
-		});
+		commandMounts = arg.mounts;
 	}
 	let commandStdin: tg.Blob.Arg | undefined = undefined;
 	if ("stdin" in arg && arg.stdin !== undefined) {
@@ -249,7 +243,7 @@ export class BuildBuilder<
 	}
 
 	mount(
-		...mounts: Array<tg.Unresolved<string | tg.Template | tg.Command.Mount>>
+		...mounts: Array<tg.Unresolved<tg.Command.Mount>>
 	): this {
 		this.#args.push({ mounts });
 		return this;
@@ -258,7 +252,7 @@ export class BuildBuilder<
 	mounts(
 		...mounts: Array<
 			tg.Unresolved<
-				tg.MaybeMutation<Array<string | tg.Template | tg.Command.Mount>>
+				tg.MaybeMutation<Array<tg.Command.Mount>>
 			>
 		>
 	): this {

--- a/packages/runtime/src/process.ts
+++ b/packages/runtime/src/process.ts
@@ -184,7 +184,7 @@ export namespace Process {
 		env?: tg.MaybeMutationMap | undefined;
 		executable?: tg.Command.ExecutableArg | undefined;
 		host?: string | undefined;
-		mounts?: Array<string | tg.Template | tg.Command.Mount> | undefined;
+		mounts?: Array<tg.Command.Mount> | undefined;
 		network?: boolean | undefined;
 		stdin?: tg.Blob.Arg | undefined;
 		user?: string | undefined;

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -591,7 +591,7 @@ declare namespace tg {
 			host?: string | undefined;
 
 			/** The command's mounts. */
-			mounts?: Array<string | tg.Template | tg.Command.Mount> | undefined;
+			mounts?: Array<tg.Command.Mount> | undefined;
 
 			/** The command's user. */
 			user?: string | undefined;
@@ -1089,7 +1089,7 @@ declare namespace tg {
 			host?: string | undefined;
 
 			/** The command's mounts. */
-			mounts?: Array<string | tg.Template | tg.Command.Mount> | undefined;
+			mounts?: Array<tg.Command.Mount> | undefined;
 
 			/** Configure whether the process has access to the network. **/
 			network?: boolean | undefined;
@@ -1197,13 +1197,13 @@ declare namespace tg {
 		host(host: tg.Unresolved<tg.MaybeMutation<string>>): this;
 
 		mount(
-			...mounts: Array<tg.Unresolved<string | tg.Template | tg.Command.Mount>>
+			...mounts: Array<tg.Unresolved<tg.Command.Mount>>
 		): this;
 
 		mounts(
 			...mounts: Array<
 				tg.Unresolved<
-					tg.MaybeMutation<Array<string | tg.Template | tg.Command.Mount>>
+					tg.MaybeMutation<Array<tg.Command.Mount>>
 				>
 			>
 		): this;
@@ -1257,13 +1257,13 @@ declare namespace tg {
 		host(host: tg.Unresolved<tg.MaybeMutation<string>>): this;
 
 		mount(
-			...mounts: Array<tg.Unresolved<string | tg.Template | tg.Command.Mount>>
+			...mounts: Array<tg.Unresolved<tg.Command.Mount>>
 		): this;
 
 		mounts(
 			...mounts: Array<
 				tg.Unresolved<
-					tg.MaybeMutation<Array<string | tg.Template | tg.Command.Mount>>
+					tg.MaybeMutation<Array<tg.Command.Mount>>
 				>
 			>
 		): this;

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -658,13 +658,6 @@ declare namespace tg {
 			source: tg.Artifact;
 			target: string;
 		};
-
-		export namespace Mount {
-			/** Parse a mount. */
-			export let parse: (
-				arg: string | tg.Template,
-			) => Promise<tg.Command.Mount>;
-		}
 	}
 
 	export namespace path {

--- a/packages/server/src/checkout.rs
+++ b/packages/server/src/checkout.rs
@@ -115,9 +115,9 @@ impl Server {
 		// Get the path.
 		let Some(path) = arg.path.clone() else {
 			if !self.vfs.lock().unwrap().is_some() {
-				self.cache_artifact(&artifact, progress)
-					.await
-					.map_err(|source| tg::error!(!source, "failed to cache the artifact"))?;
+				self.cache_artifact(&artifact, progress).await.map_err(
+					|source| tg::error!(!source, %artifact, "failed to cache the artifact"),
+				)?;
 			}
 			let path = self.artifacts_path().join(artifact.to_string());
 			let output = tg::checkout::Output { path };


### PR DESCRIPTION
This implementation dropped the handle. Instead, force callers to construct the object themselves.

Leaves tg.Process.Mount.parse intact, as we ensure all elements are strings.

Additionally, add the artifact ID to the cache error.