### PR TITLE
fix(cli, client, server): rollup of fixes to streams

### DIFF
--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -356,6 +356,8 @@ impl Cli {
 
 		// Stop and await the stdio task.
 		stdio_task.stop();
+
+		// Wait the task.
 		stdio_task.wait().await.unwrap()?;
 
 		// Delete stdio.

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -357,7 +357,7 @@ impl Cli {
 		// Stop and await the stdio task.
 		stdio_task.stop();
 
-		// Wait the task.
+		// Await the stdio task.
 		stdio_task.wait().await.unwrap()?;
 
 		// Delete stdio.

--- a/packages/cli/src/run/stdio.rs
+++ b/packages/cli/src/run/stdio.rs
@@ -39,16 +39,16 @@ where
 			let remote = stdio.remote.clone();
 			let stdin = stdio.stdin.clone();
 			let tty = stdio.tty.clone();
-			let stream = crate::util::stdio::stdin_stream();
+			
 			async move {
 				let Some(stdin) = stdin else {
 					return Ok(());
 				};
+				let stream = crate::util::stdio::stdin_stream().take_until(stop.wait());
 
 				// Write to stdin until it is finished or the task is stopped.
 				let future = match &stdin {
-					tg::process::Stdio::Pipe(id) => {
-						let stream = stream.take_until(stop.wait());
+					tg::process::Stdio::Pipe(id) => {		
 						async {
 							let mut stream = pin!(stream);
 							while let Some(bytes) = stream.try_next().await? {
@@ -70,7 +70,7 @@ where
 						let Some(tty) = tty else {
 							return Err(tg::error!("expected a tty"));
 						};
-						
+
 						// Spawn a task to handle sigwinch, which is canceled after stdin is finished.
 						let sigwinch_task = Task::spawn({
 							let handle = handle.clone();

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -357,7 +357,6 @@ pub trait Pipe: Clone + Unpin + Send + Sync + 'static {
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
 	) -> impl Future<Output = tg::Result<()>> + Send;
 }
 
@@ -382,8 +381,14 @@ pub trait Pty: Clone + Unpin + Send + Sync + 'static {
 	fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> impl Future<Output = tg::Result<Option<tg::pty::Size>>> + Send;
+
+	fn put_pty_size(
+		&self,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> impl Future<Output = tg::Result<()>> + Send;
 
 	fn try_read_pty(
 		&self,
@@ -399,7 +404,6 @@ pub trait Pty: Clone + Unpin + Send + Sync + 'static {
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
 	) -> impl Future<Output = tg::Result<()>> + Send;
 }
 
@@ -886,9 +890,8 @@ impl tg::handle::Pipe for tg::Client {
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
 	) -> impl Future<Output = tg::Result<()>> {
-		self.write_pipe(id, arg, stream)
+		self.write_pipe(id, arg)
 	}
 }
 
@@ -919,9 +922,17 @@ impl tg::handle::Pty for tg::Client {
 	fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> impl Future<Output = tg::Result<Option<tg::pty::Size>>> {
 		self.get_pty_size(id, arg)
+	}
+
+	fn put_pty_size(
+		&self,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> impl Future<Output = tg::Result<()>> {
+		self.put_pty_size(id, arg)
 	}
 
 	fn try_read_pty(
@@ -940,9 +951,8 @@ impl tg::handle::Pty for tg::Client {
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
 	) -> impl Future<Output = tg::Result<()>> {
-		self.write_pty(id, arg, stream)
+		self.write_pty(id, arg)
 	}
 }
 

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -108,7 +108,7 @@ pub trait Handle:
 		>,
 	> + Send;
 
-	fn sync(
+	fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -343,7 +343,7 @@ pub trait Pipe: Clone + Unpin + Send + Sync + 'static {
 		arg: tg::pipe::delete::Arg,
 	) -> impl Future<Output = tg::Result<()>> + Send;
 
-	fn try_read_pipe(
+	fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -390,7 +390,7 @@ pub trait Pty: Clone + Unpin + Send + Sync + 'static {
 		arg: tg::pty::size::put::Arg,
 	) -> impl Future<Output = tg::Result<()>> + Send;
 
-	fn try_read_pty(
+	fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
@@ -575,14 +575,14 @@ impl tg::Handle for tg::Client {
 		self.push(arg)
 	}
 
-	fn sync(
+	fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> impl Future<
 		Output = tg::Result<impl Stream<Item = tg::Result<tg::sync::Message>> + Send + 'static>,
 	> {
-		self.sync(arg, stream)
+		self.sync_stream(arg, stream)
 	}
 
 	fn try_get(
@@ -874,7 +874,7 @@ impl tg::handle::Pipe for tg::Client {
 		self.delete_pipe(id, arg)
 	}
 
-	fn try_read_pipe(
+	fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -883,7 +883,7 @@ impl tg::handle::Pipe for tg::Client {
 			Option<impl Stream<Item = tg::Result<tg::pipe::Event>> + Send + 'static>,
 		>,
 	> {
-		self.try_read_pipe(id, arg)
+		self.try_read_pipe_stream(id, arg)
 	}
 
 	fn write_pipe(
@@ -935,7 +935,7 @@ impl tg::handle::Pty for tg::Client {
 		self.put_pty_size(id, arg)
 	}
 
-	fn try_read_pty(
+	fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
@@ -944,7 +944,7 @@ impl tg::handle::Pty for tg::Client {
 			Option<impl Stream<Item = tg::Result<tg::pty::Event>> + Send + 'static>,
 		>,
 	> {
-		self.try_read_pty(id, arg)
+		self.try_read_pty_stream(id, arg)
 	}
 
 	fn write_pty(

--- a/packages/client/src/handle.rs
+++ b/packages/client/src/handle.rs
@@ -108,7 +108,7 @@ pub trait Handle:
 		>,
 	> + Send;
 
-	fn sync_stream(
+	fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -575,14 +575,14 @@ impl tg::Handle for tg::Client {
 		self.push(arg)
 	}
 
-	fn sync_stream(
+	fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> impl Future<
 		Output = tg::Result<impl Stream<Item = tg::Result<tg::sync::Message>> + Send + 'static>,
 	> {
-		self.sync_stream(arg, stream)
+		self.sync(arg, stream)
 	}
 
 	fn try_get(

--- a/packages/client/src/handle/dynamic.rs
+++ b/packages/client/src/handle/dynamic.rs
@@ -468,9 +468,8 @@ impl tg::handle::Pipe for Handle {
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
 	) -> impl Future<Output = tg::Result<()>> {
-		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.write_pipe(id, arg, stream)) }
+		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.write_pipe(id, arg)) }
 	}
 }
 
@@ -501,9 +500,17 @@ impl tg::handle::Pty for Handle {
 	fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> impl Future<Output = tg::Result<Option<tg::pty::Size>>> {
 		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.get_pty_size(id, arg)) }
+	}
+
+	fn put_pty_size(
+		&self,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> impl Future<Output = tg::Result<()>> {
+		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.put_pty_size(id, arg)) }
 	}
 
 	fn try_read_pty(
@@ -526,9 +533,8 @@ impl tg::handle::Pty for Handle {
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
 	) -> impl Future<Output = tg::Result<()>> {
-		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.write_pty(id, arg, stream)) }
+		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.write_pty(id, arg)) }
 	}
 }
 

--- a/packages/client/src/handle/dynamic.rs
+++ b/packages/client/src/handle/dynamic.rs
@@ -117,14 +117,14 @@ impl tg::Handle for Handle {
 		self.0.push(arg)
 	}
 
-	fn sync_stream(
+	fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> impl Future<
 		Output = tg::Result<impl Stream<Item = tg::Result<tg::sync::Message>> + Send + 'static>,
 	> {
-		self.0.sync_stream(arg, stream)
+		self.0.sync(arg, stream)
 	}
 
 	fn try_get(

--- a/packages/client/src/handle/dynamic.rs
+++ b/packages/client/src/handle/dynamic.rs
@@ -117,14 +117,14 @@ impl tg::Handle for Handle {
 		self.0.push(arg)
 	}
 
-	fn sync(
+	fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> impl Future<
 		Output = tg::Result<impl Stream<Item = tg::Result<tg::sync::Message>> + Send + 'static>,
 	> {
-		self.0.sync(arg, stream)
+		self.0.sync_stream(arg, stream)
 	}
 
 	fn try_get(
@@ -448,7 +448,7 @@ impl tg::handle::Pipe for Handle {
 		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.delete_pipe(id, arg)) }
 	}
 
-	fn try_read_pipe(
+	fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -459,7 +459,7 @@ impl tg::handle::Pipe for Handle {
 	> {
 		unsafe {
 			std::mem::transmute::<_, BoxFuture<'_, tg::Result<Option<BoxStream<_>>>>>(
-				self.0.try_read_pipe(id, arg),
+				self.0.try_read_pipe_stream(id, arg),
 			)
 		}
 	}
@@ -513,7 +513,7 @@ impl tg::handle::Pty for Handle {
 		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.put_pty_size(id, arg)) }
 	}
 
-	fn try_read_pty(
+	fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
@@ -524,7 +524,7 @@ impl tg::handle::Pty for Handle {
 	> {
 		unsafe {
 			std::mem::transmute::<_, BoxFuture<'_, tg::Result<Option<BoxStream<_>>>>>(
-				self.0.try_read_pty(id, arg),
+				self.0.try_read_pty_stream(id, arg),
 			)
 		}
 	}

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -189,7 +189,7 @@ where
 		}
 	}
 
-	fn sync(
+	fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -198,11 +198,11 @@ where
 	> {
 		match self {
 			tg::Either::Left(s) => s
-				.sync(arg, stream)
+				.sync_stream(arg, stream)
 				.map(|result| result.map(futures::StreamExt::left_stream))
 				.left_future(),
 			tg::Either::Right(s) => s
-				.sync(arg, stream)
+				.sync_stream(arg, stream)
 				.map(|result| result.map(futures::StreamExt::right_stream))
 				.right_future(),
 		}
@@ -654,7 +654,7 @@ where
 		}
 	}
 
-	fn try_read_pipe(
+	fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -665,11 +665,11 @@ where
 	> {
 		match self {
 			tg::Either::Left(s) => s
-				.try_read_pipe(id, arg)
+				.try_read_pipe_stream(id, arg)
 				.map(|result| result.map(|option| option.map(futures::StreamExt::left_stream)))
 				.left_future(),
 			tg::Either::Right(s) => s
-				.try_read_pipe(id, arg)
+				.try_read_pipe_stream(id, arg)
 				.map(|result| result.map(|option| option.map(futures::StreamExt::right_stream)))
 				.right_future(),
 		}
@@ -746,7 +746,7 @@ where
 		}
 	}
 
-	fn try_read_pty(
+	fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
@@ -757,11 +757,11 @@ where
 	> {
 		match self {
 			tg::Either::Left(s) => s
-				.try_read_pty(id, arg)
+				.try_read_pty_stream(id, arg)
 				.map(|result| result.map(|opt| opt.map(futures::StreamExt::left_stream)))
 				.left_future(),
 			tg::Either::Right(s) => s
-				.try_read_pty(id, arg)
+				.try_read_pty_stream(id, arg)
 				.map(|result| result.map(|opt| opt.map(futures::StreamExt::right_stream)))
 				.right_future(),
 		}

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -679,11 +679,10 @@ where
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
 	) -> impl Future<Output = tg::Result<()>> {
 		match self {
-			tg::Either::Left(s) => s.write_pipe(id, arg, stream).left_future(),
-			tg::Either::Right(s) => s.write_pipe(id, arg, stream).right_future(),
+			tg::Either::Left(s) => s.write_pipe(id, arg).left_future(),
+			tg::Either::Right(s) => s.write_pipe(id, arg).right_future(),
 		}
 	}
 }
@@ -728,11 +727,22 @@ where
 	fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> impl Future<Output = tg::Result<Option<tg::pty::Size>>> {
 		match self {
 			tg::Either::Left(s) => s.get_pty_size(id, arg).left_future(),
 			tg::Either::Right(s) => s.get_pty_size(id, arg).right_future(),
+		}
+	}
+
+	fn put_pty_size(
+		&self,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> impl Future<Output = tg::Result<()>> {
+		match self {
+			tg::Either::Left(s) => s.put_pty_size(id, arg).left_future(),
+			tg::Either::Right(s) => s.put_pty_size(id, arg).right_future(),
 		}
 	}
 
@@ -761,11 +771,10 @@ where
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
 	) -> impl Future<Output = tg::Result<()>> {
 		match self {
-			tg::Either::Left(s) => s.write_pty(id, arg, stream).left_future(),
-			tg::Either::Right(s) => s.write_pty(id, arg, stream).right_future(),
+			tg::Either::Left(s) => s.write_pty(id, arg).left_future(),
+			tg::Either::Right(s) => s.write_pty(id, arg).right_future(),
 		}
 	}
 }

--- a/packages/client/src/handle/either.rs
+++ b/packages/client/src/handle/either.rs
@@ -189,7 +189,7 @@ where
 		}
 	}
 
-	fn sync_stream(
+	fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -198,11 +198,11 @@ where
 	> {
 		match self {
 			tg::Either::Left(s) => s
-				.sync_stream(arg, stream)
+				.sync(arg, stream)
 				.map(|result| result.map(futures::StreamExt::left_stream))
 				.left_future(),
 			tg::Either::Right(s) => s
-				.sync_stream(arg, stream)
+				.sync(arg, stream)
 				.map(|result| result.map(futures::StreamExt::right_stream))
 				.right_future(),
 		}

--- a/packages/client/src/handle/erased.rs
+++ b/packages/client/src/handle/erased.rs
@@ -69,7 +69,7 @@ pub trait Handle:
 		tg::Result<BoxStream<'static, tg::Result<tg::progress::Event<tg::push::Output>>>>,
 	>;
 
-	fn sync<'a>(
+	fn sync_stream<'a>(
 		&'a self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -277,7 +277,7 @@ pub trait Pipe: Send + Sync + 'static {
 		arg: tg::pipe::delete::Arg,
 	) -> BoxFuture<'a, tg::Result<()>>;
 
-	fn try_read_pipe<'a>(
+	fn try_read_pipe_stream<'a>(
 		&'a self,
 		id: &'a tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -320,7 +320,7 @@ pub trait Pty: Send + Sync + 'static {
 		arg: tg::pty::size::put::Arg,
 	) -> BoxFuture<'a, tg::Result<()>>;
 
-	fn try_read_pty<'a>(
+	fn try_read_pty_stream<'a>(
 		&'a self,
 		id: &'a tg::pty::Id,
 		arg: tg::pty::read::Arg,
@@ -482,12 +482,12 @@ where
 		self.push(arg).map_ok(futures::StreamExt::boxed).boxed()
 	}
 
-	fn sync<'a>(
+	fn sync_stream<'a>(
 		&'a self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> BoxFuture<'a, tg::Result<BoxStream<'static, tg::Result<tg::sync::Message>>>> {
-		self.sync(arg, stream)
+		self.sync_stream(arg, stream)
 			.map_ok(futures::StreamExt::boxed)
 			.boxed()
 	}
@@ -785,12 +785,12 @@ where
 		self.delete_pipe(id, arg).boxed()
 	}
 
-	fn try_read_pipe<'a>(
+	fn try_read_pipe_stream<'a>(
 		&'a self,
 		id: &'a tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
 	) -> BoxFuture<'a, tg::Result<Option<BoxStream<'static, tg::Result<tg::pipe::Event>>>>> {
-		self.try_read_pipe(id, arg)
+		self.try_read_pipe_stream(id, arg)
 			.map_ok(|option| option.map(futures::StreamExt::boxed))
 			.boxed()
 	}
@@ -847,12 +847,12 @@ where
 		self.put_pty_size(id, arg).boxed()
 	}
 
-	fn try_read_pty<'a>(
+	fn try_read_pty_stream<'a>(
 		&'a self,
 		id: &'a tg::pty::Id,
 		arg: tg::pty::read::Arg,
 	) -> BoxFuture<'a, tg::Result<Option<BoxStream<'static, tg::Result<tg::pty::Event>>>>> {
-		tg::handle::Pty::try_read_pty(self, id, arg)
+		tg::handle::Pty::try_read_pty_stream(self, id, arg)
 			.map_ok(|opt| opt.map(futures::StreamExt::boxed))
 			.boxed()
 	}

--- a/packages/client/src/handle/erased.rs
+++ b/packages/client/src/handle/erased.rs
@@ -287,7 +287,6 @@ pub trait Pipe: Send + Sync + 'static {
 		&'a self,
 		id: &'a tg::pipe::Id,
 		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
 	) -> BoxFuture<'a, tg::Result<()>>;
 }
 
@@ -312,8 +311,14 @@ pub trait Pty: Send + Sync + 'static {
 	fn get_pty_size<'a>(
 		&'a self,
 		id: &'a tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> BoxFuture<'a, tg::Result<Option<tg::pty::Size>>>;
+
+	fn put_pty_size<'a>(
+		&'a self,
+		id: &'a tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> BoxFuture<'a, tg::Result<()>>;
 
 	fn try_read_pty<'a>(
 		&'a self,
@@ -325,7 +330,6 @@ pub trait Pty: Send + Sync + 'static {
 		&'a self,
 		id: &'a tg::pty::Id,
 		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
 	) -> BoxFuture<'a, tg::Result<()>>;
 }
 
