### PR TITLE
fix(server): correct variable name collision

### DIFF
--- a/packages/cli/tests/build.rs
+++ b/packages/cli/tests/build.rs
@@ -871,9 +871,8 @@ async fn command_set_checksum() {
 	test_build(artifact, reference, args, assertions).await;
 }
 
-#[ignore = "zip is not working"]
 #[tokio::test]
-async fn builtin_artifact_archive_extract_simple_dir_roundtrip() {
+async fn builtin_artifact_archive_extract_simple_dir_roundtrip_tar() {
 	let module = indoc!(
 		r#"
 			export default async () => {
@@ -883,7 +882,7 @@ async fn builtin_artifact_archive_extract_simple_dir_roundtrip() {
 				});
 				let archive = await tg.archive(artifact, "format");
 				let extracted = await tg.extract(archive);
-				tg.assert(extracted.id() === artifact.id());
+				tg.assert(extracted.id === artifact.id);
 			};
 		"#
 	);
@@ -894,6 +893,24 @@ async fn builtin_artifact_archive_extract_simple_dir_roundtrip() {
 		assert_success!(output);
 	};
 	test_archive(module, format, assertions).await;
+}
+
+#[ignore = "zip is not working"]
+#[tokio::test]
+async fn builtin_artifact_archive_extract_simple_dir_roundtrip_zip() {
+	let module = indoc!(
+		r#"
+			export default async () => {
+				let artifact = await tg.directory({
+					"hello.txt": "contents",
+					"link": tg.symlink("./hello.txt"),
+				});
+				let archive = await tg.archive(artifact, "format");
+				let extracted = await tg.extract(archive);
+				tg.assert(extracted.id === artifact.id);
+			};
+		"#
+	);
 
 	let format = "zip";
 	let assertions = |output: std::process::Output| async move {

--- a/packages/server/src/runtime/builtin/archive.rs
+++ b/packages/server/src/runtime/builtin/archive.rs
@@ -175,7 +175,7 @@ where
 			if symlink.artifact(server).await?.is_some() {
 				return Err(tg::error!("cannot archive a symlink with an artifact"));
 			}
-			let path = symlink
+			let target = symlink
 				.path(server)
 				.await?
 				.ok_or_else(|| tg::error!("cannot archive a symlink without a path"))?;
@@ -184,7 +184,7 @@ where
 			header.set_entry_type(tokio_tar::EntryType::Symlink);
 			header.set_mode(0o777);
 			header
-				.set_link_name(path.to_string_lossy().as_ref())
+				.set_link_name(target.to_string_lossy().as_ref())
 				.map_err(|source| tg::error!(!source, "failed to set symlink target"))?;
 			builder
 				.append_data(&mut header, path, &[][..])
@@ -296,7 +296,7 @@ where
 			if symlink.artifact(server).await?.is_some() {
 				return Err(tg::error!("cannot archive a symlink with an artifact"));
 			}
-			let path = symlink
+			let target = symlink
 				.path(server)
 				.await?
 				.ok_or_else(|| tg::error!("cannot archive a symlink without a path"))?;
@@ -306,7 +306,7 @@ where
 			)
 			.unix_permissions(0o120_777);
 			builder
-				.write_entry_whole(entry.build(), path.to_string_lossy().as_bytes())
+				.write_entry_whole(entry.build(), target.to_string_lossy().as_bytes())
 				.await
 				.map_err(|source| tg::error!(!source, "failed to write the symlink entry"))
 		},


### PR DESCRIPTION
Also separate the `tar` and `zip` archive roundtrip tests, and only ignore zip.