### PR TITLE
feat(cli): rollup of TUI improvements

### DIFF
--- a/packages/cli/src/publish.rs
+++ b/packages/cli/src/publish.rs
@@ -539,7 +539,7 @@ where
 			.as_ref()
 			.is_some_and(|p| p == &PathBuf::from(""))
 		{
-			return Err(tg::error!(id = ?directory.id(), "invalid path (1)"));
+			return Err(tg::error!(id = ?directory.id(), "invalid path"));
 		}
 
 		if let Some(tag) = directory.tag() {
@@ -569,7 +569,7 @@ where
 			.as_ref()
 			.is_some_and(|p| p == &PathBuf::from(""))
 		{
-			return Err(tg::error!(id = ?file.id(), "invalid path (2)"));
+			return Err(tg::error!(id = ?file.id(), "invalid path"));
 		}
 		if let Some(tag) = file.tag() {
 			self.tags.push((tag.clone(), file.item().id().into()));

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -1,7 +1,7 @@
 use {
 	self::{data::Data, help::Help, log::Log, tree::Tree},
 	anstream::println,
-	crossterm as ct,
+	crossterm::{self as ct, event::KeyModifiers},
 	futures::{FutureExt as _, TryFutureExt as _, TryStreamExt as _, future},
 	num::ToPrimitive as _,
 	ratatui::{self as tui, prelude::*},
@@ -9,7 +9,6 @@ use {
 		io::{IsTerminal as _, Write as _},
 		os::fd::AsRawFd,
 		pin::pin,
-		sync::Arc,
 		time::Duration,
 	},
 	tangram_client::prelude::*,
@@ -21,6 +20,7 @@ use {
 mod data;
 mod help;
 mod log;
+
 mod tree;
 mod util;
 
@@ -28,7 +28,7 @@ pub struct Viewer<H> {
 	data: Data,
 	focus: Focus,
 	help: Help,
-	log: Option<Arc<Log<H>>>,
+	log: Option<Log<H>>,
 	split: Split,
 	stopped: bool,
 	tree: Tree<H>,
@@ -126,7 +126,11 @@ where
 				},
 				ct::event::MouseEventKind::ScrollUp => {
 					if self.data.hit_test(event.column, event.row) {
-						self.data.up();
+						if event.modifiers.contains(KeyModifiers::SHIFT) {
+							self.data.left();
+						} else {
+							self.data.up();
+						}
 					} else if let Some(log) = &self.log
 						&& log.hit_test(event.column, event.row)
 					{
@@ -135,7 +139,11 @@ where
 				},
 				ct::event::MouseEventKind::ScrollDown => {
 					if self.data.hit_test(event.column, event.row) {
-						self.data.down();
+						if event.modifiers.contains(KeyModifiers::SHIFT) {
+							self.data.right();
+						} else {
+							self.data.down();
+						}
 					} else if let Some(log) = &self.log
 						&& log.hit_test(event.column, event.row)
 					{

--- a/packages/cli/src/viewer/log.rs
+++ b/packages/cli/src/viewer/log.rs
@@ -1,409 +1,451 @@
-#![allow(dead_code)]
-
 use {
-	futures::{StreamExt as _, TryStreamExt as _, future},
+	futures::{StreamExt as _, TryStreamExt as _, stream::BoxStream},
 	num::ToPrimitive as _,
 	ratatui::{self as tui, prelude::*},
-	std::{
-		io::SeekFrom,
-		sync::{
-			Arc, Mutex,
-			atomic::{AtomicBool, AtomicU64, Ordering},
-		},
-		time::Duration,
-	},
+	scroll::Scroll,
+	std::{pin::pin, sync::Arc},
 	tangram_client::prelude::*,
+	tokio::{sync::mpsc, task::JoinHandle},
 };
+
+const PAGE_SIZE: u64 = 4096;
 
 mod scroll;
 
 pub struct Log<H> {
-	// A buffer of log chunks.
-	chunks: tokio::sync::Mutex<Vec<tg::process::log::get::Chunk>>,
-
-	// Whether the log has reached EOF.
-	eof: AtomicBool,
-
-	// Channel used to send UI events.
-	event_sender: tokio::sync::mpsc::UnboundedSender<LogEvent>,
-
-	// The event handler task.
-	event_task: Mutex<Option<tokio::task::JoinHandle<tg::Result<()>>>>,
-
-	// The handle.
-	handle: H,
-
-	// The lines of text that will be displayed.
-	lines: Mutex<Vec<String>>,
-
-	// The maximum position of the log seen so far.
-	max_position: AtomicU64,
-
-	// The process.
-	process: tg::Process,
-
-	// The current state of the log's scrolling position.
-	scroll: tokio::sync::Mutex<Option<scroll::Scroll>>,
-
-	// The log streaming task.
-	task: Mutex<Option<tokio::task::JoinHandle<tg::Result<()>>>>,
-
-	// A watch to be notified when new logs are received from the log task.
-	watch: tokio::sync::Mutex<Option<tokio::sync::watch::Receiver<()>>>,
-
-	rect: std::sync::Mutex<Option<Rect>>,
+	state: Arc<State<H>>,
+	task: JoinHandle<()>,
 }
 
-enum LogEvent {
-	ScrollUp,
-	ScrollDown,
+impl<H> Drop for Log<H> {
+	fn drop(&mut self) {
+		self.task.abort();
+	}
+}
+
+struct State<H> {
+	handle: H,
+	sender: mpsc::UnboundedSender<Event>,
+	process: tg::Process,
+	stream: tokio::sync::Mutex<StreamState>,
+	view: std::sync::Mutex<ViewState>,
+}
+
+#[derive(Default)]
+struct ViewState {
+	area: Option<Rect>,
+	lines: Option<scroll::Lines>,
+}
+
+#[derive(derive_more::TryUnwrap, derive_more::Unwrap)]
+#[try_unwrap(ref, ref_mut)]
+#[unwrap(ref, ref_mut)]
+enum StreamState {
+	Scrolling(Scrolling),
+	Tailing(Tailing),
+}
+
+#[derive(Default)]
+struct Scrolling {
+	chunks: Vec<tg::process::log::get::Chunk>,
+	eof: bool,
+	forwards: bool,
+	scroll: Option<Scroll>,
+	stream: Option<BoxStream<'static, tg::Result<tg::process::log::get::Chunk>>>,
+}
+
+struct Tailing {
+	chunks: Vec<tg::process::log::get::Chunk>,
+	task: JoinHandle<()>,
+}
+
+impl Drop for Tailing {
+	fn drop(&mut self) {
+		self.task.abort();
+	}
+}
+
+#[derive(Debug)]
+enum Event {
+	Page(scroll::Error),
+	Scroll(isize),
+	Update,
 }
 
 impl<H> Log<H>
 where
 	H: tg::Handle,
 {
-	pub fn _stop(&self) {
-		if let Some(task) = self.task.lock().unwrap().take() {
-			task.abort();
-		}
-		if let Some(task) = self.event_task.lock().unwrap().take() {
-			task.abort();
-		}
-	}
+	pub fn new(handle: &H, process: &tg::Process) -> Self {
+		let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+		let stream = StreamState::Scrolling(Scrolling::default());
+		let view = ViewState::default();
+		let state = Arc::new(State {
+			handle: handle.clone(),
+			sender,
+			process: process.clone(),
+			stream: tokio::sync::Mutex::new(stream),
+			view: std::sync::Mutex::new(view),
+		});
 
-	/// Send a scroll down event.
-	pub fn down(&self) {
-		self.event_sender.send(LogEvent::ScrollDown).ok();
-	}
-
-	// Handle a scroll down event.
-	async fn down_impl(self: &Arc<Self>) -> tg::Result<()> {
-		loop {
-			let mut scroll = self.scroll.lock().await;
-			let Some(scroll_) = scroll.as_mut() else {
-				return Ok(());
-			};
-			let chunks = self.chunks.lock().await;
-			match scroll_.scroll_down(1, &chunks) {
-				// If the scroll succeeded but we didn't scroll any lines and the process is not yet complete, we need to start tailing.
-				Ok(count) if count != 1 && !self.is_complete() => {
-					drop(chunks);
-					scroll.take();
-					self.update_log_stream(true).await?;
-				},
-				Ok(_) => {
-					return Ok(());
-				},
-				Err(error) => {
-					drop(chunks);
-					self.update_log_stream(matches!(error, scroll::Error::Append))
-						.await?;
-				},
+		let task = tokio::spawn({
+			let state = Arc::downgrade(&state);
+			async move {
+				let state_ = state.upgrade();
+				if let Some(state_) = &state_ {
+					state_.tail().await;
+				}
+				drop(state_);
+				while let Some(event) = receiver.recv().await {
+					let Some(state) = state.upgrade() else {
+						break;
+					};
+					let result = match event {
+						Event::Scroll(height) => {
+							state.scroll(height).await;
+							Ok(())
+						},
+						Event::Update => {
+							state.update_view().await;
+							Ok(())
+						},
+						Event::Page(scroll::Error::Append) => state.append().await,
+						Event::Page(scroll::Error::Prepend) => state.prepend().await,
+					};
+					if let Err(error) = result {
+						tracing::error!(?error, "failed to handle event");
+					}
+				}
 			}
-		}
+		});
+
+		Self { state, task }
+	}
+
+	pub fn down(&self) {
+		self.state.sender.send(Event::Scroll(1)).ok();
+	}
+
+	pub fn up(&self) {
+		self.state.sender.send(Event::Scroll(-1)).ok();
 	}
 
 	pub fn hit_test(&self, x: u16, y: u16) -> bool {
-		let Some(rect) = *self.rect.lock().unwrap() else {
+		let Some(rect) = self.state.view.lock().unwrap().area else {
 			return false;
 		};
 		let position = Position { x, y };
 		rect.contains(position)
 	}
 
-	async fn init(self: &Arc<Self>) -> tg::Result<()> {
-		let client = &self.handle;
-
-		// Get at least one chunk.
-		let position = Some(std::io::SeekFrom::End(0));
-		let length = Some(-1);
-		let timeout = Duration::from_millis(16);
-		let timeout = tokio::time::sleep(timeout);
-		let arg = tg::process::log::get::Arg {
-			length,
-			position,
-			..Default::default()
-		};
-		let chunk = self
-			.process
-			.log(client, arg)
-			.await?
-			.take_until(timeout)
-			.boxed()
-			.try_next()
-			.await?;
-		let max_position = chunk.map_or(0, |chunk| {
-			chunk.position + chunk.bytes.len().to_u64().unwrap()
-		});
-		self.max_position.store(max_position, Ordering::Relaxed);
-
-		// Start tailing if necessary.
-		self.update_log_stream(true).await?;
-
-		Ok(())
-	}
-
-	fn is_complete(&self) -> bool {
-		self.eof.load(Ordering::SeqCst)
-	}
-
-	pub fn new(handle: &H, process: &tg::Process) -> Arc<Self> {
-		let handle = handle.clone();
-		let process = process.clone();
-		let chunks = tokio::sync::Mutex::new(Vec::new());
-		let (event_sender, mut event_receiver) = tokio::sync::mpsc::unbounded_channel();
-		let lines = Mutex::new(Vec::new());
-
-		let log = Arc::new(Log {
-			process,
-			chunks,
-			handle,
-			eof: AtomicBool::new(false),
-			event_sender,
-			event_task: Mutex::new(None),
-			lines,
-			task: Mutex::new(None),
-			watch: tokio::sync::Mutex::new(None),
-			max_position: AtomicU64::new(0),
-			scroll: tokio::sync::Mutex::new(None),
-			rect: std::sync::Mutex::new(None),
-		});
-
-		// Create the event handler task.
-		let event_task = tokio::spawn({
-			let log = log.clone();
-			async move {
-				log.init().await?;
-				loop {
-					let log_receiver = log.watch.lock().await.clone();
-					let log_receiver = async move {
-						if let Some(mut log_receiver) = log_receiver {
-							log_receiver.changed().await.ok()
-						} else {
-							future::pending().await
-						}
-					};
-					tokio::select! {
-						event = event_receiver.recv() => match event.unwrap() {
-							LogEvent::ScrollDown => {
-								log.down_impl().await.ok();
-							}
-							LogEvent::ScrollUp => {
-								log.up_impl().await.ok();
-							}
-						},
-						_ = log_receiver => (),
-					}
-					log.update_lines().await?;
-				}
-			}
-		});
-		log.event_task.lock().unwrap().replace(event_task);
-
-		log
-	}
-
-	/// Render the log.
-	pub fn render(&self, area: tui::layout::Rect, buf: &mut tui::buffer::Buffer) {
-		self.rect.lock().unwrap().replace(area);
-		let lines = self.lines.lock().unwrap();
-		for (y, line) in (0..area.height).zip(lines.iter()) {
+	pub fn render(&self, area: Rect, buf: &mut tui::buffer::Buffer) {
+		let mut view = self.state.view.lock().unwrap();
+		view.area.replace(area);
+		let lines = view
+			.lines
+			.as_ref()
+			.into_iter()
+			.flat_map(|lines| lines.content.iter());
+		for (y, line) in (0..area.height).zip(lines) {
 			buf.set_line(area.x, area.y + y, &tui::text::Line::raw(line), area.width);
 		}
 	}
-
-	/// Send a scroll up event.
-	pub fn up(&self) {
-		self.event_sender.send(LogEvent::ScrollUp).ok();
-	}
-
-	// Handle a scroll up event.
-	async fn up_impl(self: &Arc<Self>) -> tg::Result<()> {
-		let Some(rect) = *self.rect.lock().unwrap() else {
-			return Ok(());
-		};
-
-		// Create the scroll state if necessary.
-		if self.scroll.lock().await.is_none() {
-			loop {
-				let chunks = self.chunks.lock().await;
-				if chunks.is_empty() {
-					return Ok(());
-				}
-				match scroll::Scroll::new(rect, &chunks) {
-					Ok(inner) => {
-						self.scroll.lock().await.replace(inner);
-						break;
-					},
-					Err(error) => {
-						drop(chunks);
-						self.update_log_stream(matches!(error, scroll::Error::Append))
-							.await?;
-					},
-				}
-			}
-		}
-
-		// Attempt to scroll up by 1 line.
-		loop {
-			let mut scroll = self.scroll.lock().await;
-			let scroll = scroll.as_mut().unwrap();
-			let chunks = self.chunks.lock().await;
-			match scroll.scroll_up(1, &chunks) {
-				Ok(_) => {
-					return Ok(());
-				},
-				// If we need to append or prepend, update the log stream and try again.
-				Err(error) => {
-					drop(chunks);
-					self.update_log_stream(matches!(error, scroll::Error::Append))
-						.await?;
-				},
-			}
-		}
-	}
-
-	// Update the rendered lines.
-	async fn update_lines(self: &Arc<Self>) -> tg::Result<()> {
-		let Some(rect) = *self.rect.lock().unwrap() else {
-			return Ok(());
-		};
-		loop {
-			let chunks = self.chunks.lock().await;
-			if chunks.is_empty() {
-				self.lines.lock().unwrap().clear();
-				return Ok(());
-			}
-			let mut scroll = self.scroll.lock().await;
-			let result = scroll.as_mut().map_or_else(
-				|| {
-					let mut scroll = scroll::Scroll::new(rect, &chunks)?;
-					scroll.read_lines(&chunks)
-				},
-				|scroll| scroll.read_lines(&chunks),
-			);
-
-			// Update the list of lines and break out if successful.
-			match result {
-				Ok(lines) => {
-					*self.lines.lock().unwrap() = lines;
-					break;
-				},
-				Err(error) => {
-					drop(chunks);
-					self.update_log_stream(matches!(error, scroll::Error::Append))
-						.await?;
-				},
-			}
-		}
-
-		Ok(())
-	}
-
-	// Update the log stream. If prepend is Some, the tailing stream is destroyed and bytes are appended to the the front.
-	async fn update_log_stream(self: &Arc<Self>, append: bool) -> tg::Result<()> {
-		// If we're appending and the task already exists, just wait for more data to be available.
-		if append && self.watch.lock().await.is_some() {
-			let mut watch = self.watch.lock().await.clone().unwrap();
-			watch.changed().await.ok();
-			return Ok(());
-		}
-
-		// Otherwise, abort an existing log task.
-		if let Some(task) = self.task.lock().unwrap().take() {
-			task.abort();
-		}
-
-		// Compute the position and length.
-		let Some(area) = *self.rect.lock().unwrap() else {
-			return Ok(());
-		};
-		let area = area.height.to_i64().unwrap();
-		let mut chunks = self.chunks.lock().await;
-		let max_position = self.max_position.load(Ordering::Relaxed);
-		let (position, length) = if append {
-			let last_position = chunks
-				.last()
-				.map(|chunk| chunk.position + chunk.bytes.len().to_u64().unwrap());
-			match last_position {
-				Some(position) if position == max_position => {
-					(Some(SeekFrom::Start(position)), None)
-				},
-				Some(position) => (Some(SeekFrom::Start(position)), Some(3 * area / 2)),
-				None => (Some(SeekFrom::End(0)), Some(-3 * area / 2)),
-			}
-		} else {
-			let position = chunks.first().map(|chunk| chunk.position);
-
-			let length = (3 * area / 2).to_u64().unwrap();
-			match position {
-				Some(position) if position >= length => {
-					(Some(SeekFrom::Start(0)), Some(position.to_i64().unwrap()))
-				},
-				Some(position) => (
-					Some(SeekFrom::Start(position)),
-					Some(-length.to_i64().unwrap()),
-				),
-				None => (Some(SeekFrom::End(0)), Some(-length.to_i64().unwrap())),
-			}
-		};
-
-		// Create the stream.
-		let mut stream = self
-			.process
-			.log(
-				&self.handle,
-				tg::process::log::get::Arg {
-					length,
-					position,
-					..Default::default()
-				},
-			)
-			.await?;
-
-		// Spawn the log task if necessary.
-		if append && chunks.last().is_none_or(|chunk| !chunk.bytes.is_empty()) {
-			drop(chunks);
-			let log = self.clone();
-			let (tx, rx) = tokio::sync::watch::channel(());
-			let task = tokio::spawn(async move {
-				while let Some(chunk) = stream.try_next().await? {
-					let mut chunks = log.chunks.lock().await;
-					if chunk.bytes.is_empty() {
-						log.eof.store(true, Ordering::SeqCst);
-						break;
-					}
-					let max_position = chunk.position + chunk.bytes.len().to_u64().unwrap();
-					log.max_position.fetch_max(max_position, Ordering::AcqRel);
-					chunks.push(chunk);
-					drop(chunks);
-					tx.send(()).ok();
-				}
-				log.watch.lock().await.take();
-				Ok::<_, tg::Error>(())
-			});
-			self.task.lock().unwrap().replace(task);
-			self.watch.lock().await.replace(rx);
-		} else {
-			// Drain the stream and prepend the chunks.
-			let new_chunks = stream.try_collect::<Vec<_>>().await?;
-			let mid = chunks.len();
-			chunks.extend_from_slice(&new_chunks);
-			chunks.rotate_left(mid);
-		}
-
-		Ok(())
-	}
 }
 
-impl<H> Drop for Log<H> {
-	fn drop(&mut self) {
-		if let Some(task) = self.event_task.lock().unwrap().take() {
-			task.abort();
+impl<H> State<H>
+where
+	H: tg::Handle,
+{
+	async fn scroll(self: &Arc<Self>, height: isize) {
+		// Do nothing if asked to scroll by 0.
+		if height == 0 {
+			return;
 		}
-		if let Some(task) = self.task.lock().unwrap().take() {
-			task.abort();
+
+		// Do nothing if we don't have a height het.
+		let Some(rect) = self.view.lock().unwrap().area else {
+			return;
+		};
+
+		// Get the stream.
+		let mut stream = self.stream.lock().await;
+
+		// Cancel the tailing task if it exists and height < 0.
+		if let Ok(tailing) = stream.try_unwrap_tailing_mut() {
+			// Do nothing if asked to scroll down and we're already tailing.
+			if height > 0 {
+				return;
+			}
+
+			// Check the EOF condition.
+			let eof = tailing
+				.chunks
+				.first()
+				.is_some_and(|chunk| chunk.position == 0);
+
+			// Update the state.
+			let scrolling = Scrolling {
+				chunks: tailing.chunks.clone(),
+				eof,
+				forwards: false,
+				scroll: None,
+				stream: None,
+			};
+			*stream = StreamState::Scrolling(scrolling);
 		}
+
+		let scrolling = stream.unwrap_scrolling_mut();
+
+		// Handle EOF condition:
+		// - If the chunks stream is going forwards (down) and height is < 0 (up), clear eof.
+		// - If the chunks stream is going backwards (up) and height is > 0 (down), clear eof.
+		scrolling.eof &= scrolling.forwards == (height < 0);
+
+		// Note the intended direction of the chunks stream.
+		scrolling.forwards = height >= 0;
+
+		// Try to create new scroll state if not exists. If an error occurs send the page event and retry the scroll event.
+		if scrolling.scroll.is_none() {
+			match Scroll::new(rect, &scrolling.chunks) {
+				Ok(scroll) => {
+					scrolling.scroll.replace(scroll);
+				},
+				Err(error) => {
+					self.sender.send(Event::Page(error)).ok();
+					self.sender.send(Event::Scroll(height)).ok();
+					return;
+				},
+			}
+		}
+
+		// Attempt to scroll.
+		match scrolling
+			.scroll
+			.as_mut()
+			.unwrap()
+			.scroll(height, &scrolling.chunks)
+		{
+			// If we scrolled down, but we can't scroll anymore, begin tailing.
+			Ok(0) if scrolling.forwards && height > 0 && !scrolling.eof => {
+				drop(stream);
+				self.tail().await;
+			},
+
+			// If successful send the update event.
+			Ok(_) => {
+				self.sender.send(Event::Update).ok();
+			},
+
+			// Otherwise send the error event.
+			Err(error) => {
+				self.sender.send(Event::Page(error)).ok();
+				self.sender.send(Event::Scroll(height)).ok();
+			},
+		}
+	}
+
+	async fn append(&self) -> tg::Result<()> {
+		let mut stream = self.stream.lock().await;
+		let scrolling = stream
+			.try_unwrap_scrolling_mut()
+			.map_err(|_| tg::error!("cannot append while tailing"))?;
+		if scrolling.eof {
+			return Ok(());
+		}
+
+		// Rebuild the stream if necessary.
+		if !scrolling.forwards || scrolling.stream.is_none() {
+			let position = scrolling.chunks.last().map(|chunk| {
+				std::io::SeekFrom::Start(chunk.position + chunk.bytes.len().to_u64().unwrap())
+			});
+			let arg = tg::process::log::get::Arg {
+				position,
+				size: Some(PAGE_SIZE),
+				..tg::process::log::get::Arg::default()
+			};
+			let stream = self
+				.process
+				.log(&self.handle, arg)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to create the log stream"))?
+				.boxed();
+			scrolling.stream.replace(stream);
+		}
+
+		// Try to read a chunk.
+		let chunk = scrolling
+			.stream
+			.as_mut()
+			.unwrap()
+			.try_next()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to page down"))?;
+
+		// Update EOF.
+		if let Some(chunk) = chunk {
+			scrolling.eof = chunk.bytes.is_empty();
+			scrolling.chunks.push(chunk);
+		} else {
+			scrolling.stream.take();
+		}
+		Ok(())
+	}
+
+	async fn prepend(&self) -> tg::Result<()> {
+		let mut stream = self.stream.lock().await;
+		let scrolling = stream
+			.try_unwrap_scrolling_mut()
+			.map_err(|_| tg::error!("cannot page while tailing"))?;
+		if scrolling.eof {
+			return Ok(());
+		}
+
+		// Rebuild the stream if necessary.
+		if scrolling.forwards || scrolling.stream.is_none() {
+			let position = scrolling
+				.chunks
+				.first()
+				.map(|chunk| std::io::SeekFrom::Start(chunk.position));
+			let arg = tg::process::log::get::Arg {
+				position,
+				length: Some(-(PAGE_SIZE.to_i64().unwrap())),
+				..tg::process::log::get::Arg::default()
+			};
+			let stream = self
+				.process
+				.log(&self.handle, arg)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to create the log stream"))?
+				.boxed();
+			scrolling.stream.replace(stream);
+		}
+
+		// Attempt to read a chunk.
+		let chunk = scrolling
+			.stream
+			.as_mut()
+			.unwrap()
+			.try_next()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to page down"))?;
+		if let Some(chunk) = chunk {
+			scrolling.eof = chunk.position == 0;
+			scrolling.chunks.insert(0, chunk);
+		} else {
+			scrolling.stream.take();
+		}
+		Ok(())
+	}
+
+	async fn update_view(&self) {
+		let Some(area) = self.view.lock().unwrap().area else {
+			return;
+		};
+		let mut stream = self.stream.lock().await;
+		match &mut *stream {
+			StreamState::Scrolling(scrolling) => {
+				let Some(scroll) = scrolling.scroll.as_mut() else {
+					return;
+				};
+				let lines = match scroll.read_lines(&scrolling.chunks) {
+					Ok(lines) => lines,
+					Err(error) => {
+						self.sender.send(Event::Page(error)).ok();
+						return;
+					},
+				};
+				scrolling.chunks.retain(|chunk| {
+					chunk.position < lines.end
+						&& (chunk.position + chunk.bytes.len().to_u64().unwrap()) > lines.start
+				});
+				self.view.lock().unwrap().lines.replace(lines);
+			},
+			StreamState::Tailing(tailing) => {
+				let Ok(mut scroll) = Scroll::new(area, &tailing.chunks) else {
+					return;
+				};
+				let Ok(lines) = scroll.read_lines(&tailing.chunks) else {
+					return;
+				};
+				tailing.chunks.retain(|chunk| {
+					chunk.position < lines.end
+						&& (chunk.position + chunk.bytes.len().to_u64().unwrap()) > lines.start
+				});
+				self.view.lock().unwrap().lines.replace(lines);
+			},
+		}
+	}
+
+	async fn tail(self: &Arc<Self>) {
+		let mut stream = self.stream.lock().await;
+		let position = match &*stream {
+			StreamState::Scrolling(scrolling) => scrolling.chunks.last().map_or(0, |chunk| {
+				chunk.position + chunk.bytes.len().to_u64().unwrap()
+			}),
+			StreamState::Tailing(tailing) => tailing.chunks.last().map_or(0, |chunk| {
+				chunk.position + chunk.bytes.len().to_u64().unwrap()
+			}),
+		};
+		let state = Arc::downgrade(self);
+		let task = tokio::spawn(async move {
+			let arg = tg::process::log::get::Arg {
+				position: Some(std::io::SeekFrom::Start(position)),
+				..tg::process::log::get::Arg::default()
+			};
+			let Some(state_) = state.upgrade() else {
+				return;
+			};
+			let Some(stream) = state_
+				.process
+				.log(&state_.handle, arg)
+				.await
+				.inspect_err(|error| tracing::error!(?error, "failed to tail the log"))
+				.ok()
+			else {
+				return;
+			};
+			drop(state_);
+			let mut stream = pin!(stream);
+			while let Ok(Some(chunk)) = stream.try_next().await {
+				let Some(state) = state.upgrade() else {
+					return;
+				};
+				let mut stream = state.stream.lock().await;
+				let Ok(tailing) = stream.try_unwrap_tailing_mut() else {
+					return;
+				};
+				if chunk.bytes.is_empty() {
+					break;
+				}
+				tailing.chunks.push(chunk);
+				state.sender.send(Event::Update).ok();
+			}
+			let Some(state) = state.upgrade() else {
+				return;
+			};
+			let mut stream = state.stream.lock().await;
+			let Some(chunks) = stream
+				.try_unwrap_tailing_ref()
+				.ok()
+				.map(|t| t.chunks.clone())
+			else {
+				return;
+			};
+			let scrolling = StreamState::Scrolling(Scrolling {
+				chunks,
+				eof: true,
+				forwards: true,
+				scroll: None,
+				stream: None,
+			});
+			*stream = scrolling;
+			state.sender.send(Event::Update).ok();
+		});
+		let chunks = match &*stream {
+			StreamState::Scrolling(scrolling) => scrolling.chunks.clone(),
+			StreamState::Tailing(scrolling) => scrolling.chunks.clone(),
+		};
+		let tailing = Tailing { chunks, task };
+		*stream = StreamState::Tailing(tailing);
 	}
 }

--- a/packages/cli/src/viewer/log.rs
+++ b/packages/cli/src/viewer/log.rs
@@ -345,6 +345,9 @@ where
 		match &mut *stream {
 			StreamState::Scrolling(scrolling) => {
 				if scrolling.scroll.is_none() {
+					if scrolling.chunks.is_empty() {
+						return;
+					}
 					match Scroll::new(area, &scrolling.chunks) {
 						Ok(scroll) => {
 							scrolling.scroll.replace(scroll);
@@ -353,7 +356,7 @@ where
 							self.sender.send(Event::Page(error)).ok();
 							self.sender.send(Event::Update).ok();
 							return;
-						}
+						},
 					}
 				}
 				let scroll = scrolling.scroll.as_mut().unwrap();
@@ -371,6 +374,9 @@ where
 				self.view.lock().unwrap().lines.replace(lines);
 			},
 			StreamState::Tailing(tailing) => {
+				if tailing.chunks.is_empty() {
+					return;
+				}
 				let Ok(mut scroll) = Scroll::new(area, &tailing.chunks) else {
 					return;
 				};

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -1789,18 +1789,22 @@ where
 				_ => (),
 			}
 		}
-		if let ct::event::Event::Mouse(event) = event {
+		if let ct::event::Event::Mouse(event) = event
+			&& self
+				.rect
+				.is_some_and(|rect| rect.contains(Position::new(event.column, event.row)))
+		{
 			match &event.kind {
 				MouseEventKind::ScrollDown => {
 					if event.modifiers.contains(KeyModifiers::SHIFT) {
-						self.scroll_left();
+						self.scroll_right();
 					} else {
 						self.scroll_down();
 					}
 				},
 				MouseEventKind::ScrollUp => {
 					if event.modifiers.contains(KeyModifiers::SHIFT) {
-						self.scroll_right();
+						self.scroll_left();
 					} else {
 						self.scroll_up();
 					}

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -2217,7 +2217,7 @@ where
 			.take(rect.height.to_usize().unwrap());
 
 		// Render the nodes.
-		self.num_rendered_columns = 0;
+		let mut num_rendered_columns = 0;
 		let mut lines = Vec::new();
 		for node in nodes {
 			let line = tui::text::Line::default();
@@ -2227,7 +2227,6 @@ where
 				Style::default()
 			};
 			let mut line = line.style(style);
-
 			let mut prefix = String::new();
 			for ancestor in Self::ancestors(&node)
 				.iter()
@@ -2283,20 +2282,21 @@ where
 			line.push_span(node.borrow().title.clone());
 
 			// Update the number of columns that we've written to the line.
-			let num_rendered_columns = line
+			let width = line
 				.spans
 				.iter()
 				.map(|span| {
 					span.content
 						.graphemes(false)
 						.map(UnicodeWidthStr::width)
-						.sum()
+						.sum::<usize>()
 				})
-				.max()
-				.unwrap_or_default();
-			self.num_rendered_columns = self.num_rendered_columns.max(num_rendered_columns);
+				.sum();
+			num_rendered_columns = num_rendered_columns.max(width);
+
 			lines.push(line);
 		}
+		self.num_rendered_columns = num_rendered_columns;
 		let max = self
 			.num_rendered_columns
 			.saturating_sub(rect.width.to_usize().unwrap());

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -1,7 +1,10 @@
 use {
-	super::{Item, Options, Package, data, log::Log},
-	crossterm as ct,
-	futures::{TryStreamExt as _, future, stream::FuturesUnordered},
+	super::{Item, Log, Options, Package, data},
+	crossterm::{
+		self as ct,
+		event::{KeyModifiers, MouseEventKind},
+	},
+	futures::{TryFutureExt as _, TryStreamExt as _, future, stream::FuturesUnordered},
 	num::ToPrimitive as _,
 	ratatui::{self as tui, prelude::*},
 	std::{
@@ -17,6 +20,8 @@ use {
 	},
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
+	unicode_segmentation::UnicodeSegmentation as _,
+	unicode_width::UnicodeWidthStr,
 };
 
 const SPINNER: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -25,11 +30,12 @@ pub struct Tree<H> {
 	handle: H,
 	counter: UpdateCounter,
 	data: data::UpdateSender,
+	num_rendered_columns: usize,
 	rect: Option<Rect>,
 	roots: Vec<Rc<RefCell<Node>>>,
 	selected: Rc<RefCell<Node>>,
 	selected_task: Option<Task<()>>,
-	scroll: usize,
+	scroll: (usize, usize),
 	viewer: super::UpdateSender<H>,
 }
 
@@ -157,13 +163,6 @@ where
 		ancestors
 	}
 
-	fn bottom(&mut self) {
-		let nodes = self.nodes();
-		self.select(nodes.last().unwrap().clone());
-		let height = self.rect.as_ref().unwrap().height.to_usize().unwrap();
-		self.scroll = nodes.len().saturating_sub(height);
-	}
-
 	fn collapse(&mut self) {
 		if matches!(self.selected.borrow().expanded, Some(true)) {
 			let mut node = self.selected.borrow_mut();
@@ -185,7 +184,7 @@ where
 					.iter()
 					.position(|n| Rc::ptr_eq(n, &parent))
 					.unwrap();
-				self.scroll = self.scroll.min(index);
+				self.scroll.0 = self.scroll.0.min(index);
 				self.select(parent);
 			}
 		}
@@ -361,10 +360,38 @@ where
 			.unwrap();
 		let index = (index + 1).min(nodes.len() - 1);
 		self.select(nodes[index].clone());
+		self.clamp_scroll(index);
+	}
+
+	fn clamp_scroll(&mut self, index: usize) {
 		let height = self.rect.as_ref().unwrap().height.to_usize().unwrap();
-		if index >= self.scroll + height {
-			self.scroll += 1;
+		if index >= self.scroll.0 + height {
+			self.scroll.0 = index.saturating_sub(height.saturating_sub(1));
 		}
+		if index < self.scroll.0 {
+			self.scroll.0 = index;
+		}
+	}
+
+	fn scroll_down(&mut self) {
+		let nodes = self.nodes();
+		let height = self.rect.map_or(0, |r| r.height.to_usize().unwrap());
+		let max = nodes.len().saturating_sub(height);
+		self.scroll.0 = (self.scroll.0 + 1).min(max);
+	}
+
+	fn scroll_up(&mut self) {
+		self.scroll.0 = self.scroll.0.saturating_sub(1);
+	}
+
+	fn scroll_left(&mut self) {
+		self.scroll.1 = self.scroll.1.saturating_sub(1);
+	}
+
+	fn scroll_right(&mut self) {
+		let width = self.rect.map_or(0, |r| r.width.to_usize().unwrap());
+		let max = self.num_rendered_columns.saturating_sub(width);
+		self.scroll.1 = (self.scroll.1 + 1).min(max);
 	}
 
 	pub(crate) fn expand(&mut self) {
@@ -425,16 +452,26 @@ where
 				.map(|child| child.blob.clone().into())
 				.collect(),
 		};
+		let metadata = get_object_metadata_as_value(handle, blob.id()).await?;
+
 		blob.unload();
 		let handle = handle.clone();
 		let value = tg::Value::Array(children);
 		let update = move |node: Rc<RefCell<Node>>| {
 			let item = tg::Referent::with_item(Item::Value(value));
 			let child = Self::create_node(&handle, &node, Some("children".to_owned()), Some(item));
+			let metadata = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
 			node.borrow_mut().children.push(child);
+			node.borrow_mut().children.push(metadata);
 			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
+
 		Ok(())
 	}
 
@@ -515,6 +552,7 @@ where
 			mounts.push(tg::Value::Map(map));
 		}
 		children.push(("mounts".to_owned(), tg::Value::Array(mounts)));
+		let metadata = get_object_metadata_as_value(handle, command.id()).await?;
 		command.unload();
 
 		// Send the update.
@@ -525,6 +563,13 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			let metadata = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
+			node.borrow_mut().children.push(metadata);
 			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
@@ -704,6 +749,7 @@ where
 			));
 		}
 
+		let metadata = get_object_metadata_as_value(handle, error.id()).await?;
 		error.unload();
 
 		// Send the update.
@@ -714,6 +760,13 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			let metadata = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
+			node.borrow_mut().children.push(metadata);
 			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
@@ -798,6 +851,7 @@ where
 				},
 			},
 		};
+		let metadata = get_object_metadata_as_value(handle, directory.id()).await?;
 		directory.unload();
 
 		// Send the update.
@@ -808,6 +862,13 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			let metadata = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
+			node.borrow_mut().children.push(metadata);
 			node.borrow_mut().guard.replace(guard);
 		};
 		update_sender.send(Box::new(update)).unwrap();
@@ -900,6 +961,7 @@ where
 				children
 			},
 		};
+		let metadata = get_object_metadata_as_value(handle, file.id()).await?;
 		file.unload();
 
 		// Send the update.
@@ -911,6 +973,13 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			let metadata = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
+			node.borrow_mut().children.push(metadata);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 		Ok(())
@@ -922,8 +991,9 @@ where
 		update_sender: NodeUpdateSender,
 		guard: UpdateGuard,
 	) -> tg::Result<()> {
-		// Get the graph nodes and unload the object immediately.
+		// Get the graph nodes and metadata, then unload the object immediately.
 		let nodes = graph.nodes(handle).await?;
+		let metadata = get_object_metadata_as_value(handle, graph.id()).await?;
 		graph.unload();
 
 		// Convert nodes to tg::Value::Maps
@@ -1088,6 +1158,13 @@ where
 			let item = tg::Referent::with_item(Item::Value(value));
 			let child = Self::create_node(&handle, &node, Some("nodes".to_owned()), Some(item));
 			node.borrow_mut().children.push(child);
+			let metadata_node = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
+			node.borrow_mut().children.push(metadata_node);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 		Ok(())
@@ -1366,6 +1443,7 @@ where
 
 		let command = process.command(handle).await?;
 		let value = tg::Value::Object(command.clone().into());
+		let metadata = get_process_metadata_as_value(handle, process.id()).await?;
 		update_sender
 			.send({
 				let handle = handle.clone();
@@ -1373,13 +1451,20 @@ where
 				Box::new(move |node| {
 					node.borrow_mut().guard.replace(guard);
 					if node.borrow().options.show_process_commands {
-						let child = Self::create_node(
+						let command = Self::create_node(
 							&handle,
 							&node,
 							Some("command".to_owned()),
 							Some(tg::Referent::with_item(Item::Value(value))),
 						);
-						node.borrow_mut().children.push(child);
+						let metadata = Self::create_node(
+							&handle,
+							&node,
+							Some("metadata".to_owned()),
+							Some(tg::Referent::with_item(Item::Value(metadata))),
+						);
+						node.borrow_mut().children.push(command);
+						node.borrow_mut().children.push(metadata);
 					}
 				})
 			})
@@ -1523,6 +1608,7 @@ where
 				children
 			},
 		};
+		let metadata = get_object_metadata_as_value(handle, symlink.id()).await?;
 		symlink.unload();
 
 		// Send the update.
@@ -1534,6 +1620,13 @@ where
 				let child = Self::create_node(&handle, &node, Some(name), Some(item));
 				node.borrow_mut().children.push(child);
 			}
+			let metadata_node = Self::create_node(
+				&handle,
+				&node,
+				Some("metadata".to_owned()),
+				Some(tg::Referent::with_item(Item::Value(metadata))),
+			);
+			node.borrow_mut().children.push(metadata_node);
 		};
 		update_sender.send(Box::new(update)).unwrap();
 
@@ -1696,6 +1789,27 @@ where
 				_ => (),
 			}
 		}
+		if let ct::event::Event::Mouse(event) = event {
+			match &event.kind {
+				MouseEventKind::ScrollDown => {
+					if event.modifiers.contains(KeyModifiers::SHIFT) {
+						self.scroll_left();
+					} else {
+						self.scroll_down();
+					}
+				},
+				MouseEventKind::ScrollUp => {
+					if event.modifiers.contains(KeyModifiers::SHIFT) {
+						self.scroll_right();
+					} else {
+						self.scroll_up();
+					}
+				},
+				MouseEventKind::ScrollLeft => self.scroll_left(),
+				MouseEventKind::ScrollRight => self.scroll_right(),
+				_ => (),
+			}
+		}
 	}
 
 	fn is_last_child(node: &Rc<RefCell<Node>>) -> bool {
@@ -1853,9 +1967,10 @@ where
 			handle: handle.clone(),
 			counter,
 			data,
+			num_rendered_columns: 0,
 			rect: None,
 			roots,
-			scroll: 0,
+			scroll: (0, 0),
 			selected: root.clone(),
 			selected_task: None,
 			viewer,
@@ -2092,7 +2207,7 @@ where
 		// Filter by the scroll and height.
 		let nodes = nodes
 			.into_iter()
-			.skip(self.scroll)
+			.skip(self.scroll.0)
 			.take(rect.height.to_usize().unwrap());
 
 		// Render the nodes.
@@ -2158,7 +2273,27 @@ where
 			}
 
 			line.push_span(node.borrow().title.clone());
-			tui::widgets::Paragraph::new(line).render(rect, buffer);
+
+			// Update the number of columns that we've written to the line.
+			self.num_rendered_columns = line
+				.spans
+				.iter()
+				.map(|span| {
+					span.content
+						.graphemes(false)
+						.map(UnicodeWidthStr::width)
+						.sum()
+				})
+				.max()
+				.unwrap_or_default();
+			let max = self
+				.num_rendered_columns
+				.saturating_sub(rect.width.to_usize().unwrap());
+			self.scroll.1 = self.scroll.1.min(max);
+
+			tui::widgets::Paragraph::new(line)
+				.scroll((0, self.scroll.1.to_u16().unwrap()))
+				.render(rect, buffer);
 		}
 
 		self.rect.replace(rect);
@@ -2203,12 +2338,26 @@ where
 						match referent.item {
 							Item::Process(process) => handle
 								.get_process(process.id())
-								.await
-								.and_then(|output| {
-									serde_json::to_string_pretty(&output).map_err(|source| {
-										tg::error!(!source, "failed to serialize the process data")
-									})
+								.and_then(async |output: tg::process::get::Output| {
+									#[derive(serde::Serialize)]
+									struct ProcessData {
+										process: tg::process::get::Output,
+										metadata: Option<tg::process::Metadata>,
+									}
+									let metadata = handle
+										.try_get_process_metadata(
+											process.id(),
+											tg::process::metadata::Arg::default(),
+										)
+										.await?;
+									let data = ProcessData {
+										process: output,
+										metadata,
+									};
+									let output = serde_json::to_string_pretty(&data).unwrap();
+									Ok::<_, tg::Error>(output)
 								})
+								.await
 								.unwrap_or_else(|error| error.to_string()),
 							Item::Value(tg::Value::Object(tg::Object::Blob(blob))) => {
 								super::util::format_blob(&handle, &blob)
@@ -2219,7 +2368,19 @@ where
 								let value = match value {
 									tg::Value::Object(object) => {
 										object.load(&handle).await.ok();
-										tg::Value::Object(object)
+										let metadata =
+											get_object_metadata_as_value(&handle, object.id())
+												.await
+												.unwrap_or_else(|error| {
+													tg::Value::String(error.to_string())
+												});
+										let value = [
+											("object".into(), tg::Value::Object(object)),
+											("metadata".into(), metadata),
+										]
+										.into_iter()
+										.collect();
+										tg::Value::Map(value)
 									},
 									value => value,
 								};
@@ -2233,7 +2394,19 @@ where
 							},
 							Item::Package(package) => {
 								package.0.load(&handle).await.ok();
-								let value = tg::Value::Object(package.0);
+								let metadata =
+									get_object_metadata_as_value(&handle, package.0.id())
+										.await
+										.unwrap_or_else(|error| {
+											tg::Value::String(error.to_string())
+										});
+								let value = [
+									("package".into(), tg::Value::Object(package.0)),
+									("metadata".into(), metadata),
+								]
+								.into_iter()
+								.collect();
+								let value = tg::Value::Map(value);
 								let options = tg::value::print::Options {
 									depth: Some(1),
 									style: tg::value::print::Style::Pretty { indentation: "  " },
@@ -2272,10 +2445,17 @@ where
 		}
 	}
 
+	fn bottom(&mut self) {
+		let nodes = self.nodes();
+		self.select(nodes.last().unwrap().clone());
+		let height = self.rect.as_ref().unwrap().height.to_usize().unwrap();
+		self.scroll.0 = nodes.len().saturating_sub(height);
+	}
+
 	fn top(&mut self) {
 		let nodes = self.nodes();
 		self.select(nodes.first().unwrap().clone());
-		self.scroll = 0;
+		self.scroll.0 = 0;
 	}
 
 	fn up(&mut self) {
@@ -2286,9 +2466,7 @@ where
 			.unwrap();
 		let index = index.saturating_sub(1);
 		self.select(nodes[index].clone());
-		if index < self.scroll {
-			self.scroll = self.scroll.saturating_sub(1);
-		}
+		self.clamp_scroll(index);
 	}
 
 	pub fn update(&mut self) {
@@ -2431,4 +2609,104 @@ where
 	) -> tg::Result<bool> {
 		Ok(false)
 	}
+}
+
+async fn get_process_metadata_as_value(
+	handle: &impl tg::Handle,
+	id: &tg::process::Id,
+) -> tg::Result<tg::Value> {
+	let Some(metadata) = handle
+		.try_get_process_metadata(id, tg::process::metadata::Arg::default())
+		.await?
+	else {
+		return Ok(tg::Value::Null);
+	};
+	let node = [
+		("command".into(), subtree_to_value(&metadata.node.command)),
+		("error".into(), subtree_to_value(&metadata.node.error)),
+		("log".into(), subtree_to_value(&metadata.node.log)),
+		("output".into(), subtree_to_value(&metadata.node.output)),
+	]
+	.into_iter()
+	.collect();
+	let node = tg::Value::Map(node);
+	let subtree = [
+		("command".into(), subtree_to_value(&metadata.subtree.command)),
+		(
+			"count".into(),
+			metadata
+				.subtree
+				.count
+				.map_or(tg::Value::Null, |n| n.to_f64().unwrap().into()),
+		),
+		("error".into(), subtree_to_value(&metadata.subtree.error)),
+		("log".into(), subtree_to_value(&metadata.subtree.log)),
+		("output".into(), subtree_to_value(&metadata.subtree.output)),
+	]
+	.into_iter()
+	.collect();
+	let subtree = tg::Value::Map(subtree);
+	let metadata = [("node".into(), node), ("subtree".into(), subtree)]
+		.into_iter()
+		.collect();
+	Ok(tg::Value::Map(metadata))
+}
+
+async fn get_object_metadata_as_value(
+	handle: &impl tg::Handle,
+	id: impl Into<tg::object::Id>,
+) -> tg::Result<tg::Value> {
+	let Some(metadata) = handle
+		.try_get_object_metadata(&id.into(), tg::object::metadata::Arg::default())
+		.await?
+	else {
+		return Ok(tg::Value::Null);
+	};
+	let node = [
+		("size".into(), metadata.node.size.to_f64().unwrap().into()),
+		("solvable".into(), metadata.node.solvable.into()),
+		("solved".into(), metadata.node.solved.into()),
+	]
+	.into_iter()
+	.collect();
+	let node = tg::Value::Map(node);
+	let subtree = subtree_to_value(&metadata.subtree);
+	let metadata = [("node".into(), node), ("subtree".into(), subtree)]
+		.into_iter()
+		.collect();
+	Ok(tg::Value::Map(metadata))
+}
+
+fn subtree_to_value(subtree: &tg::object::metadata::Subtree) -> tg::Value {
+	let subtree = [
+		(
+			"count".into(),
+			subtree
+				.count
+				.map_or(tg::Value::Null, |n| n.to_f64().unwrap().into()),
+		),
+		(
+			"depth".into(),
+			subtree
+				.depth
+				.map_or(tg::Value::Null, |n| n.to_f64().unwrap().into()),
+		),
+		(
+			"size".into(),
+			subtree
+				.size
+				.map_or(tg::Value::Null, |n| n.to_f64().unwrap().into()),
+		),
+		(
+			"solvable".into(),
+			subtree.solvable.map_or(tg::Value::Null, tg::Value::from),
+		),
+		(
+			"solved".into(),
+			subtree.solved.map_or(tg::Value::Null, tg::Value::from),
+		),
+	]
+	.into_iter()
+	.collect();
+	tg::Value::Map(subtree)
 }

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -183,9 +183,9 @@ where
 					.nodes()
 					.iter()
 					.position(|n| Rc::ptr_eq(n, &parent))
-					.unwrap();
+					.unwrap_or_default();
 				self.scroll.0 = self.scroll.0.min(index);
-				self.select(parent);
+				self.set_selected(parent);
 			}
 		}
 	}
@@ -1979,7 +1979,7 @@ where
 
 	pub fn ensure_root_selected(&mut self) {
 		let root = self.roots.first().unwrap().clone();
-		self.select(root);
+		self.set_selected(root);
 	}
 
 	fn nodes(&mut self) -> Vec<Rc<RefCell<Node>>> {
@@ -2300,6 +2300,13 @@ where
 	}
 
 	fn select(&mut self, node: Rc<RefCell<Node>>) {
+		if Rc::ptr_eq(&self.selected, &node) {
+			return;
+		}
+		self.set_selected(node);
+	}
+
+	fn set_selected(&mut self, node: Rc<RefCell<Node>>) {
 		self.selected = node.clone();
 		let Some(referent) = node.borrow().referent.clone() else {
 			return;

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -2348,7 +2348,7 @@ where
 								.and_then(async |output: tg::process::get::Output| {
 									#[derive(serde::Serialize)]
 									struct ProcessData {
-										process: tg::process::get::Output,
+										data: tg::process::get::Output,
 										metadata: Option<tg::process::Metadata>,
 									}
 									let metadata = handle
@@ -2358,7 +2358,7 @@ where
 										)
 										.await?;
 									let data = ProcessData {
-										process: output,
+										data: output,
 										metadata,
 									};
 									let output = serde_json::to_string_pretty(&data).unwrap();
@@ -2382,7 +2382,7 @@ where
 													tg::Value::String(error.to_string())
 												});
 										let value = [
-											("object".into(), tg::Value::Object(object)),
+											("data".into(), tg::Value::Object(object)),
 											("metadata".into(), metadata),
 										]
 										.into_iter()
@@ -2392,7 +2392,7 @@ where
 									value => value,
 								};
 								let options = tg::value::print::Options {
-									depth: Some(1),
+									depth: Some(2),
 									style: tg::value::print::Style::Pretty { indentation: "  " },
 									blobs: false,
 									indent: 0,
@@ -2408,7 +2408,7 @@ where
 											tg::Value::String(error.to_string())
 										});
 								let value = [
-									("package".into(), tg::Value::Object(package.0)),
+									("data".into(), tg::Value::Object(package.0)),
 									("metadata".into(), metadata),
 								]
 								.into_iter()
