### PR TITLE
fix(server/checkin): address outstanding nondeterminisim in graph creation

### DIFF
--- a/packages/cli/tests/checkin/cyclic_dependencies/object.snapshot
+++ b/packages/cli/tests/checkin/cyclic_dependencies/object.snapshot
@@ -18,12 +18,30 @@ tg.directory({
         "module": "ts",
       },
       {
+        "kind": "directory",
+        "entries": {
+          "tangram.ts": {
+            "index": 0,
+            "kind": "file",
+          },
+        },
+      },
+      {
+        "kind": "directory",
+        "entries": {
+          "tangram.ts": {
+            "index": 3,
+            "kind": "file",
+          },
+        },
+      },
+      {
         "kind": "file",
         "contents": tg.blob("import * as foo from \"../foo\";"),
         "dependencies": {
           "../foo": {
             "item": {
-              "index": 3,
+              "index": 1,
               "kind": "directory",
             },
             "options": {
@@ -33,26 +51,8 @@ tg.directory({
         },
         "module": "ts",
       },
-      {
-        "kind": "directory",
-        "entries": {
-          "tangram.ts": {
-            "index": 1,
-            "kind": "file",
-          },
-        },
-      },
-      {
-        "kind": "directory",
-        "entries": {
-          "tangram.ts": {
-            "index": 0,
-            "kind": "file",
-          },
-        },
-      },
     ],
   }),
-  "index": 3,
+  "index": 1,
   "kind": "directory",
 })

