### PR TITLE
fix(server): rollup of small fixes

### DIFF
--- a/packages/server/src/checkin/index.rs
+++ b/packages/server/src/checkin/index.rs
@@ -40,11 +40,7 @@ impl Server {
 					touched_at,
 				});
 			let message = message.serialize()?;
-			let _published = self
-				.messenger
-				.stream_publish("index".to_owned(), message)
-				.await
-				.map_err(|source| tg::error!(!source, "failed to publish the message"))?;
+			messages.push(message);
 		} else {
 			// Serialize and add cache entry messages.
 			for message in cache_entry_messages {

--- a/packages/server/src/clean.rs
+++ b/packages/server/src/clean.rs
@@ -88,6 +88,28 @@ impl Server {
 			.map_or(1024, |config| config.batch_size);
 		let now = time::OffsetDateTime::now_utc().unix_timestamp();
 		let ttl = Duration::from_secs(0);
+		progress.start(
+			"cache".into(),
+			"cache".into(),
+			tangram_client::progress::IndicatorFormat::Normal,
+			Some(0),
+			None,
+		);
+		progress.start(
+			"objects".into(),
+			"objects".into(),
+			tangram_client::progress::IndicatorFormat::Normal,
+			Some(0),
+			None,
+		);
+		progress.start(
+			"processes".into(),
+			"processes".into(),
+			tangram_client::progress::IndicatorFormat::Normal,
+			Some(0),
+			None,
+		);
+
 		loop {
 			let inner_output = match self.cleaner_task_inner(now, ttl, batch_size).await {
 				Ok(inner_output) => inner_output,

--- a/packages/server/src/clean.rs
+++ b/packages/server/src/clean.rs
@@ -1,9 +1,9 @@
 use {
 	crate::{Context, Server},
-	futures::{Stream, StreamExt as _},
+	futures::{FutureExt as _, Stream, StreamExt as _},
 	indoc::formatdoc,
 	num::ToPrimitive as _,
-	std::time::Duration,
+	std::{panic::AssertUnwindSafe, time::Duration},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
 	tangram_futures::{stream::Ext as _, task::Stop},
@@ -23,13 +23,6 @@ struct InnerOutput {
 	processes: Vec<tg::process::Id>,
 }
 
-#[derive(Debug, serde::Deserialize)]
-struct Count {
-	cache_entries: u64,
-	objects: u64,
-	processes: u64,
-}
-
 impl Server {
 	pub(crate) async fn clean_with_context(
 		&self,
@@ -42,112 +35,85 @@ impl Server {
 		}
 		let progress = crate::progress::Handle::new();
 		let task = AbortOnDropHandle::new(tokio::spawn({
-			let progress = progress.clone();
 			let server = self.clone();
+			let progress = progress.clone();
 			async move {
-				// Clean the temporary directory.
-				tangram_util::fs::remove(server.temp_path())
-					.await
-					.map_err(|source| {
-						tg::error!(!source, "failed to remove the temporary directory")
-					})?;
-				tokio::fs::create_dir_all(server.temp_path())
-					.await
-					.map_err(|error| {
-						tg::error!(source = error, "failed to recreate the temporary directory")
-					})?;
-
-				let mut output = tg::clean::Output {
-					cache: 0,
-					objects: 0,
-					processes: 0,
-				};
-				let batch_size = server
-					.config
-					.cleaner
-					.as_ref()
-					.map_or(1024, |config| config.batch_size);
-				let now = time::OffsetDateTime::now_utc().unix_timestamp();
-				let ttl = Duration::from_secs(0);
-				let max_touched_at = now - ttl.as_secs().to_i64().unwrap();
-
-				let count = server.clean_count_items(max_touched_at).await?;
-				if count.cache_entries > 0 {
-					progress.start(
-						"cache".into(),
-						"cache entries".into(),
-						tg::progress::IndicatorFormat::Normal,
-						Some(0),
-						Some(count.cache_entries),
-					);
+				let result = AssertUnwindSafe(server.clean_inner(&progress))
+					.catch_unwind()
+					.await;
+				match result {
+					Ok(Ok(output)) => {
+						progress.output(output);
+					},
+					Ok(Err(error)) => {
+						progress.error(error);
+					},
+					Err(payload) => {
+						let message = payload
+							.downcast_ref::<String>()
+							.map(String::as_str)
+							.or(payload.downcast_ref::<&str>().copied());
+						progress.error(tg::error!(?message, "the task panicked"));
+					},
 				}
-				if count.objects > 0 {
-					progress.start(
-						"objects".into(),
-						"objects".into(),
-						tg::progress::IndicatorFormat::Normal,
-						Some(0),
-						Some(count.objects),
-					);
-				}
-				if count.processes > 0 {
-					progress.start(
-						"processes".into(),
-						"processes".into(),
-						tg::progress::IndicatorFormat::Normal,
-						Some(0),
-						Some(count.processes),
-					);
-				}
-
-				loop {
-					let count = server.clean_count_items(max_touched_at).await?;
-					progress.set_total("cache", count.cache_entries);
-					progress.set_total("objects", count.objects);
-					progress.set_total("processes", count.processes);
-					let inner_output = match server.cleaner_task_inner(now, ttl, batch_size).await {
-						Ok(inner_output) => inner_output,
-						Err(error) => {
-							progress.error(error);
-							break;
-						},
-					};
-					let cache = inner_output.cache_entries.len().to_u64().unwrap();
-					let objects = inner_output.objects.len().to_u64().unwrap();
-					let processes = inner_output.processes.len().to_u64().unwrap();
-					output.cache += cache;
-					output.objects += objects;
-					output.processes += processes;
-					progress.increment("cache", cache);
-					progress.increment("objects", objects);
-					progress.increment("processes", processes);
-					let n = cache + objects + processes;
-					if n == 0 {
-						break;
-					}
-				}
-
-				progress.output(output);
-
-				Ok::<_, tg::Error>(())
 			}
 		}));
 		let stream = progress.stream().attach(task);
 		Ok(stream)
 	}
 
-	async fn clean_count_items(&self, max_touched_at: i64) -> tg::Result<Count> {
-		match &self.index {
-			#[cfg(feature = "postgres")]
-			crate::index::Index::Postgres(database) => {
-				self.clean_count_items_postgres(database, max_touched_at)
-					.await
-			},
-			crate::index::Index::Sqlite(database) => {
-				self.clean_count_items_sqlite(database, max_touched_at)
-					.await
-			},
+	async fn clean_inner(
+		&self,
+		progress: &crate::progress::Handle<tg::clean::Output>,
+	) -> tg::Result<tg::clean::Output> {
+		// Clean the temporary directory.
+		tangram_util::fs::remove(self.temp_path())
+			.await
+			.map_err(|source| tg::error!(!source, "failed to remove the temporary directory"))?;
+		tokio::fs::create_dir_all(self.temp_path())
+			.await
+			.map_err(|error| {
+				tg::error!(source = error, "failed to recreate the temporary directory")
+			})?;
+
+		let mut output = tg::clean::Output {
+			cache: 0,
+			objects: 0,
+			processes: 0,
+		};
+		let batch_size = self
+			.config
+			.cleaner
+			.as_ref()
+			.map_or(1024, |config| config.batch_size);
+		let now = time::OffsetDateTime::now_utc().unix_timestamp();
+		let ttl = Duration::from_secs(0);
+		loop {
+			let inner_output = match self.cleaner_task_inner(now, ttl, batch_size).await {
+				Ok(inner_output) => inner_output,
+				Err(error) => {
+					progress.error(error);
+					break;
+				},
+			};
+
+			// Get the number of items cleaned.
+			let cache = inner_output.cache_entries.len().to_u64().unwrap();
+			let objects = inner_output.objects.len().to_u64().unwrap();
+			let processes = inner_output.processes.len().to_u64().unwrap();
+			output.cache += cache;
+			output.objects += objects;
+			output.processes += processes;
+			progress.increment("cache", cache);
+			progress.increment("objects", objects);
+			progress.increment("processes", processes);
+			let n = cache + objects + processes;
+			if n == 0 {
+				break;
+			}
 		}
+
+		Ok::<_, tg::Error>(output)
 	}
 
 	pub(crate) async fn cleaner_task(&self, config: &crate::config::Cleaner) -> tg::Result<()> {

--- a/packages/server/src/clean/postgres.rs
+++ b/packages/server/src/clean/postgres.rs
@@ -1,5 +1,5 @@
 use {
-	super::{Count, InnerOutput, Server},
+	super::{InnerOutput, Server},
 	indoc::indoc,
 	num::ToPrimitive as _,
 	tangram_client::prelude::*,
@@ -7,34 +7,6 @@ use {
 };
 
 impl Server {
-	#[cfg(feature = "postgres")]
-	pub(super) async fn clean_count_items_postgres(
-		&self,
-		database: &db::postgres::Database,
-		max_touched_at: i64,
-	) -> tg::Result<Count> {
-		let connection = database
-			.connection()
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get an index connection"))?;
-		let statement = indoc!(
-			"
-				select
-					(select count(*) from cache_entries where reference_count = 0 and touched_at < $1) as cache_entries,
-					(select count(*) from objects where reference_count = 0 and touched_at < $1) as objects,
-					(select count(*) from processes where reference_count = 0 and touched_at < $1) as processes;
-				;
-			"
-		);
-		let params = db::params![max_touched_at];
-		let count = connection
-			.query_one_into::<db::row::Serde<Count>>(statement.into(), params)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?
-			.0;
-		Ok(count)
-	}
-
 	#[cfg(feature = "postgres")]
 	pub(super) async fn cleaner_task_inner_postgres(
 		&self,

--- a/packages/server/src/progress.rs
+++ b/packages/server/src/progress.rs
@@ -88,11 +88,6 @@ impl<T> Handle<T> {
 				.as_ref()
 				.unwrap()
 				.fetch_add(amount, std::sync::atomic::Ordering::Relaxed);
-			if let Some(total) = &indicator.total {
-				let current = indicator.current.as_ref().unwrap().load(Ordering::SeqCst);
-				let total = total.load(Ordering::SeqCst);
-				assert!(current <= total);
-			}
 		}
 	}
 
@@ -103,22 +98,12 @@ impl<T> Handle<T> {
 				.as_ref()
 				.unwrap()
 				.store(value, std::sync::atomic::Ordering::Relaxed);
-			if let Some(total) = &indicator.total {
-				let current = indicator.current.as_ref().unwrap().load(Ordering::SeqCst);
-				let total = total.load(Ordering::SeqCst);
-				assert!(current <= total);
-			}
 		}
 	}
 
 	pub fn set_total(&self, name: &str, total: impl Into<Option<u64>>) {
 		if let Some(indicator) = self.indicators.write().unwrap().get_mut(name) {
 			indicator.total = total.into().map(Into::into);
-			if let Some(current) = &indicator.current {
-				let current = current.load(Ordering::SeqCst);
-				let total = indicator.total.as_ref().unwrap().load(Ordering::SeqCst);
-				assert!(current <= total);
-			}
 		}
 	}
 

--- a/packages/server/src/sync/get.rs
+++ b/packages/server/src/sync/get.rs
@@ -116,9 +116,9 @@ impl Server {
 				},
 				tg::sync::Message::Missing(missing) => {
 					return match missing {
-						tg::sync::MissingMessage::Process(message) => {
-							Err(tg::error!(%id = message.id, "the process is missing on the remote"))
-						},
+						tg::sync::MissingMessage::Process(message) => Err(
+							tg::error!(%id = message.id, "the process is missing on the remote"),
+						),
 						tg::sync::MissingMessage::Object(message) => {
 							Err(tg::error!(%id = message.id, "the object is missing on the remote"))
 						},

--- a/packages/server/src/sync/put.rs
+++ b/packages/server/src/sync/put.rs
@@ -848,9 +848,7 @@ impl Server {
 			let ObjectQueueItem { object, .. } = item;
 			let Some(output) = output else {
 				let message = tg::sync::Message::Missing(tg::sync::MissingMessage::Object(
-					tg::sync::ObjectMissingMessage {
-						id: object.clone(),
-					},
+					tg::sync::ObjectMissingMessage { id: object.clone() },
 				));
 				state.sender.send(Ok(message)).await.ok();
 				continue;
@@ -940,9 +938,7 @@ impl Server {
 		// Get the object.
 		let Some(output) = self.try_get_object_sync(&object, &mut state.file)? else {
 			let message = tg::sync::Message::Missing(tg::sync::MissingMessage::Object(
-				tg::sync::ObjectMissingMessage {
-					id: object.clone(),
-				},
+				tg::sync::ObjectMissingMessage { id: object.clone() },
 			));
 			state
 				.sender

--- a/packages/server/src/watchdog.rs
+++ b/packages/server/src/watchdog.rs
@@ -1,6 +1,6 @@
 use {
 	crate::Server,
-	futures::{FutureExt, StreamExt as _, stream::FuturesUnordered},
+	futures::{FutureExt as _, StreamExt as _, stream::FuturesUnordered},
 	indoc::formatdoc,
 	num::ToPrimitive as _,
 	std::pin::pin,


### PR DESCRIPTION
- Use single transaction for `clean` in SQlite
- Use a single batch of index messages in checkin
- Add `catch_unwind` to index/clean/push
- Fix progress reporting in `clean` 
- Cargo fmt