### PR TITLE
feat: implement tg tree

### DIFF
--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -144,23 +144,20 @@ impl Cli {
 					local_set
 						.block_on(&runtime, async move {
 							let viewer_options = crate::viewer::Options {
+								collapse_process_children: true,
 								depth: None,
-								expand: crate::view::ExpandOptions {
-									collapse_process_children: true,
-									process: true,
-									package: false,
-									tag: false,
-									object: false,
-								},
+								expand_objects: false,
+								expand_packages: false,
+								expand_processes: true,
+								expand_tags: false,
 								show_process_commands: false,
-								clear_at_end: true,
 							};
 							let mut viewer =
 								crate::viewer::Viewer::new(&handle, root, viewer_options);
 							match options.view {
 								View::None => (),
 								View::Inline => {
-									viewer.run_inline(stop).await?;
+									viewer.run_inline(stop, false).await?;
 								},
 								View::Fullscreen => {
 									viewer.run_fullscreen(stop).await?;

--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -145,8 +145,15 @@ impl Cli {
 					local_set
 						.block_on(&runtime, async move {
 							let viewer_options = crate::viewer::Options {
-								auto_expand_and_collapse_processes: true,
+								expand: crate::view::ExpandOptions {
+									collapse_process_children: true,
+									process: true,
+									package: false,
+									tag: false,
+									object: false,
+								},
 								show_process_commands: false,
+								clear_at_end: true,
 							};
 							let mut viewer =
 								crate::viewer::Viewer::new(&handle, root, viewer_options);

--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -145,6 +145,7 @@ impl Cli {
 					local_set
 						.block_on(&runtime, async move {
 							let viewer_options = crate::viewer::Options {
+								depth: None,
 								expand: crate::view::ExpandOptions {
 									collapse_process_children: true,
 									process: true,

--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -138,7 +138,6 @@ impl Cli {
 				let task = Task::spawn_blocking(move |stop| {
 					let local_set = tokio::task::LocalSet::new();
 					let runtime = tokio::runtime::Builder::new_current_thread()
-						.worker_threads(1)
 						.enable_all()
 						.build()
 						.unwrap();

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -57,11 +57,11 @@ mod server;
 mod tag;
 mod tangram;
 mod tree;
-mod watch;
 mod update;
 mod util;
 mod view;
 mod viewer;
+mod watch;
 mod write;
 
 pub use self::config::Config;

--- a/packages/cli/src/publish.rs
+++ b/packages/cli/src/publish.rs
@@ -212,11 +212,8 @@ async fn try_get_package_tag(
 		// For directories, look for a root module.
 		tg::Object::Directory(directory) => {
 			// Get the root file name.
-			let Some(name) = tg::package::try_get_root_module_file_name(
-				handle,
-				Either::Left(&directory.clone()),
-			)
-			.await?
+			let Some(name) =
+				tg::package::try_get_root_module_file_name(handle, Either::Left(directory)).await?
 			else {
 				return Ok(None);
 			};
@@ -282,7 +279,7 @@ impl State {
 		// Edge case: make sure the root is added if it is on the local file system.
 		if root.path().is_some() {
 			self.local_packages.push(root.clone());
-			self.add_package(&root.clone());
+			self.add_package(root);
 		}
 
 		// Visit all the objects.

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -142,8 +142,18 @@ impl Cli {
 						local_set
 							.block_on(&runtime, async move {
 								let viewer_options = crate::viewer::Options {
-									auto_expand_and_collapse_processes: true,
-									show_process_commands: false,
+									expand: crate::view::ExpandOptions {
+										collapse_process_children: true,
+										process: true,
+										package: false,
+										tag: false,
+										object: false,
+									},
+									show_process_commands: matches!(
+										options.build_view,
+										crate::build::View::Inline
+									),
+									clear_at_end: true,
 								};
 								let mut viewer =
 									crate::viewer::Viewer::new(&handle, root, viewer_options);

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -141,26 +141,20 @@ impl Cli {
 						local_set
 							.block_on(&runtime, async move {
 								let viewer_options = crate::viewer::Options {
+									collapse_process_children: true,
 									depth: None,
-									expand: crate::view::ExpandOptions {
-										collapse_process_children: true,
-										process: true,
-										package: false,
-										tag: false,
-										object: false,
-									},
-									show_process_commands: matches!(
-										options.build_view,
-										crate::build::View::Inline
-									),
-									clear_at_end: true,
+									expand_objects: false,
+									expand_packages: false,
+									expand_processes: true,
+									expand_tags: false,
+									show_process_commands: false,
 								};
 								let mut viewer =
 									crate::viewer::Viewer::new(&handle, root, viewer_options);
 								match options.build_view {
 									crate::build::View::None => (),
 									crate::build::View::Inline => {
-										viewer.run_inline(stop).await?;
+										viewer.run_inline(stop, false).await?;
 									},
 									crate::build::View::Fullscreen => {
 										viewer.run_fullscreen(stop).await?;

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -135,7 +135,6 @@ impl Cli {
 					let task = Task::spawn_blocking(move |stop| {
 						let local_set = tokio::task::LocalSet::new();
 						let runtime = tokio::runtime::Builder::new_current_thread()
-							.worker_threads(1)
 							.enable_all()
 							.build()
 							.unwrap();

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -142,6 +142,7 @@ impl Cli {
 						local_set
 							.block_on(&runtime, async move {
 								let viewer_options = crate::viewer::Options {
+									depth: None,
 									expand: crate::view::ExpandOptions {
 										collapse_process_children: true,
 										process: true,

--- a/packages/cli/src/tree.rs
+++ b/packages/cli/src/tree.rs
@@ -12,6 +12,9 @@ pub struct Args {
 	#[arg(long)]
 	pub locked: bool,
 
+	#[arg(long, default_value = "value")]
+	pub mode: crate::view::Mode,
+
 	/// The reference to display a tree for.
 	#[arg(index = 1)]
 	pub reference: tg::Reference,
@@ -19,10 +22,19 @@ pub struct Args {
 
 impl Cli {
 	pub async fn command_tree(&mut self, args: Args) -> tg::Result<()> {
+		let expand = crate::view::ExpandOptions {
+			collapse_process_children: false,
+			package: true,
+			process: true,
+			tag: true,
+			object: matches!(args.mode, crate::view::Mode::Value | crate::view::Mode::Tag),
+		};
 		let args = crate::view::Args {
 			depth: args.depth,
+			expand,
 			kind: crate::view::Kind::Inline,
 			locked: args.locked,
+			mode: args.mode,
 			reference: args.reference,
 		};
 		self.command_view(args).await?;

--- a/packages/cli/src/tree.rs
+++ b/packages/cli/src/tree.rs
@@ -8,10 +8,6 @@ pub struct Args {
 	#[arg(long)]
 	pub depth: Option<u32>,
 
-	/// If this flag is set, the lock will not be updated.
-	#[arg(long)]
-	pub locked: bool,
-
 	#[arg(long, default_value = "value")]
 	pub mode: crate::view::Mode,
 
@@ -22,18 +18,14 @@ pub struct Args {
 
 impl Cli {
 	pub async fn command_tree(&mut self, args: Args) -> tg::Result<()> {
-		let expand = crate::view::ExpandOptions {
-			collapse_process_children: false,
-			package: true,
-			process: true,
-			tag: true,
-			object: matches!(args.mode, crate::view::Mode::Value | crate::view::Mode::Tag),
-		};
 		let args = crate::view::Args {
+			collapse_process_children: false,
 			depth: args.depth,
-			expand,
+			expand_objects: matches!(args.mode, crate::view::Mode::Value | crate::view::Mode::Tag),
+			expand_packages: true,
+			expand_processes: true,
+			expand_tags: true,
 			kind: crate::view::Kind::Inline,
-			locked: args.locked,
 			mode: args.mode,
 			reference: args.reference,
 		};

--- a/packages/cli/src/tree.rs
+++ b/packages/cli/src/tree.rs
@@ -26,8 +26,8 @@ impl Cli {
 			expand_packages: true,
 			expand_processes: true,
 			expand_tags: true,
-			mode: crate::view::Mode::Inline,
 			kind: args.kind,
+			mode: crate::view::Mode::Inline,
 			reference: args.reference,
 		};
 		self.command_view(args).await?;

--- a/packages/cli/src/tree.rs
+++ b/packages/cli/src/tree.rs
@@ -8,8 +8,9 @@ pub struct Args {
 	#[arg(long)]
 	pub depth: Option<u32>,
 
+	/// Whether to view the item as a tag, package, or value.
 	#[arg(long, default_value = "value")]
-	pub mode: crate::view::Mode,
+	pub kind: crate::view::Kind,
 
 	/// The reference to display a tree for.
 	#[arg(index = 1)]
@@ -21,12 +22,12 @@ impl Cli {
 		let args = crate::view::Args {
 			collapse_process_children: false,
 			depth: args.depth,
-			expand_objects: matches!(args.mode, crate::view::Mode::Value | crate::view::Mode::Tag),
+			expand_objects: matches!(args.kind, crate::view::Kind::Value | crate::view::Kind::Tag),
 			expand_packages: true,
 			expand_processes: true,
 			expand_tags: true,
-			kind: crate::view::Kind::Inline,
-			mode: args.mode,
+			mode: crate::view::Mode::Inline,
+			kind: args.kind,
 			reference: args.reference,
 		};
 		self.command_view(args).await?;

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -8,6 +8,9 @@ pub struct Args {
 	#[arg(long)]
 	pub depth: Option<u32>,
 
+	#[command(flatten)]
+	pub expand: ExpandOptions,
+
 	/// Choose the kind of view, either inline or fullscreen.
 	#[arg(default_value = "fullscreen", long)]
 	pub kind: Kind,
@@ -16,9 +19,36 @@ pub struct Args {
 	#[arg(long)]
 	pub locked: bool,
 
+	/// If set, view the reference as a tag, package, or value.
+	#[arg(long = "mode", default_value = "value")]
+	pub mode: Mode,
+
 	/// The reference to view.
 	#[arg(index = 1, default_value = ".")]
 	pub reference: tg::Reference,
+}
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct ExpandOptions {
+	/// Auto collapse process children when processes finish.
+	#[arg(long)]
+	pub collapse_process_children: bool,
+
+	/// Auto expand objects.
+	#[arg(long = "expand-value")]
+	pub object: bool,
+
+	/// Auto expand package nodes.
+	#[arg(long = "expand-package")]
+	pub package: bool,
+
+	/// Auto expand process nodes.
+	#[arg(long = "expand-process")]
+	pub process: bool,
+
+	/// Auto expand tag nodes.
+	#[arg(long = "expand-tag")]
+	pub tag: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, clap::ValueEnum, serde::Deserialize, serde::Serialize)]
@@ -29,17 +59,46 @@ pub enum Kind {
 	Fullscreen,
 }
 
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum Mode {
+	Tag,
+	Package,
+	Value,
+}
+
 impl Cli {
 	pub async fn command_view(&mut self, args: Args) -> tg::Result<()> {
 		let handle = self.handle().await?;
 
 		// Get the reference.
-		let referent = self.get_reference(&args.reference).await?;
-		let item = match referent.item() {
-			Either::Left(process) => crate::viewer::Item::Process(process.clone()),
-			Either::Right(object) => crate::viewer::Item::Value(object.clone().into()),
+		let root = match args.mode {
+			Mode::Tag => {
+				let item = args.reference.item();
+				let pattern = item.clone().try_unwrap_tag().map_err(
+					|source| tg::error!(!source, %reference = args.reference, "expected a tag"),
+				)?;
+				tg::Referent::with_item(crate::viewer::Item::Tag(pattern.clone()))
+			},
+			Mode::Value | Mode::Package => {
+				let referent = self.get_reference(&args.reference).await?;
+				let item = match (referent.item(), args.mode) {
+					(Either::Left(_), Mode::Package) => {
+						return Err(tg::error!(%reference = args.reference, "expected an object"));
+					},
+					(Either::Left(process), Mode::Value) => {
+						crate::viewer::Item::Process(process.clone())
+					},
+					(Either::Right(object), Mode::Package) => {
+						crate::viewer::Item::Package(crate::viewer::Package(object.clone()))
+					},
+					(Either::Right(object), Mode::Value) => {
+						crate::viewer::Item::Value(object.clone().into())
+					},
+					(_, Mode::Tag) => unreachable!(),
+				};
+				referent.map(|_| item)
+			},
 		};
-		let root = referent.map(|_| item);
 
 		let kind = args.kind;
 		Task::spawn_blocking(move |stop| {
@@ -52,8 +111,9 @@ impl Cli {
 			local_set
 				.block_on(&runtime, async move {
 					let options = crate::viewer::Options {
-						auto_expand_and_collapse_processes: false,
+						expand: args.expand,
 						show_process_commands: true,
+						clear_at_end: !matches!(kind, Kind::Inline),
 					};
 					let mut viewer = crate::viewer::Viewer::new(&handle, root, options);
 					match kind {

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -104,7 +104,6 @@ impl Cli {
 		Task::spawn_blocking(move |stop| {
 			let local_set = tokio::task::LocalSet::new();
 			let runtime = tokio::runtime::Builder::new_current_thread()
-				.worker_threads(1)
 				.enable_all()
 				.build()
 				.unwrap();

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -90,7 +90,7 @@ impl Cli {
 			},
 		};
 
-		let kind = args.mode;
+		let mode = args.mode;
 		Task::spawn_blocking(move |stop| {
 			let local_set = tokio::task::LocalSet::new();
 			let runtime = tokio::runtime::Builder::new_current_thread()
@@ -109,7 +109,7 @@ impl Cli {
 						show_process_commands: true,
 					};
 					let mut viewer = crate::viewer::Viewer::new(&handle, root, options);
-					match kind {
+					match mode {
 						Mode::Inline => {
 							viewer.run_inline(stop, true).await?;
 						},

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -111,6 +111,7 @@ impl Cli {
 			local_set
 				.block_on(&runtime, async move {
 					let options = crate::viewer::Options {
+						depth: args.depth,
 						expand: args.expand,
 						show_process_commands: true,
 						clear_at_end: !matches!(kind, Kind::Inline),

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -52,10 +52,13 @@ pub struct Package(pub tg::Object);
 
 #[derive(Clone, Debug)]
 pub struct Options {
+	pub collapse_process_children: bool,
 	pub depth: Option<u32>,
-	pub expand: crate::view::ExpandOptions,
+	pub expand_objects: bool,
+	pub expand_packages: bool,
+	pub expand_processes: bool,
+	pub expand_tags: bool,
 	pub show_process_commands: bool,
-	pub clear_at_end: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -315,7 +318,7 @@ where
 		result
 	}
 
-	pub async fn run_inline(&mut self, stop: Stop) -> tg::Result<()> {
+	pub async fn run_inline(&mut self, stop: Stop, print: bool) -> tg::Result<()> {
 		let mut tty: Option<std::io::Stderr> = if std::io::stderr().is_terminal() {
 			Some(std::io::stderr())
 		} else {
@@ -405,7 +408,7 @@ where
 		}
 
 		// Render the tree one more time if necessary.
-		if !self.tree.options().clear_at_end {
+		if print {
 			println!("{}", self.tree.display());
 		}
 

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -391,6 +391,7 @@ where
 		// Handle any pending updates.
 		self.update();
 
+		// Clear.
 		// Clear previous output if it exists.
 		if let Some(tty) = tty.as_mut() {
 			ct::queue!(
@@ -400,21 +401,11 @@ where
 				ct::cursor::Show,
 			)
 			.map_err(|source| tg::error!(!source, "failed to write to the terminal"))?;
-		
-		// Get the tty or print the tree.
-		let Some(tty) = tty.as_mut() else {
-			eprintln!("{}", self.tree.display());
-			return Ok(());
-		};
+		}
 
-		// Clear.
-		if self.tree.options().clear_at_end && lines.is_some_and(|lines| lines > 0) {
-			ct::queue!(
-				tty,
-				ct::cursor::MoveToPreviousLine(lines.unwrap()),
-				ct::terminal::Clear(ct::terminal::ClearType::FromCursorDown),
-			)
-			.unwrap();
+		// Render one more time.
+		if !self.tree.options().clear_at_end {
+			eprintln!("{}", self.tree.display());
 		}
 
 		Ok(())

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -52,6 +52,7 @@ pub struct Package(pub tg::Object);
 
 #[derive(Clone, Debug)]
 pub struct Options {
+	pub depth: Option<u32>,
 	pub expand: crate::view::ExpandOptions,
 	pub show_process_commands: bool,
 	pub clear_at_end: bool,

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -380,11 +380,11 @@ where
 			tokio::select! {
 				() = changed => (),
 				() = sleep => (),
-				() = stop => break 'display,
+				() = stop => break,
 			};
 
 			if self.tree.is_finished() {
-				break 'display;
+				break;
 			}
 		}
 

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -352,16 +352,6 @@ where
 		return None;
 	}
 
-	fn clear_node(node: &Rc<RefCell<Node>>, recurse: bool) {
-		node.borrow_mut().guard.take();
-		if !recurse {
-			return;
-		}
-		for child in &node.borrow().children {
-			Self::clear_node(child, true);
-		}
-	}
-
 	fn down(&mut self) {
 		let nodes = self.nodes();
 		let index = nodes

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -349,7 +349,7 @@ where
 			return Some(Display { title, children });
 		}
 
-		return None;
+		None
 	}
 
 	fn down(&mut self) {

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -1,17 +1,22 @@
 use {
-	super::{Item, Options, data, log::Log},
+	super::{Item, Options, Package, data, log::Log},
 	crossterm as ct,
 	futures::{TryStreamExt as _, future, stream::FuturesUnordered},
 	num::ToPrimitive as _,
 	ratatui::{self as tui, prelude::*},
 	std::{
 		cell::RefCell,
-		collections::BTreeMap,
+		collections::{BTreeMap, HashSet},
 		io::Write as _,
 		pin::pin,
 		rc::{Rc, Weak},
+		sync::{
+			Arc,
+			atomic::{AtomicU32, Ordering},
+		},
 	},
 	tangram_client::{self as tg, prelude::*},
+	tangram_either::Either,
 	tangram_futures::task::Task,
 };
 
@@ -19,7 +24,9 @@ const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '�
 
 pub struct Tree<H> {
 	handle: H,
+	counter: UpdateCounter,
 	data: data::UpdateSender,
+	options: Rc<Options>,
 	rect: Option<Rect>,
 	roots: Vec<Rc<RefCell<Node>>>,
 	selected: Rc<RefCell<Node>>,
@@ -30,9 +37,12 @@ pub struct Tree<H> {
 
 struct Node {
 	children: Vec<Rc<RefCell<Self>>>,
+	counter: UpdateCounter,
 	depth: usize,
 	expand_task: Option<Task<()>>,
 	expanded: Option<bool>,
+	expanded_nodes: Rc<RefCell<HashSet<NodeID>>>,
+	guard: Option<UpdateGuard>,
 	indicator: Option<Indicator>,
 	label: Option<String>,
 	log_task: Option<Task<()>>,
@@ -43,6 +53,62 @@ struct Node {
 	update_receiver: NodeUpdateReceiver,
 	update_sender: NodeUpdateSender,
 	update_task: Option<Task<()>>,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+enum NodeID {
+	Object(tg::object::Id),
+	Package(tg::object::Id),
+	Process(tg::process::Id),
+	Tag(String),
+}
+
+#[derive(Clone)]
+struct UpdateCounter {
+	num_pending: Arc<AtomicU32>,
+	watch: tokio::sync::watch::Sender<()>,
+}
+
+struct UpdateGuard {
+	num_pending: Arc<AtomicU32>,
+	watch: tokio::sync::watch::Sender<()>,
+}
+
+impl UpdateCounter {
+	fn new() -> Self {
+		let watch = tokio::sync::watch::Sender::new(());
+		Self {
+			num_pending: Arc::new(AtomicU32::new(0)),
+			watch,
+		}
+	}
+
+	fn guard(&self) -> UpdateGuard {
+		self.num_pending.fetch_add(1, Ordering::AcqRel);
+		self.watch.send(()).ok();
+		UpdateGuard {
+			num_pending: self.num_pending.clone(),
+			watch: self.watch.clone(),
+		}
+	}
+
+	fn is_finished(&self) -> bool {
+		self.num_pending.load(Ordering::Acquire) == 0
+	}
+
+	fn changed(&self) -> impl Future<Output = ()> + Send + Sync {
+		let mut receiver = self.watch.subscribe();
+		async move {
+			receiver.changed().await.ok();
+		}
+	}
+}
+
+impl Drop for UpdateGuard {
+	fn drop(&mut self) {
+		self.num_pending.fetch_sub(1, Ordering::AcqRel);
+		self.watch.send(()).ok();
+	}
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -61,6 +127,7 @@ type NodeUpdateSender = std::sync::mpsc::Sender<Box<dyn FnOnce(Rc<RefCell<Node>>
 
 type NodeUpdateReceiver = std::sync::mpsc::Receiver<Box<dyn FnOnce(Rc<RefCell<Node>>)>>;
 
+#[derive(Debug)]
 pub struct Display {
 	title: String,
 	children: Vec<Self>,
@@ -70,6 +137,14 @@ impl<H> Tree<H>
 where
 	H: tg::Handle,
 {
+	pub fn options(&self) -> Rc<Options> {
+		self.options.clone()
+	}
+
+	pub fn changed(&self) -> impl Future<Output = ()> + Send + Sync {
+		self.counter.changed()
+	}
+
 	fn ancestors(node: &Rc<RefCell<Node>>) -> Vec<Rc<RefCell<Node>>> {
 		let mut ancestors = vec![node.clone()];
 		let mut node = node.clone();
@@ -131,21 +206,48 @@ where
 	where
 		H: tg::Handle,
 	{
+		let counter = parent.borrow().counter.clone();
 		let depth = parent.borrow().depth + 1;
+		let expanded_nodes = parent.borrow().expanded_nodes.clone();
 		let (update_sender, update_receiver) = std::sync::mpsc::channel();
 		let options = parent.borrow().options.clone();
 		let parent = Rc::downgrade(parent);
 		let title = referent
 			.as_ref()
 			.map_or(String::new(), |referent| Self::item_title(referent.item()));
+		let expand = match referent.as_ref().map(tg::Referent::item) {
+			Some(Item::Package(package)) if options.expand.package => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Package(package.0.id())),
+			Some(Item::Process(process)) if options.expand.process => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Process(process.id().clone())),
+			Some(Item::Tag(pattern)) if options.expand.tag => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Tag(pattern.to_string())),
+			Some(Item::Value(tg::Value::Object(object))) => {
+				if options.expand.object {
+					expanded_nodes
+						.borrow_mut()
+						.insert(NodeID::Object(object.id()))
+				} else {
+					false
+				}
+			},
+			Some(Item::Value(_)) => true,
+			_ => false,
+		};
 
-		let expand_task = match (&referent, options.auto_expand_and_collapse_processes) {
+		let expand_task = match (&referent, expand) {
 			(Some(referent), true) => {
+				let counter = counter.clone();
 				let handle = handle.clone();
 				let referent = referent.clone();
 				let update_sender = update_sender.clone();
+				let guard = counter.guard();
 				let task = Task::spawn_local(|_| async move {
-					Self::expand_task(&handle, referent, update_sender).await;
+					Self::expand_task(&handle, counter.clone(), referent, update_sender).await;
+					drop(guard);
 				});
 				Some(task)
 			},
@@ -162,15 +264,19 @@ where
 					| tg::Value::Object(_)
 					| tg::Value::Template(_),
 				),
-			) => Some(false),
+			) => Some(expand),
 			_ => None,
 		};
 
+		let guard = Some(counter.guard());
 		Rc::new(RefCell::new(Node {
 			children: Vec::new(),
+			counter,
 			depth,
 			expand_task,
 			expanded,
+			expanded_nodes,
+			guard,
 			indicator: None,
 			referent,
 			label,
@@ -190,6 +296,10 @@ where
 			.unwrap()
 			.as_millis();
 		Self::display_node(self.roots.last().unwrap(), now)
+	}
+
+	pub fn is_finished(&self) -> bool {
+		self.counter.is_finished()
 	}
 
 	fn display_node(node: &Rc<RefCell<Node>>, now: u128) -> Display {
@@ -224,6 +334,7 @@ where
 			.iter()
 			.map(|node| Self::display_node(node, now))
 			.collect();
+		node.borrow_mut().guard.take();
 		Display { title, children }
 	}
 
@@ -250,10 +361,15 @@ where
 			return;
 		}
 		let children_task = Task::spawn_local({
+			let counter = self.counter.clone();
+			let guard = counter.guard();
 			let handle = self.handle.clone();
 			let update_sender = node.update_sender.clone();
 			let referent = referent.clone();
-			move |_| async move { Self::expand_task(&handle, referent, update_sender).await }
+			move |_| async move {
+				Self::expand_task(&handle, counter, referent, update_sender).await;
+				drop(guard);
+			}
 		});
 		node.expand_task.replace(children_task);
 		node.expanded.replace(true);
@@ -263,6 +379,7 @@ where
 		handle: &H,
 		array: tg::value::Array,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let handle = handle.clone();
 		let update = move |node: Rc<RefCell<Node>>| {
@@ -271,6 +388,7 @@ where
 				let child = Self::create_node(&handle, &node, None, Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 		Ok(())
@@ -280,6 +398,7 @@ where
 		handle: &H,
 		blob: tg::Blob,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let children = match blob.load(handle).await?.as_ref() {
 			tg::blob::Object::Leaf(_) => {
@@ -298,6 +417,7 @@ where
 			let item = tg::Referent::with_item(Item::Value(value));
 			let child = Self::create_node(&handle, &node, Some("children".to_owned()), Some(item));
 			node.borrow_mut().children.push(child);
+			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 		Ok(())
@@ -307,6 +427,7 @@ where
 		handle: &H,
 		command: tg::Command,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let object = command.object(handle).await?;
 		let mut children = Vec::new();
@@ -381,6 +502,7 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 		Ok(())
@@ -390,6 +512,7 @@ where
 		handle: &H,
 		directory: tg::Directory,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let object = directory.object(handle).await?;
 		let children: Vec<_> = match object.as_ref() {
@@ -437,6 +560,7 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 		Ok(())
@@ -446,6 +570,7 @@ where
 		handle: &H,
 		file: tg::File,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let object = file.object(handle).await?;
 
@@ -510,6 +635,7 @@ where
 		// Send the update.
 		let handle = handle.clone();
 		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
 			for (name, child) in children {
 				let item = tg::Referent::with_item(Item::Value(child));
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
@@ -524,6 +650,7 @@ where
 		handle: &H,
 		graph: tg::Graph,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		// Get the graph nodes and unload the object immediately.
 		let nodes = graph.nodes(handle).await?;
@@ -635,6 +762,7 @@ where
 		let handle = handle.clone();
 		let value = tg::Value::Array(nodes);
 		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
 			let item = tg::Referent::with_item(Item::Value(value));
 			let child = Self::create_node(&handle, &node, Some("nodes".to_owned()), Some(item));
 			node.borrow_mut().children.push(child);
@@ -647,9 +775,11 @@ where
 		handle: &H,
 		map: tg::value::Map,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let handle = handle.clone();
 		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
 			for (name, value) in map {
 				let item = tg::Referent::with_item(Item::Value(value));
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
@@ -664,6 +794,7 @@ where
 		handle: &H,
 		value: tg::Mutation,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let children: Vec<_> = match value {
 			tg::Mutation::Append { values } => [
@@ -730,6 +861,7 @@ where
 
 		let handle = handle.clone();
 		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
 			for (name, child) in children {
 				let item = tg::Referent::with_item(Item::Value(child));
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
@@ -744,32 +876,129 @@ where
 		handle: &H,
 		object: tg::Object,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		match object {
 			tg::Object::Blob(blob) => {
-				Self::expand_blob(handle, blob, update_sender).await?;
+				Self::expand_blob(handle, blob, update_sender, guard).await?;
 			},
 			tg::Object::Directory(directory) => {
-				Self::expand_directory(handle, directory, update_sender).await?;
+				Self::expand_directory(handle, directory, update_sender, guard).await?;
 			},
 			tg::Object::File(file) => {
-				Self::expand_file(handle, file, update_sender).await?;
+				Self::expand_file(handle, file, update_sender, guard).await?;
 			},
 			tg::Object::Symlink(symlink) => {
-				Self::expand_symlink(handle, symlink, update_sender).await?;
+				Self::expand_symlink(handle, symlink, update_sender, guard).await?;
 			},
 			tg::Object::Graph(graph) => {
-				Self::expand_graph(handle, graph, update_sender).await?;
+				Self::expand_graph(handle, graph, update_sender, guard).await?;
 			},
 			tg::Object::Command(command) => {
-				Self::expand_command(handle, command, update_sender).await?;
+				Self::expand_command(handle, command, update_sender, guard).await?;
 			},
 		}
 		Ok(())
 	}
 
+	async fn expand_package(
+		handle: &H,
+		counter: UpdateCounter,
+		package: tg::Referent<tg::Object>,
+		update_sender: NodeUpdateSender,
+	) -> tg::Result<()> {
+		let mut visitor = PackageVisitor {
+			dependencies: BTreeMap::new(),
+		};
+		tg::object::visit(handle, &mut visitor, &package).await?;
+		let dependencies = visitor
+			.dependencies
+			.into_iter()
+			.map(|(reference, referent)| {
+				let item = referent.map(|r| r.map(|o| Item::Package(Package(o))));
+				(reference.to_string(), item)
+			})
+			.collect::<Vec<_>>();
+		let guard = counter.guard();
+		let handle = handle.clone();
+		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
+
+			// Add the dependencies.
+			for (label, item) in dependencies {
+				let child = Self::create_node(&handle, &node, Some(label), item);
+				node.borrow_mut().children.push(child);
+			}
+		};
+		update_sender.send(Box::new(update)).unwrap();
+
+		Ok(())
+	}
+
+	async fn expand_tag(
+		handle: &H,
+		counter: UpdateCounter,
+		pattern: &tg::tag::Pattern,
+		update_sender: NodeUpdateSender,
+	) -> tg::Result<()> {
+		// List the tag.
+		let output = handle
+			.list_tags(tg::tag::list::Arg {
+				pattern: tg::tag::Pattern::new(pattern.to_string()),
+				length: None,
+				recursive: false,
+				remote: None,
+				reverse: false,
+			})
+			.await
+			.map_err(|source| tg::error!(!source, %tag = pattern, "failed to list tags"))?;
+
+		// Get the children of this tag.
+		let children = output
+			.data
+			.into_iter()
+			.map(move |output| {
+				let options = tg::referent::Options {
+					tag: Some(output.tag.clone()),
+					..tg::referent::Options::default()
+				};
+				let item = match output.item {
+					Some(Either::Left(process)) => Item::Process(tg::Process::new(
+						process,
+						None,
+						output.remote.clone(),
+						None,
+						None,
+					)),
+					Some(Either::Right(object)) => {
+						Item::Value(tg::Value::Object(tg::Object::with_id(object)))
+					},
+					None => Item::Tag(tg::tag::Pattern::new(output.tag.to_string())),
+				};
+				if let Item::Tag(_) = item {
+					(None, tg::Referent::with_item(item))
+				} else {
+					(Some(output.tag.to_string()), tg::Referent { item, options })
+				}
+			})
+			.collect::<Vec<_>>();
+		let guard = counter.guard();
+		let handle = handle.clone();
+		let update = move |node: Rc<RefCell<Node>>| {
+			let children = children
+				.into_iter()
+				.map(|(label, referent)| Self::create_node(&handle, &node, label, Some(referent)))
+				.collect();
+			node.borrow_mut().children = children;
+			node.borrow_mut().guard.replace(guard);
+		};
+		update_sender.send(Box::new(update)).unwrap();
+		Ok(())
+	}
+
 	async fn expand_process(
 		handle: &H,
+		counter: UpdateCounter,
 		referent: tg::Referent<tg::Process>,
 		update_sender: NodeUpdateSender,
 	) -> tg::Result<()> {
@@ -779,11 +1008,13 @@ where
 		let log_task = Task::spawn_local({
 			let process = process.clone();
 			let handle = handle.clone();
+			let guard = counter.guard();
 			let update_sender = update_sender.clone();
 			|_| async move {
 				Self::process_log_task(&handle, process, update_sender)
 					.await
 					.ok();
+				drop(guard);
 			}
 		});
 		let update = move |node: Rc<RefCell<Node>>| {
@@ -796,7 +1027,9 @@ where
 		update_sender
 			.send({
 				let handle = handle.clone();
+				let guard = counter.guard();
 				Box::new(move |node| {
+					node.borrow_mut().guard.replace(guard);
 					if node.borrow().options.show_process_commands {
 						let child = Self::create_node(
 							&handle,
@@ -851,11 +1084,12 @@ where
 
 			// Post the update.
 			let handle = handle.clone();
+			let guard = counter.guard();
 			let update = move |node: Rc<RefCell<Node>>| {
-				if node.borrow().options.auto_expand_and_collapse_processes && finished {
+				if node.borrow().options.expand.collapse_process_children && finished {
 					return;
 				}
-				if !node.borrow().options.auto_expand_and_collapse_processes
+				if node.borrow().options.expand.process
 					&& node
 						.borrow()
 						.children
@@ -867,7 +1101,7 @@ where
 					node.borrow_mut().children.insert(0, child);
 				}
 
-				let parent = if node.borrow().options.auto_expand_and_collapse_processes {
+				let parent = if node.borrow().options.expand.process {
 					node
 				} else {
 					node.borrow().children[0].clone()
@@ -878,12 +1112,22 @@ where
 
 				// Create the update task.
 				let update_task = Task::spawn_local({
+					parent.borrow_mut().guard.replace(guard);
+					let counter = child_node.borrow().counter.clone();
+					let guard = counter.guard();
 					let options = child_node.borrow().options.clone();
 					let update_sender = child_node.borrow().update_sender.clone();
 					|_| async move {
-						Self::process_update_task(&handle, &child, options.as_ref(), update_sender)
-							.await
-							.ok();
+						Self::process_update_task(
+							&handle,
+							counter,
+							&child,
+							options.as_ref(),
+							update_sender,
+						)
+						.await
+						.ok();
+						drop(guard);
 					}
 				});
 				child_node.borrow_mut().update_task.replace(update_task);
@@ -919,6 +1163,7 @@ where
 		handle: &H,
 		symlink: tg::Symlink,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let object = symlink.object(handle).await?;
 		let children = match object.as_ref() {
@@ -957,6 +1202,7 @@ where
 		// Send the update.
 		let handle = handle.clone();
 		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
 			for (name, child) in children {
 				let item = tg::Referent::with_item(Item::Value(child));
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
@@ -970,22 +1216,38 @@ where
 
 	async fn expand_task(
 		handle: &H,
+		counter: UpdateCounter,
 		referent: tg::Referent<Item>,
 		update_sender: NodeUpdateSender,
 	) {
 		let result = match referent.item() {
 			Item::Process(process) => {
 				let referent = referent.clone().map(|_| process.clone());
-				Self::expand_process(handle, referent, update_sender.clone()).await
+				Self::expand_process(handle, counter.clone(), referent, update_sender.clone()).await
 			},
 			Item::Value(value) => {
-				Self::expand_value(handle, value.clone(), update_sender.clone()).await
+				Self::expand_value(
+					handle,
+					counter.clone(),
+					value.clone(),
+					update_sender.clone(),
+				)
+				.await
+			},
+			Item::Package(package) => {
+				let referent = referent.clone().map(|_| package.0.clone());
+				Self::expand_package(handle, counter.clone(), referent, update_sender.clone()).await
+			},
+			Item::Tag(tag) => {
+				Self::expand_tag(handle, counter.clone(), tag, update_sender.clone()).await
 			},
 		};
 		if let Err(error) = result {
+			let guard = counter.guard();
 			let update = move |node: Rc<RefCell<Node>>| {
 				node.borrow_mut().indicator.replace(Indicator::Error);
 				node.borrow_mut().title = error.to_string();
+				node.borrow_mut().guard.replace(guard);
 			};
 			update_sender.send(Box::new(update)).ok();
 		}
@@ -995,6 +1257,7 @@ where
 		handle: &H,
 		template: tg::Template,
 		update_sender: NodeUpdateSender,
+		guard: UpdateGuard,
 	) -> tg::Result<()> {
 		let array = template
 			.components
@@ -1017,6 +1280,7 @@ where
 		let value = tg::Value::Array(array);
 		let handle = handle.clone();
 		let update = move |node: Rc<RefCell<Node>>| {
+			node.borrow_mut().guard.replace(guard);
 			let item = tg::Referent::with_item(Item::Value(value));
 			let child =
 				Self::create_node(&handle, &node, Some("components".to_owned()), Some(item));
@@ -1028,24 +1292,26 @@ where
 
 	async fn expand_value(
 		handle: &H,
+		counter: UpdateCounter,
 		value: tg::Value,
 		update_sender: NodeUpdateSender,
 	) -> tg::Result<()> {
+		let guard = counter.guard();
 		match value {
 			tg::Value::Array(array) => {
-				Self::expand_array(handle, array, update_sender).await?;
+				Self::expand_array(handle, array, update_sender, guard).await?;
 			},
 			tg::Value::Map(map) => {
-				Self::expand_map(handle, map, update_sender).await?;
+				Self::expand_map(handle, map, update_sender, guard).await?;
 			},
 			tg::Value::Object(object) => {
-				Self::expand_object(handle, object, update_sender).await?;
+				Self::expand_object(handle, object, update_sender, guard).await?;
 			},
 			tg::Value::Mutation(mutation) => {
-				Self::expand_mutation(handle, mutation, update_sender).await?;
+				Self::expand_mutation(handle, mutation, update_sender, guard).await?;
 			},
 			tg::Value::Template(template) => {
-				Self::expand_template(handle, template, update_sender).await?;
+				Self::expand_template(handle, template, update_sender, guard).await?;
 			},
 			_ => (),
 		}
@@ -1116,7 +1382,8 @@ where
 
 	fn item_title(item: &Item) -> String {
 		match item {
-			Item::Process(_) => String::new(),
+			Item::Package(package) => Self::object_id(&package.0),
+			Item::Tag(pattern) => pattern.to_string(),
 			Item::Value(value) => match value {
 				tg::Value::Null => "null".to_owned(),
 				tg::Value::Bool(bool) => {
@@ -1135,6 +1402,14 @@ where
 				tg::Value::Mutation(_) => "mutation".to_owned(),
 				tg::Value::Template(_) => "template".to_owned(),
 			},
+			Item::Process(_) => String::new(),
+		}
+	}
+
+	fn item_label(item: &Item) -> Option<String> {
+		match item {
+			Item::Package(_) => Some("package".into()),
+			_ => None,
 		}
 	}
 
@@ -1145,15 +1420,38 @@ where
 		data: data::UpdateSender,
 		viewer: super::UpdateSender<H>,
 	) -> Self {
+		let counter = UpdateCounter::new();
+		let expanded_nodes = Rc::new(RefCell::new(HashSet::new()));
 		let options = Rc::new(options);
 		let (update_sender, update_receiver) = std::sync::mpsc::channel();
+		let label = Self::item_label(referent.item());
 		let title = Self::item_title(referent.item());
-		let expand_task = if options.auto_expand_and_collapse_processes {
+		let expand = match referent.item() {
+			Item::Package(package) if options.expand.package => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Package(package.0.id())),
+			Item::Process(process) if options.expand.process => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Process(process.id().clone())),
+			Item::Tag(pattern) if options.expand.tag => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Tag(pattern.to_string())),
+			Item::Value(tg::Value::Object(object)) if options.expand.object => expanded_nodes
+				.borrow_mut()
+				.insert(NodeID::Object(object.id())),
+			Item::Value(_) => true,
+			_ => false,
+		};
+
+		let expand_task = if expand {
+			let counter = counter.clone();
+			let guard = counter.guard();
 			let handle = handle.clone();
 			let referent = referent.clone();
 			let update_sender = update_sender.clone();
 			let task: Task<()> = Task::spawn_local(|_| async move {
-				Self::expand_task(&handle, referent, update_sender).await;
+				Self::expand_task(&handle, counter, referent, update_sender).await;
+				drop(guard);
 			});
 			Some(task)
 		} else {
@@ -1163,28 +1461,42 @@ where
 		let update_task = if let Item::Process(process) = referent.item() {
 			// Create the update task.
 			let update_task = Task::spawn_local({
+				let counter = counter.clone();
+				let guard = counter.guard();
 				let process = referent.clone().map(|_| process.clone());
 				let handle = handle.clone();
 				let options = options.clone();
 				let update_sender = update_sender.clone();
 				|_| async move {
-					Self::process_update_task(&handle, &process, options.as_ref(), update_sender)
-						.await
-						.ok();
+					Self::process_update_task(
+						&handle,
+						counter,
+						&process,
+						options.as_ref(),
+						update_sender,
+					)
+					.await
+					.ok();
+					drop(guard);
 				}
 			});
 			Some(update_task)
 		} else {
 			None
 		};
+		let displayed_at_least_once = Some(counter.guard());
+
 		let root = Rc::new(RefCell::new(Node {
+			counter: counter.clone(),
 			children: Vec::new(),
 			depth: 1,
-			expanded: Some(expand_task.is_some()),
+			expanded: Some(expand),
+			expanded_nodes,
 			expand_task,
+			guard: displayed_at_least_once,
 			indicator: None,
 			referent: Some(referent),
-			label: None,
+			label,
 			log_task: None,
 			options: options.clone(),
 			parent: None,
@@ -1194,9 +1506,12 @@ where
 			update_task,
 		}));
 		let roots = vec![root.clone()];
+
 		let mut tree = Self {
 			handle: handle.clone(),
+			counter,
 			data,
+			options,
 			rect: None,
 			roots,
 			scroll: 0,
@@ -1361,6 +1676,7 @@ where
 
 	async fn process_update_task(
 		handle: &H,
+		counter: UpdateCounter,
 		process: &tg::Referent<tg::Process>,
 		options: &Options,
 		update_sender: NodeUpdateSender,
@@ -1369,9 +1685,11 @@ where
 		H: tg::Handle,
 	{
 		if let Some(title) = Self::process_title(handle, process).await {
+			let guard = counter.guard();
 			update_sender
 				.send(Box::new(|node| {
 					node.borrow_mut().title = title;
+					node.borrow_mut().guard.replace(guard);
 				}))
 				.unwrap();
 		}
@@ -1379,6 +1697,7 @@ where
 		// Create the status stream.
 		let mut status = process.item.status(handle).await?;
 		while let Some(status) = status.try_next().await? {
+			let guard = counter.guard();
 			let indicator = match status {
 				tg::process::Status::Created => Indicator::Created,
 				tg::process::Status::Enqueued => Indicator::Enqueued,
@@ -1386,7 +1705,7 @@ where
 				tg::process::Status::Started => Indicator::Started,
 				tg::process::Status::Finished => {
 					// Remove the child if necessary.
-					if options.auto_expand_and_collapse_processes {
+					if options.expand.collapse_process_children {
 						let update = move |node: Rc<RefCell<Node>>| {
 							// Get the parent if it exists.
 							let Some(parent) =
@@ -1404,6 +1723,9 @@ where
 							else {
 								return;
 							};
+
+							// Mark the parent as dirty.
+							parent.borrow_mut().guard.replace(guard);
 
 							// Remove this node from its parent.
 							parent.borrow_mut().children.remove(index);
@@ -1544,83 +1866,96 @@ where
 		let handle = self.handle.clone();
 		let data = self.data.clone();
 		let viewer = self.viewer.clone();
-		let task = Task::spawn_local(|_| async move {
-			// Update the log view if the selected item is a process.
-			let process =
-				node.borrow()
-					.referent
-					.as_ref()
-					.and_then(|referent| match referent.item() {
-						Item::Process(process) => Some(process.clone()),
-						Item::Value(_) => None,
-					});
-			{
-				let handle = handle.clone();
-				let update = move |viewer: &mut super::Viewer<H>| {
-					if let Some(process) = process {
-						let log = Log::new(&handle, &process);
-						viewer.log.replace(log);
-					} else {
-						viewer.log.take();
+		let task = Task::spawn_local(|_| {
+			async move {
+				// Update the log view if the selected item is a process.
+				let process =
+					node.borrow()
+						.referent
+						.as_ref()
+						.and_then(|referent| match referent.item() {
+							Item::Process(process) => Some(process.clone()),
+							_ => None,
+						});
+				{
+					let handle = handle.clone();
+					let update = move |viewer: &mut super::Viewer<H>| {
+						if let Some(process) = process {
+							let log = Log::new(&handle, &process);
+							viewer.log.replace(log);
+						} else {
+							viewer.log.take();
+						}
+					};
+					viewer.send(Box::new(update)).unwrap();
+				}
+
+				// Update the data view.
+				let content_future = {
+					let handle = handle.clone();
+					async move {
+						match referent.item {
+							Item::Process(process) => handle
+								.get_process(process.id())
+								.await
+								.and_then(|output| {
+									serde_json::to_string_pretty(&output).map_err(|source| {
+										tg::error!(!source, "failed to serialize the process data")
+									})
+								})
+								.unwrap_or_else(|error| error.to_string()),
+							Item::Value(tg::Value::Object(tg::Object::Blob(blob))) => {
+								super::util::format_blob(&handle, &blob)
+									.await
+									.unwrap_or_else(|error| error.to_string())
+							},
+							Item::Value(value) => {
+								let value = match value {
+									tg::Value::Object(object) => {
+										object.load(&handle).await.ok();
+										tg::Value::Object(object)
+									},
+									value => value,
+								};
+								let options = tg::value::print::Options {
+									depth: Some(1),
+									style: tg::value::print::Style::Pretty { indentation: "  " },
+									blobs: false,
+								};
+								value.print(options)
+							},
+							Item::Package(package) => {
+								package.0.load(&handle).await.ok();
+								let value = tg::Value::Object(package.0);
+								let options = tg::value::print::Options {
+									depth: Some(1),
+									style: tg::value::print::Style::Pretty { indentation: "  " },
+									blobs: false,
+								};
+								value.print(options)
+							},
+							Item::Tag(tag) => tag.to_string(),
+						}
 					}
 				};
-				viewer.send(Box::new(update)).unwrap();
-			}
-
-			// Update the data view.
-			let content_future = {
-				let handle = handle.clone();
-				async move {
-					match referent.item {
-						Item::Process(process) => handle
-							.get_process(process.id())
-							.await
-							.and_then(|output| {
-								serde_json::to_string_pretty(&output).map_err(|source| {
-									tg::error!(!source, "failed to serialize the process data")
-								})
-							})
-							.unwrap_or_else(|error| error.to_string()),
-						Item::Value(tg::Value::Object(tg::Object::Blob(blob))) => {
-							super::util::format_blob(&handle, &blob)
-								.await
-								.unwrap_or_else(|error| error.to_string())
-						},
-						Item::Value(value) => {
-							let value = match value {
-								tg::Value::Object(object) => {
-									object.load(&handle).await.ok();
-									tg::Value::Object(object)
-								},
-								value => value,
-							};
-							let options = tg::value::print::Options {
-								depth: Some(1),
-								style: tg::value::print::Style::Pretty { indentation: "  " },
-								blobs: false,
-							};
-							value.print(options)
-						},
-					}
-				}
-			};
-			let timeout = tokio::time::sleep(std::time::Duration::from_millis(20));
-			match future::select(pin!(content_future), pin!(timeout)).await {
-				future::Either::Left((content, _)) => {
-					data.send(Box::new(move |this| this.set_contents(content)))
+				let timeout = tokio::time::sleep(std::time::Duration::from_millis(20));
+				match future::select(pin!(content_future), pin!(timeout)).await {
+					future::Either::Left((content, _)) => {
+						data.send(Box::new(move |this| this.set_contents(content)))
+							.unwrap();
+					},
+					future::Either::Right(((), future)) => {
+						data.send(Box::new(move |this| {
+							this.set_contents("...loading...".to_owned());
+						}))
 						.unwrap();
-				},
-				future::Either::Right(((), future)) => {
-					data.send(Box::new(move |this| {
-						this.set_contents("...loading...".to_owned());
-					}))
-					.unwrap();
-					let contents = future.await;
-					data.send(Box::new(move |this| {
-						this.set_contents(contents);
-					}))
-					.unwrap();
-				},
+						let contents = future.await;
+						data.send(Box::new(move |this| {
+							this.set_contents(contents);
+						}))
+						.unwrap();
+					},
+				}
 			}
 		});
 
@@ -1649,13 +1984,22 @@ where
 	}
 
 	pub fn update(&mut self) {
-		for node in self.nodes() {
+		// Note we can't use .nodes() here because update() may create new ones.
+		let mut stack = vec![self.roots.last().unwrap().clone()];
+		while let Some(node) = stack.pop() {
 			loop {
 				let Ok(update) = node.borrow_mut().update_receiver.try_recv() else {
 					break;
 				};
 				update(node.clone());
 			}
+			stack.extend(node.borrow().children.iter().rev().cloned());
+		}
+	}
+
+	pub fn clear_guards(&mut self) {
+		for node in self.nodes() {
+			node.borrow_mut().guard.take();
 		}
 	}
 
@@ -1664,6 +2008,8 @@ where
 			return;
 		};
 		let contents = match referent.item() {
+			Item::Package(package) => package.0.id().to_string(),
+			Item::Tag(tag) => tag.to_string(),
 			Item::Process(process) => process.id().to_string(),
 			Item::Value(value) => {
 				if let tg::Value::Object(object) = value {
@@ -1735,5 +2081,37 @@ impl std::fmt::Display for Display {
 		}
 		inner(self, f, "")?;
 		Ok(())
+	}
+}
+
+struct PackageVisitor {
+	dependencies: BTreeMap<tg::Reference, Option<tg::Referent<tg::Object>>>,
+}
+
+impl<H> tg::object::Visitor<H> for PackageVisitor
+where
+	H: tg::Handle,
+{
+	async fn visit_directory(
+		&mut self,
+		_handle: &H,
+		_directory: tg::Referent<&tg::Directory>,
+	) -> tg::Result<bool> {
+		Ok(true)
+	}
+	async fn visit_file(&mut self, handle: &H, file: tg::Referent<&tg::File>) -> tg::Result<bool> {
+		if file.path().is_none() {
+			return Ok(false);
+		}
+		let dependencies = file.item().dependencies(handle).await?;
+		self.dependencies.extend(dependencies);
+		Ok(true)
+	}
+	async fn visit_symlink(
+		&mut self,
+		_handle: &H,
+		_symlink: tg::Referent<&tg::Symlink>,
+	) -> tg::Result<bool> {
+		Ok(true)
 	}
 }

--- a/packages/cli/tests/tree.rs
+++ b/packages/cli/tests/tree.rs
@@ -47,7 +47,7 @@ async fn package() {
 	directory.to_path(temp.path()).await.unwrap();
 	let stdout = test(
 		&server,
-		vec![temp.path().display().to_string(), "--mode=package".into()],
+		vec![temp.path().display().to_string(), "--kind=package".into()],
 		objects,
 	)
 	.await;
@@ -76,7 +76,7 @@ async fn tag() {
 		(Some("tree/of/tags/bar".into()), bar),
 	];
 
-	let stdout = test(&server, vec!["tree".into(), "--mode=tag".into()], objects).await;
+	let stdout = test(&server, vec!["tree".into(), "--kind=tag".into()], objects).await;
 	assert_snapshot!(stdout, @r#"
 	tree
 	└╴tree/of

--- a/packages/cli/tests/tree.rs
+++ b/packages/cli/tests/tree.rs
@@ -62,7 +62,6 @@ async fn package() {
 #[tokio::test]
 async fn tag() {
 	let server = Server::new(TG).await.unwrap();
-	let temp = Temp::new();
 	let foo = temp::directory! {
 		"tangram.ts" => temp::file!("// tree/of/tags/foo"),
 	}
@@ -105,7 +104,7 @@ async fn test(
 	// Tag the objects.
 	for (tag, artifact) in objects {
 		let temp = Temp::new();
-		artifact.to_path(&temp.path()).await.unwrap();
+		artifact.to_path(temp.path()).await.unwrap();
 		let mut command = server.tg();
 		if let Some(tag) = tag {
 			// Tag the dependency

--- a/packages/cli/tests/tree.rs
+++ b/packages/cli/tests/tree.rs
@@ -1,0 +1,126 @@
+use {
+	indoc::indoc,
+	insta::assert_snapshot,
+	tangram_cli_test::{Server, assert_success},
+	tangram_temp::{self as temp, Temp},
+};
+
+const TG: &str = env!("CARGO_BIN_EXE_tangram");
+
+#[tokio::test]
+async fn object() {
+	let server = Server::new(TG).await.unwrap();
+	let temp = Temp::new();
+	let directory = temp::directory! {
+		"tangram.ts" => temp::file!("export default () => 42;"),
+	};
+	directory.to_path(temp.path()).await.unwrap();
+	let stderr = test(&server, vec![temp.path().display().to_string()], Vec::new()).await;
+	assert_snapshot!(stderr, @r"
+	dir_01kv4fvampbgahwqgd7z0ctaq1eff5bv4mavrr982f9b1vmft06bpg
+	└╴entries: map
+	  └╴tangram.ts: fil_01c3d141vk7v44j4krd8800sc11z2ddfyr4x7xp8z8r778r4rb4qr0
+	    └╴contents: blb_01mdez7rn5622ncqxr3the1thtqwp9tv919f5xyaj021mbp0egfa40
+	");
+}
+
+#[tokio::test]
+async fn package() {
+	let server = Server::new(TG).await.unwrap();
+	let temp = Temp::new();
+	let foo = temp::directory! {
+		"tangram.ts" => temp::file!("// foo"),
+	}
+	.into();
+	let bar = temp::directory! {
+		"tangram.ts" => temp::file!(r#"import * as foo from "foo""#),
+	}
+	.into();
+
+	let objects = vec![(Some("foo".into()), foo), (Some("bar".into()), bar)];
+	let directory = temp::directory! {
+		"tangram.ts" => temp::file!(indoc!(r#"
+            import * as foo from "foo";
+            import * as bar from "bar";
+        "#)),
+	};
+	directory.to_path(temp.path()).await.unwrap();
+	let stderr = test(
+		&server,
+		vec![temp.path().display().to_string(), "--mode=package".into()],
+		objects,
+	)
+	.await;
+	assert_snapshot!(stderr, @r"
+	package: dir_01f97dr5h20x9by01c4gwk46e0x9hnc40fedsbffykfe3h21bhy5q0
+	├╴bar: dir_0130zet0544m0nx01je1zqyy399fyeyn6m27mf3krfnvs2pj7qsac0
+	│ └╴foo: dir_01vddbk4t4h179fppw4pe9bz6prhh3vt7s1qeaa0fqgakbpbf4stp0
+	└╴foo: dir_01vddbk4t4h179fppw4pe9bz6prhh3vt7s1qeaa0fqgakbpbf4stp0
+	");
+}
+
+#[tokio::test]
+async fn tag() {
+	let server = Server::new(TG).await.unwrap();
+	let temp = Temp::new();
+	let foo = temp::directory! {
+		"tangram.ts" => temp::file!("// tree/of/tags/foo"),
+	}
+	.into();
+	let bar = temp::directory! {
+		"tangram.ts" => temp::file!(r#"import * as foo from "tree/of/tags/foo""#),
+	}
+	.into();
+
+	let objects = vec![
+		(Some("tree/of/tags/foo".into()), foo),
+		(Some("tree/of/tags/bar".into()), bar),
+	];
+
+	let stderr = test(&server, vec!["tree".into(), "--mode=tag".into()], objects).await;
+	assert_snapshot!(stderr, @r#"
+	tree
+	└╴tree/of
+	  └╴tree/of/tags
+	    ├╴tree/of/tags/bar: dir_01apgd3f4my7he6be8a0kckf32bpw01k4ez11pbhfhzzsm6chy9dgg
+	    │ └╴entries: map
+	    │   └╴tangram.ts: fil_014461y623bj37gwnaf682c81vh8rwps2bjj0sa7222gncqqe6vj10
+	    │     ├╴contents: blb_0171ytyz9bccy0k15hrep1as9ccybpy2ny0bjq2cmshydz9265zbz0
+	    │     └╴dependencies: map
+	    │       └╴tree/of/tags/foo: map
+	    │         ├╴item: dir_01x6rye7cfh2jjq6f58ffrs4s6pwb25e4xepm61z9nkg7hq3dky7y0
+	    │         └╴tag: "tree/of/tags/foo"
+	    └╴tree/of/tags/foo: dir_01x6rye7cfh2jjq6f58ffrs4s6pwb25e4xepm61z9nkg7hq3dky7y0
+	      └╴entries: map
+	        └╴tangram.ts: fil_01kvs4ge7sm2h03a0dc4fbbz4g4m8rg0b04mvxregc85v90bgs56z0
+	          └╴contents: blb_0194cvce5k7jhd4ywjr3b9k3ax0gqv8af172q1mk1y287bwz6gaarg
+	"#);
+}
+
+async fn test(
+	server: &Server,
+	args: Vec<String>,
+	objects: Vec<(Option<String>, temp::Artifact)>,
+) -> String {
+	// Tag the objects.
+	for (tag, artifact) in objects {
+		let temp = Temp::new();
+		artifact.to_path(&temp.path()).await.unwrap();
+		let mut command = server.tg();
+		if let Some(tag) = tag {
+			// Tag the dependency
+			command.arg("tag").arg(tag);
+		} else {
+			// Check in the artifact
+			command.arg("checkin");
+		}
+		command.arg(temp.path());
+		let output = command.output().await.unwrap();
+		assert_success!(output);
+	}
+
+	// Print the tree.
+	let output = server.tg().arg("tree").args(args).output().await.unwrap();
+	assert_success!(output);
+	String::from_utf8(output.stderr).unwrap()
+}

--- a/packages/cli/tests/tree.rs
+++ b/packages/cli/tests/tree.rs
@@ -15,8 +15,8 @@ async fn object() {
 		"tangram.ts" => temp::file!("export default () => 42;"),
 	};
 	directory.to_path(temp.path()).await.unwrap();
-	let stderr = test(&server, vec![temp.path().display().to_string()], Vec::new()).await;
-	assert_snapshot!(stderr, @r"
+	let stdout = test(&server, vec![temp.path().display().to_string()], Vec::new()).await;
+	assert_snapshot!(stdout, @r"
 	dir_01kv4fvampbgahwqgd7z0ctaq1eff5bv4mavrr982f9b1vmft06bpg
 	└╴entries: map
 	  └╴tangram.ts: fil_01c3d141vk7v44j4krd8800sc11z2ddfyr4x7xp8z8r778r4rb4qr0
@@ -45,13 +45,13 @@ async fn package() {
         "#)),
 	};
 	directory.to_path(temp.path()).await.unwrap();
-	let stderr = test(
+	let stdout = test(
 		&server,
 		vec![temp.path().display().to_string(), "--mode=package".into()],
 		objects,
 	)
 	.await;
-	assert_snapshot!(stderr, @r"
+	assert_snapshot!(stdout, @r"
 	package: dir_01f97dr5h20x9by01c4gwk46e0x9hnc40fedsbffykfe3h21bhy5q0
 	├╴bar: dir_0130zet0544m0nx01je1zqyy399fyeyn6m27mf3krfnvs2pj7qsac0
 	│ └╴foo: dir_01vddbk4t4h179fppw4pe9bz6prhh3vt7s1qeaa0fqgakbpbf4stp0
@@ -76,8 +76,8 @@ async fn tag() {
 		(Some("tree/of/tags/bar".into()), bar),
 	];
 
-	let stderr = test(&server, vec!["tree".into(), "--mode=tag".into()], objects).await;
-	assert_snapshot!(stderr, @r#"
+	let stdout = test(&server, vec!["tree".into(), "--mode=tag".into()], objects).await;
+	assert_snapshot!(stdout, @r#"
 	tree
 	└╴tree/of
 	  └╴tree/of/tags
@@ -121,5 +121,5 @@ async fn test(
 	// Print the tree.
 	let output = server.tg().arg("tree").args(args).output().await.unwrap();
 	assert_success!(output);
-	String::from_utf8(output.stderr).unwrap()
+	String::from_utf8(output.stdout).unwrap()
 }


### PR DESCRIPTION
- Supporting printing `tg view --kind=inline` to stderr if not a TTY
- Add new items to tree view (`Tag` and `Package`)
- Add more configuration operations for auto-expanding nodes 
- Deduplicate nodes that have already been expanded by checking if their `Id` (defined per item) has been expanded already, but only when auto-expanding.
- Implement `tg tree` in terms of `tg view`. 
- Clear a bunch of warnings

Resolves #520 