### PR TITLE
feat: add busybox to test environment

### DIFF
--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -732,7 +732,7 @@ export def --env spawn [
 				tg.assert(kv, `unknown host: ${host_}`);
 				const { url, checksum } = kv[1];
 				const dir = tg.download(url, checksum, { mode: "extract" }).then(tg.Directory.expect);
-				return { PATH: tg.Mutation.suffix(tg`${dir}/bin`, ":") };
+				return { PATH: tg.Mutation.suffix(tg`/bin:${dir}/bin`, ":") };
 			};
 
 			export default env;

--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -703,9 +703,8 @@ export def --env spawn [
 
 	# Tag busybox if requested.
 	if $busybox {
-		# Create a temp for busybox
-		let busybox_path = mktemp -d
-		let busybox_source = '
+		let path = mktemp -d
+		let source = '
 			const SOURCES: Record<string, { url: string, checksum: tg.Checksum }> = {
 				"aarch64-darwin": {
 					url: "https://github.com/tangramdotdev/bootstrap/releases/download/v2024.10.03/utils_universal_darwin.tar.zst",
@@ -737,10 +736,10 @@ export def --env spawn [
 
 			export default env;
 		';
-		$busybox_source | save ($busybox_path | path join 'tangram.ts')
-		run tangram check $busybox_path
-		run tangram -c ($config_path) tag 'busybox' $busybox_path
-		run rm -rf $busybox_path
+		$source | save ($path | path join 'tangram.ts')
+		run tangram check $path
+		run tangram -c ($config_path) tag 'busybox' $path
+		run rm -rf $path
 	}
 
 	{ config: $config_path, directory: $directory_path, url: $url }

--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -693,11 +693,16 @@ export def --env spawn [
 		}
 	}
 
+	loop {
+		let output = tg health | complete
+		if $output.exit_code == 0 {
+			break;
+		}
+		sleep 10ms
+	}
+
 	# Tag busybox if requested.
 	if $busybox {
-		# Tiny sleep to wait for the server to start up.
-		sleep 0.1sec
-
 		# Create a temp for busybox
 		let busybox_path = mktemp -d
 		let busybox_source = '
@@ -736,14 +741,6 @@ export def --env spawn [
 		run tangram check $busybox_path
 		run tangram -c ($config_path) tag 'busybox' $busybox_path
 		run rm -rf $busybox_path
-	}
-
-	loop {
-		let output = tg health | complete
-		if $output.exit_code == 0 {
-			break;
-		}
-		sleep 10ms
 	}
 
 	{ config: $config_path, directory: $directory_path, url: $url }

--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -588,6 +588,7 @@ def snapshot_path [path: string] {
 }
 
 export def --env spawn [
+	--busybox
 	--cloud
 	--config (-c): record
 	--name (-n): string
@@ -692,6 +693,50 @@ export def --env spawn [
 		}
 	}
 
+	# Tag busybox if requested.
+	if $busybox {
+		# Tiny sleep to wait for the server to start up.
+		sleep 0.1sec
+
+		# Create a temp for busybox
+		let busybox_path = mktemp -d
+		let busybox_source = '
+			const SOURCES: Record<string, { url: string, checksum: tg.Checksum }> = {
+				"aarch64-darwin": {
+					url: "https://github.com/tangramdotdev/bootstrap/releases/download/v2024.10.03/utils_universal_darwin.tar.zst",
+					checksum: "sha256:7bd26e53a370d66eb05436c0a128d183a66dd2aba3c2524d94b916bd4515be40",
+				},
+				"x86_64-darwin": {
+					url: "https://github.com/tangramdotdev/bootstrap/releases/download/v2024.10.03/utils_universal_darwin.tar.zst",
+					checksum: "sha256:7bd26e53a370d66eb05436c0a128d183a66dd2aba3c2524d94b916bd4515be40",
+				},
+				"aarch64-linux": {
+					url: "https://github.com/tangramdotdev/bootstrap/releases/download/v2024.10.03/utils_aarch64_linux.tar.zst",
+					checksum: "sha256:486ef386ca587e5a3366df556da6140e9fd633462580a53c63942af411c9f40f",
+				},
+				"x86_64-linux": {
+					url: "https://github.com/tangramdotdev/bootstrap/releases/download/v2024.10.03/utils_x86_64_linux.tar.zst",
+					checksum: "sha256:dcbc2b66a046a66216f4c54d79f2a434c086346799f28b7f405bd6a2dc0e8543",
+				},
+			};
+
+			export const env = (host?: string) => {
+				const host_ = host ?? tg.process.env.TANGRAM_HOST;
+				tg.assert(typeof host_ === "string");
+				const kv = Object.entries(SOURCES).find(([k, _]) => k === host_);
+				tg.assert(kv, `unknown host: ${host_}`);
+				const { url, checksum } = kv[1];
+				const dir = tg.download(url, checksum, { mode: "extract" }).then(tg.Directory.expect);
+				return { PATH: tg.Mutation.suffix(tg`${dir}/bin`, ":") };
+			};
+
+			export default env;
+		';
+		$busybox_source | save ($busybox_path | path join 'tangram.ts')
+		run tangram check $busybox_path
+		run tangram -c ($config_path) tag 'busybox' $busybox_path
+		run rm -rf $busybox_path
+	}
 
 	loop {
 		let output = tg health | complete

--- a/packages/cli/tests/build/host_command_hello_world.nu
+++ b/packages/cli/tests/build/host_command_hello_world.nu
@@ -1,13 +1,14 @@
 use ../../test.nu *
 
-let server = spawn
+let server = spawn --busybox
 
 let path = artifact {
 	tangram.ts: '
-		export default async () => {
-			return await tg.run`echo "Hello, World!"`;
-		};
+		import busybox from "busybox";
+		export default () => tg.run`echo "Hello, World!" > ${tg.output}`.env(tg.build(busybox));
 	'
 }
 
-run tg build $path
+let id = run tg build $path
+let object = run tg object get --blobs --depth=inf --pretty $id
+snapshot $object

--- a/packages/cli/tests/build/host_command_hello_world.snapshot
+++ b/packages/cli/tests/build/host_command_hello_world.snapshot
@@ -1,0 +1,3 @@
+tg.file({
+  "contents": tg.blob("Hello, World!\n"),
+})

--- a/packages/clients/js/src/build.ts
+++ b/packages/clients/js/src/build.ts
@@ -27,8 +27,10 @@ export function build(...args: any): any {
 		let strings = args[0] as TemplateStringsArray;
 		let placeholders = args.slice(1);
 		let template = tg.template(strings, ...placeholders);
+		let executable = tg.process.env.SHELL ?? "sh";
+		tg.assert(tg.Command.Arg.Executable.is(executable));
 		let arg = {
-			executable: "/bin/sh",
+			executable,
 			args: ["-c", template],
 		};
 		return new BuildBuilder(arg);
@@ -182,9 +184,10 @@ async function arg_(
 				arg instanceof tg.Template
 			) {
 				let host = tg.process.env.TANGRAM_HOST;
+				let executable = tg.process.env.SHELL ?? "sh";
 				return {
 					args: ["-c", arg],
-					executable: "/bin/sh",
+					executable,
 					host,
 				};
 			} else if (arg instanceof tg.Command) {

--- a/packages/clients/js/src/command.ts
+++ b/packages/clients/js/src/command.ts
@@ -29,8 +29,10 @@ export function command(...args: any): any {
 		let strings = args[0] as TemplateStringsArray;
 		let placeholders = args.slice(1);
 		let template = tg.template(strings, ...placeholders);
+		let executable = tg.process.env.SHELL ?? "sh";
+		tg.assert(tg.Command.Arg.Executable.is(executable));
 		let arg = {
-			executable: "/bin/sh",
+			executable,
 			args: ["-c", template],
 		};
 		return new CommandBuilder(arg);
@@ -288,6 +290,28 @@ export namespace Command {
 
 			export type Path = {
 				path: string;
+			};
+
+			export let is = (value: unknown): value is Executable => {
+				return (
+					tg.Artifact.is(value) ||
+					typeof value === "string" ||
+					(typeof value === "object" &&
+						value !== null &&
+						"artifact" in value &&
+						tg.Artifact.is(value.artifact)) ||
+					(typeof value === "object" &&
+						value !== null &&
+						"module" in value &&
+						typeof value.module === "object" &&
+						value.module !== null &&
+						"kind" in value.module &&
+						"referent" in value.module) ||
+					(typeof value === "object" &&
+						value !== null &&
+						"path" in value &&
+						typeof value.path === "string")
+				);
 			};
 		}
 	}

--- a/packages/clients/js/src/run.ts
+++ b/packages/clients/js/src/run.ts
@@ -27,8 +27,10 @@ export function run(...args: any): any {
 		let strings = args[0] as TemplateStringsArray;
 		let placeholders = args.slice(1);
 		let template = tg.template(strings, ...placeholders);
+		let executable = tg.process.env.SHELL ?? "sh";
+		tg.assert(tg.Command.Arg.Executable.is(executable));
 		let arg = {
-			executable: "/bin/sh",
+			executable,
 			args: ["-c", template],
 		};
 		return new RunBuilder(arg);
@@ -222,9 +224,10 @@ async function arg_(
 				arg instanceof tg.Template
 			) {
 				let host = tg.process.env.TANGRAM_HOST;
+				let executable = tg.process.env.SHELL ?? "sh";
 				return {
 					args: ["-c", arg],
-					executable: "/bin/sh",
+					executable,
 					host,
 				};
 			} else if (arg instanceof tg.Command) {

--- a/packages/js/src/start.ts
+++ b/packages/js/src/start.ts
@@ -40,7 +40,7 @@ export let start = async (arg: Arg): Promise<tg.Value.Data> => {
 	// Call the export.
 	let output: tg.Value;
 	if (!(arg.executable.export in namespace)) {
-		throw new Error("failed to find the export");
+		throw new Error(`failed to find the export named ${arg.executable.export}`);
 	}
 	let value = await namespace[arg.executable.export];
 	if (tg.Value.is(value)) {

--- a/packages/server/src/run/linux.rs
+++ b/packages/server/src/run/linux.rs
@@ -131,7 +131,6 @@ impl Server {
 					which(&executable.path, &env).await?
 				},
 				tg::command::data::Executable::Path(executable) => {
-					// Render the env relative to the host. Note: we have not constructed the Paths context yet, so we do the path replacement directly.
 					let host_artifacts_path = self.artifacts_path();
 					let env = render_env(&command.env, &host_artifacts_path, &output_path)?;
 					let executable = which(&executable.path, &env).await?;


### PR DESCRIPTION
- fix bug in linux runtime where path detection used guest-paths in place of host-paths
- replace usage of /bin/sh everywhere in the js runtime
- add busybox option to `spawn` command in tests 