### PR TITLE
fix(server/checkin): variable shadowing

### DIFF
--- a/packages/server/src/checkin/artifact.rs
+++ b/packages/server/src/checkin/artifact.rs
@@ -651,9 +651,9 @@ impl Server {
 
 				// Get the artifact and path.
 				let (artifact, path) = if arg.options.destructive {
-					let index = graph.paths.get(root).unwrap();
-					let node = graph.nodes.get(index).unwrap();
-					let id = node.id.as_ref().unwrap().clone();
+					let root_index = graph.paths.get(root).unwrap();
+					let root_node = graph.nodes.get(root_index).unwrap();
+					let id = root_node.id.as_ref().unwrap().clone();
 					let path = node
 						.path
 						.as_ref()


### PR DESCRIPTION
Separating getting the root index from the id caused the `node` variable on line 642 to get shadowed.