--- a/packages/cli/tests/checkin/import_package_from_current/object.snapshot
+++ b/packages/cli/tests/checkin/import_package_from_current/object.snapshot
@@ -3,25 +3,12 @@ tg.directory({
     "graph": tg.graph({
       "nodes": [
         {
-          "kind": "directory",
-          "entries": {
-            "mod.tg.ts": {
-              "index": 1,
-              "kind": "file",
-            },
-            "tangram.ts": tg.file({
-              "contents": tg.blob(""),
-              "module": "ts",
-            }),
-          },
-        },
-        {
           "kind": "file",
           "contents": tg.blob("import * as a from \".\";"),
           "dependencies": {
             ".": {
               "item": {
-                "index": 0,
+                "index": 1,
                 "kind": "directory",
               },
               "options": {
@@ -31,9 +18,22 @@ tg.directory({
           },
           "module": "ts",
         },
+        {
+          "kind": "directory",
+          "entries": {
+            "mod.tg.ts": {
+              "index": 0,
+              "kind": "file",
+            },
+            "tangram.ts": tg.file({
+              "contents": tg.blob(""),
+              "module": "ts",
+            }),
+          },
+        },
       ],
     }),
-    "index": 0,
+    "index": 1,
     "kind": "directory",
   },
 })

--- a/packages/cli/tests/checkin/package_with_cyclic_modules/object.snapshot
+++ b/packages/cli/tests/checkin/package_with_cyclic_modules/object.snapshot
@@ -4,27 +4,11 @@ tg.directory({
       "nodes": [
         {
           "kind": "file",
-          "contents": tg.blob("import * as root from \"./tangram.ts\";"),
-          "dependencies": {
-            "./tangram.ts": {
-              "item": {
-                "index": 1,
-                "kind": "file",
-              },
-              "options": {
-                "path": "tangram.ts",
-              },
-            },
-          },
-          "module": "ts",
-        },
-        {
-          "kind": "file",
           "contents": tg.blob("import * as foo from \"./foo.tg.ts\";"),
           "dependencies": {
             "./foo.tg.ts": {
               "item": {
-                "index": 0,
+                "index": 1,
                 "kind": "file",
               },
               "options": {
@@ -34,41 +18,17 @@ tg.directory({
           },
           "module": "ts",
         },
-      ],
-    }),
-    "index": 0,
-    "kind": "file",
-  },
-  "tangram.ts": {
-    "graph": tg.graph({
-      "nodes": [
         {
           "kind": "file",
           "contents": tg.blob("import * as root from \"./tangram.ts\";"),
           "dependencies": {
             "./tangram.ts": {
               "item": {
-                "index": 1,
-                "kind": "file",
-              },
-              "options": {
-                "path": "tangram.ts",
-              },
-            },
-          },
-          "module": "ts",
-        },
-        {
-          "kind": "file",
-          "contents": tg.blob("import * as foo from \"./foo.tg.ts\";"),
-          "dependencies": {
-            "./foo.tg.ts": {
-              "item": {
                 "index": 0,
                 "kind": "file",
               },
               "options": {
-                "path": "foo.tg.ts",
+                "path": "tangram.ts",
               },
             },
           },
@@ -77,6 +37,46 @@ tg.directory({
       ],
     }),
     "index": 1,
+    "kind": "file",
+  },
+  "tangram.ts": {
+    "graph": tg.graph({
+      "nodes": [
+        {
+          "kind": "file",
+          "contents": tg.blob("import * as foo from \"./foo.tg.ts\";"),
+          "dependencies": {
+            "./foo.tg.ts": {
+              "item": {
+                "index": 1,
+                "kind": "file",
+              },
+              "options": {
+                "path": "foo.tg.ts",
+              },
+            },
+          },
+          "module": "ts",
+        },
+        {
+          "kind": "file",
+          "contents": tg.blob("import * as root from \"./tangram.ts\";"),
+          "dependencies": {
+            "./tangram.ts": {
+              "item": {
+                "index": 0,
+                "kind": "file",
+              },
+              "options": {
+                "path": "tangram.ts",
+              },
+            },
+          },
+          "module": "ts",
+        },
+      ],
+    }),
+    "index": 0,
     "kind": "file",
   },
 })

--- a/packages/cli/tests/checkin/repeated_checkin_with_cycles.nu
+++ b/packages/cli/tests/checkin/repeated_checkin_with_cycles.nu
@@ -1,0 +1,35 @@
+use ../../test.nu *
+
+# Graph IDs must be identical regardless of entry point for cyclic imports.
+#
+# Two issues were identified:
+#
+# 1. External pointers (references to nodes outside the SCC) used ephemeral
+#    checkin graph indices, causing initial labels to differ by entry point.
+#    Fix: Resolve external pointers to object IDs in checkin_graph_node_initial_label.
+#
+# 2. Symmetric nodes (identical content and structure) produce identical WL labels.
+#    Fix: Use node paths as a tiebreaker in the sort.
+
+let server = spawn
+
+# Minimal 3-node star cycle: hub imports a and b, both a and b import hub.
+# Nodes a and b have identical content and structure, producing identical WL labels.
+let path = artifact {
+	a.tg.ts: 'import "./hub.tg.ts"; export default {};'
+	b.tg.ts: 'import "./hub.tg.ts"; export default {};'
+	hub.tg.ts: 'import "./a.tg.ts"; import "./b.tg.ts"; export default {};'
+}
+
+# Check in from hub first.
+let hub_id = tg checkin ($path | path join 'hub.tg.ts')
+let hub_obj = tg get $hub_id
+let graph_from_hub = $hub_obj | parse --regex '"graph":(gph_[a-z0-9]+)' | get capture0 | first
+
+# Check in from a.
+let a_id = tg checkin ($path | path join 'a.tg.ts')
+let a_obj = tg get $a_id
+let graph_from_a = $a_obj | parse --regex '"graph":(gph_[a-z0-9]+)' | get capture0 | first
+
+# The graph IDs should be identical regardless of entry point.
+assert equal $graph_from_hub $graph_from_a

--- a/packages/cli/tests/checkin/tag_dependency_cycles/lock.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_cycles/lock.snapshot
@@ -18,7 +18,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_01p23dxncarc4nhkjpyy3tjbj7fmekx9fwty3gyzkt1as9t4vphg60",
+            "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
             "tag": "a/1.1.0"
           }
         },
@@ -106,7 +106,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_01p23dxncarc4nhkjpyy3tjbj7fmekx9fwty3gyzkt1as9t4vphg60",
+            "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
             "tag": "a/1.1.0"
           }
         }

--- a/packages/cli/tests/checkin/tag_dependency_cycles/lock.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_cycles/lock.snapshot
@@ -18,7 +18,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
+            "id": "dir_01bh601syfs5twxg1h0d8ar0avybnk2k91ggcqh7ptq01n78av2p90",
             "tag": "a/1.1.0"
           }
         },
@@ -28,7 +28,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
+            "id": "dir_01jrxzb298n5pwk7q89bp3wv5q3yawmbwm1ynt2rgs8x3aedbfw0h0",
             "tag": "b/1.0.0"
           }
         }
@@ -66,7 +66,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
+            "id": "dir_01jrxzb298n5pwk7q89bp3wv5q3yawmbwm1ynt2rgs8x3aedbfw0h0",
             "tag": "b/1.0.0"
           }
         }
@@ -106,7 +106,7 @@
             "kind": "directory"
           },
           "options": {
-            "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
+            "id": "dir_01bh601syfs5twxg1h0d8ar0avybnk2k91ggcqh7ptq01n78av2p90",
             "tag": "a/1.1.0"
           }
         }

