### PR TITLE
fix(server/process/queue): unconditionally ACK dequeued messages from the work queue and avoid batch streaming/redelivery of unack'd messages.

### DIFF
--- a/packages/messenger/src/nats.rs
+++ b/packages/messenger/src/nats.rs
@@ -346,6 +346,7 @@ impl Consumer {
 		let stream = self
 			.consumer
 			.stream()
+			.max_messages_per_batch(1)
 			.messages()
 			.await
 			.map_err(Error::other)?

--- a/packages/server/src/process/queue.rs
+++ b/packages/server/src/process/queue.rs
@@ -84,16 +84,16 @@ impl Server {
 				.await
 				.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
-			// Only return the process if we successfully changed the status of the process.
-			if result == 0 {
-				continue;
-			}
-
-			// Ack the message.
+			// Ack the message unconditionally to avoid redelivery.
 			acker
 				.ack()
 				.await
 				.map_err(|source| tg::error!(!source, "failed to ack the message"))?;
+
+			// Only return the process if we successfully changed the status of the process.
+			if result == 0 {
+				continue;
+			}
 
 			// Publish a message that the status changed.
 			let subject = format!("processes.{}.status", payload.id);


### PR DESCRIPTION
Resolves a bug where `remote_fanout` times out. 

Resolves #800 