@@ -2638,7 +2638,10 @@ async fn get_process_metadata_as_value(
 	.collect();
 	let node = tg::Value::Map(node);
 	let subtree = [
-		("command".into(), subtree_to_value(&metadata.subtree.command)),
+		(
+			"command".into(),
+			subtree_to_value(&metadata.subtree.command),
+		),
 		(
 			"count".into(),
 			metadata

--- a/packages/cli/tests/run/log_stream.nu
+++ b/packages/cli/tests/run/log_stream.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+let server = spawn
+let path = artifact {
+	tangram.ts: r#'
+		export default async () => {
+            let alphabet = "abcdefghijklmnopqrstuvwxyz";
+            for (let i = 0; i < 26; i++) {
+                let s = "";
+                for (let j = 0; j < 20; j++) {
+                    s = s + alphabet[i];
+                }
+                console.log(s);
+            }
+            while(true) {
+                await tg.sleep(100);
+            }
+        };
+	'#
+}
+let id = tg build -d $path | str trim
+sleep 1sec
+
+# Check that we can read just one chunk forwards
+let output = tg log $id --position 0 --length 20 
+snapshot $output 'aaaaaaaaaaaaaaaaaaaa'
+
+# Check that we can read chunks backwards.
+let output = tg log $id --position 41 --length='-20'
+snapshot $output 'bbbbbbbbbbbbbbbbbbbb'

--- a/packages/server/src/checkin/artifact.rs
+++ b/packages/server/src/checkin/artifact.rs
@@ -89,7 +89,7 @@ impl Server {
 		let index = graph.paths.get(&arg.path).copied().unwrap();
 		let node = graph.nodes.get(&index).unwrap();
 		if let tg::graph::data::Edge::Pointer(pointer) = node.edge.as_ref().unwrap().clone() {
-			Self::checkin_create_reference_artifact(
+			Self::checkin_create_pointer_artifact(
 				graph,
 				store_args,
 				index_object_args,
@@ -526,7 +526,7 @@ impl Server {
 		Ok(())
 	}
 
-	fn checkin_create_reference_artifact(
+	fn checkin_create_pointer_artifact(
 		graph: &mut Graph,
 		store_args: &mut StoreArgs,
 		index_object_args: &mut IndexObjectArgs,

--- a/packages/server/src/process/log/get.rs
+++ b/packages/server/src/process/log/get.rs
@@ -156,6 +156,10 @@ impl Server {
 				if sender.send(event).await.is_err() {
 					break 'outer;
 				}
+
+				if arg.length.is_some_and(|length| length == 0) {
+					break;
+				}
 			}
 
 			// Send the finished event if we've reached the end of the stream.

--- a/packages/server/src/process/log/stream.rs
+++ b/packages/server/src/process/log/stream.rs
@@ -121,14 +121,18 @@ impl Server {
 					return Ok(None);
 				}
 
+				// Compute the length and position.
+				let length = state.read_length.unwrap_or(4096);
+				let position = if state.reverse {
+					state.position.saturating_sub(length)
+				} else {
+					state.position
+				};
+
 				// Get as many entries from the log as possible.
 				state.entries = state
 					.inner
-					.try_read_process_log(
-						state.position,
-						state.read_length.unwrap_or(4096),
-						state.stream,
-					)
+					.try_read_process_log(position, length, state.stream)
 					.await?
 					.into();
 
@@ -153,14 +157,18 @@ impl Server {
 						index,
 					});
 
+					// Compute the position and length.
+					let length = state.read_length.unwrap_or(4096);
+					let position = if state.reverse {
+						state.position.saturating_sub(length)
+					} else {
+						state.position
+					};
+
 					// Retry reading from the blob.
 					state.entries = state
 						.inner
-						.try_read_process_log(
-							state.position,
-							state.read_length.unwrap_or(4096),
-							state.stream,
-						)
+						.try_read_process_log(position, length, state.stream)
 						.await?
 						.into();
 				}


### PR DESCRIPTION
- Fix bug in server where `try_get_process_log` with `length < 0` would not iterate logs in reverse
- Fix bug in server where `try_get_process_log` did not terminate after `length` bytes
- Simplify the implementation of `cli/src/viewer/log.rs`, with two states `Scrolling | Tailing` and handle edge cases where the `chunk`s start/end positions do not match the displayed lines end positions 
- Add vscroll/hscroll to the tree view 
- Fix vscroll/hscroll clamping in the data view 

Resolves #619, #767, #777