--- a/packages/cli/tests/checkin/tag_dependency_cycles/object.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_cycles/object.snapshot
@@ -10,19 +10,6 @@ tg.directory({
                 "kind": "directory",
                 "entries": {
                   "tangram.ts": {
-                    "index": 2,
-                    "kind": "file",
-                  },
-                },
-              },
-              {
-                "kind": "directory",
-                "entries": {
-                  "foo.tg.ts": {
-                    "index": 3,
-                    "kind": "file",
-                  },
-                  "tangram.ts": {
                     "index": 4,
                     "kind": "file",
                   },
@@ -30,44 +17,11 @@ tg.directory({
               },
               {
                 "kind": "file",
-                "contents": tg.blob("import * as b from \"b/*\";"),
-                "dependencies": {
-                  "b/*": {
-                    "item": {
-                      "index": 1,
-                      "kind": "directory",
-                    },
-                    "options": {
-                      "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
-                      "tag": "b/1.0.0",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-              {
-                "kind": "file",
-                "contents": tg.blob("import * as b from \"./tangram.ts\";"),
-                "dependencies": {
-                  "./tangram.ts": {
-                    "item": {
-                      "index": 4,
-                      "kind": "file",
-                    },
-                    "options": {
-                      "path": "tangram.ts",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-              {
-                "kind": "file",
                 "contents": tg.blob("import * as a from \"a/*\";\nimport * as foo from \"./foo.tg.ts\";"),
                 "dependencies": {
                   "./foo.tg.ts": {
                     "item": {
-                      "index": 3,
+                      "index": 2,
                       "kind": "file",
                     },
                     "options": {
@@ -80,8 +34,54 @@ tg.directory({
                       "kind": "directory",
                     },
                     "options": {
-                      "id": "dir_01p23dxncarc4nhkjpyy3tjbj7fmekx9fwty3gyzkt1as9t4vphg60",
+                      "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
                       "tag": "a/1.1.0",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+              {
+                "kind": "file",
+                "contents": tg.blob("import * as b from \"./tangram.ts\";"),
+                "dependencies": {
+                  "./tangram.ts": {
+                    "item": {
+                      "index": 1,
+                      "kind": "file",
+                    },
+                    "options": {
+                      "path": "tangram.ts",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+              {
+                "kind": "directory",
+                "entries": {
+                  "foo.tg.ts": {
+                    "index": 2,
+                    "kind": "file",
+                  },
+                  "tangram.ts": {
+                    "index": 1,
+                    "kind": "file",
+                  },
+                },
+              },
+              {
+                "kind": "file",
+                "contents": tg.blob("import * as b from \"b/*\";"),
+                "dependencies": {
+                  "b/*": {
+                    "item": {
+                      "index": 3,
+                      "kind": "directory",
+                    },
+                    "options": {
+                      "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
+                      "tag": "b/1.0.0",
                     },
                   },
                 },
@@ -93,7 +93,7 @@ tg.directory({
           "kind": "directory",
         },
         "options": {
-          "id": "dir_01p23dxncarc4nhkjpyy3tjbj7fmekx9fwty3gyzkt1as9t4vphg60",
+          "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
           "tag": "a/1.1.0",
         },
       },
@@ -105,19 +105,6 @@ tg.directory({
                 "kind": "directory",
                 "entries": {
                   "tangram.ts": {
-                    "index": 2,
-                    "kind": "file",
-                  },
-                },
-              },
-              {
-                "kind": "directory",
-                "entries": {
-                  "foo.tg.ts": {
-                    "index": 3,
-                    "kind": "file",
-                  },
-                  "tangram.ts": {
                     "index": 4,
                     "kind": "file",
                   },
@@ -125,44 +112,11 @@ tg.directory({
               },
               {
                 "kind": "file",
-                "contents": tg.blob("import * as b from \"b/*\";"),
-                "dependencies": {
-                  "b/*": {
-                    "item": {
-                      "index": 1,
-                      "kind": "directory",
-                    },
-                    "options": {
-                      "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
-                      "tag": "b/1.0.0",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-              {
-                "kind": "file",
-                "contents": tg.blob("import * as b from \"./tangram.ts\";"),
-                "dependencies": {
-                  "./tangram.ts": {
-                    "item": {
-                      "index": 4,
-                      "kind": "file",
-                    },
-                    "options": {
-                      "path": "tangram.ts",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-              {
-                "kind": "file",
                 "contents": tg.blob("import * as a from \"a/*\";\nimport * as foo from \"./foo.tg.ts\";"),
                 "dependencies": {
                   "./foo.tg.ts": {
                     "item": {
-                      "index": 3,
+                      "index": 2,
                       "kind": "file",
                     },
                     "options": {
@@ -175,8 +129,54 @@ tg.directory({
                       "kind": "directory",
                     },
                     "options": {
-                      "id": "dir_01p23dxncarc4nhkjpyy3tjbj7fmekx9fwty3gyzkt1as9t4vphg60",
+                      "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
                       "tag": "a/1.1.0",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+              {
+                "kind": "file",
+                "contents": tg.blob("import * as b from \"./tangram.ts\";"),
+                "dependencies": {
+                  "./tangram.ts": {
+                    "item": {
+                      "index": 1,
+                      "kind": "file",
+                    },
+                    "options": {
+                      "path": "tangram.ts",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+              {
+                "kind": "directory",
+                "entries": {
+                  "foo.tg.ts": {
+                    "index": 2,
+                    "kind": "file",
+                  },
+                  "tangram.ts": {
+                    "index": 1,
+                    "kind": "file",
+                  },
+                },
+              },
+              {
+                "kind": "file",
+                "contents": tg.blob("import * as b from \"b/*\";"),
+                "dependencies": {
+                  "b/*": {
+                    "item": {
+                      "index": 3,
+                      "kind": "directory",
+                    },
+                    "options": {
+                      "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
+                      "tag": "b/1.0.0",
                     },
                   },
                 },
@@ -184,7 +184,7 @@ tg.directory({
               },
             ],
           }),
-          "index": 1,
+          "index": 3,
           "kind": "directory",
         },
         "options": {

--- a/packages/cli/tests/checkin/tag_dependency_cycles/object.snapshot
+++ b/packages/cli/tests/checkin/tag_dependency_cycles/object.snapshot
@@ -9,8 +9,12 @@ tg.directory({
               {
                 "kind": "directory",
                 "entries": {
+                  "foo.tg.ts": {
+                    "index": 3,
+                    "kind": "file",
+                  },
                   "tangram.ts": {
-                    "index": 4,
+                    "index": 1,
                     "kind": "file",
                   },
                 },
@@ -21,7 +25,7 @@ tg.directory({
                 "dependencies": {
                   "./foo.tg.ts": {
                     "item": {
-                      "index": 2,
+                      "index": 3,
                       "kind": "file",
                     },
                     "options": {
@@ -30,16 +34,25 @@ tg.directory({
                   },
                   "a/*": {
                     "item": {
-                      "index": 0,
+                      "index": 2,
                       "kind": "directory",
                     },
                     "options": {
-                      "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
+                      "id": "dir_01bh601syfs5twxg1h0d8ar0avybnk2k91ggcqh7ptq01n78av2p90",
                       "tag": "a/1.1.0",
                     },
                   },
                 },
                 "module": "ts",
+              },
+              {
+                "kind": "directory",
+                "entries": {
+                  "tangram.ts": {
+                    "index": 4,
+                    "kind": "file",
+                  },
+                },
               },
               {
                 "kind": "file",
@@ -58,10 +71,41 @@ tg.directory({
                 "module": "ts",
               },
               {
+                "kind": "file",
+                "contents": tg.blob("import * as b from \"b/*\";"),
+                "dependencies": {
+                  "b/*": {
+                    "item": {
+                      "index": 0,
+                      "kind": "directory",
+                    },
+                    "options": {
+                      "id": "dir_01jrxzb298n5pwk7q89bp3wv5q3yawmbwm1ynt2rgs8x3aedbfw0h0",
+                      "tag": "b/1.0.0",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+            ],
+          }),
+          "index": 2,
+          "kind": "directory",
+        },
+        "options": {
+          "id": "dir_01bh601syfs5twxg1h0d8ar0avybnk2k91ggcqh7ptq01n78av2p90",
+          "tag": "a/1.1.0",
+        },
+      },
+      "b/*": {
+        "item": {
+          "graph": tg.graph({
+            "nodes": [
+              {
                 "kind": "directory",
                 "entries": {
                   "foo.tg.ts": {
-                    "index": 2,
+                    "index": 3,
                     "kind": "file",
                   },
                   "tangram.ts": {
@@ -72,15 +116,66 @@ tg.directory({
               },
               {
                 "kind": "file",
+                "contents": tg.blob("import * as a from \"a/*\";\nimport * as foo from \"./foo.tg.ts\";"),
+                "dependencies": {
+                  "./foo.tg.ts": {
+                    "item": {
+                      "index": 3,
+                      "kind": "file",
+                    },
+                    "options": {
+                      "path": "foo.tg.ts",
+                    },
+                  },
+                  "a/*": {
+                    "item": {
+                      "index": 2,
+                      "kind": "directory",
+                    },
+                    "options": {
+                      "id": "dir_01bh601syfs5twxg1h0d8ar0avybnk2k91ggcqh7ptq01n78av2p90",
+                      "tag": "a/1.1.0",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+              {
+                "kind": "directory",
+                "entries": {
+                  "tangram.ts": {
+                    "index": 4,
+                    "kind": "file",
+                  },
+                },
+              },
+              {
+                "kind": "file",
+                "contents": tg.blob("import * as b from \"./tangram.ts\";"),
+                "dependencies": {
+                  "./tangram.ts": {
+                    "item": {
+                      "index": 1,
+                      "kind": "file",
+                    },
+                    "options": {
+                      "path": "tangram.ts",
+                    },
+                  },
+                },
+                "module": "ts",
+              },
+              {
+                "kind": "file",
                 "contents": tg.blob("import * as b from \"b/*\";"),
                 "dependencies": {
                   "b/*": {
                     "item": {
-                      "index": 3,
+                      "index": 0,
                       "kind": "directory",
                     },
                     "options": {
-                      "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
+                      "id": "dir_01jrxzb298n5pwk7q89bp3wv5q3yawmbwm1ynt2rgs8x3aedbfw0h0",
                       "tag": "b/1.0.0",
                     },
                   },
@@ -93,102 +188,7 @@ tg.directory({
           "kind": "directory",
         },
         "options": {
-          "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
-          "tag": "a/1.1.0",
-        },
-      },
-      "b/*": {
-        "item": {
-          "graph": tg.graph({
-            "nodes": [
-              {
-                "kind": "directory",
-                "entries": {
-                  "tangram.ts": {
-                    "index": 4,
-                    "kind": "file",
-                  },
-                },
-              },
-              {
-                "kind": "file",
-                "contents": tg.blob("import * as a from \"a/*\";\nimport * as foo from \"./foo.tg.ts\";"),
-                "dependencies": {
-                  "./foo.tg.ts": {
-                    "item": {
-                      "index": 2,
-                      "kind": "file",
-                    },
-                    "options": {
-                      "path": "foo.tg.ts",
-                    },
-                  },
-                  "a/*": {
-                    "item": {
-                      "index": 0,
-                      "kind": "directory",
-                    },
-                    "options": {
-                      "id": "dir_01nw818dthjf3d9zn3vb0gnw2be83zjvenzty15be6355k8v1tyvgg",
-                      "tag": "a/1.1.0",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-              {
-                "kind": "file",
-                "contents": tg.blob("import * as b from \"./tangram.ts\";"),
-                "dependencies": {
-                  "./tangram.ts": {
-                    "item": {
-                      "index": 1,
-                      "kind": "file",
-                    },
-                    "options": {
-                      "path": "tangram.ts",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-              {
-                "kind": "directory",
-                "entries": {
-                  "foo.tg.ts": {
-                    "index": 2,
-                    "kind": "file",
-                  },
-                  "tangram.ts": {
-                    "index": 1,
-                    "kind": "file",
-                  },
-                },
-              },
-              {
-                "kind": "file",
-                "contents": tg.blob("import * as b from \"b/*\";"),
-                "dependencies": {
-                  "b/*": {
-                    "item": {
-                      "index": 3,
-                      "kind": "directory",
-                    },
-                    "options": {
-                      "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
-                      "tag": "b/1.0.0",
-                    },
-                  },
-                },
-                "module": "ts",
-              },
-            ],
-          }),
-          "index": 3,
-          "kind": "directory",
-        },
-        "options": {
-          "id": "dir_01zp51yz7v92dwny4m5jvr3vkf33086z9vpjmhc0sk7rkt35pp8qg0",
+          "id": "dir_01jrxzb298n5pwk7q89bp3wv5q3yawmbwm1ynt2rgs8x3aedbfw0h0",
           "tag": "b/1.0.0",
         },
       },

--- a/packages/cli/tests/checkin/tagged_package_with_cyclic_dependency/lock.snapshot
+++ b/packages/cli/tests/checkin/tagged_package_with_cyclic_dependency/lock.snapshot
@@ -15,7 +15,7 @@
         "a": {
           "item": null,
           "options": {
-            "id": "dir_01dtdtrz5tqh3s7c19sfdbhh3mmhgmnte751wz7g7spfqq1y9re340",
+            "id": "dir_01zbr8sgp4jttp8z078yxbnqtabk07avfamzafr9ka2g22ezxdnp10",
             "tag": "a"
           }
         }

--- a/packages/cli/tests/checkin/tagged_package_with_cyclic_dependency/object.snapshot
+++ b/packages/cli/tests/checkin/tagged_package_with_cyclic_dependency/object.snapshot
@@ -9,27 +9,11 @@ tg.directory({
               "nodes": [
                 {
                   "kind": "file",
-                  "contents": tg.blob("import * as a from \"./tangram.ts\";"),
-                  "dependencies": {
-                    "./tangram.ts": {
-                      "item": {
-                        "index": 1,
-                        "kind": "file",
-                      },
-                      "options": {
-                        "path": "tangram.ts",
-                      },
-                    },
-                  },
-                  "module": "ts",
-                },
-                {
-                  "kind": "file",
                   "contents": tg.blob("import foo from \"./foo.tg.ts\";"),
                   "dependencies": {
                     "./foo.tg.ts": {
                       "item": {
-                        "index": 0,
+                        "index": 1,
                         "kind": "file",
                       },
                       "options": {
@@ -39,41 +23,17 @@ tg.directory({
                   },
                   "module": "ts",
                 },
-              ],
-            }),
-            "index": 0,
-            "kind": "file",
-          },
-          "tangram.ts": {
-            "graph": tg.graph({
-              "nodes": [
                 {
                   "kind": "file",
                   "contents": tg.blob("import * as a from \"./tangram.ts\";"),
                   "dependencies": {
                     "./tangram.ts": {
                       "item": {
-                        "index": 1,
-                        "kind": "file",
-                      },
-                      "options": {
-                        "path": "tangram.ts",
-                      },
-                    },
-                  },
-                  "module": "ts",
-                },
-                {
-                  "kind": "file",
-                  "contents": tg.blob("import foo from \"./foo.tg.ts\";"),
-                  "dependencies": {
-                    "./foo.tg.ts": {
-                      "item": {
                         "index": 0,
                         "kind": "file",
                       },
                       "options": {
-                        "path": "foo.tg.ts",
+                        "path": "tangram.ts",
                       },
                     },
                   },
@@ -84,9 +44,49 @@ tg.directory({
             "index": 1,
             "kind": "file",
           },
+          "tangram.ts": {
+            "graph": tg.graph({
+              "nodes": [
+                {
+                  "kind": "file",
+                  "contents": tg.blob("import foo from \"./foo.tg.ts\";"),
+                  "dependencies": {
+                    "./foo.tg.ts": {
+                      "item": {
+                        "index": 1,
+                        "kind": "file",
+                      },
+                      "options": {
+                        "path": "foo.tg.ts",
+                      },
+                    },
+                  },
+                  "module": "ts",
+                },
+                {
+                  "kind": "file",
+                  "contents": tg.blob("import * as a from \"./tangram.ts\";"),
+                  "dependencies": {
+                    "./tangram.ts": {
+                      "item": {
+                        "index": 0,
+                        "kind": "file",
+                      },
+                      "options": {
+                        "path": "tangram.ts",
+                      },
+                    },
+                  },
+                  "module": "ts",
+                },
+              ],
+            }),
+            "index": 0,
+            "kind": "file",
+          },
         }),
         "options": {
-          "id": "dir_01dtdtrz5tqh3s7c19sfdbhh3mmhgmnte751wz7g7spfqq1y9re340",
+          "id": "dir_01zbr8sgp4jttp8z078yxbnqtabk07avfamzafr9ka2g22ezxdnp10",
           "tag": "a",
         },
       },

--- a/packages/cli/tests/object/get_by_id_with_path_cycle.nu
+++ b/packages/cli/tests/object/get_by_id_with_path_cycle.nu
@@ -17,27 +17,11 @@ snapshot $output.stdout '
 	    "nodes": [
 	      {
 	        "kind": "file",
-	        "contents": blb_010pwqd32ehjhaj9eswh61x95cgqby7x5w0fybj56a34cmbehs3mhg,
-	        "dependencies": {
-	          "./tangram.ts": {
-	            "item": {
-	              "index": 1,
-	              "kind": "file",
-	            },
-	            "options": {
-	              "path": "tangram.ts",
-	            },
-	          },
-	        },
-	        "module": "ts",
-	      },
-	      {
-	        "kind": "file",
 	        "contents": blb_01b7ka1dzz1k7n5fh52av0vxtkycf3z2kntyvnvv549x2xdy36mm9g,
 	        "dependencies": {
 	          "./file.tg.ts": {
 	            "item": {
-	              "index": 0,
+	              "index": 1,
 	              "kind": "file",
 	            },
 	            "options": {
@@ -47,9 +31,25 @@ snapshot $output.stdout '
 	        },
 	        "module": "ts",
 	      },
+	      {
+	        "kind": "file",
+	        "contents": blb_010pwqd32ehjhaj9eswh61x95cgqby7x5w0fybj56a34cmbehs3mhg,
+	        "dependencies": {
+	          "./tangram.ts": {
+	            "item": {
+	              "index": 0,
+	              "kind": "file",
+	            },
+	            "options": {
+	              "path": "tangram.ts",
+	            },
+	          },
+	        },
+	        "module": "ts",
+	      },
 	    ],
 	  }),
-	  "index": 0,
+	  "index": 1,
 	  "kind": "file",
 	})
 

--- a/packages/cli/tests/publish/publish_external_dependency_determinism.nu
+++ b/packages/cli/tests/publish/publish_external_dependency_determinism.nu
@@ -1,0 +1,58 @@
+use ../../test.nu *
+
+# Test that graph IDs are deterministic when a package with cycles is entered via an external dependency.
+#
+# This reproduces the bug where publishing std directly vs via jq produced different IDs.
+# The root cause was external pointers (references to nodes outside the SCC) using ephemeral
+# checkin graph indices instead of resolved object IDs.
+
+let remote = spawn --cloud -n remote
+let local = spawn -n local -c {
+	remotes: [{ name: default, url: $remote.url }]
+}
+
+# Create a package "inner" where nodes in a cycle reference nodes outside the cycle.
+# - a.tg.ts and b.tg.ts form a cycle AND both reference helper.tg.ts
+# - helper.tg.ts is outside the cycle
+# This means a-b SCC has external pointers to helper.
+let root = artifact {
+	packages: {
+		inner: {
+			"a.tg.ts": '
+				import b from "./b.tg.ts";
+				import helper from "./helper.tg.ts";
+				export default {};
+			'
+			"b.tg.ts": '
+				import a from "./a.tg.ts";
+				import helper from "./helper.tg.ts";
+				export default {};
+			'
+			"helper.tg.ts": '
+				export default {};
+			'
+			tangram.ts: '
+				import a from "./a.tg.ts";
+				import b from "./b.tg.ts";
+				export let metadata = { tag: "inner/0" };
+			'
+		}
+		outer: {
+			tangram.ts: '
+				import inner from "inner" with { local: "../inner" };
+				export let metadata = { tag: "outer/0" };
+			'
+		}
+	}
+}
+
+# Publish inner directly (like publishing std).
+tg publish ($root | path join "packages/inner")
+let inner_from_inner = tg tag get inner/0 | from json | get item
+
+# Publish outer which depends on inner (like publishing jq which depends on std).
+tg publish ($root | path join "packages/outer")
+let inner_from_outer = tg tag get inner/0 | from json | get item
+
+# Inner should have the same ID regardless of entry point.
+assert ($inner_from_inner == $inner_from_outer) $"inner has different IDs when published directly vs via outer. Direct: ($inner_from_inner), via outer: ($inner_from_outer)"

--- a/packages/server/src/checkin/artifact.rs
+++ b/packages/server/src/checkin/artifact.rs
@@ -274,38 +274,25 @@ impl Server {
 		// Compute canonical labels using the Weisfeiler-Leman algorithm.
 		let canonical_labels = Self::checkin_graph_canonical_labels(graph, paths, scc)?;
 
-		// Group nodes by their canonical labels. Nodes with identical labels are structurally
-		// identical and will be deduplicated into a single node in the graph.
-		let mut label_groups: BTreeMap<u64, Vec<usize>> = BTreeMap::new();
-		for &idx in scc {
-			let label = canonical_labels[&idx];
-			label_groups.entry(label).or_default().push(idx);
-		}
+		// Sort the SCC indices by canonical labels, using paths as a tiebreaker for locally
+		// checked-in nodes with identical content (e.g., symmetric imports).
+		let mut sorted_scc: Vec<usize> = scc.to_vec();
+		sorted_scc.sort_by(|a, b| {
+			canonical_labels[a]
+				.cmp(&canonical_labels[b])
+				.then_with(|| graph.nodes[a].path.cmp(&graph.nodes[b].path))
+		});
 
-		// Create mappings for deduplication:
-		// - scc_positions: maps every global index to its deduplicated position
-		// - unique_indices: one index per deduplicated position (used to create nodes)
-		// - all_indices_by_position: all global indices for each position (used to set edges/ids)
-		let mut scc_positions: BTreeMap<usize, usize> = BTreeMap::new();
-		let mut unique_indices: Vec<usize> = Vec::new();
-		let mut all_indices_by_position: Vec<Vec<usize>> = Vec::new();
+		// Create a mapping from global node index to position in the sorted SCC.
+		let scc_positions: BTreeMap<usize, usize> = sorted_scc
+			.iter()
+			.enumerate()
+			.map(|(position, &global)| (global, position))
+			.collect();
 
-		for (position, (_, group)) in label_groups.iter().enumerate() {
-			// Pick the index with the smallest path for determinism.
-			let unique_index = *group
-				.iter()
-				.min_by_key(|idx| &graph.nodes[idx].path)
-				.unwrap();
-			unique_indices.push(unique_index);
-			all_indices_by_position.push(group.clone());
-			for &idx in group {
-				scc_positions.insert(idx, position);
-			}
-		}
-
-		// Create the nodes using the unique_indices.
-		let mut nodes = Vec::with_capacity(unique_indices.len());
-		for index in &unique_indices {
+		// Create the nodes using the sorted order.
+		let mut nodes = Vec::with_capacity(sorted_scc.len());
+		for index in &sorted_scc {
 			Self::checkin_create_graph_node(graph, paths, &scc_positions, &mut nodes, *index)?;
 		}
 
@@ -314,57 +301,55 @@ impl Server {
 		let (id, _, _) = Self::checkin_create_artifact(
 			graph,
 			&data,
-			&unique_indices,
+			&sorted_scc,
 			store_args,
 			object_messages,
 			touched_at,
 		)?;
 
-		// Set edges and ids for all nodes in the graph (including deduplicated ones).
+		// Set edges and ids for the nodes in the graph.
 		let graph_id = tg::graph::Id::try_from(id).unwrap();
-		for (local, global_indices) in all_indices_by_position.iter().enumerate() {
-			for &global in global_indices {
-				let node = graph.nodes.get_mut(&global).unwrap();
-				let artifact_kind = node.variant.kind();
-				let data = match &node.variant {
-					Variant::Directory(_) => {
-						let pointer = tg::graph::data::Pointer {
-							graph: Some(graph_id.clone()),
-							index: local,
-							kind: artifact_kind,
-						};
-						tg::object::Data::Directory(tg::directory::Data::Pointer(pointer))
-					},
-					Variant::File(_) => {
-						let pointer = tg::graph::data::Pointer {
-							graph: Some(graph_id.clone()),
-							index: local,
-							kind: artifact_kind,
-						};
-						tg::object::Data::File(tg::file::Data::Pointer(pointer))
-					},
-					Variant::Symlink(_) => {
-						let pointer = tg::graph::data::Pointer {
-							graph: Some(graph_id.clone()),
-							index: local,
-							kind: artifact_kind,
-						};
-						tg::object::Data::Symlink(tg::symlink::Data::Pointer(pointer))
-					},
-				};
-				let kind = data.kind();
-				let bytes = data
-					.serialize()
-					.map_err(|source| tg::error!(!source, "failed to serialize the data"))?;
-				let id = tg::object::Id::new(kind, &bytes);
-				node.edge
-					.replace(tg::graph::data::Edge::Pointer(tg::graph::data::Pointer {
+		for (local, global) in sorted_scc.iter().copied().enumerate() {
+			let node = graph.nodes.get_mut(&global).unwrap();
+			let artifact_kind = node.variant.kind();
+			let data = match &node.variant {
+				Variant::Directory(_) => {
+					let pointer = tg::graph::data::Pointer {
 						graph: Some(graph_id.clone()),
 						index: local,
 						kind: artifact_kind,
-					}));
-				node.id.replace(id);
-			}
+					};
+					tg::object::Data::Directory(tg::directory::Data::Pointer(pointer))
+				},
+				Variant::File(_) => {
+					let pointer = tg::graph::data::Pointer {
+						graph: Some(graph_id.clone()),
+						index: local,
+						kind: artifact_kind,
+					};
+					tg::object::Data::File(tg::file::Data::Pointer(pointer))
+				},
+				Variant::Symlink(_) => {
+					let pointer = tg::graph::data::Pointer {
+						graph: Some(graph_id.clone()),
+						index: local,
+						kind: artifact_kind,
+					};
+					tg::object::Data::Symlink(tg::symlink::Data::Pointer(pointer))
+				},
+			};
+			let kind = data.kind();
+			let bytes = data
+				.serialize()
+				.map_err(|source| tg::error!(!source, "failed to serialize the data"))?;
+			let id = tg::object::Id::new(kind, &bytes);
+			node.edge
+				.replace(tg::graph::data::Edge::Pointer(tg::graph::data::Pointer {
+					graph: Some(graph_id.clone()),
+					index: local,
+					kind: artifact_kind,
+				}));
+			node.id.replace(id);
 		}
 
 		Ok(())


### PR DESCRIPTION
  Publishing packages from different entry points produced different IDs for the same package (e.g., tg publish std then tg publish jq would give std different IDs).

  Root causes:
  1. When computing initial labels for the Weisfeiler-Leman algorithm, external pointers (references to nodes
  outside the SCC) retained ephemeral checkin graph indices instead of resolved object IDs. These indices differ based on entry point.
  2. Symmetric nodes with identical content produce identical WL labels, and the sort preserves non-deterministic input order from Tarjan's SCC discovery.

  Fix:
  1. In checkin_graph_node_initial_label, resolve external pointers to their object/artifact IDs.
  2. Use file paths as a tiebreaker when sorting nodes with identical canonical labels.