### PR TITLE
fix(clients/js): fix MaybePromise inference

### DIFF
--- a/packages/cli/tests/check/mutation_inference.nu
+++ b/packages/cli/tests/check/mutation_inference.nu
@@ -1,0 +1,21 @@
+use ../../test.nu *
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		// Test that tg.Mutation.setIfUnset infers type from argument.
+		export default async () => {
+			const template = tg`hello`;
+			const mutation = await tg.Mutation.setIfUnset(template);
+			const env: { FOO?: tg.MaybeMutation<tg.Template.Arg> } = {
+				FOO: mutation,
+			};
+			return env;
+		};
+	'
+}
+
+# Check should succeed if inference works correctly.
+let output = tg check $path | complete
+success $output

--- a/packages/cli/tests/check/mutation_inference.nu
+++ b/packages/cli/tests/check/mutation_inference.nu
@@ -4,7 +4,6 @@ let server = spawn
 
 let path = artifact {
 	tangram.ts: '
-		// Test that tg.Mutation.setIfUnset infers type from argument.
 		export default async () => {
 			const template = tg`hello`;
 			const mutation = await tg.Mutation.setIfUnset(template);
@@ -16,6 +15,5 @@ let path = artifact {
 	'
 }
 
-# Check should succeed if inference works correctly.
 let output = tg check $path | complete
 success $output

--- a/packages/clients/js/src/util.ts
+++ b/packages/clients/js/src/util.ts
@@ -1,6 +1,6 @@
 import type * as tg from "./index.ts";
 
-export type MaybePromise<T> = T | PromiseLike<T>;
+export type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;
 
 export type MaybeMutation<T extends tg.Value = tg.Value> = T | tg.Mutation<T>;
 

--- a/packages/js/src/tangram.d.ts
+++ b/packages/js/src/tangram.d.ts
@@ -1730,7 +1730,7 @@ declare namespace tg {
 		tg.Unresolved<tg.ValueOrMaybeMutationMap<T>>
 	>;
 
-	type MaybePromise<T> = T | PromiseLike<T>;
+	type MaybePromise<T> = T | Promise<T> | PromiseLike<T>;
 
 	type MaybeMutation<T extends tg.Value = tg.Value> = T | tg.Mutation<T>;
 


### PR DESCRIPTION
Changing from the concrete `Promise<T>` to the structural `PromiseLike<T>` broke TS's ability to infer the type, causing it to fall back to the default `tg.Value`. By adding `Promise<T>` back first, actual promises now still support the stronger inference, though PromiseLike values will still require annotations.

The included test passes before the breaking change, fails without the d.ts fix, and passes with the fix applied.