### PR TITLE
fix(index): do not send request to put tasks when the put arg is empty

### DIFF
--- a/packages/index/src/fdb/put.rs
+++ b/packages/index/src/fdb/put.rs
@@ -48,6 +48,9 @@ enum ObjectSubtreeMetadataField {
 
 impl Index {
 	pub async fn put(&self, arg: PutArg) -> tg::Result<()> {
+		if arg.cache_entries.is_empty() && arg.objects.is_empty() && arg.processes.is_empty() {
+			return Ok(());
+		}
 		let (sender, receiver) = tokio::sync::oneshot::channel();
 		self.put_sender
 			.send(Request { arg, sender })

--- a/packages/index/src/lmdb/put.rs
+++ b/packages/index/src/lmdb/put.rs
@@ -11,6 +11,9 @@ use {
 
 impl Index {
 	pub async fn put(&self, arg: PutArg) -> tg::Result<()> {
+		if arg.cache_entries.is_empty() && arg.objects.is_empty() && arg.processes.is_empty() {
+			return Ok(());
+		}
 		let (sender, receiver) = tokio::sync::oneshot::channel();
 		let request = Request::Put(arg);
 		self.sender_high


### PR DESCRIPTION
This avoids spurious errors when batching creates empty batches, and the response sender is dropped. 