### PR TITLE
fix: replace usage of std::env::current_exe() with tangram_util::env::current_exe()

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1038,7 +1038,7 @@ impl Cli {
 			.await;
 
 		// Get the path to the current executable.
-		let executable = std::env::current_exe()
+		let executable = tangram_util::env::current_exe()
 			.map_err(|source| tg::error!(!source, "failed to get the current executable path"))?;
 
 		// Spawn the server.

--- a/packages/server/src/pty.rs
+++ b/packages/server/src/pty.rs
@@ -64,7 +64,7 @@ impl Pty {
 		let temp = Temp::new(server);
 
 		// Spawn the session process.
-		let executable = std::env::current_exe()
+		let executable = tangram_util::env::current_exe()
 			.map_err(|source| tg::error!(!source, "failed to get the current executable path"))?;
 		let pty = name
 			.to_str()

--- a/packages/server/src/run/darwin.rs
+++ b/packages/server/src/run/darwin.rs
@@ -68,7 +68,7 @@ impl Server {
 		// Render the executable.
 		let executable = match command.host.as_str() {
 			"builtin" => {
-				let tg = std::env::current_exe().map_err(|source| {
+				let tg = tangram_util::env::current_exe().map_err(|source| {
 					tg::error!(!source, "failed to get the current executable")
 				})?;
 				args.insert(0, "builtin".to_owned());
@@ -77,7 +77,7 @@ impl Server {
 			},
 
 			"js" => {
-				let tg = std::env::current_exe().map_err(|source| {
+				let tg = tangram_util::env::current_exe().map_err(|source| {
 					tg::error!(!source, "failed to get the current executable")
 				})?;
 				args.insert(0, "js".to_owned());
@@ -212,7 +212,7 @@ impl Server {
 			};
 			let cwd = PathBuf::from("/");
 			let env = BTreeMap::new();
-			let executable = std::env::current_exe()
+			let executable = tangram_util::env::current_exe()
 				.map_err(|source| tg::error!(!source, "failed to get the current executable"))?;
 			(args, cwd, env, executable)
 		};

--- a/packages/server/src/run/linux.rs
+++ b/packages/server/src/run/linux.rs
@@ -93,7 +93,7 @@ impl Server {
 		// Render the executable.
 		let executable = match command.host.as_str() {
 			"builtin" => {
-				let tg = std::env::current_exe().map_err(|source| {
+				let tg = tangram_util::env::current_exe().map_err(|source| {
 					tg::error!(!source, "failed to get the current executable")
 				})?;
 				args.insert(0, "builtin".to_owned());
@@ -102,7 +102,7 @@ impl Server {
 			},
 
 			"js" => {
-				let tg = std::env::current_exe().map_err(|source| {
+				let tg = tangram_util::env::current_exe().map_err(|source| {
 					tg::error!(!source, "failed to get the current executable")
 				})?;
 				args.insert(0, "js".to_owned());
@@ -287,7 +287,7 @@ async fn sandbox(arg: SandboxArg<'_>) -> tg::Result<SandboxOutput> {
 		args: vec!["sandbox".to_owned()],
 		cwd: PathBuf::from("/"),
 		env: BTreeMap::new(),
-		executable: std::env::current_exe()
+		executable: tangram_util::env::current_exe()
 			.map_err(|source| tg::error!(!source, "failed to get the current executable"))?,
 	};
 

--- a/packages/util/src/env.rs
+++ b/packages/util/src/env.rs
@@ -1,0 +1,17 @@
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _, path::PathBuf};
+
+pub fn current_exe() -> std::io::Result<PathBuf> {
+	let path = std::env::current_exe()?;
+	let path = if cfg!(target_os = "linux")
+		&& path.as_os_str().as_encoded_bytes().ends_with(b" (deleted)")
+	{
+		let path = path.into_os_string();
+		let path = path.as_encoded_bytes();
+		let path = path.strip_suffix(b" (deleted)").unwrap();
+		let path = OsStr::from_bytes(path);
+		PathBuf::from(path)
+	} else {
+		path
+	};
+	Ok(path)
+}

--- a/packages/util/src/lib.rs
+++ b/packages/util/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod arc;
 pub mod collections;
+pub mod env;
 pub mod fs;
 pub mod iter;
 pub mod path;


### PR DESCRIPTION
On Linux, if the current executable is overwritten on the filesystem /proc/self/exe will be changed to read "path/to/exe (deleted)". This breaks serverl places where we spawn child processes using the current executable path. To fix , we strip the string " (deleted)" from the executable path if we find it (this will break if for some reason you name your executable "thing (deleted)"). 
