### PR TITLE
refactor(compiler): make biome optional under the typescript feature

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -15,8 +15,9 @@ name = "tangram"
 path = "src/main.rs"
 
 [features]
+biome = ["tangram_server/biome"]
 boa = ["tangram_server/boa"]
-default = ["js", "typescript", "v8"]
+default = ["biome", "js", "typescript", "v8"]
 foundationdb = ["dep:foundationdb", "dep:tangram_fdb", "tangram_server/foundationdb"]
 js = ["tangram_server/js"]
 nats = ["tangram_server/nats"]

--- a/packages/compiler/Cargo.toml
+++ b/packages/compiler/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [features]
 default = []
-typescript = ["dep:tangram_v8", "dep:v8"]
+typescript = ["dep:biome_js_formatter", "dep:biome_js_parser", "dep:biome_js_syntax", "dep:tangram_v8", "dep:v8"]
 
 [build-dependencies]
 data-encoding = { workspace = true }
@@ -25,9 +25,9 @@ serde_json = { workspace = true }
 v8 = { workspace = true, optional = true }
 
 [dependencies]
-biome_js_formatter = { workspace = true }
-biome_js_parser = { workspace = true }
-biome_js_syntax = { workspace = true }
+biome_js_formatter = { workspace = true, optional = true }
+biome_js_parser = { workspace = true, optional = true }
+biome_js_syntax = { workspace = true, optional = true }
 bytes = { workspace = true }
 dashmap = { workspace = true }
 data-encoding = { workspace = true }

--- a/packages/compiler/Cargo.toml
+++ b/packages/compiler/Cargo.toml
@@ -15,7 +15,8 @@ workspace = true
 
 [features]
 default = []
-typescript = ["dep:biome_js_formatter", "dep:biome_js_parser", "dep:biome_js_syntax", "dep:tangram_v8", "dep:v8"]
+biome = ["dep:biome_js_formatter", "dep:biome_js_parser", "dep:biome_js_syntax"]
+typescript = ["dep:tangram_v8", "dep:v8"]
 
 [build-dependencies]
 data-encoding = { workspace = true }

--- a/packages/compiler/src/format.rs
+++ b/packages/compiler/src/format.rs
@@ -1,6 +1,12 @@
 use {super::Compiler, lsp_types as lsp, tangram_client::prelude::*};
 
 impl Compiler {
+	#[cfg(not(feature = "biome"))]
+	pub fn format(_text: &str) -> tg::Result<String> {
+		Err(tg::error!("biome is not enabled"))
+	}
+
+	#[cfg(feature = "biome")]
 	pub fn format(text: &str) -> tg::Result<String> {
 		let source_type = biome_js_syntax::JsFileSource::ts();
 		let options = biome_js_parser::JsParserOptions::default();

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -28,7 +28,6 @@ pub mod completion;
 pub mod definition;
 pub mod diagnostics;
 pub mod document;
-#[cfg(feature = "biome")]
 pub mod format;
 pub mod hover;
 pub mod initialize;
@@ -450,7 +449,6 @@ impl Compiler {
 				})
 				.boxed(),
 
-			#[cfg(feature = "biome")]
 			lsp::request::Formatting::METHOD => self
 				.handle_request_with::<lsp::request::Formatting, _, _>(request, |params| {
 					self.handle_format_request(params)

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -28,7 +28,7 @@ pub mod completion;
 pub mod definition;
 pub mod diagnostics;
 pub mod document;
-#[cfg(feature = "typescript")]
+#[cfg(feature = "biome")]
 pub mod format;
 pub mod hover;
 pub mod initialize;
@@ -450,7 +450,7 @@ impl Compiler {
 				})
 				.boxed(),
 
-			#[cfg(feature = "typescript")]
+			#[cfg(feature = "biome")]
 			lsp::request::Formatting::METHOD => self
 				.handle_request_with::<lsp::request::Formatting, _, _>(request, |params| {
 					self.handle_format_request(params)

--- a/packages/compiler/src/lib.rs
+++ b/packages/compiler/src/lib.rs
@@ -28,6 +28,7 @@ pub mod completion;
 pub mod definition;
 pub mod diagnostics;
 pub mod document;
+#[cfg(feature = "typescript")]
 pub mod format;
 pub mod hover;
 pub mod initialize;
@@ -449,6 +450,7 @@ impl Compiler {
 				})
 				.boxed(),
 
+			#[cfg(feature = "typescript")]
 			lsp::request::Formatting::METHOD => self
 				.handle_request_with::<lsp::request::Formatting, _, _>(request, |params| {
 					self.handle_format_request(params)

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -14,8 +14,9 @@ version = { workspace = true }
 workspace = true
 
 [features]
+biome = ["tangram_compiler/biome"]
 boa = ["tangram_js/boa"]
-default = ["js", "typescript"]
+default = ["biome", "js", "typescript"]
 v8 = ["js", "tangram_js/v8"]
 foundationdb = ["tangram_store/foundationdb"]
 js = ["dep:tangram_js"]

--- a/packages/server/src/format.rs
+++ b/packages/server/src/format.rs
@@ -3,22 +3,22 @@ use {
 	tangram_client::prelude::*,
 	tangram_http::{Body, request::Ext as _, response::builder::Ext as _},
 };
-#[cfg(feature = "typescript")]
+#[cfg(feature = "biome")]
 use {std::path::Path, tangram_ignore as ignore};
 
 impl Server {
-	#[cfg(not(feature = "typescript"))]
+	#[cfg(not(feature = "biome"))]
 	pub(crate) async fn format_with_context(
 		&self,
 		_context: &Context,
 		_arg: tg::format::Arg,
 	) -> tg::Result<()> {
 		Err(tg::error!(
-			"this version of tangram was not compiled with typescript support"
+			"this version of tangram was not compiled with biome support"
 		))
 	}
 
-	#[cfg(feature = "typescript")]
+	#[cfg(feature = "biome")]
 	pub(crate) async fn format_with_context(
 		&self,
 		context: &Context,
@@ -49,7 +49,7 @@ impl Server {
 		Ok(())
 	}
 
-	#[cfg(feature = "typescript")]
+	#[cfg(feature = "biome")]
 	fn format_inner(&self, path: &Path, ignore: &mut ignore::Ignorer) -> tg::Result<()> {
 		let metadata = std::fs::symlink_metadata(path)
 			.map_err(|source| tg::error!(!source, "failed to read the metadata"))?;
@@ -61,7 +61,7 @@ impl Server {
 		Ok(())
 	}
 
-	#[cfg(feature = "typescript")]
+	#[cfg(feature = "biome")]
 	fn format_directory(&self, path: &Path, ignore: &mut ignore::Ignorer) -> tg::Result<()> {
 		// Read the directory entries.
 		let mut entries = Vec::new();
@@ -101,7 +101,7 @@ impl Server {
 		Ok(())
 	}
 
-	#[cfg(feature = "typescript")]
+	#[cfg(feature = "biome")]
 	fn format_file(path: &Path) -> tg::Result<()> {
 		// Get the text.
 		let text = std::fs::read_to_string(path)


### PR DESCRIPTION
The `biome` crate includes a build script that doesn't work when dependencies are vendored. We have a patch for this, but as the typescript feature is not required at present for the cloud case, and biome is eventually going to be removed, this PR just removes biome from builds without the typescript feature enabled.