### PR TITLE
feat(server): feature-gate biome formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ tangram_ignore = { path = "packages/ignore" }
 tangram_itertools = { path = "packages/itertools" }
 tangram_messenger = { path = "packages/messenger" }
 tangram_sandbox = { path = "packages/sandbox" }
-tangram_server = { path = "packages/server" }
+tangram_server = { path = "packages/server", default-features = false }
 tangram_temp = { path = "packages/temp" }
 tangram_uri = { path = "packages/uri" }
 tangram_v8 = { path = "packages/v8" }

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"formatter": {
+		"useEditorconfig": true
+	},
 	"json": {
 		"formatter": {
 			"indentStyle": "tab"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -15,6 +15,8 @@ name = "tangram"
 path = "src/main.rs"
 
 [features]
+default = ["format", "foundationdb"]
+format = ["tangram_server/format"]
 foundationdb = ["dep:foundationdb", "tangram_server/foundationdb"]
 
 [lints]

--- a/packages/runtime/tangram.d.ts
+++ b/packages/runtime/tangram.d.ts
@@ -1,11 +1,10 @@
 /// <reference lib="es2023" />
 
-interface ImportAttributes {
+export interface ImportAttributes {
 	path?: string;
-	subpath?: string;
 }
 
-interface ImportMeta {
+export interface ImportMeta {
 	module: tg.Module;
 }
 
@@ -891,7 +890,7 @@ declare namespace tg {
 			input: string | Uint8Array | tg.Blob | tg.Artifact,
 			algorithm: tg.Checksum.Algorithm,
 		) => tg.Checksum;
-		export { new_ as new };
+		export type { new_ as new };
 	}
 
 	/** Assert that a condition is truthy. If not, throw an error with an optional message. */
@@ -1156,6 +1155,7 @@ declare namespace tg {
 	}
 
 	export class BuildBuilder<
+		// biome-ignore lint/correctness/noUnusedVariables: <reason>
 		A extends Array<tg.Value> = Array<tg.Value>,
 		R extends tg.Value = tg.Value,
 	> extends Function {
@@ -1267,6 +1267,7 @@ declare namespace tg {
 	}
 
 	export class RunBuilder<
+		// biome-ignore lint/correctness/noUnusedVariables: <reason>
 		A extends Array<tg.Value> = Array<tg.Value>,
 		R extends tg.Value = tg.Value,
 	> extends Function {

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -13,6 +13,14 @@ version = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+default = ["format"]
+format = [
+  "dep:biome_js_formatter",
+  "dep:biome_js_parser",
+  "dep:biome_js_syntax",
+]
+
 [build-dependencies]
 data-encoding = { workspace = true }
 glob = { workspace = true }
@@ -35,9 +43,9 @@ async-nats = { workspace = true }
 async_zip = { workspace = true }
 aws-credential-types = { workspace = true }
 aws-sigv4 = { workspace = true }
-biome_js_formatter = { workspace = true }
-biome_js_parser = { workspace = true }
-biome_js_syntax = { workspace = true }
+biome_js_formatter = { workspace = true, optional = true }
+biome_js_parser = { workspace = true, optional = true }
+biome_js_syntax = { workspace = true, optional = true }
 byte-unit = { workspace = true }
 bytes = { workspace = true }
 crossterm = { workspace = true }
@@ -94,7 +102,7 @@ tangram_either = { workspace = true }
 tangram_futures = { workspace = true }
 tangram_http = { workspace = true }
 tangram_ignore = { workspace = true }
-tangram_messenger  = { workspace = true }
+tangram_messenger = { workspace = true }
 tangram_sandbox = { workspace = true }
 tangram_temp = { workspace = true }
 tangram_uri = { workspace = true }

--- a/packages/server/src/compiler/format.rs
+++ b/packages/server/src/compiler/format.rs
@@ -3,6 +3,7 @@ use lsp_types as lsp;
 use tangram_client as tg;
 
 impl Compiler {
+	#[cfg(feature = "format")]
 	pub fn format(text: &str) -> tg::Result<String> {
 		let source_type = biome_js_syntax::JsFileSource::ts();
 		let options = biome_js_parser::JsParserOptions::default();
@@ -15,6 +16,11 @@ impl Compiler {
 			.map_err(|source| tg::error!(!source, "failed to format"))?
 			.into_code();
 		Ok(text)
+	}
+
+	#[cfg(not(feature = "format"))]
+	pub fn format(_text: &str) -> tg::Result<String> {
+		Err(tg::error!("formatting not enabled"))
 	}
 }
 


### PR DESCRIPTION
Add the `js-formatting` feature, enabled by default, allowing compilation without the biome dependencies. Formatting requests will return an error if the feature is disabled.