@@ -795,9 +799,8 @@ where
 		&'a self,
 		id: &'a tg::pipe::Id,
 		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
 	) -> BoxFuture<'a, tg::Result<()>> {
-		self.write_pipe(id, arg, stream).boxed()
+		self.write_pipe(id, arg).boxed()
 	}
 }
 
@@ -831,9 +834,17 @@ where
 	fn get_pty_size<'a>(
 		&'a self,
 		id: &'a tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> BoxFuture<'a, tg::Result<Option<tg::pty::Size>>> {
 		self.get_pty_size(id, arg).boxed()
+	}
+
+	fn put_pty_size<'a>(
+		&'a self,
+		id: &'a tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> BoxFuture<'a, tg::Result<()>> {
+		self.put_pty_size(id, arg).boxed()
 	}
 
 	fn try_read_pty<'a>(
@@ -850,9 +861,8 @@ where
 		&'a self,
 		id: &'a tg::pty::Id,
 		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
 	) -> BoxFuture<'a, tg::Result<()>> {
-		self.write_pty(id, arg, stream).boxed()
+		self.write_pty(id, arg).boxed()
 	}
 }
 

--- a/packages/client/src/handle/erased.rs
+++ b/packages/client/src/handle/erased.rs
@@ -69,7 +69,7 @@ pub trait Handle:
 		tg::Result<BoxStream<'static, tg::Result<tg::progress::Event<tg::push::Output>>>>,
 	>;
 
