### PR TITLE
feat(cli): print cancellation token if present for build --detach

### DIFF
--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -105,7 +105,11 @@ impl Cli {
 		// If the detach flag is set, then print the process ID and return.
 		if options.detach {
 			if print {
-				println!("{}", process.id());
+				print!("{}", process.id());
+				if let Some(token) = process.token() {
+					print!(" {token}");
+				}
+				println!();
 			}
 			return Ok(None);
 		}


### PR DESCRIPTION
This PR implements a stopgap fix to provide the cancellation token if present when using `build --detach`, pending the larger change to output JSON or CLI tables. This is necessary for the package automation script to handle cancellation of processes it creates if interrupted, which will be updated to use JSON in the future.