### PR TITLE
fix(server/read): do not assume an empty `ReadBuf` in the blob file reader.

### DIFF
--- a/packages/cli/tests/build/process_log_early_eof.nu
+++ b/packages/cli/tests/build/process_log_early_eof.nu
@@ -1,0 +1,24 @@
+use ../../test.nu *
+
+# Reproduces a bug where reading a compacted log fails with early eof.
+
+let remote = spawn -n remote
+
+let path = artifact {
+	tangram.ts: '
+		export default () => {
+			for (let i = 0; i < 9900; i++) {
+				console.log(`Line ${i.toString().padStart(4, "0")}: ${"x".repeat(200)}`);
+			}
+		};
+	'
+}
+
+let id = tg build -d $path | str trim
+tg wait $id
+tg remote put default $remote.url | complete
+tg push --logs $id
+
+# Read from remote blob should not fail with early eof.
+let output = tg --url $remote.url process log $id | complete
+success $output "Log read failed"

--- a/packages/server/src/process/log/stream.rs
+++ b/packages/server/src/process/log/stream.rs
@@ -324,20 +324,18 @@ impl BlobInner {
 			.await
 			.map_err(|source| tg::error!(!source, "failed to seek"))?;
 		let mut bytes = vec![0u8; entry.blob_length.to_usize().unwrap()];
-		{
-			let mut offset = 0;
-			loop {
-				let amount = self.reader.read(&mut bytes[offset..])
-					.await
-					.map_err(|source| tg::error!(!source, "failed to read the entry"))?;
-				if amount == 0 {
-					break;
-				}
-				offset += amount;
+		let mut offset = 0;
+		loop {
+			let amount = self.reader.read(&mut bytes[offset..])
+				.await
+				.map_err(|source| tg::error!(!source, "failed to read the entry"))?;
+			offset += amount;
+			if amount == 0 {
+				break;
 			}
-			if offset != bytes.len() {
-				return Err(tg::error!("unexpected eof"));
-			}
+		}
+		if offset != bytes.len() {
+			return Err(tg::error!("unexpected eof"));
 		}
 		let entry: tangram_store::ProcessLogEntry<'_> = tangram_serialize::from_slice(&bytes)
 			.map_err(|source| tg::error!(!source, "log blob is corrupted"))?;

--- a/packages/server/src/read.rs
+++ b/packages/server/src/read.rs
@@ -436,12 +436,13 @@ impl AsyncRead for File {
 		if this.current >= this.length {
 			return Poll::Ready(Ok(()));
 		}
+		let old = buf.filled().len();
 		let poll = Pin::new(this.reader.as_mut().unwrap_left()).poll_read(cx, buf);
 		if let Poll::Ready(Ok(())) = poll {
-			let n = buf.filled().len();
-			let n = n.min((this.length - this.current).to_usize().unwrap());
-			buf.set_filled(n);
-			this.current += n.to_u64().unwrap();
+			let new = buf.filled().len();
+			let diff = (new - old).min((this.length - this.current).to_usize().unwrap());
+			buf.set_filled(old + diff);
+			this.current += diff.to_u64().unwrap();
 			return Poll::Ready(Ok(()));
 		}
 		poll


### PR DESCRIPTION
~~Resolves an issue where `read_exact` incorrectly returns an EOF error when reading log entries from blobs stored as a cache pointer. Unclear if this is a bug in tokio.~~

~~I've confirmed that the correct number of bytes are computed and written, and `read_exact` works when used as a sanity check just after calling `write()` which creates the blob file on disk. However when called in context, an "early eof" error is returned, whereas manually implementing the read_exact loop works as expected.~~

The bug is in our implementation of the `File` variant of the blob reader - it would only work under the assumption the `ReadBuf` passed in by tokio is empty. `read_exact` reuses the same `ReadBuf` across calls, causing the discrepancy when calling `read_exact` on large chunks of data. 