### PR TITLE
fix(server/pty): refactor PTYs to use a single writer and handle EBADF errors

### DIFF
--- a/packages/client/src/health.rs
+++ b/packages/client/src/health.rs
@@ -18,7 +18,7 @@ pub struct Health {
 	pub processes: Option<Processes>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub ptys: Option<Vec<tg::pty::Id>>,
+	pub ptys: Option<Vec<Pty>>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub version: Option<String>,
@@ -36,6 +36,14 @@ pub struct Processes {
 	pub permits: Option<u64>,
 
 	pub started: u64,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Pty {
+	pub id: tg::pty::Id,
+	pub master: Option<i32>,
+	pub slave: Option<i32>,
+	pub name: String,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/packages/server/src/pty/close.rs
+++ b/packages/server/src/pty/close.rs
@@ -36,6 +36,7 @@ impl Server {
 			.ptys
 			.get_mut(id)
 			.ok_or_else(|| tg::error!("failed to get the pty"))?;
+		pty.task.abort();
 		if arg.master {
 			pty.master.take();
 		} else {

--- a/packages/server/src/pty/create.rs
+++ b/packages/server/src/pty/create.rs
@@ -33,7 +33,7 @@ impl Server {
 
 		// Create the pty.
 		let id = tg::pty::Id::new();
-		let pty = super::Pty::new(self, arg.size)
+		let pty = super::Pty::new(self, arg.size, id.clone())
 			.await
 			.map_err(|source| tg::error!(!source, "failed to create the pty"))?;
 		self.ptys.insert(id.clone(), pty);

--- a/packages/server/src/pty/delete.rs
+++ b/packages/server/src/pty/delete.rs
@@ -31,7 +31,11 @@ impl Server {
 			return Err(tg::error!("forbidden"));
 		}
 
-		self.ptys.remove(id);
+		let Some((_, pty)) = self.ptys.remove(id) else {
+			return Ok(());
+		};
+
+		pty.task.abort();
 
 		Ok(())
 	}

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -71,10 +71,12 @@ impl Server {
 					let error = std::io::Error::last_os_error();
 					#[cfg(target_os = "linux")]
 					{
-						if error.raw_os_error() == Some(libc::EIO)
-						{
+						if error.raw_os_error() == Some(libc::EIO) {
 							return Ok(None);
 						}
+					}
+					if error.raw_os_error() == Some(libc::EBADF) {
+						return Ok(None);
 					}
 					return Err(error);
 				}


### PR DESCRIPTION
- Treat EBADF errors as EOF in read/write endpoints to handle the case where a PTY is closed before blocking read/writes are handled.
- Use an MPSC channel and shared asynchronous task to handle incoming write messages to a given PTY in a single task.

Buffering incoming writes into a single channel avoids a condition where a blocked/slow reader allows for write streams to back up, and avoids many concurrent blocking writes to the same PTY. What's unclear is why this doesn't resolve the deadlock in PTYs where the process eventually blocks on a read call to its stdin, waiting for writes that never appear while the client is blocked trying to write to a stream that is never polled.