### PR TITLE
fix(sandbox): defer executable path resolution to libc

### DIFF
--- a/packages/cli/tests/build/host_command_hello_world.nu
+++ b/packages/cli/tests/build/host_command_hello_world.nu
@@ -5,10 +5,11 @@ let server = spawn --busybox
 let path = artifact {
 	tangram.ts: '
 		import busybox from "busybox";
-		export default () => tg.run`echo "Hello, World!" > ${tg.output}`.env(tg.build(busybox));
+		export default () => tg.build`echo "Hello, World!" > ${tg.output}`.env(tg.build(busybox));
 	'
 }
 
 let id = tg build $path
+
 let object = tg object get --blobs --depth=inf --pretty $id
 snapshot $object

--- a/packages/cli/tests/build/modifying_artifacts_dir_in_sandbox_fails.nu
+++ b/packages/cli/tests/build/modifying_artifacts_dir_in_sandbox_fails.nu
@@ -1,15 +1,18 @@
 use ../../test.nu *
+
 let server = spawn --busybox
+
 let path = artifact {
 	tangram.ts: '
 		import busybox from "busybox";
 		export default async () => {
-            const bb = tg.build(busybox);
-            const file = await tg.build`echo "Hello, World!" > ${tg.output}`.env(bb);
-            await tg.run`echo "Goodbye, Reproducibility!" > ${file}`.env(bb);
-            return file;
-        }
+			const bb = tg.build(busybox);
+			const file = await tg.build`echo "Hello, World!" > ${tg.output}`.env(bb);
+			await tg.run`echo "Goodbye, Reproducibility!" > ${file}`.env(bb);
+			return file;
+		}
 	'
 }
+
 let output = tg build $path | complete
 failure $output

--- a/packages/cli/tests/build/modifying_artifacts_dir_in_sandbox_fails.nu
+++ b/packages/cli/tests/build/modifying_artifacts_dir_in_sandbox_fails.nu
@@ -1,0 +1,15 @@
+use ../../test.nu *
+let server = spawn --busybox
+let path = artifact {
+	tangram.ts: '
+		import busybox from "busybox";
+		export default async () => {
+            const bb = tg.build(busybox);
+            const file = await tg.build`echo "Hello, World!" > ${tg.output}`.env(bb);
+            await tg.run`echo "Goodbye, Reproducibility!" > ${file}`.env(bb);
+            return file;
+        }
+	'
+}
+let output = tg build $path | complete
+failure $output

