### PR TITLE
fix(log): compacted logs looping

### DIFF
--- a/packages/cli/tests/build/process_logs_large.nu
+++ b/packages/cli/tests/build/process_logs_large.nu
@@ -1,0 +1,25 @@
+use ../../test.nu *
+
+# Reproduces a bug where reading a compacted log with mid-entry position repeats endlessly.
+
+let remote = spawn -n remote
+
+let path = artifact {
+	tangram.ts: '
+		export default () => {
+			console.log("Line 000 content here");
+			console.log("Line 001 content here");
+		};
+	'
+}
+
+let id = tg build -d $path | str trim
+tg wait $id
+tg remote put default $remote.url | complete
+tg push --logs $id
+
+# Read from remote blob starting mid-entry. Should not hang or repeat.
+let output = tg --url $remote.url process log --position 5 $id o+e>| complete
+
+# Output should be ~37 bytes, not infinite. The bug causes endless repetition.
+assert (($output.stdout | str length) < 100) "Log should not repeat"

--- a/packages/server/src/process/log/stream.rs
+++ b/packages/server/src/process/log/stream.rs
@@ -285,6 +285,7 @@ impl BlobInner {
 				continue;
 			}
 			entry.bytes = entry.bytes[offset..offset + take].to_vec().into();
+			entry.position += offset.to_u64().unwrap();
 			entry.stream_position += offset.to_u64().unwrap();
 			length -= take.to_u64().unwrap();
 			output.push(entry);


### PR DESCRIPTION
I observed compacted logs looping endlessly after compaction. The included test reproduces this on main, timing out.  It passes quickly with the included fix.