-	fn sync_stream<'a>(
+	fn sync<'a>(
 		&'a self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -482,12 +482,12 @@ where
 		self.push(arg).map_ok(futures::StreamExt::boxed).boxed()
 	}
 
-	fn sync_stream<'a>(
+	fn sync<'a>(
 		&'a self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> BoxFuture<'a, tg::Result<BoxStream<'static, tg::Result<tg::sync::Message>>>> {
-		self.sync_stream(arg, stream)
+		self.sync(arg, stream)
 			.map_ok(futures::StreamExt::boxed)
 			.boxed()
 	}

--- a/packages/client/src/handle/ext.rs
+++ b/packages/client/src/handle/ext.rs
@@ -567,7 +567,7 @@ pub trait Ext: tg::Handle {
 						handle
 							.try_read_pipe_stream(&id, arg)
 							.await?
-							.unwrap()
+							.ok_or_else(|| tg::error!(%id, "the pipe was not found"))?
 							.boxed()
 					};
 					Ok::<_, tg::Error>(Some((stream, state)))
@@ -616,7 +616,11 @@ pub trait Ext: tg::Handle {
 						stream
 					} else {
 						let arg = state.lock().unwrap().arg.clone();
-						handle.try_read_pty_stream(&id, arg).await?.unwrap().boxed()
+						handle
+							.try_read_pty_stream(&id, arg)
+							.await?
+							.ok_or_else(|| tg::error!(%id, "the pty was not found"))?
+							.boxed()
 					};
 					Ok::<_, tg::Error>(Some((stream, state)))
 				}

