### PR TITLE
fix(tangram.d.ts): add permissive function type to enable assignability

### DIFF
--- a/packages/cli/tests/check/function_as_command_type_preservation.nu
+++ b/packages/cli/tests/check/function_as_command_type_preservation.nu
@@ -1,0 +1,28 @@
+# This test verifies that when a function is resolved to a Command,
+# the Command preserves the function's parameter and return types.
+
+use ../../test.nu *
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		type BuildArg = { host?: string; debug?: boolean };
+
+		const build = async (...args: tg.Args<BuildArg>): Promise<tg.Directory> => {
+			return tg.directory();
+		};
+
+		// Resolve the function and verify the Command has correct types
+		export default async () => {
+			const resolved = await tg.resolve(build);
+
+			// Verify the resolved type matches what tg.Resolved computes
+			const _checkType: tg.Resolved<typeof build> = resolved;
+
+			return resolved;
+		};
+	'
+}
+
+tg check $path

--- a/packages/cli/tests/check/function_as_command_unresolved.nu
+++ b/packages/cli/tests/check/function_as_command_unresolved.nu
@@ -1,0 +1,27 @@
+# This test verifies that tg.Unresolved<tg.Command<..., tg.Directory>> properly
+# accepts functions that return tg.Directory. Functions passed where Commands
+# are expected will be wrapped into Commands at runtime.
+
+use ../../test.nu *
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		type Arg = { host?: string };
+
+		const build = async (...args: tg.Args<Arg>): Promise<tg.Directory> => {
+			return tg.directory();
+		};
+
+		type EnvArg = tg.Command<Array<tg.Value>, tg.Directory> | tg.Directory;
+
+		const env = async (...args: tg.Args<EnvArg>) => {};
+
+		export default async () => {
+			return env(build);
+		};
+	'
+}
+
+tg check $path

--- a/packages/clients/js/src/resolve.ts
+++ b/packages/clients/js/src/resolve.ts
@@ -12,6 +12,7 @@ export type Unresolved<T extends tg.Value> = tg.MaybePromise<
 						UnresolvedFunctionArgs<A>,
 						UnresolvedFunctionReturnValue<R>
 				  >
+				| ((...args: Array<never>) => tg.MaybePromise<R | void>)
 		: T extends
 					| undefined
 					| boolean

--- a/packages/js/src/tangram.d.ts
+++ b/packages/js/src/tangram.d.ts
@@ -1649,6 +1649,7 @@ declare namespace tg {
 							tg.UnresolvedFunctionArgs<A>,
 							tg.UnresolvedFunctionReturnValue<R>
 					  >
+					| ((...args: Array<never>) => tg.MaybePromise<R | void>)
 			: T extends
 						| undefined
 						| boolean


### PR DESCRIPTION
This PR adds two tests that fail on main, along with a proposed fix that allows both tests to pass.

## Explanation

 The existing implementation of `tg.Unresolved<tg.Command>` did not accept functions with `tg.Args<T>` parameters. This prevented passing package build functions (like `ripgrep`) directly to functions expecting commands (like `std.env`).

The root cause was a type mismatch: `UnresolvedFunctionArgs` used `UnresolvedFunctionReturnValue` for parameter types, whereas the actual functions use `tg.Args<T>`, which uses `Unresolved`.

## Fix

Added a permissive function type to the `tg.Unresolved<Command>` expansion:

```ts
  | tg.Function<UnresolvedFunctionArgs<A>, UnresolvedFunctionReturnValue<R>>  // preserves types
  | ((...args: Array<never>) => tg.MaybePromise<R | void>)  // enables assignability
```

The `Array<never>` parameter type satisfies contravariance for any actual parameter type, while the existing `tg.Function` branch preserves type information for `Resolved` to extract when wrapping functions into commands.

Essentially, we previously expected `(...args: UnresolvedFunctionReturnValue<Value>[]) => R`, but actually had `(...args: tg.Args<{host?: string}>) => R`. `UnresolvedFunctionReturnValue<Value>` includes `undefined`, but `tg.Args<{host?: string}>` expects an object. The expected type isn't assignable to the actual type, and the function is rejected.