### PR TITLE
feat(cli): implement tg outdated

### DIFF
--- a/packages/cli/src/outdated.rs
+++ b/packages/cli/src/outdated.rs
@@ -1,4 +1,4 @@
-use {crate::Cli, tangram_client as tg};
+use {crate::Cli, std::collections::HashSet, tangram_client as tg};
 
 /// Get a package's outdated dependencies.
 #[derive(Clone, Debug, clap::Args)]
@@ -9,7 +9,97 @@ pub struct Args {
 }
 
 impl Cli {
-	pub async fn command_outdated(&mut self, _args: Args) -> tg::Result<()> {
-		Err(tg::error!("unimplemented"))
+	pub async fn command_outdated(&mut self, args: Args) -> tg::Result<()> {
+		let handle = self.handle().await?;
+		let object = self
+			.get_reference(&args.reference)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get reference"))?
+			.item()
+			.clone()
+			.right()
+			.ok_or_else(|| tg::error!(%reference = args.reference, "expected an object"))?;
+		let mut visitor = Visitor::default();
+		tg::object::visit(&handle, &mut visitor, [object])
+			.await
+			.map_err(|source| tg::error!(!source, "failed to walk objects"))?;
+		let entries = visitor.entries.into_iter().collect::<Vec<_>>();
+		let output = serde_json::to_string_pretty(&entries)
+			.map_err(|source| tg::error!(!source, "failed to serialize entries"))?;
+		println!("{output}");
+		Ok(())
+	}
+}
+
+#[derive(Default)]
+struct Visitor {
+	entries: HashSet<Entry>,
+}
+
+#[derive(serde::Serialize, Debug, PartialEq, Eq, Hash)]
+struct Entry {
+	compatible: Option<tg::Tag>,
+	current: tg::Tag,
+	latest: Option<tg::Tag>,
+}
+
+impl<H> tg::object::Visitor<H> for Visitor
+where
+	H: tg::Handle,
+{
+	async fn visit_file(
+		&mut self,
+		handle: &H,
+		file: &tangram_client::File,
+	) -> tangram_client::Result<()> {
+		// Get the file's dependencies.
+		let dependencies = file
+			.dependencies(handle)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get the file's dependencies"))?
+			.into_iter()
+			.filter_map(|(reference, referent)| {
+				let pattern = reference.item().clone().try_unwrap_tag().ok()?;
+				let tag = referent?.options.tag.take()?;
+				Some((pattern, tag))
+			});
+		for (pattern, current) in dependencies {
+			let compatible = handle
+				.list_tags(tg::tag::list::Arg {
+					pattern: pattern.clone(),
+					length: Some(1),
+					remote: None,
+					reverse: false,
+				})
+				.await?
+				.data
+				.into_iter()
+				.map(|o| o.tag)
+				.next();
+
+			let mut components = pattern.components().collect::<Vec<_>>();
+			components.pop();
+			components.push("*");
+			let pattern = tg::tag::Pattern::new(components.join("/"));
+			let latest = handle
+				.list_tags(tg::tag::list::Arg {
+					pattern: pattern.clone(),
+					length: Some(1),
+					remote: None,
+					reverse: true,
+				})
+				.await?
+				.data
+				.into_iter()
+				.map(|o| o.tag)
+				.next();
+			let entry = Entry {
+				current,
+				compatible,
+				latest,
+			};
+			self.entries.insert(entry);
+		}
+		Ok(())
 	}
 }

--- a/packages/cli/src/outdated.rs
+++ b/packages/cli/src/outdated.rs
@@ -69,7 +69,7 @@ where
 					pattern: pattern.clone(),
 					length: Some(1),
 					remote: None,
-					reverse: false,
+					reverse: true,
 				})
 				.await?
 				.data