--- a/packages/clients/js/src/command.ts
+++ b/packages/clients/js/src/command.ts
@@ -149,7 +149,7 @@ export class Command<
 					let host = tg.process.env.TANGRAM_HOST;
 					return {
 						args: ["-c", arg],
-						executable: "/bin/sh",
+						executable: "sh",
 						host,
 					};
 				} else if (arg instanceof tg.Command) {

--- a/packages/sandbox/src/common.rs
+++ b/packages/sandbox/src/common.rs
@@ -20,15 +20,6 @@ pub fn cstring(s: impl AsRef<OsStr>) -> CString {
 	CString::new(s.as_ref().as_bytes()).unwrap()
 }
 
-pub fn envstring(k: impl AsRef<OsStr>, v: impl AsRef<OsStr>) -> CString {
-	let string = format!(
-		"{}={}",
-		k.as_ref().to_string_lossy(),
-		v.as_ref().to_string_lossy()
-	);
-	CString::new(string).unwrap()
-}
-
 impl FromIterator<CString> for CStringVec {
 	fn from_iter<T: IntoIterator<Item = CString>>(iter: T) -> Self {
 		let mut strings = Vec::new();

--- a/packages/sandbox/src/darwin.rs
+++ b/packages/sandbox/src/darwin.rs
@@ -1,7 +1,7 @@
 use {
 	crate::{
 		Command,
-		common::{CStringVec, abort_errno, cstring, envstring},
+		common::{CStringVec, abort_errno, cstring},
 	},
 	indoc::writedoc,
 	num::ToPrimitive as _,
@@ -16,28 +16,26 @@ use {
 struct Context {
 	argv: CStringVec,
 	cwd: CString,
-	envp: CStringVec,
 	executable: CString,
 	profile: CString,
 }
 
 #[expect(clippy::needless_pass_by_value)]
 pub fn spawn(command: Command) -> std::io::Result<std::process::ExitCode> {
-	// Create argv, cwd, and envp strings.
+	// Create the argv.
 	let argv = std::iter::once(cstring(&command.executable))
 		.chain(command.trailing.iter().map(cstring))
 		.collect::<CStringVec>();
+
+	// Create the cwd.
 	let cwd = command
 		.cwd
 		.clone()
 		.map_or_else(std::env::current_dir, Ok::<_, std::io::Error>)
 		.inspect_err(|_| eprintln!("failed to get cwd"))
 		.map(cstring)?;
-	let envp = command
-		.env
-		.iter()
-		.map(|(k, v)| envstring(k, v))
-		.collect::<CStringVec>();
+
+	// Create the executable.
 	let executable = cstring(&command.executable);
 
 	if command.chroot.is_some() {
@@ -48,6 +46,16 @@ pub fn spawn(command: Command) -> std::io::Result<std::process::ExitCode> {
 		return Err(std::io::Error::other("uid/gid is not allowed on darwin"));
 	}
 
+	// Set the environment.
+	unsafe {
+		for (key, _) in std::env::vars() {
+			std::env::remove_var(key);
+		}
+		for (key, value) in &command.env {
+			std::env::set_var(key, value);
+		}
+	}
+
 	// Create the sandbox profile.
 	let profile = create_sandbox_profile(&command);
 
@@ -55,7 +63,6 @@ pub fn spawn(command: Command) -> std::io::Result<std::process::ExitCode> {
 	let context = Context {
 		argv,
 		cwd,
-		envp,
 		executable,
 		profile,
 	};
@@ -87,11 +94,7 @@ pub fn spawn(command: Command) -> std::io::Result<std::process::ExitCode> {
 
 		// Exec.
 		unsafe {
-			libc::execve(
-				context.executable.as_ptr(),
-				context.argv.as_ptr(),
-				context.envp.as_ptr(),
-			);
+			libc::execvp(context.executable.as_ptr(), context.argv.as_ptr());
 			abort_errno!("failed to exec");
 		}
 	}

--- a/packages/sandbox/src/darwin.rs
+++ b/packages/sandbox/src/darwin.rs
@@ -48,7 +48,7 @@ pub fn spawn(command: Command) -> std::io::Result<std::process::ExitCode> {
 
 	// Set the environment.
 	unsafe {
-		for (key, _) in std::env::vars() {
+		for (key, _) in std::env::vars_os() {
 			std::env::remove_var(key);
 		}
 		for (key, value) in &command.env {

--- a/packages/sandbox/src/linux.rs
+++ b/packages/sandbox/src/linux.rs
@@ -80,7 +80,9 @@ pub fn spawn(mut command: Command) -> std::io::Result<std::process::ExitCode> {
 			}
 		});
 		let source = mount.source.as_ref().map(cstring);
-		let flags = if let Some(source) = &source && mount.fstype.is_none() {
+		let flags = if let Some(source) = &source
+			&& mount.fstype.is_none()
+		{
 			let existing = get_existing_mount_flags(source)?;
 			existing | mount.flags
 		} else {

--- a/packages/sandbox/src/linux/guest.rs
+++ b/packages/sandbox/src/linux/guest.rs
@@ -46,7 +46,7 @@ pub fn main(mut context: Context) -> ! {
 			context.envp.as_ptr().cast(),
 		);
 
-		abort_errno!("execve failed")
+		abort_errno!("execvpe failed")
 	}
 }
 

--- a/packages/sandbox/src/linux/guest.rs
+++ b/packages/sandbox/src/linux/guest.rs
@@ -83,7 +83,7 @@ fn mount_and_chroot(context: &mut Context) {
 
 			// The initial bind mount ignores flags other than MS_BIND and MS_REC. To support read-only bind mounts we must immediately remount the source/target pair with MS_REMOUNT to change the permissions of the mount point.
 			if (flags & libc::MS_BIND != 0) && (flags & libc::MS_RDONLY != 0) {
-				let flags = libc::MS_BIND | libc::MS_REC | libc::MS_REMOUNT | libc::MS_RDONLY;
+				let flags = flags | libc::MS_REMOUNT;
 				let ret = libc::mount(source, target, fstype, flags, data);
 				if ret == -1 {
 					abort_errno!("failed to remount bind mount as read-only {mount:#?}");

--- a/packages/sandbox/src/linux/guest.rs
+++ b/packages/sandbox/src/linux/guest.rs
@@ -40,7 +40,7 @@ pub fn main(mut context: Context) -> ! {
 		}
 
 		// Finally, exec the process.
-		libc::execve(
+		libc::execvpe(
 			context.executable.as_ptr(),
 			context.argv.as_ptr().cast(),
 			context.envp.as_ptr().cast(),

--- a/packages/server/src/run/darwin.rs
+++ b/packages/server/src/run/darwin.rs
@@ -1,7 +1,5 @@
 use {
-	super::util::{
-		cache_children, render_args_dash_a, render_args_string, render_env, which, whoami,
-	},
+	super::util::{cache_children, render_args_dash_a, render_args_string, render_env, whoami},
 	crate::{Context, Server, temp::Temp},
 	std::{
 		collections::BTreeMap,
@@ -110,9 +108,7 @@ impl Server {
 				tg::command::data::Executable::Module(_) => {
 					return Err(tg::error!("invalid executable"));
 				},
-				tg::command::data::Executable::Path(executable) => which(&executable.path, &env)
-					.await
-					.map_err(|source| tg::error!(!source, "failed to find the executable"))?,
+				tg::command::data::Executable::Path(executable) => executable.path.clone(),
 			},
 		};
 

--- a/packages/server/src/run/linux.rs
+++ b/packages/server/src/run/linux.rs
@@ -1,7 +1,5 @@
 use {
-	super::util::{
-		cache_children, render_args_dash_a, render_args_string, render_env, which, whoami,
-	},
+	super::util::{cache_children, render_args_dash_a, render_args_string, render_env, whoami},
 	crate::{Context, Server, temp::Temp},
 	indoc::formatdoc,
 	std::{
@@ -137,23 +135,7 @@ impl Server {
 				tg::command::data::Executable::Module(_) => {
 					return Err(tg::error!("invalid executable"));
 				},
-				tg::command::data::Executable::Path(executable) if root_mounted => {
-					which(&executable.path, &env)
-						.await
-						.map_err(|source| tg::error!(!source, "failed to find the executable"))?
-				},
-				tg::command::data::Executable::Path(executable) => {
-					let host_artifacts_path = self.artifacts_path();
-					let env = render_env(&command.env, &host_artifacts_path, &output_path)?;
-					let executable = which(&executable.path, &env)
-						.await
-						.map_err(|source| tg::error!(!source, "failed to find the executable"))?;
-					if let Ok(subpath) = executable.strip_prefix(&host_artifacts_path) {
-						artifacts_path.join(subpath)
-					} else {
-						executable
-					}
-				},
+				tg::command::data::Executable::Path(executable) => executable.path.clone(),
 			},
 		};
 

--- a/packages/server/src/run/util.rs
+++ b/packages/server/src/run/util.rs
@@ -2,10 +2,7 @@ use {
 	crate::Server,
 	bytes::Bytes,
 	futures::{future, stream},
-	std::{
-		collections::BTreeMap,
-		path::{Path, PathBuf},
-	},
+	std::{collections::BTreeMap, path::Path},
 	tangram_client::prelude::*,
 };
 
@@ -197,27 +194,6 @@ pub fn render_value_string(
 		},
 		_ => Ok(tg::Value::try_from_data(value.clone()).unwrap().to_string()),
 	}
-}
-
-pub async fn which(exe: &Path, env: &BTreeMap<String, String>) -> tg::Result<PathBuf> {
-	if exe.is_absolute() || exe.components().count() > 1 {
-		return Ok(exe.to_owned());
-	}
-	let Some(pathenv) = env.get("PATH") else {
-		return Ok(exe.to_owned());
-	};
-	let name = exe.components().next();
-	let Some(std::path::Component::Normal(name)) = name else {
-		return Err(tg::error!(path = %exe.display(), "invalid executable path"));
-	};
-	let sep = ":";
-	for path in pathenv.split(sep) {
-		let path = Path::new(path).join(name);
-		if tokio::fs::try_exists(&path).await.ok() == Some(true) {
-			return Ok(path);
-		}
-	}
-	Err(tg::error!(path = %exe.display(), "failed to find the executable"))
 }
 
 pub fn whoami() -> tg::Result<String> {


### PR DESCRIPTION
- use execvpe on Linux
- use execvp on Darwin
- command.env_clear() on Darwin to avoid leaking environment variables.
- set PATH in the root process of the sandbox.