### PR TITLE
feat: add path to reference options

### DIFF
--- a/packages/cli/tests/build/import_with_path.nu
+++ b/packages/cli/tests/build/import_with_path.nu
@@ -1,0 +1,22 @@
+use ../../test.nu *
+
+let server = spawn
+let path = artifact {
+	"subdirectory": {
+		file.txt: "hello, world!\n"
+	}
+}
+tg tag test $path
+
+let path = artifact {
+	tangram.ts: '
+		import file from "test" with { 
+			"path": "subdirectory/file.txt", 
+			"type": "file" 
+		};
+		export default () => file.text();
+	'
+};
+
+let output = tg build $path
+snapshot $output '"hello, world!"'

--- a/packages/cli/tests/check/tag_import_with_path.nu
+++ b/packages/cli/tests/check/tag_import_with_path.nu
@@ -1,0 +1,48 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and tag it.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+tg tag my-lib $dep_path
+
+# Create a package that imports the tag with a path to access the nested file.
+let test_path = artifact {
+	tangram.ts: '
+		import { helper } from "my-lib" with { path: "lib/utils.tg.ts" };
+		export default () => helper();
+	'
+}
+
+# Checkin and verify the snapshot.
+let id = tg checkin $test_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import { helper } from \"my-lib\" with { path: \"lib/utils.tg.ts\" };\nexport default () => helper();"),
+	    "dependencies": {
+	      "my-lib?path=lib/utils.tg.ts": {
+	        "item": tg.file({
+	          "contents": tg.blob("export const helper = () => \"helper\";"),
+	          "module": "ts",
+	        }),
+	        "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	        "path": "lib/utils.tg.ts",
+	        "tag": "my-lib",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'
+
+# Check should succeed.
+let output = tg check $test_path | complete
+success $output

--- a/packages/cli/tests/checkin/path_import_by_id.nu
+++ b/packages/cli/tests/checkin/path_import_by_id.nu
@@ -1,0 +1,42 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and checkin to get an ID.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+let dep_id = tg checkin $dep_path
+
+# Create a package that imports by ID with a path option.
+let test_path = artifact {
+	tangram.ts: $'
+		import { helper } from "($dep_id)" with { path: "lib/utils.tg.ts" };
+	'
+}
+
+# Checkin and verify the snapshot.
+let id = tg checkin $test_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import { helper } from \"dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0\" with { path: \"lib/utils.tg.ts\" };"),
+	    "dependencies": {
+	      "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0?path=lib/utils.tg.ts": {
+	        "item": tg.file({
+	          "contents": tg.blob("export const helper = () => \"helper\";"),
+	          "module": "ts",
+	        }),
+	        "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	        "path": "lib/utils.tg.ts",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_id_transitive_by_id.nu
+++ b/packages/cli/tests/checkin/path_import_by_id_transitive_by_id.nu
@@ -1,0 +1,60 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and checkin to get an ID for inner dependency.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+let dep_id = tg checkin $dep_path
+
+# Create inner package that imports by ID with path option.
+let inner_path = artifact {
+	tangram.ts: $'
+		import { helper } from "($dep_id)" with { path: "lib/utils.tg.ts" };
+	'
+}
+let inner_id = tg checkin $inner_path
+
+# Create outer package that imports inner by ID.
+let outer_path = artifact {
+	tangram.ts: $'
+		import * as inner from "($inner_id)";
+	'
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin $outer_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"dir_01m5p1nhzytngtxrhrass4kzejycet3y1hpbhgvcywcy26by9szeng\";"),
+	    "dependencies": {
+	      "dir_01m5p1nhzytngtxrhrass4kzejycet3y1hpbhgvcywcy26by9szeng": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	                "path": "lib/utils.tg.ts",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_id_transitive_by_path.nu
+++ b/packages/cli/tests/checkin/path_import_by_id_transitive_by_path.nu
@@ -1,0 +1,60 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and checkin to get an ID for inner dependency.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+let dep_id = tg checkin $dep_path
+
+# Create inner package that imports by ID with path option, and outer that imports by path.
+let path = artifact {
+	inner: {
+		tangram.ts: $'
+			import { helper } from "($dep_id)" with { path: "lib/utils.tg.ts" };
+		'
+	}
+	outer: {
+		tangram.ts: '
+			import * as inner from "../inner";
+		'
+	}
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin ($path | path join 'outer')
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"../inner\";"),
+	    "dependencies": {
+	      "../inner": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	                "path": "lib/utils.tg.ts",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	        "path": "../inner",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_id_transitive_by_tag.nu
+++ b/packages/cli/tests/checkin/path_import_by_id_transitive_by_tag.nu
@@ -1,0 +1,62 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and checkin to get an ID for inner dependency.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+let dep_id = tg checkin $dep_path
+
+# Create inner package that imports by ID with path option and tag it.
+let inner_path = artifact {
+	tangram.ts: $'
+		import { helper } from "($dep_id)" with { path: "lib/utils.tg.ts" };
+	'
+}
+tg tag inner-pkg $inner_path
+
+# Create outer package that imports inner by tag.
+let outer_path = artifact {
+	tangram.ts: '
+		import * as inner from "inner-pkg";
+	'
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin $outer_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"inner-pkg\";"),
+	    "dependencies": {
+	      "inner-pkg": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	                "path": "lib/utils.tg.ts",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	        "id": "dir_01m5p1nhzytngtxrhrass4kzejycet3y1hpbhgvcywcy26by9szeng",
+	        "tag": "inner-pkg",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_path.nu
+++ b/packages/cli/tests/checkin/path_import_by_path.nu
@@ -1,0 +1,40 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure.
+let path = artifact {
+	sibling: {
+		lib: {
+			utils.tg.ts: 'export const helper = () => "helper";'
+		},
+		tangram.ts: "import * as utils from ./lib/utils.tg.ts;"
+	}
+	package: {
+		tangram.ts: '
+			import { helper } from "../sibling" with { path: "lib/utils.tg.ts" };
+		'
+	}
+}
+
+# Checkin and verify the snapshot.
+let id = tg checkin ($path | path join 'package')
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import { helper } from \"../sibling\" with { path: \"lib/utils.tg.ts\" };"),
+	    "dependencies": {
+	      "../sibling?path=lib/utils.tg.ts": {
+	        "item": tg.file({
+	          "contents": tg.blob("export const helper = () => \"helper\";"),
+	          "module": "ts",
+	        }),
+	        "path": "../sibling/lib/utils.tg.ts",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_path_transitive_by_id.nu
+++ b/packages/cli/tests/checkin/path_import_by_path_transitive_by_id.nu
@@ -1,0 +1,58 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure where inner package imports sibling by path with path option.
+let inner_root = artifact {
+	sibling: {
+		lib: {
+			utils.tg.ts: 'export const helper = () => "helper";'
+		}
+		tangram.ts: "import * as utils from ./lib/utils.tg.ts;"
+	}
+	package: {
+		tangram.ts: '
+			import { helper } from "../sibling" with { path: "lib/utils.tg.ts" };
+		'
+	}
+}
+let inner_id = tg checkin ($inner_root | path join 'package')
+
+# Create outer package that imports inner by ID.
+let outer_path = artifact {
+	tangram.ts: $'
+		import * as inner from "($inner_id)";
+	'
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin $outer_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"dir_019kh7jnxz71er60sktvsaqfyy3n9s87cfxrekhnyaqebb7r1vazt0\";"),
+	    "dependencies": {
+	      "dir_019kh7jnxz71er60sktvsaqfyy3n9s87cfxrekhnyaqebb7r1vazt0": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"../sibling\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "../sibling?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "path": "../sibling/lib/utils.tg.ts",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_path_transitive_by_path.nu
+++ b/packages/cli/tests/checkin/path_import_by_path_transitive_by_path.nu
@@ -1,0 +1,56 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure where inner package imports sibling by path with path option.
+let path = artifact {
+	sibling: {
+		lib: {
+			utils.tg.ts: 'export const helper = () => "helper";'
+		}
+		tangram.ts: "import * as utils from ./lib/utils.tg.ts;"
+	}
+	inner: {
+		tangram.ts: '
+			import { helper } from "../sibling" with { path: "lib/utils.tg.ts" };
+		'
+	}
+	outer: {
+		tangram.ts: '
+			import * as inner from "../inner";
+		'
+	}
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin ($path | path join 'outer')
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"../inner\";"),
+	    "dependencies": {
+	      "../inner": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"../sibling\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "../sibling?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "path": "../sibling/lib/utils.tg.ts",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	        "path": "../inner",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_path_transitive_by_tag.nu
+++ b/packages/cli/tests/checkin/path_import_by_path_transitive_by_tag.nu
@@ -1,0 +1,60 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure where inner package imports sibling by path with path option.
+let inner_root = artifact {
+	sibling: {
+		lib: {
+			utils.tg.ts: 'export const helper = () => "helper";'
+		}
+		tangram.ts: "import * as utils from ./lib/utils.tg.ts;"
+	}
+	package: {
+		tangram.ts: '
+			import { helper } from "../sibling" with { path: "lib/utils.tg.ts" };
+		'
+	}
+}
+tg tag inner-pkg ($inner_root | path join 'package')
+
+# Create outer package that imports inner by tag.
+let outer_path = artifact {
+	tangram.ts: '
+		import * as inner from "inner-pkg";
+	'
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin $outer_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"inner-pkg\";"),
+	    "dependencies": {
+	      "inner-pkg": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"../sibling\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "../sibling?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "path": "../sibling/lib/utils.tg.ts",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	        "id": "dir_019kh7jnxz71er60sktvsaqfyy3n9s87cfxrekhnyaqebb7r1vazt0",
+	        "tag": "inner-pkg",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_tag.nu
+++ b/packages/cli/tests/checkin/path_import_by_tag.nu
@@ -1,0 +1,43 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and tag it.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+tg tag my-lib $dep_path
+
+# Create a package that imports by tag with a path option.
+let test_path = artifact {
+	tangram.ts: '
+		import { helper } from "my-lib" with { path: "lib/utils.tg.ts" };
+	'
+}
+
+# Checkin and verify the snapshot.
+let id = tg checkin $test_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import { helper } from \"my-lib\" with { path: \"lib/utils.tg.ts\" };"),
+	    "dependencies": {
+	      "my-lib?path=lib/utils.tg.ts": {
+	        "item": tg.file({
+	          "contents": tg.blob("export const helper = () => \"helper\";"),
+	          "module": "ts",
+	        }),
+	        "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	        "path": "lib/utils.tg.ts",
+	        "tag": "my-lib",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_tag_transitive_by_id.nu
+++ b/packages/cli/tests/checkin/path_import_by_tag_transitive_by_id.nu
@@ -1,0 +1,61 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and tag it for inner dependency.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+tg tag my-lib $dep_path
+
+# Create inner package that imports by tag with path option.
+let inner_path = artifact {
+	tangram.ts: '
+		import { helper } from "my-lib" with { path: "lib/utils.tg.ts" };
+	'
+}
+let inner_id = tg checkin $inner_path
+
+# Create outer package that imports inner by ID.
+let outer_path = artifact {
+	tangram.ts: $'
+		import * as inner from "($inner_id)";
+	'
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin $outer_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"dir_015jdnyf5aafrdjynkkw3ymz5j9dcj59a43j387qhx5p1j16r3bxpg\";"),
+	    "dependencies": {
+	      "dir_015jdnyf5aafrdjynkkw3ymz5j9dcj59a43j387qhx5p1j16r3bxpg": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"my-lib\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "my-lib?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	                "path": "lib/utils.tg.ts",
+	                "tag": "my-lib",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_tag_transitive_by_path.nu
+++ b/packages/cli/tests/checkin/path_import_by_tag_transitive_by_path.nu
@@ -1,0 +1,61 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and tag it for inner dependency.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+tg tag my-lib $dep_path
+
+# Create inner package that imports by tag with path option, and outer that imports by path.
+let path = artifact {
+	inner: {
+		tangram.ts: '
+			import { helper } from "my-lib" with { path: "lib/utils.tg.ts" };
+		'
+	}
+	outer: {
+		tangram.ts: '
+			import * as inner from "../inner";
+		'
+	}
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin ($path | path join 'outer')
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"../inner\";"),
+	    "dependencies": {
+	      "../inner": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"my-lib\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "my-lib?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	                "path": "lib/utils.tg.ts",
+	                "tag": "my-lib",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	        "path": "../inner",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/checkin/path_import_by_tag_transitive_by_tag.nu
+++ b/packages/cli/tests/checkin/path_import_by_tag_transitive_by_tag.nu
@@ -1,0 +1,63 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure and tag it for inner dependency.
+let dep_path = artifact {
+	lib: {
+		utils.tg.ts: 'export const helper = () => "helper";'
+	}
+	tangram.ts: 'export default () => "root";'
+}
+tg tag my-lib $dep_path
+
+# Create inner package that imports by tag with path option and tag it.
+let inner_path = artifact {
+	tangram.ts: '
+		import { helper } from "my-lib" with { path: "lib/utils.tg.ts" };
+	'
+}
+tg tag inner-pkg $inner_path
+
+# Create outer package that imports inner by tag.
+let outer_path = artifact {
+	tangram.ts: '
+		import * as inner from "inner-pkg";
+	'
+}
+
+# Checkin outer package and verify the snapshot.
+let id = tg checkin $outer_path
+tg index
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot $object '
+	tg.directory({
+	  "tangram.ts": tg.file({
+	    "contents": tg.blob("import * as inner from \"inner-pkg\";"),
+	    "dependencies": {
+	      "inner-pkg": {
+	        "item": tg.directory({
+	          "tangram.ts": tg.file({
+	            "contents": tg.blob("import { helper } from \"my-lib\" with { path: \"lib/utils.tg.ts\" };"),
+	            "dependencies": {
+	              "my-lib?path=lib/utils.tg.ts": {
+	                "item": tg.file({
+	                  "contents": tg.blob("export const helper = () => \"helper\";"),
+	                  "module": "ts",
+	                }),
+	                "id": "dir_01sqqe6wh137xnctptzwprcm7pp9bye8nbqw79701ph4b63bhdzsr0",
+	                "path": "lib/utils.tg.ts",
+	                "tag": "my-lib",
+	              },
+	            },
+	            "module": "ts",
+	          }),
+	        }),
+	        "id": "dir_015jdnyf5aafrdjynkkw3ymz5j9dcj59a43j387qhx5p1j16r3bxpg",
+	        "tag": "inner-pkg",
+	      },
+	    },
+	    "module": "ts",
+	  }),
+	})
+'

--- a/packages/cli/tests/object/get_by_id_with_path.nu
+++ b/packages/cli/tests/object/get_by_id_with_path.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure.
+let path = artifact {
+	foo: {
+		bar: {
+			file.txt: 'Hello, World!'
+		}
+	}
+}
+
+# Check in the directory.
+let id = tg checkin $path
+
+# Get the nested file using the path option.
+let output = tg get --pretty $"($id)?path=foo/bar/file.txt" | complete
+
+snapshot $output.stdout '
+	tg.file({
+	  "contents": blb_01b7mbpwtwk7vv4n50rn5cab07zcxvpq8d7pggwc2g54d0cjd8nnm0,
+	})
+
+'
+snapshot $output.stderr '
+	info fil_0161g41yea30wb48ta1dt778xfgfxrm09e1p1dznezech34e27tp60?id=dir_0141ez1f9wny9knjrbegp3gnx9z4am8fa9ww584xbv64fm8azg1g80&path=foo/bar/file.txt
+
+'

--- a/packages/cli/tests/object/get_by_tag_with_path.nu
+++ b/packages/cli/tests/object/get_by_tag_with_path.nu
@@ -1,0 +1,31 @@
+use ../../test.nu *
+
+let server = spawn
+
+# Create a directory with nested structure.
+let path = artifact {
+	foo: {
+		bar: {
+			file.txt: 'Hello, World!'
+		}
+	}
+}
+
+# Check in and tag the directory.
+let dir_id = tg checkin $path
+tg tag test $dir_id
+
+# Get the nested file using the path option with a tag reference.
+let output = tg get --pretty "test?path=foo/bar/file.txt" | complete
+
+# Verify the output is a file ID.
+snapshot $output.stdout '
+	tg.file({
+	  "contents": blb_01b7mbpwtwk7vv4n50rn5cab07zcxvpq8d7pggwc2g54d0cjd8nnm0,
+	})
+
+'
+snapshot $output.stderr '
+	info fil_0161g41yea30wb48ta1dt778xfgfxrm09e1p1dznezech34e27tp60?id=dir_0141ez1f9wny9knjrbegp3gnx9z4am8fa9ww584xbv64fm8azg1g80&path=foo/bar/file.txt&tag=test
+
+'

--- a/packages/client/src/module/import.rs
+++ b/packages/client/src/module/import.rs
@@ -37,8 +37,13 @@ impl Import {
 				let attributes = serde_json::from_value::<tg::reference::Options>(attributes)
 					.map_err(|source| tg::error!(!source, "invalid attributes"))?;
 				let local = attributes.local.or(reference.options().local.clone());
+				let path = attributes.path.or(reference.options().path.clone());
 				let remote = attributes.remote.or(reference.options().remote.clone());
-				let options = tg::reference::Options { local, remote };
+				let options = tg::reference::Options {
+					local,
+					path,
+					remote,
+				};
 				tg::Reference::with_item_and_options(reference.item().clone(), options)
 			}
 		} else {

--- a/packages/client/src/reference.rs
+++ b/packages/client/src/reference.rs
@@ -65,6 +65,9 @@ pub struct Options {
 	pub local: Option<PathBuf>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub path: Option<PathBuf>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub remote: Option<String>,
 }
 
@@ -146,6 +149,9 @@ impl Reference {
 						"local" => {
 							options.local.replace(value.into_owned().into());
 						},
+						"path" => {
+							options.path.replace(value.into_owned().into());
+						},
 						"remote" => {
 							options.remote.replace(value.into_owned());
 						},
@@ -173,6 +179,12 @@ impl Reference {
 			let local = tangram_uri::encode_query_value(&local);
 			let local = format!("local={local}");
 			query.push(local);
+		}
+		if let Some(path) = &self.options.path {
+			let path = path.to_string_lossy();
+			let path = tangram_uri::encode_query_value(&path);
+			let path = format!("path={path}");
+			query.push(path);
 		}
 		if let Some(remote) = &self.options.remote {
 			let remote = tangram_uri::encode_query_value(remote);

--- a/packages/server/src/checkin/subpath.rs
+++ b/packages/server/src/checkin/subpath.rs
@@ -1,0 +1,159 @@
+use {
+	crate::{Server, checkin::Graph},
+	std::path::{Path, PathBuf},
+	tangram_client as tg,
+};
+
+#[derive(Clone)]
+pub struct Subpath {
+	pub index: usize,
+	pub reference: tg::Reference,
+}
+
+impl Server {
+	pub(super) async fn checkin_resolve_subpaths(
+		&self,
+		subpaths: &[Subpath],
+		graph: &mut Graph,
+	) -> tg::Result<()> {
+		let old_graph = graph.clone();
+		for subpath in subpaths {
+			let path = subpath.reference.options().path.as_ref().unwrap();
+			let node = &mut graph.nodes[&subpath.index];
+			let file = node
+				.variant
+				.try_unwrap_file_mut()
+				.map_err(|_| tg::error!("expected a file"))?;
+			let Some(dependency) = file
+				.dependencies
+				.get_mut(&subpath.reference)
+				.ok_or_else(|| tg::error!("expected a dependency"))?
+			else {
+				continue;
+			};
+			let Some(item) = dependency.item.take() else {
+				continue;
+			};
+			let fixed = match item {
+				tg::graph::data::Edge::Object(object) => {
+					self.checkin_resolve_subpath_with_object(object, path)
+						.await?
+				},
+				tg::graph::data::Edge::Pointer(pointer) => {
+					self.checkin_resolve_subpath_with_pointer(pointer, path, &old_graph)
+						.await?
+				},
+			};
+			// Should this be allowed?
+			let resolved = fixed.ok_or_else(|| tg::error!("expected an item at the path"))?;
+			dependency.item.replace(resolved);
+			dependency.options.path.replace(path.clone());
+			if let Ok(id) = subpath.reference.item().try_unwrap_object_ref()
+				&& subpath.reference.options().local.is_none()
+				&& dependency.options.id.is_none()
+			{
+				dependency.options.id.replace(id.clone());
+			}
+		}
+		Ok(())
+	}
+
+	async fn checkin_resolve_subpath_with_pointer(
+		&self,
+		mut pointer: tg::graph::data::Pointer,
+		path: &Path,
+		graph: &Graph,
+	) -> tg::Result<Option<tg::graph::data::Edge<tg::object::Id>>> {
+		let mut stack = vec![];
+		let mut components = path.components().peekable();
+		while let Some(component) = components.next() {
+			match component {
+				std::path::Component::CurDir => (),
+				std::path::Component::ParentDir => {
+					let Some((index, kind)) = stack.pop() else {
+						return Ok(None);
+					};
+					pointer.index = index;
+					pointer.kind = kind;
+				},
+				std::path::Component::Normal(component) => {
+					let name = component
+						.to_str()
+						.ok_or_else(|| tg::error!(path = %path.display(), "invalid path"))?;
+					let edge = if let Some(graph) = &pointer.graph {
+						let graph = tg::Graph::with_id(graph.clone());
+						let nodes = graph.nodes(self).await?;
+						let node = nodes
+							.get(pointer.index)
+							.ok_or_else(|| tg::error!("invalid graph pointer"))?;
+						let directory = node
+							.try_unwrap_directory_ref()
+							.map_err(|_| tg::error!("expected a directory"))?;
+						let leaf = directory
+							.try_unwrap_leaf_ref()
+							.map_err(|_| tg::error!("expected a leaf directory"))?;
+						let Some(entry) = leaf.entries.get(name) else {
+							return Ok(None);
+						};
+						match entry {
+							tg::graph::Edge::Object(object) => {
+								let id: tg::object::Id = object.id().into();
+								tg::graph::data::Edge::Object(id)
+							},
+							tg::graph::Edge::Pointer(p) => {
+								tg::graph::data::Edge::Pointer(p.to_data())
+							},
+						}
+					} else {
+						let directory = graph.nodes[&pointer.index]
+							.variant
+							.try_unwrap_directory_ref()
+							.map_err(|_| tg::error!("expected a directory"))?;
+						let Some(edge) = directory.entries.get(name) else {
+							return Ok(None);
+						};
+						edge.clone().into()
+					};
+					match edge {
+						tg::graph::data::Edge::Object(id) => {
+							if components.peek().is_none() {
+								return Ok(Some(tg::graph::data::Edge::Object(id.clone())));
+							}
+							let directory = id.clone();
+							let path = components.collect::<PathBuf>();
+							return self
+								.checkin_resolve_subpath_with_object(directory, &path)
+								.await;
+						},
+						tg::graph::data::Edge::Pointer(p) => {
+							stack.push((pointer.index, pointer.kind));
+							pointer.index = p.index;
+							pointer.kind = p.kind;
+							if let Some(graph) = &p.graph {
+								pointer.graph.replace(graph.clone());
+							}
+						},
+					}
+				},
+				_ => return Err(tg::error!(path = %path.display(), "invalid path")),
+			}
+		}
+		Ok(Some(tg::graph::data::Edge::Pointer(pointer)))
+	}
+
+	async fn checkin_resolve_subpath_with_object(
+		&self,
+		object: tg::object::Id,
+		path: &Path,
+	) -> tg::Result<Option<tg::graph::data::Edge<tg::object::Id>>> {
+		let directory = object
+			.try_unwrap_directory()
+			.map_err(|_| tg::error!("expected a directory"))?;
+		let directory = tg::Directory::with_id(directory.clone());
+		let child = directory.try_get(self, &path).await.map_err(
+			|source| tg::error!(!source, path = %path.display(), "failed to resolve path"),
+		)?;
+		let edge = child.map(|artifact| tg::graph::data::Edge::Object(artifact.id().into()));
+		Ok(edge)
+	}
+}


### PR DESCRIPTION
- add `path` field to `tg::reference::Options`
- update `tg::object::get` implementation to check if the returned item is a directory and resolve its path
- update `resolve` to allow `import <ref> with { path: "..." }` as appopriate
- add tests for `tg object get` and `tg build` that flex the new logic

Resolves #595 