--- a/packages/client/src/handle/ext.rs
+++ b/packages/client/src/handle/ext.rs
@@ -1,8 +1,12 @@
 use {
-	crate::prelude::*, bytes::Bytes, futures::{
+	crate::prelude::*,
+	bytes::Bytes,
+	futures::{
 		FutureExt as _, Stream, StreamExt as _, TryFutureExt as _, TryStreamExt as _, future,
 		stream::{self, BoxStream},
-	}, num::ToPrimitive as _, std::{
+	},
+	num::ToPrimitive as _,
+	std::{
 		io::SeekFrom,
 		sync::{Arc, Mutex},
 	},
@@ -533,9 +537,7 @@ pub trait Ext: tg::Handle {
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
 	) -> impl Future<
-		Output = tg::Result<
-			Option<impl Stream<Item = tg::Result<Bytes>> + Send + 'static>,
-		>,
+		Output = tg::Result<Option<impl Stream<Item = tg::Result<Bytes>> + Send + 'static>>,
 	> + Send {
 		let id = id.clone();
 		async move {
@@ -547,27 +549,26 @@ pub trait Ext: tg::Handle {
 			struct State {
 				stream: Option<BoxStream<'static, tg::Result<tg::pipe::Event>>>,
 				arg: tg::pipe::read::Arg,
-				end: bool,
 			}
 			let state = State {
 				stream: Some(stream),
 				arg,
-				end: false,
 			};
 			let state = Arc::new(Mutex::new(state));
 			let stream = stream::try_unfold(state.clone(), move |state| {
 				let handle = handle.clone();
 				let id = id.clone();
 				async move {
-					if state.lock().unwrap().end {
-						return Ok(None);
-					}
 					let stream = state.lock().unwrap().stream.take();
 					let stream = if let Some(stream) = stream {
 						stream
 					} else {
 						let arg = state.lock().unwrap().arg.clone();
-						handle.try_read_pipe_stream(&id, arg).await?.unwrap().boxed()
+						handle
+							.try_read_pipe_stream(&id, arg)
+							.await?
+							.unwrap()
+							.boxed()
 					};
 					Ok::<_, tg::Error>(Some((stream, state)))
 				}
@@ -588,9 +589,7 @@ pub trait Ext: tg::Handle {
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
 	) -> impl Future<
-		Output = tg::Result<
-			Option<impl Stream<Item = tg::Result<Bytes>> + Send + 'static>,
-		>,
+		Output = tg::Result<Option<impl Stream<Item = tg::Result<Bytes>> + Send + 'static>>,
 	> + Send {
 		let id = id.clone();
 		async move {

--- a/packages/client/src/pipe/read.rs
+++ b/packages/client/src/pipe/read.rs
@@ -19,7 +19,7 @@ pub struct Arg {
 }
 
 impl tg::Client {
-	pub async fn try_read_pipe(
+	pub async fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: Arg,

--- a/packages/client/src/pipe/write.rs
+++ b/packages/client/src/pipe/write.rs
@@ -24,8 +24,6 @@ impl tg::Client {
 	pub async fn write_pipe(&self, id: &tg::pipe::Id, arg: Arg) -> tg::Result<()> {
 		let method = http::Method::POST;
 		let uri = format!("/pipes/{id}/write");
-
-		// Create the request.
 		let request = http::request::Builder::default()
 			.method(method)
 			.uri(uri)

--- a/packages/client/src/pty.rs
+++ b/packages/client/src/pty.rs
@@ -15,6 +15,5 @@ pub mod write;
 #[serde(rename_all = "snake_case", tag = "kind", content = "value")]
 pub enum Event {
 	Chunk(#[serde_as(as = "BytesBase64")] Bytes),
-	Size(Size),
 	End,
 }

--- a/packages/client/src/pty/size.rs
+++ b/packages/client/src/pty/size.rs
@@ -1,38 +1,8 @@
-use {
-	crate::prelude::*,
-	tangram_http::{request::builder::Ext as _, response::Ext as _},
-};
+pub mod get;
+pub mod put;
 
 #[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Size {
 	pub rows: u16,
 	pub cols: u16,
-}
-
-impl tg::Client {
-	pub async fn get_pty_size(
-		&self,
-		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
-	) -> tg::Result<Option<tg::pty::Size>> {
-		let method = http::Method::GET;
-		let uri = format!("/ptys/{id}/size");
-		let request = http::request::Builder::default()
-			.method(method)
-			.uri(uri)
-			.header(http::header::ACCEPT, mime::APPLICATION_JSON.to_string())
-			.header(
-				http::header::CONTENT_TYPE,
-				mime::APPLICATION_JSON.to_string(),
-			)
-			.json(arg)
-			.map_err(|source| tg::error!(!source, "failed to serialize the arg"))?
-			.unwrap();
-		self.send(request)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get the response"))?
-			.json()
-			.await
-			.map_err(|source| tg::error!(!source, "failed to deserialize the body"))
-	}
 }

--- a/packages/client/src/pty/size/get.rs
+++ b/packages/client/src/pty/size/get.rs
@@ -1,19 +1,17 @@
 use {
 	crate::prelude::*,
-	bytes::Bytes,
 	serde_with::serde_as,
 	tangram_http::{request::builder::Ext as _, response::Ext as _},
-	tangram_util::serde::{BytesBase64, CommaSeparatedString},
+	tangram_util::serde::CommaSeparatedString,
 };
 
 #[serde_as]
 #[derive(Default, Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Arg {
-	#[serde_as(as = "BytesBase64")]
-	pub bytes: Bytes,
-
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub local: Option<bool>,
+
+	pub master: bool,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[serde_as(as = "Option<CommaSeparatedString>")]
@@ -21,14 +19,17 @@ pub struct Arg {
 }
 
 impl tg::Client {
-	pub async fn write_pipe(&self, id: &tg::pipe::Id, arg: Arg) -> tg::Result<()> {
-		let method = http::Method::POST;
-		let uri = format!("/pipes/{id}/write");
-
-		// Create the request.
+	pub async fn get_pty_size(
+		&self,
+		id: &tg::pty::Id,
+		arg: Arg,
+	) -> tg::Result<Option<tg::pty::Size>> {
+		let method = http::Method::GET;
+		let uri = format!("/ptys/{id}/size");
 		let request = http::request::Builder::default()
 			.method(method)
 			.uri(uri)
+			.header(http::header::ACCEPT, mime::APPLICATION_JSON.to_string())
 			.header(
 				http::header::CONTENT_TYPE,
 				mime::APPLICATION_JSON.to_string(),
@@ -36,16 +37,11 @@ impl tg::Client {
 			.json(arg)
 			.map_err(|source| tg::error!(!source, "failed to serialize the arg"))?
 			.unwrap();
-		let response = self
-			.send(request)
+		self.send(request)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to send the request"))?;
-		if !response.status().is_success() {
-			let error = response.json().await.map_err(|source| {
-				tg::error!(!source, "failed to deserialize the error response")
-			})?;
-			return Err(error);
-		}
-		Ok(())
+			.map_err(|source| tg::error!(!source, "failed to get the response"))?
+			.json()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to deserialize the body"))
 	}
 }

--- a/packages/client/src/pty/size/put.rs
+++ b/packages/client/src/pty/size/put.rs
@@ -35,11 +35,16 @@ impl tg::Client {
 			.json(arg)
 			.map_err(|source| tg::error!(!source, "failed to serialize the arg"))?
 			.unwrap();
-		self.send(request)
+		let response = self
+			.send(request)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to get the response"))?
-			.json()
-			.await
-			.map_err(|source| tg::error!(!source, "failed to deserialize the body"))
+			.map_err(|source| tg::error!(!source, "failed to send the request"))?;
+		if !response.status().is_success() {
+			let error = response.json().await.map_err(|source| {
+				tg::error!(!source, "failed to deserialize the error response")
+			})?;
+			return Err(error);
+		}
+		Ok(())
 	}
 }

--- a/packages/client/src/pty/size/put.rs
+++ b/packages/client/src/pty/size/put.rs
@@ -1,6 +1,5 @@
 use {
 	crate::prelude::*,
-	bytes::Bytes,
 	serde_with::serde_as,
 	tangram_http::{request::builder::Ext as _, response::Ext as _},
 	tangram_util::serde::CommaSeparatedString,
@@ -9,12 +8,12 @@ use {
 #[serde_as]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Arg {
-	pub bytes: Bytes,
-
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub local: Option<bool>,
 
 	pub master: bool,
+
+	pub size: tg::pty::Size,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[serde_as(as = "Option<CommaSeparatedString>")]
@@ -22,14 +21,13 @@ pub struct Arg {
 }
 
 impl tg::Client {
-	pub async fn write_pty(&self, id: &tg::pty::Id, arg: Arg) -> tg::Result<()> {
-		let method = http::Method::POST;
-		let uri = format!("/ptys/{id}");
-
-		// Create the request.
+	pub async fn put_pty_size(&self, id: &tg::pty::Id, arg: Arg) -> tg::Result<()> {
+		let method = http::Method::PUT;
+		let uri = format!("/ptys/{id}/size");
 		let request = http::request::Builder::default()
 			.method(method)
 			.uri(uri)
+			.header(http::header::ACCEPT, mime::APPLICATION_JSON.to_string())
 			.header(
 				http::header::CONTENT_TYPE,
 				mime::APPLICATION_JSON.to_string(),
@@ -37,16 +35,11 @@ impl tg::Client {
 			.json(arg)
 			.map_err(|source| tg::error!(!source, "failed to serialize the arg"))?
 			.unwrap();
-		let response = self
-			.send(request)
+		self.send(request)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to send the request"))?;
-		if !response.status().is_success() {
-			let error = response.json().await.map_err(|source| {
-				tg::error!(!source, "failed to deserialize the error response")
-			})?;
-			return Err(error);
-		}
-		Ok(())
+			.map_err(|source| tg::error!(!source, "failed to get the response"))?
+			.json()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to deserialize the body"))
 	}
 }

--- a/packages/client/src/pty/write.rs
+++ b/packages/client/src/pty/write.rs
@@ -25,8 +25,6 @@ impl tg::Client {
 	pub async fn write_pty(&self, id: &tg::pty::Id, arg: Arg) -> tg::Result<()> {
 		let method = http::Method::POST;
 		let uri = format!("/ptys/{id}/write");
-
-		// Create the request.
 		let request = http::request::Builder::default()
 			.method(method)
 			.uri(uri)

--- a/packages/client/src/pty/write.rs
+++ b/packages/client/src/pty/write.rs
@@ -24,7 +24,7 @@ pub struct Arg {
 impl tg::Client {
 	pub async fn write_pty(&self, id: &tg::pty::Id, arg: Arg) -> tg::Result<()> {
 		let method = http::Method::POST;
-		let uri = format!("/ptys/{id}");
+		let uri = format!("/ptys/{id}/write");
 
 		// Create the request.
 		let request = http::request::Builder::default()

--- a/packages/client/src/sync.rs
+++ b/packages/client/src/sync.rs
@@ -281,7 +281,7 @@ pub struct ProgressMessageAmounts {
 }
 
 impl tg::Client {
-	pub async fn sync(
+	pub async fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,

--- a/packages/client/src/sync.rs
+++ b/packages/client/src/sync.rs
@@ -281,7 +281,7 @@ pub struct ProgressMessageAmounts {
 }
 
 impl tg::Client {
-	pub async fn sync_stream(
+	pub async fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,

--- a/packages/ignore/src/tests.rs
+++ b/packages/ignore/src/tests.rs
@@ -45,9 +45,7 @@ async fn test() {
 	];
 	let mut left = Vec::new();
 	for (path, _) in &right {
-		let matches = matcher
-			.matches(None, &root.join(path), None)
-			.unwrap();
+		let matches = matcher.matches(None, &root.join(path), None).unwrap();
 		left.push((*path, matches));
 	}
 	assert_eq!(left, right);

--- a/packages/server/src/handle.rs
+++ b/packages/server/src/handle.rs
@@ -87,12 +87,12 @@ impl tg::Handle for Owned {
 		self.0.push(arg).await
 	}
 
-	async fn sync(
+	async fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> tg::Result<impl Stream<Item = tg::Result<tg::sync::Message>> + Send + 'static> {
-		self.0.sync(arg, stream).await
+		self.0.sync_stream(arg, stream).await
 	}
 
 	async fn try_get(
@@ -347,12 +347,12 @@ impl tg::handle::Pipe for Owned {
 		self.0.delete_pipe(id, arg).await
 	}
 
-	async fn try_read_pipe(
+	async fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
 	) -> tg::Result<Option<impl Stream<Item = tg::Result<tg::pipe::Event>> + Send + 'static>> {
-		self.0.try_read_pipe(id, arg).await
+		self.0.try_read_pipe_stream(id, arg).await
 	}
 
 	async fn write_pipe(&self, id: &tg::pipe::Id, arg: tg::pipe::write::Arg) -> tg::Result<()> {
@@ -385,12 +385,12 @@ impl tg::handle::Pty for Owned {
 		self.0.put_pty_size(id, arg).await
 	}
 
-	async fn try_read_pty(
+	async fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
 	) -> tg::Result<Option<impl Stream<Item = tg::Result<tg::pty::Event>> + Send + 'static>> {
-		self.0.try_read_pty(id, arg).await
+		self.0.try_read_pty_stream(id, arg).await
 	}
 
 	async fn write_pty(&self, id: &tg::pty::Id, arg: tg::pty::write::Arg) -> tg::Result<()> {
@@ -544,7 +544,7 @@ impl tg::Handle for Server {
 		self.push_with_context(&Context::default(), arg).await
 	}
 
-	async fn sync(
+	async fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -833,7 +833,7 @@ impl tg::handle::Pipe for Server {
 			.await
 	}
 
-	async fn try_read_pipe(
+	async fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -877,7 +877,7 @@ impl tg::handle::Pty for Server {
 			.await
 	}
 
-	async fn try_read_pty(
+	async fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,
@@ -1050,7 +1050,7 @@ impl tg::Handle for ServerWithContext {
 		self.0.push_with_context(&self.1, arg).await
 	}
 
-	async fn sync(
+	async fn sync_stream(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -1326,7 +1326,7 @@ impl tg::handle::Pipe for ServerWithContext {
 		self.0.delete_pipe_with_context(&self.1, id, arg).await
 	}
 
-	async fn try_read_pipe(
+	async fn try_read_pipe_stream(
 		&self,
 		id: &tg::pipe::Id,
 		arg: tg::pipe::read::Arg,
@@ -1364,7 +1364,7 @@ impl tg::handle::Pty for ServerWithContext {
 		self.0.try_put_pty_size_with_context(&self.1, id, arg).await
 	}
 
-	async fn try_read_pty(
+	async fn try_read_pty_stream(
 		&self,
 		id: &tg::pty::Id,
 		arg: tg::pty::read::Arg,

--- a/packages/server/src/handle.rs
+++ b/packages/server/src/handle.rs
@@ -355,13 +355,8 @@ impl tg::handle::Pipe for Owned {
 		self.0.try_read_pipe(id, arg).await
 	}
 
-	async fn write_pipe(
-		&self,
-		id: &tg::pipe::Id,
-		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
-	) -> tg::Result<()> {
-		self.0.write_pipe(id, arg, stream).await
+	async fn write_pipe(&self, id: &tg::pipe::Id, arg: tg::pipe::write::Arg) -> tg::Result<()> {
+		self.0.write_pipe(id, arg).await
 	}
 }
 
@@ -381,9 +376,13 @@ impl tg::handle::Pty for Owned {
 	async fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> tg::Result<Option<tg::pty::Size>> {
 		self.0.get_pty_size(id, arg).await
+	}
+
+	async fn put_pty_size(&self, id: &tg::pty::Id, arg: tg::pty::size::put::Arg) -> tg::Result<()> {
+		self.0.put_pty_size(id, arg).await
 	}
 
 	async fn try_read_pty(
@@ -394,13 +393,8 @@ impl tg::handle::Pty for Owned {
 		self.0.try_read_pty(id, arg).await
 	}
 
-	async fn write_pty(
-		&self,
-		id: &tg::pty::Id,
-		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
-	) -> tg::Result<()> {
-		self.0.write_pty(id, arg, stream).await
+	async fn write_pty(&self, id: &tg::pty::Id, arg: tg::pty::write::Arg) -> tg::Result<()> {
+		self.0.write_pty(id, arg).await
 	}
 }
 
@@ -848,13 +842,8 @@ impl tg::handle::Pipe for Server {
 			.await
 	}
 
-	async fn write_pipe(
-		&self,
-		id: &tg::pipe::Id,
-		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
-	) -> tg::Result<()> {
-		self.write_pipe_with_context(&Context::default(), id, arg, stream)
+	async fn write_pipe(&self, id: &tg::pipe::Id, arg: tg::pipe::write::Arg) -> tg::Result<()> {
+		self.write_pipe_with_context(&Context::default(), id, arg)
 			.await
 	}
 }
@@ -877,9 +866,14 @@ impl tg::handle::Pty for Server {
 	async fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> tg::Result<Option<tg::pty::Size>> {
 		self.try_get_pty_size_with_context(&Context::default(), id, arg)
+			.await
+	}
+
+	async fn put_pty_size(&self, id: &tg::pty::Id, arg: tg::pty::size::put::Arg) -> tg::Result<()> {
+		self.try_put_pty_size_with_context(&Context::default(), id, arg)
 			.await
 	}
 
@@ -892,13 +886,8 @@ impl tg::handle::Pty for Server {
 			.await
 	}
 
-	async fn write_pty(
-		&self,
-		id: &tg::pty::Id,
-		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
-	) -> tg::Result<()> {
-		self.write_pty_with_context(&Context::default(), id, arg, stream)
+	async fn write_pty(&self, id: &tg::pty::Id, arg: tg::pty::write::Arg) -> tg::Result<()> {
+		self.write_pty_with_context(&Context::default(), id, arg)
 			.await
 	}
 }
@@ -1345,15 +1334,8 @@ impl tg::handle::Pipe for ServerWithContext {
 		self.0.try_read_pipe_with_context(&self.1, id, arg).await
 	}
 
-	async fn write_pipe(
-		&self,
-		id: &tg::pipe::Id,
-		arg: tg::pipe::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pipe::Event>>,
-	) -> tg::Result<()> {
-		self.0
-			.write_pipe_with_context(&self.1, id, arg, stream)
-			.await
+	async fn write_pipe(&self, id: &tg::pipe::Id, arg: tg::pipe::write::Arg) -> tg::Result<()> {
+		self.0.write_pipe_with_context(&self.1, id, arg).await
 	}
 }
 
@@ -1373,9 +1355,13 @@ impl tg::handle::Pty for ServerWithContext {
 	async fn get_pty_size(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> tg::Result<Option<tg::pty::Size>> {
 		self.0.try_get_pty_size_with_context(&self.1, id, arg).await
+	}
+
+	async fn put_pty_size(&self, id: &tg::pty::Id, arg: tg::pty::size::put::Arg) -> tg::Result<()> {
+		self.0.try_put_pty_size_with_context(&self.1, id, arg).await
 	}
 
 	async fn try_read_pty(
@@ -1386,15 +1372,8 @@ impl tg::handle::Pty for ServerWithContext {
 		self.0.try_read_pty_with_context(&self.1, id, arg).await
 	}
 
-	async fn write_pty(
-		&self,
-		id: &tg::pty::Id,
-		arg: tg::pty::write::Arg,
-		stream: BoxStream<'static, tg::Result<tg::pty::Event>>,
-	) -> tg::Result<()> {
-		self.0
-			.write_pty_with_context(&self.1, id, arg, stream)
-			.await
+	async fn write_pty(&self, id: &tg::pty::Id, arg: tg::pty::write::Arg) -> tg::Result<()> {
+		self.0.write_pty_with_context(&self.1, id, arg).await
 	}
 }
 

--- a/packages/server/src/handle.rs
+++ b/packages/server/src/handle.rs
@@ -87,12 +87,12 @@ impl tg::Handle for Owned {
 		self.0.push(arg).await
 	}
 
-	async fn sync_stream(
+	async fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
 	) -> tg::Result<impl Stream<Item = tg::Result<tg::sync::Message>> + Send + 'static> {
-		self.0.sync_stream(arg, stream).await
+		self.0.sync(arg, stream).await
 	}
 
 	async fn try_get(
@@ -544,7 +544,7 @@ impl tg::Handle for Server {
 		self.push_with_context(&Context::default(), arg).await
 	}
 
-	async fn sync_stream(
+	async fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,
@@ -1050,7 +1050,7 @@ impl tg::Handle for ServerWithContext {
 		self.0.push_with_context(&self.1, arg).await
 	}
 
-	async fn sync_stream(
+	async fn sync(
 		&self,
 		arg: tg::sync::Arg,
 		stream: BoxStream<'static, tg::Result<tg::sync::Message>>,

--- a/packages/server/src/http.rs
+++ b/packages/server/src/http.rs
@@ -317,7 +317,7 @@ impl Server {
 			(http::Method::GET, ["pipes", pipe, "read"]) => server
 				.handle_read_pipe_request(request, &context, pipe)
 				.boxed(),
-			(http::Method::POST, ["pipes", pipe]) => server
+			(http::Method::POST, ["pipes", pipe, "write"]) => server
 				.handle_write_pipe_request(request, &context, pipe)
 				.boxed(),
 
@@ -337,7 +337,7 @@ impl Server {
 			(http::Method::GET, ["ptys", pty, "read"]) => server
 				.handle_read_pty_request(request, &context, pty)
 				.boxed(),
-			(http::Method::POST, ["ptys", pty]) => server
+			(http::Method::POST, ["ptys", pty, "write"]) => server
 				.handle_write_pty_request(request, &context, pty)
 				.boxed(),
 

--- a/packages/server/src/http.rs
+++ b/packages/server/src/http.rs
@@ -334,6 +334,9 @@ impl Server {
 			(http::Method::GET, ["ptys", pty, "size"]) => server
 				.handle_get_pty_size_request(request, &context, pty)
 				.boxed(),
+			(http::Method::PUT, ["ptys", pty, "size"]) => server
+				.handle_put_pty_size_request(request, &context, pty)
+				.boxed(),
 			(http::Method::GET, ["ptys", pty, "read"]) => server
 				.handle_read_pty_request(request, &context, pty)
 				.boxed(),

--- a/packages/server/src/http.rs
+++ b/packages/server/src/http.rs
@@ -317,7 +317,7 @@ impl Server {
 			(http::Method::GET, ["pipes", pipe, "read"]) => server
 				.handle_read_pipe_request(request, &context, pipe)
 				.boxed(),
-			(http::Method::POST, ["pipes", pipe, "write"]) => server
+			(http::Method::POST, ["pipes", pipe]) => server
 				.handle_write_pipe_request(request, &context, pipe)
 				.boxed(),
 
@@ -337,7 +337,7 @@ impl Server {
 			(http::Method::GET, ["ptys", pty, "read"]) => server
 				.handle_read_pty_request(request, &context, pty)
 				.boxed(),
-			(http::Method::POST, ["ptys", pty, "write"]) => server
+			(http::Method::POST, ["ptys", pty]) => server
 				.handle_write_pty_request(request, &context, pty)
 				.boxed(),
 

--- a/packages/server/src/pipe/read.rs
+++ b/packages/server/src/pipe/read.rs
@@ -56,11 +56,12 @@ impl Server {
 		let receiver = tokio::net::unix::pipe::Receiver::from_owned_fd_unchecked(fd)
 			.map_err(|source| tg::error!(!source, "failed to clone the receiver"))?;
 
-		let stream = ReaderStream::new(receiver).map(|result| match result {
-			Ok(bytes) => Ok(tg::pipe::Event::Chunk(bytes)),
-			Err(source) => Err(tg::error!(!source, "failed to read pipe")),
-		})
-		.chain(stream::once(future::ok(tg::pipe::Event::End)));
+		let stream = ReaderStream::new(receiver)
+			.map(|result| match result {
+				Ok(bytes) => Ok(tg::pipe::Event::Chunk(bytes)),
+				Err(source) => Err(tg::error!(!source, "failed to read pipe")),
+			})
+			.chain(stream::once(future::ok(tg::pipe::Event::End)));
 
 		Ok(Some(stream))
 	}

--- a/packages/server/src/pipe/read.rs
+++ b/packages/server/src/pipe/read.rs
@@ -86,7 +86,7 @@ impl Server {
 					|source| tg::error!(!source, %remote, "failed to get the remote client"),
 				)?;
 				client
-					.try_read_pipe(id, arg)
+					.try_read_pipe_stream(id, arg)
 					.await
 					.map_err(|source| tg::error!(!source, %remote, "failed to read the pipe"))?
 					.ok_or_else(|| tg::error!("not found"))

--- a/packages/server/src/pty/create.rs
+++ b/packages/server/src/pty/create.rs
@@ -42,7 +42,7 @@ impl Server {
 		// Update the the database.
 		let connection = self
 			.database
-			.connection()
+			.write_connection()
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 		let p = connection.p();

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -119,7 +119,7 @@ impl Server {
 					|source| tg::error!(!source, %remote, "failed to get the remote client"),
 				)?;
 				client
-					.try_read_pty(id, arg)
+					.try_read_pty_stream(id, arg)
 					.await
 					.map_err(|source| tg::error!(!source, %remote, "failed to read the pty"))?
 					.ok_or_else(|| tg::error!("not found"))

--- a/packages/server/src/pty/read.rs
+++ b/packages/server/src/pty/read.rs
@@ -71,8 +71,7 @@ impl Server {
 					let error = std::io::Error::last_os_error();
 					#[cfg(target_os = "linux")]
 					{
-						if error.raw_os_error() == Some(libc::EIO)
-						{
+						if error.raw_os_error() == Some(libc::EIO) {
 							return Ok(None);
 						}
 					}

--- a/packages/server/src/pty/size.rs
+++ b/packages/server/src/pty/size.rs
@@ -2,6 +2,7 @@ use {
 	crate::{Context, Server},
 	futures::{FutureExt as _, future},
 	indoc::formatdoc,
+	std::os::fd::AsRawFd,
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
 	tangram_http::{Body, request::Ext as _},
@@ -12,7 +13,7 @@ impl Server {
 		&self,
 		_context: &Context,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 	) -> tg::Result<Option<tg::pty::Size>> {
 		// Try local first if requested.
 		if Self::local(arg.local, arg.remotes.as_ref())
@@ -39,6 +40,32 @@ impl Server {
 		}
 
 		Ok(None)
+	}
+
+	pub async fn try_put_pty_size_with_context(
+		&self,
+		_context: &Context,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> tg::Result<()> {
+		// Try local first if requested.
+		if Self::local(arg.local, arg.remotes.as_ref()) {
+			return self
+				.try_put_pty_size_local(id, arg)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to get the pty size"));
+		}
+
+		// Try remotes.
+		let remotes = self
+			.remotes(arg.local, arg.remotes.clone())
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get the remotes"))?;
+		self.try_put_pty_size_remote(id, arg, &remotes)
+			.await
+			.map_err(
+				|source| tg::error!(!source, %id, "failed to get the pty size from the remote"),
+			)
 	}
 
 	async fn try_get_pty_size_local(&self, id: &tg::pty::Id) -> tg::Result<Option<tg::pty::Size>> {
@@ -71,16 +98,81 @@ impl Server {
 		Ok(Some(row.size))
 	}
 
+	async fn try_put_pty_size_local(
+		&self,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+	) -> tg::Result<()> {
+		// First attempt to update the size of the TTY.
+		let pty = self
+			.ptys
+			.get_mut(id)
+			.ok_or_else(|| tg::error!("expected a pty"))?;
+
+		// Update the underlying PTY.
+		let fd = if arg.master
+			&& let Some(master) = pty.master.as_ref()
+		{
+			master.as_raw_fd()
+		} else if let Some(slave) = pty.slave.as_ref() {
+			slave.as_raw_fd()
+		} else {
+			return Ok(());
+		};
+		let size = arg.size;
+		tokio::task::spawn_blocking(move || unsafe {
+			let mut winsize = libc::winsize {
+				ws_col: size.cols,
+				ws_row: size.rows,
+				ws_xpixel: 0,
+				ws_ypixel: 0,
+			};
+			let ret = libc::ioctl(fd, libc::TIOCSWINSZ, std::ptr::addr_of_mut!(winsize));
+			if ret != 0 {
+				let error = std::io::Error::last_os_error();
+				if !matches!(error.raw_os_error(), Some(libc::EBADF)) {
+					return Err(error);
+				}
+			}
+			Ok(())
+		})
+		.await
+		.map_err(|source| tg::error!(!source, "the task panicked"))?
+		.map_err(|source| tg::error!(!source, "failed to set the pty size"))?;
+		drop(pty);
+
+		// Update the database.
+		let connection = self
+			.database
+			.connection()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
+		let p = connection.p();
+		let statement = formatdoc!(
+			"
+				update ptys
+				set size = {p}2
+				where id = {p}1;
+			"
+		);
+		let params = db::params![id.to_string(), serde_json::to_string(&size).unwrap()];
+		connection
+			.execute(statement.into(), params)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
+		Ok(())
+	}
+
 	async fn try_get_pty_size_remote(
 		&self,
 		id: &tg::pty::Id,
-		arg: tg::pty::read::Arg,
+		arg: tg::pty::size::get::Arg,
 		remotes: &[String],
 	) -> tg::Result<Option<tg::pty::Size>> {
 		if remotes.is_empty() {
 			return Ok(None);
 		}
-		let arg = tg::pty::read::Arg {
+		let arg = tg::pty::size::get::Arg {
 			local: None,
 			remotes: None,
 			..arg
@@ -103,6 +195,38 @@ impl Server {
 			return Ok(None);
 		};
 		Ok(size)
+	}
+
+	async fn try_put_pty_size_remote(
+		&self,
+		id: &tg::pty::Id,
+		arg: tg::pty::size::put::Arg,
+		remotes: &[String],
+	) -> tg::Result<()> {
+		if remotes.is_empty() {
+			return Ok(());
+		}
+		let arg = tg::pty::size::put::Arg {
+			local: None,
+			remotes: None,
+			..arg
+		};
+		let futures = remotes.iter().map(|remote| {
+			let remote = remote.clone();
+			let arg = arg.clone();
+			async move {
+				let client = self.get_remote_client(remote.clone()).await.map_err(
+					|source| tg::error!(!source, %remote, "failed to get the remote client"),
+				)?;
+				client
+					.put_pty_size(id, arg)
+					.await
+					.map_err(|source| tg::error!(!source, %remote, "failed to get the pty size"))
+			}
+			.boxed()
+		});
+		future::select_ok(futures).await?;
+		Ok(())
 	}
 
 	pub(crate) async fn handle_get_pty_size_request(

--- a/packages/server/src/pty/size.rs
+++ b/packages/server/src/pty/size.rs
@@ -144,7 +144,7 @@ impl Server {
 		// Update the database.
 		let connection = self
 			.database
-			.connection()
+			.write_connection()
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
 		let p = connection.p();

--- a/packages/server/src/push.rs
+++ b/packages/server/src/push.rs
@@ -284,7 +284,7 @@ impl Server {
 		};
 		let push_input_stream = ReceiverStream::new(pull_output_receiver).map(Ok).boxed();
 		let push_output_stream = src
-			.sync(push_arg, push_input_stream)
+			.sync_stream(push_arg, push_input_stream)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to create the push stream"))?;
 
@@ -305,7 +305,7 @@ impl Server {
 		};
 		let pull_input_stream = ReceiverStream::new(push_output_receiver).map(Ok).boxed();
 		let pull_output_stream = dst
-			.sync(pull_arg, pull_input_stream)
+			.sync_stream(pull_arg, pull_input_stream)
 			.await
 			.map_err(|source| tg::error!(!source, "failed to create the pull stream"))?;
 

--- a/packages/server/src/sync.rs
+++ b/packages/server/src/sync.rs
@@ -54,7 +54,7 @@ impl Server {
 				remotes: None,
 			};
 			let stream = client
-				.sync(arg, stream)
+				.sync_stream(arg, stream)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to sync with remote"))?;
 			return Ok(stream.boxed());

--- a/packages/server/src/sync.rs
+++ b/packages/server/src/sync.rs
@@ -54,7 +54,7 @@ impl Server {
 				remotes: None,
 			};
 			let stream = client
-				.sync_stream(arg, stream)
+				.sync(arg, stream)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to sync with remote"))?;
 			return Ok(stream.boxed());


### PR DESCRIPTION
- remove stream implementation of `write_(pipe, pty)`.
- add `put_pty_size` API endpoint.
- remove `tg::pty::Event::Size` variant.
- consistent arg types for `(get, put)_pty_size` 
- rename `try_read_(pipe, pty)` to `try_read_(pipe, pty)_stream` for consistency
- add retry loops in `tg::handle::Ext` methods for `try_read_(pipe, pty)` 
- fix inconsistency when setting/getting pty sizes in the server
- fix condition where `End` events were not delivered to 
- make sure `sync` is in a retry loop in `server::push_or_pull` implementation to handle remote disconnects
