### PR TITLE
feat: add .tangram/tags directory and update `tg tag` logic

### DIFF
--- a/packages/client/src/tag.rs
+++ b/packages/client/src/tag.rs
@@ -90,6 +90,11 @@ impl Tag {
 		}
 		self.as_str()
 	}
+
+	pub fn ancestors(&self) -> impl Iterator<Item = Self> + 'static {
+		let components = self.components.clone();
+		(1..components.len()).map(move |n| tg::Tag::with_components(components[0..n].to_vec()))
+	}
 }
 
 impl AsRef<str> for Tag {
@@ -266,5 +271,14 @@ mod tests {
 				.parse::<tg::Tag>()
 				.is_err()
 		);
+	}
+
+	#[test]
+	fn ancestors() {
+		let tag = "foo".parse::<tg::Tag>().unwrap();
+		assert!(tag.ancestors().next().is_none());
+
+		let tag = "foo/bar".parse::<tg::Tag>().unwrap();
+		assert_eq!(tag.ancestors().next(), Some("foo".parse().unwrap()));
 	}
 }

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -891,6 +891,11 @@ impl Server {
 	}
 
 	#[must_use]
+	pub fn tags_path(&self) -> PathBuf {
+		self.path.join("tags")
+	}
+
+	#[must_use]
 	pub fn temp_path(&self) -> PathBuf {
 		self.path.join("tmp")
 	}

--- a/packages/server/src/tag/put.rs
+++ b/packages/server/src/tag/put.rs
@@ -7,6 +7,10 @@ use tangram_messenger::prelude::*;
 
 impl Server {
 	pub async fn put_tag(&self, tag: &tg::Tag, mut arg: tg::tag::put::Arg) -> tg::Result<()> {
+		if tag.is_empty() {
+			return Err(tg::error!("invalid tag"));
+		}
+
 		// If the remote arg is set, then forward the request.
 		if let Some(remote) = arg.remote.take() {
 			let remote = self.get_remote_client(remote).await?;
@@ -16,6 +20,9 @@ impl Server {
 			};
 			remote.put_tag(tag, arg).await?;
 		}
+
+		// Check if there are any ancestors of this tag.
+		self.check_tag_ancestors(tag).await?;
 
 		// Get a database connection.
 		let connection = self
@@ -39,7 +46,17 @@ impl Server {
 			.await
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
-		// Publish the put tag index message.
+		// Create the tag entry.
+		if let Some(artifact) = arg
+			.item
+			.as_ref()
+			.right()
+			.and_then(|id| id.clone().try_into().ok())
+		{
+			self.create_tag_dir_entry(tag, &artifact).await?;
+		}
+
+		// Send the tag message.
 		let message = crate::index::Message::PutTag(crate::index::PutTagMessage {
 			tag: tag.to_string(),
 			item: arg.item,
@@ -52,6 +69,49 @@ impl Server {
 			.await
 			.map_err(|source| tg::error!(!source, "failed to publish the message"))?;
 
+		Ok(())
+	}
+
+	async fn check_tag_ancestors(&self, tag: &tg::Tag) -> tg::Result<()> {
+		let connection = self
+			.database
+			.connection()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
+		let p = connection.p();
+		let statement = formatdoc!(
+			"
+				select count(*) from tags where tag = {p}1;
+			"
+		);
+		for ancestor in tag.ancestors() {
+			let params = db::params![ancestor.to_string()];
+			let count = connection
+				.query_one_value_into::<u64>(statement.clone().into(), params)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to perform the query"))?;
+			if count != 0 {
+				return Err(tg::error!("there is an existing tag `{ancestor}`"));
+			}
+		}
+		Ok(())
+	}
+
+	async fn create_tag_dir_entry(
+		&self,
+		tag: &tg::Tag,
+		artifact: &tg::artifact::Id,
+	) -> tg::Result<()> {
+		let link = self.tags_path().join(tag.to_string());
+		tokio::fs::create_dir_all(link.parent().unwrap())
+			.await
+			.map_err(|source| tg::error!(!source, "failed to create the tag directory"))?;
+		crate::util::fs::remove(&link).await.ok();
+		let target = self.artifacts_path().join(artifact.to_string());
+		let path = crate::util::path::diff(link.parent().unwrap(), &target)?;
+		tokio::fs::symlink(path, &link)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to create the tag entry"))?;
 		Ok(())
 	}
 


### PR DESCRIPTION
- internally forbid the creation of "branch" tags
- make `tg tag list foo` equivalent to `tg tag list foo/*` when `foo` is a "branch"
- create a .tangram/tags directory for containing local tags
- make LSP URIs point into the tags directory for more legible/discoverable resolutions