### PR TITLE
fix(client/reference): do not %-encode tag patterns when serializing references to strings

### DIFF
--- a/packages/cli/tests/checkin/tag_dependency_no_solution_unsolved/lock.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_no_solution_unsolved/lock.snapshot
@@ -15,14 +15,14 @@
         "a/*": {
           "item": null,
           "options": {
-            "id": "dir_0132qzkhjkw80qeegrckdnjnk0as4desh8h89f13xk3t4d31y3e5rg",
+            "id": "dir_01r17tmc1yz32vc9mmedsej38h7t2yb3myzebbewwbn2qx510600mg",
             "tag": "a/1.0.0"
           }
         },
         "b/*": {
           "item": null,
           "options": {
-            "id": "dir_01q5hb9gy206dmjyxdq531z335egg2qjy4fyjrfjj9ph0d0h3mwbvg",
+            "id": "dir_01gwxxn7bp9pfxspzfks6xktq1n4f1r1pbpqcfm4nmkckr637fn7jg",
             "tag": "b/1.0.0"
           }
         }

--- a/packages/cli/tests/checkin/tag_dependency_no_solution_unsolved/metadata.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_no_solution_unsolved/metadata.snapshot
@@ -7,7 +7,7 @@
   "subtree": {
     "count": 9,
     "depth": 5,
-    "size": 648,
+    "size": 644,
     "solvable": true,
     "solved": false,
   },

--- a/packages/cli/tests/checkin/tag_dependency_no_solution_unsolved/object.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_no_solution_unsolved/object.snapshot
@@ -7,12 +7,12 @@ tg.directory({
           "tangram.ts": tg.file({
             "contents": tg.blob("import * as c from \"c/^1\""),
             "dependencies": {
-              "c/%5E1": null,
+              "c/^1": null,
             },
             "module": "ts",
           }),
         }),
-        "id": "dir_0132qzkhjkw80qeegrckdnjnk0as4desh8h89f13xk3t4d31y3e5rg",
+        "id": "dir_01r17tmc1yz32vc9mmedsej38h7t2yb3myzebbewwbn2qx510600mg",
         "tag": "a/1.0.0",
       },
       "b/*": {
@@ -20,12 +20,12 @@ tg.directory({
           "tangram.ts": tg.file({
             "contents": tg.blob("import * as c from \"c/^2\""),
             "dependencies": {
-              "c/%5E2": null,
+              "c/^2": null,
             },
             "module": "ts",
           }),
         }),
-        "id": "dir_01q5hb9gy206dmjyxdq531z335egg2qjy4fyjrfjj9ph0d0h3mwbvg",
+        "id": "dir_01gwxxn7bp9pfxspzfks6xktq1n4f1r1pbpqcfm4nmkckr637fn7jg",
         "tag": "b/1.0.0",
       },
     },