--- a/packages/cli/tests/tag.rs
+++ b/packages/cli/tests/tag.rs
@@ -458,7 +458,7 @@ async fn outdated() {
 	assert_snapshot!(stdout, @r#"
 	[
 	  {
-	    "compatible": "hello/1.0.0",
+	    "compatible": "hello/1.1.0",
 	    "current": "hello/1.1.0",
 	    "latest": "hello/2.0.0"
 	  }

--- a/packages/cli/tests/tag.rs
+++ b/packages/cli/tests/tag.rs
@@ -1,4 +1,5 @@
 use {
+	indoc::indoc,
 	insta::{assert_json_snapshot, assert_snapshot},
 	tangram_cli_test::{Server, assert_failure, assert_success},
 	tangram_client as tg,
@@ -402,4 +403,65 @@ async fn delete() {
 	assert_failure!(output);
 	let stderr = std::str::from_utf8(&output.stderr).unwrap();
 	assert!(stderr.contains("cannot delete an empty pattern"));
+}
+
+#[tokio::test]
+async fn outdated() {
+	// Create a server.
+	let server = Server::new(TG).await.unwrap();
+
+	// Write the artifact to a temp.
+	let artifact: temp::Artifact = temp::file!("Hello, World!").into();
+	let temp = Temp::new();
+	let path = temp.path();
+	artifact.to_path(path).await.unwrap();
+
+	// Check in.
+	let output = server.tg().arg("checkin").arg(path).output().await.unwrap();
+	assert_success!(output);
+	let id = std::str::from_utf8(&output.stdout).unwrap().trim();
+
+	// Tag it a couple times.
+	for version in ["1.0.0", "1.1.0", "2.0.0"] {
+		let output = server
+			.tg()
+			.arg("tag")
+			.arg(format!("hello/{version}"))
+			.arg(id)
+			.output()
+			.await
+			.unwrap();
+		assert_success!(output);
+	}
+
+	// Create something that uses it.
+	let artifact: temp::Artifact = temp::directory! {
+		"tangram.ts" => temp::file!(indoc!(r#"
+			import hello from "hello/^1.0";
+		"#)),
+	}
+	.into();
+	let temp = Temp::new();
+	let path = temp.path();
+	artifact.to_path(path).await.unwrap();
+
+	// Get the outdated.
+	let output = server
+		.tg()
+		.arg("outdated")
+		.arg(path)
+		.output()
+		.await
+		.unwrap();
+	assert_success!(output);
+	let stdout = std::str::from_utf8(&output.stdout).unwrap();
+	assert_snapshot!(stdout, @r#"
+	[
+	  {
+	    "compatible": "hello/1.0.0",
+	    "current": "hello/1.1.0",
+	    "latest": "hello/2.0.0"
+	  }
+	]
+	"#);
 }

--- a/packages/client/src/object.rs
+++ b/packages/client/src/object.rs
@@ -2,6 +2,9 @@ pub use self::{
 	data::Object as Data, handle::Object as Handle, id::Id, kind::Kind, metadata::Metadata,
 	object::Object, state::State,
 };
+use crate as tg;
+use futures::future;
+use std::{collections::HashSet, future::Future};
 
 pub mod data;
 pub mod get;
@@ -14,3 +17,113 @@ pub mod object;
 pub mod put;
 pub mod state;
 pub mod touch;
+
+/// Visit each object in an object graph once. Note: this is _not_ the same as walking the object tree, since it will also construct objects that point into graph objects to visit each of them.
+pub async fn visit<H, V>(
+	handle: &H,
+	visitor: &mut V,
+	objects: impl IntoIterator<Item = tg::Object>,
+) -> tg::Result<()>
+where
+	H: tg::Handle,
+	V: tg::object::Visitor<H>,
+{
+	// Stack for DFS.
+	let mut stack = objects.into_iter().collect::<Vec<_>>();
+
+	// Keep track of objects we've visited already.
+	let mut visited = HashSet::<_, fnv::FnvBuildHasher>::default();
+
+	// Recursive DFS.
+	while let Some(object) = stack.pop() {
+		// Don't visit objects more than once.
+		if !visited.insert(object.id()) {
+			continue;
+		}
+
+		// Apply the visitor method.
+		match &object {
+			tg::Object::Blob(blob) => visitor.visit_blob(handle, blob).await?,
+			tg::Object::Directory(directory) => visitor.visit_directory(handle, directory).await?,
+			tg::Object::File(file) => visitor.visit_file(handle, file).await?,
+			tg::Object::Symlink(symlink) => visitor.visit_symlink(handle, symlink).await?,
+			tg::Object::Graph(graph) => visitor.visit_graph(handle, graph).await?,
+			tg::Object::Command(command) => visitor.visit_command(handle, command).await?,
+		}
+
+		// For graphs we want to visit the objects that point into it as well. The visited set will make sure we don't visit the same graph twice.
+		if let tg::Object::Graph(graph) = &object {
+			let children =
+				graph
+					.nodes(handle)
+					.await?
+					.into_iter()
+					.enumerate()
+					.map(|(index, node)| match node.kind() {
+						tg::artifact::Kind::Directory => {
+							tg::Directory::with_graph_and_node(graph.clone(), index).into()
+						},
+						tg::artifact::Kind::File => {
+							tg::File::with_graph_and_node(graph.clone(), index).into()
+						},
+						tg::artifact::Kind::Symlink => {
+							tg::Symlink::with_graph_and_node(graph.clone(), index).into()
+						},
+					});
+			stack.extend(children);
+		} else {
+			// For everything else just visit the children.
+			stack.extend(object.children(handle).await?.into_iter());
+		}
+
+		// Unload the object since we probably don't need it anymore.
+		object.unload();
+	}
+	Ok(())
+}
+
+#[allow(unused_variables)]
+pub trait Visitor<H>
+where
+	H: tg::Handle,
+{
+	fn visit_blob(&mut self, handle: &H, blob: &tg::Blob) -> impl Future<Output = tg::Result<()>> {
+		future::ok(())
+	}
+
+	fn visit_directory(
+		&mut self,
+		handle: &H,
+		directory: &tg::Directory,
+	) -> impl Future<Output = tg::Result<()>> {
+		future::ok(())
+	}
+
+	fn visit_file(&mut self, handle: &H, file: &tg::File) -> impl Future<Output = tg::Result<()>> {
+		future::ok(())
+	}
+
+	fn visit_symlink(
+		&mut self,
+		handle: &H,
+		symlink: &tg::Symlink,
+	) -> impl Future<Output = tg::Result<()>> {
+		future::ok(())
+	}
+
+	fn visit_graph(
+		&mut self,
+		handle: &H,
+		graph: &tg::Graph,
+	) -> impl Future<Output = tg::Result<()>> {
+		future::ok(())
+	}
+
+	fn visit_command(
+		&mut self,
+		handle: &H,
+		command: &tg::Command,
+	) -> impl Future<Output = tg::Result<()>> {
+		future::ok(())
+	}
+}

--- a/packages/client/src/object.rs
+++ b/packages/client/src/object.rs
@@ -2,9 +2,11 @@ pub use self::{
 	data::Object as Data, handle::Object as Handle, id::Id, kind::Kind, metadata::Metadata,
 	object::Object, state::State,
 };
-use crate as tg;
-use futures::future;
-use std::{collections::HashSet, future::Future};
+use {
+	crate as tg,
+	futures::future,
+	std::{collections::HashSet, future::Future},
+};
 
 pub mod data;
 pub mod get;


### PR DESCRIPTION
- implement `tg outdated` command
- add `tg::object::visit` helper for walking object graphs