### PR TITLE
fix(cli): allow publishing of single file packages

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -942,7 +942,7 @@ impl Cli {
 		&mut self,
 		reference: &tg::Reference,
 	) -> tg::Result<tg::Referent<tg::Either<tg::Object, tg::Process>>> {
-		self.get_reference_with_arg(reference, tg::get::Arg::default())
+		self.get_reference_with_arg(reference, tg::get::Arg::default(), true)
 			.boxed()
 			.await
 	}
@@ -951,6 +951,7 @@ impl Cli {
 		&mut self,
 		reference: &tg::Reference,
 		arg: tg::get::Arg,
+		relative_paths: bool,
 	) -> tg::Result<tg::Referent<tg::Either<tg::Object, tg::Process>>> {
 		let handle = self.handle().await?;
 
@@ -983,6 +984,7 @@ impl Cli {
 			&& referent.tag().is_none()
 			&& relative
 			&& let Some(path) = referent.path()
+			&& relative_paths
 		{
 			let current_dir = std::env::current_dir()
 				.map_err(|source| tg::error!(!source, "failed to get the working directory"))?;

--- a/packages/cli/src/outdated.rs
+++ b/packages/cli/src/outdated.rs
@@ -23,7 +23,7 @@ impl Cli {
 			..Default::default()
 		};
 		let referent = self
-			.get_reference_with_arg(&args.reference, arg)
+			.get_reference_with_arg(&args.reference, arg, true)
 			.await?
 			.try_map(|item| item.left().ok_or_else(|| tg::error!("expected an object")))?;
 		tg::object::visit(&handle, &mut visitor, &referent, false)

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -233,7 +233,7 @@ impl Cli {
 			checkin: options.checkin.to_options(),
 			..Default::default()
 		};
-		let referent = self.get_reference_with_arg(&reference, arg).await?;
+		let referent = self.get_reference_with_arg(&reference, arg, true).await?;
 		let item = referent
 			.item
 			.clone()

--- a/packages/cli/src/read.rs
+++ b/packages/cli/src/read.rs
@@ -27,7 +27,9 @@ impl Cli {
 		};
 
 		for reference in &args.references {
-			let referent = self.get_reference_with_arg(reference, arg.clone()).await?;
+			let referent = self
+				.get_reference_with_arg(reference, arg.clone(), true)
+				.await?;
 			let tg::Either::Left(object) = referent.item() else {
 				return Err(tg::error!("expected an object"));
 			};

--- a/packages/cli/src/tag/put.rs
+++ b/packages/cli/src/tag/put.rs
@@ -32,7 +32,9 @@ impl Cli {
 			checkin: args.checkin.to_options(),
 			..Default::default()
 		};
-		let referent = self.get_reference_with_arg(&args.reference, arg).await?;
+		let referent = self
+			.get_reference_with_arg(&args.reference, arg, true)
+			.await?;
 		let item = referent
 			.item
 			.map_left(|process| process.id().clone())

--- a/packages/client/src/object/visit.rs
+++ b/packages/client/src/object/visit.rs
@@ -110,9 +110,7 @@ where
 						item,
 						options: dependency.0.options,
 					};
-					if inherit {
-						child.inherit(&referent);
-					}
+					child.inherit(&referent);
 					Some(child)
 				})
 				.collect::<Vec<_>>(),


### PR DESCRIPTION
- remove complicated path joining logic in publish.
- change --dry-run to include the paths used in checkins.
- use referent.path() explicitly to determine which path to use for checkins.
- change Cli::get_with_arg to contain a flag to choose whether absolute paths in referents should be stripped with with the current dir prefix.
- fix inherit flag usage in tg::object::visit.
- add test for single file packages with dependencies on other single file packages.