--- a/packages/cli/tests/checkin/tag_dependency_not_exist_then_resolved/lock.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_not_exist_then_resolved/lock.snapshot
@@ -12,7 +12,7 @@
     {
       "kind": "file",
       "dependencies": {
-        "a/%5E1": {
+        "a/^1": {
           "item": null,
           "options": {
             "id": "dir_01cwzqn7gdw24k2pjzty9p42ppj6jv5abcszzs6xc0qbcesbrepy50",

--- a/packages/cli/tests/checkin/tag_dependency_not_exist_then_resolved/object_after.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_not_exist_then_resolved/object_after.snapshot
@@ -2,7 +2,7 @@ tg.directory({
   "tangram.ts": tg.file({
     "contents": tg.blob("import * as a from \"a/^1\";"),
     "dependencies": {
-      "a/%5E1": {
+      "a/^1": {
         "item": tg.directory({
           "tangram.ts": tg.file({
             "contents": tg.blob(""),

--- a/packages/cli/tests/checkin/tag_dependency_not_exist_then_resolved/object_before.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_not_exist_then_resolved/object_before.snapshot
@@ -2,7 +2,7 @@ tg.directory({
   "tangram.ts": tg.file({
     "contents": tg.blob("import * as a from \"a/^1\";"),
     "dependencies": {
-      "a/%5E1": null,
+      "a/^1": null,
     },
     "module": "ts",
   }),

--- a/packages/cli/tests/checkin/tag_dependency_not_exist_unsolved/metadata.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_not_exist_unsolved/metadata.snapshot
@@ -7,7 +7,7 @@
   "subtree": {
     "count": 3,
     "depth": 3,
-    "size": 150,
+    "size": 148,
     "solvable": true,
     "solved": false,
   },

--- a/packages/cli/tests/checkin/tag_dependency_not_exist_unsolved/object.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_not_exist_unsolved/object.snapshot
@@ -2,7 +2,7 @@ tg.directory({
   "tangram.ts": tg.file({
     "contents": tg.blob("import * as a from \"a/^1.2\";"),
     "dependencies": {
-      "a/%5E1.2": null,
+      "a/^1.2": null,
     },
     "module": "ts",
   }),

--- a/packages/cli/tests/checkin/tag_diamond_dependency/lock.snapshot
+++ b/packages/cli/tests/checkin/tag_diamond_dependency/lock.snapshot
@@ -18,7 +18,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_011dqwmmm2k3bqxh2k4ena6dmzy9yse78cpcvdfqv701apyf0jy6e0",
+            "id": "dir_01x6j7t8zdbwsq0tb7q1xpd7bhhkpbh3rypc7n7hzeqmfrns0m1ak0",
             "tag": "b"
           }
         },
@@ -28,7 +28,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_017s7ea35qwm3ycj7yxdjb179sg0zcv8d9tnqhd54vcbjc3s09jpeg",
+            "id": "dir_019ehtv5k0f5c2y4y6fcsv7rm03vkbc9ywba9d4kk8zqrdyfkq70yg",
             "tag": "c"
           }
         }
@@ -56,7 +56,7 @@
     {
       "kind": "file",
       "dependencies": {
-        "d/%5E1": {
+        "d/^1": {
           "item": null,
           "options": {
             "id": "dir_01rsavphm7nnk73mtbkxawz4bhpsm94gqfb0pd194wys0dar4gynb0",
@@ -69,7 +69,7 @@
     {
       "kind": "file",
       "dependencies": {
-        "d/%5E1.0": {
+        "d/^1.0": {
           "item": null,
           "options": {
             "id": "dir_01rsavphm7nnk73mtbkxawz4bhpsm94gqfb0pd194wys0dar4gynb0",

--- a/packages/cli/tests/checkin/tag_diamond_dependency/metadata.snapshot
+++ b/packages/cli/tests/checkin/tag_diamond_dependency/metadata.snapshot
@@ -7,7 +7,7 @@
   "subtree": {
     "count": 15,
     "depth": 7,
-    "size": 1128,
+    "size": 1124,
     "solvable": true,
     "solved": true,
   },

--- a/packages/cli/tests/checkin/tag_diamond_dependency/object.snapshot
+++ b/packages/cli/tests/checkin/tag_diamond_dependency/object.snapshot
@@ -7,7 +7,7 @@ tg.directory({
           "tangram.ts": tg.file({
             "contents": tg.blob("import d from \"d/^1\";\nexport default () => \"b\";"),
             "dependencies": {
-              "d/%5E1": {
+              "d/^1": {
                 "item": tg.directory({
                   "tangram.ts": tg.file({
                     "contents": tg.blob("export default () => \"d/1.1.0\";"),
@@ -21,7 +21,7 @@ tg.directory({
             "module": "ts",
           }),
         }),
-        "id": "dir_011dqwmmm2k3bqxh2k4ena6dmzy9yse78cpcvdfqv701apyf0jy6e0",
+        "id": "dir_01x6j7t8zdbwsq0tb7q1xpd7bhhkpbh3rypc7n7hzeqmfrns0m1ak0",
         "tag": "b",
       },
       "c": {
@@ -29,7 +29,7 @@ tg.directory({
           "tangram.ts": tg.file({
             "contents": tg.blob("import d from \"d/^1.0\";\nexport default () => \"c\";"),
             "dependencies": {
-              "d/%5E1.0": {
+              "d/^1.0": {
                 "item": tg.directory({
                   "tangram.ts": tg.file({
                     "contents": tg.blob("export default () => \"d/1.1.0\";"),
@@ -43,7 +43,7 @@ tg.directory({
             "module": "ts",
           }),
         }),
-        "id": "dir_017s7ea35qwm3ycj7yxdjb179sg0zcv8d9tnqhd54vcbjc3s09jpeg",
+        "id": "dir_019ehtv5k0f5c2y4y6fcsv7rm03vkbc9ywba9d4kk8zqrdyfkq70yg",
         "tag": "c",
       },
     },

--- a/packages/cli/tests/checkin/update_tagged_package/lock_after_update.snapshot
+++ b/packages/cli/tests/checkin/update_tagged_package/lock_after_update.snapshot
@@ -12,7 +12,7 @@
     {
       "kind": "file",
       "dependencies": {
-        "a/%5E1": {
+        "a/^1": {
           "item": null,
           "options": {
             "id": "dir_01d2wvpdaajzr09jp6z75pne9tpqkx05k7sp3b87pbxxp9b722ca90",

--- a/packages/cli/tests/checkin/update_tagged_package/lock_before_update.snapshot
+++ b/packages/cli/tests/checkin/update_tagged_package/lock_before_update.snapshot
@@ -12,7 +12,7 @@
     {
       "kind": "file",
       "dependencies": {
-        "a/%5E1": {
+        "a/^1": {
           "item": null,
           "options": {
             "id": "dir_01b9n85be9e4as3yncahvbknbz8b1pq6rt556twhsvse2cjbkb4j90",

--- a/packages/cli/tests/index/graph_imports_unsolved.nu
+++ b/packages/cli/tests/index/graph_imports_unsolved.nu
@@ -66,7 +66,7 @@ snapshot -n metadata $metadata '
 	  "subtree": {
 	    "count": 13,
 	    "depth": 7,
-	    "size": 1241,
+	    "size": 1237,
 	    "solvable": true,
 	    "solved": false,
 	  },

--- a/packages/cli/tests/index/graph_unsolved.nu
+++ b/packages/cli/tests/index/graph_unsolved.nu
@@ -57,7 +57,7 @@ snapshot -n metadata $metadata '
 	  "subtree": {
 	    "count": 10,
 	    "depth": 5,
-	    "size": 915,
+	    "size": 911,
 	    "solvable": true,
 	    "solved": false,
 	  },
@@ -79,7 +79,7 @@ snapshot -n file_metadata $file_metadata '
 	  "subtree": {
 	    "count": 10,
 	    "depth": 5,
-	    "size": 844,
+	    "size": 840,
 	    "solvable": true,
 	    "solved": false,
 	  },
@@ -101,7 +101,7 @@ snapshot -n file_b_metadata $file_b_metadata '
 	  "subtree": {
 	    "count": 10,
 	    "depth": 5,
-	    "size": 844,
+	    "size": 840,
 	    "solvable": true,
 	    "solved": false,
 	  },
@@ -124,7 +124,7 @@ snapshot -n graph_metadata $graph_metadata '
 	  "subtree": {
 	    "count": 9,
 	    "depth": 4,
-	    "size": 793,
+	    "size": 789,
 	    "solvable": true,
 	    "solved": false,
 	  },

--- a/packages/cli/tests/index/tag_dep_unsolved.nu
+++ b/packages/cli/tests/index/tag_dep_unsolved.nu
@@ -51,7 +51,7 @@ snapshot -n metadata $metadata '
 	  "subtree": {
 	    "count": 9,
 	    "depth": 5,
-	    "size": 648,
+	    "size": 644,
 	    "solvable": true,
 	    "solved": false,
 	  },

--- a/packages/client/src/reference.rs
+++ b/packages/client/src/reference.rs
@@ -166,7 +166,7 @@ impl Reference {
 	pub fn to_uri(&self) -> Uri {
 		let path = self.item.to_string();
 		let mut builder = Uri::builder();
-		builder = builder.path(&path);
+		builder = builder.path_raw(&path);
 		let mut query = Vec::new();
 		if let Some(local) = &self.options.local {
 			let local = local.to_string_lossy();
@@ -300,6 +300,6 @@ mod tests {
 
 		let tag = "std/<0.0.1".parse().unwrap();
 		let reference = tg::Reference::with_tag(tag).to_string();
-		assert_snapshot!(reference, @"std/%3C0.0.1");
+		assert_snapshot!(reference, @"std/<0.0.1");
 	}
 }

--- a/packages/uri/src/lib.rs
+++ b/packages/uri/src/lib.rs
@@ -7,6 +7,10 @@ use {
 
 pub mod builder;
 
+static REGEX: LazyLock<Regex> = LazyLock::new(|| {
+	Regex::new(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?").unwrap()
+});
+
 /// Characters that must be percent-encoded in query parameter values.
 /// This encodes `=`, `&`, `#`, and other special chars, but NOT `/`.
 const QUERY_VALUE_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
@@ -18,21 +22,6 @@ const QUERY_VALUE_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::C
 	.add(b'=')
 	.add(b'&')
 	.add(b'+');
-
-/// Encode a query parameter value, preserving `/` characters.
-#[must_use]
-pub fn encode_query_value(value: &str) -> String {
-	percent_encoding::utf8_percent_encode(value, QUERY_VALUE_ENCODE_SET).to_string()
-}
-
-/// Decode a percent-encoded query parameter value.
-pub fn decode_query_value(value: &str) -> Result<Cow<'_, str>, std::str::Utf8Error> {
-	percent_encoding::percent_decode_str(value).decode_utf8()
-}
-
-static REGEX: LazyLock<Regex> = LazyLock::new(|| {
-	Regex::new(r"^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?").unwrap()
-});
 
 #[derive(
 	Clone,
@@ -276,4 +265,15 @@ impl std::str::FromStr for Uri {
 			fragment,
 		})
 	}
+}
+
+/// Encode a query parameter value, preserving `/` characters.
+#[must_use]
+pub fn encode_query_value(value: &str) -> String {
+	percent_encoding::utf8_percent_encode(value, QUERY_VALUE_ENCODE_SET).to_string()
+}
+
+/// Decode a percent-encoded query parameter value.
+pub fn decode_query_value(value: &str) -> Result<Cow<'_, str>, std::str::Utf8Error> {
+	percent_encoding::percent_decode_str(value).decode_utf8()
 }


### PR DESCRIPTION
This affects the serialization of objects and results in different IDs as well as changes to their metadata. 