### PR TITLE
perf(server): make process cycle detection asynchronous

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -690,6 +690,7 @@ impl Cli {
 
 		// Start the server.
 		let server = tangram_server::Server::start(config)
+			.boxed()
 			.await
 			.map_err(|source| tg::error!(!source, "failed to start the server"))?;
 

--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -716,7 +716,7 @@ export def --env spawn [
 		"docker:docker@localhost:4500" | save -f $cluster
 
 		nats stream create $'finalize_($id)' --discard new --retention work --subjects $'($id).finish' --defaults
-		nats consumer create $'finalize_($id)' finish --deliver all --max-pending 1000000 --pull --defaults
+		nats consumer create $'finalize_($id)' finalize --deliver all --max-pending 1000000 --pull --defaults
 		nats stream create $'queue_($id)' --discard new --retention work --subjects $'($id).queue' --defaults
 		nats consumer create $'queue_($id)' queue --deliver all --max-pending 1000000 --pull --defaults
 

--- a/packages/cli/tests/tree/double_build.nu
+++ b/packages/cli/tests/tree/double_build.nu
@@ -23,10 +23,16 @@ snapshot $output '{"exit":0,"output":42}'
 
 let output = tg view $id --mode inline --expand-processes --depth 2
 
+# Extract only the cycle error message (the last error in the chain).
+let output = $output
+	| lines
+	| str replace --all --regex 'fil_[a-z0-9]+' '<fil_id>'
+	| str replace --all --regex 'cmd_[a-z0-9]+' 'cmd_id>'
 snapshot $output '
-	✓ fil_01xw45e66hhhxemww9m1qmj7jp9n1zjhn3ewggx0f6eb9nwr4js46g#default
-	├╴command: cmd_0166tgxrezqabf2zvd3mveyr2e1ss6ws1ehfeay2amxv5tadh47bhg
+	✓ <fil_id>#default
+	├╴command: cmd_id>
 	├╴output: 42
 	├╴✓ ../b.tg.ts#default
-	└╴✓ fil_01sa3pyv7baf50x2ymmvy7p41zqnmmv8gp1fq5z3mq60ps8vcfxa30#default
+	└╴✓ <fil_id>#default
+
 '

--- a/packages/server/src/database/postgres.sql
+++ b/packages/server/src/database/postgres.sql
@@ -83,7 +83,7 @@ begin
 end;
 $$;
 
-create or replace function get_cyclic_processes(
+create or replace function get_process_cycles(
 	parent_ids text[],
 	child_ids text[]
 )

--- a/packages/server/src/database/sqlite.sql
+++ b/packages/server/src/database/sqlite.sql
@@ -50,6 +50,7 @@ create index process_tokens_token_index on process_tokens (token);
 create table process_children (
 	process text not null,
 	child text not null,
+	cycle integer,
 	options text,
 	position integer not null,
 	token text
@@ -60,6 +61,8 @@ create unique index process_children_process_child_index on process_children (pr
 create unique index process_children_process_position_index on process_children (process, position);
 
 create index process_children_child_index on process_children (child);
+
+create index process_children_cycle_index on process_children (cycle) where cycle is null;
 
 create table remotes (
 	name text primary key,

--- a/packages/server/src/database/sqlite.sql
+++ b/packages/server/src/database/sqlite.sql
@@ -50,7 +50,6 @@ create index process_tokens_token_index on process_tokens (token);
 create table process_children (
 	process text not null,
 	child text not null,
-	cycle integer,
 	options text,
 	position integer not null,
 	token text
@@ -61,8 +60,6 @@ create unique index process_children_process_child_index on process_children (pr
 create unique index process_children_process_position_index on process_children (process, position);
 
 create index process_children_child_index on process_children (child);
-
-create index process_children_cycle_index on process_children (cycle) where cycle is null;
 
 create table remotes (
 	name text primary key,

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -488,7 +488,7 @@ impl Server {
 				.await
 				.map_err(|source| tg::error!(!source, "failed to create the queue consumer"))?;
 			stream
-				.create_consumer("cycle_detector".to_owned(), consumer_config)
+				.create_consumer("watchdog".to_owned(), consumer_config)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to create the queue consumer"))?;
 		}

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -193,7 +193,8 @@ impl Server {
 				self.spawn_process_task(&process, permit, clean_guard);
 			} else {
 				let payload = crate::process::queue::Message {
-					id: output.id.clone(),
+					process: output.id.clone(),
+					parent: arg.parent.clone(),
 				};
 				self.messenger
 					.stream_publish("queue".into(), payload)
@@ -1108,19 +1109,6 @@ impl Server {
 					.publish(format!("processes.{id}.children"), ())
 					.await
 					.inspect_err(|error| tracing::error!(%error, "failed to publish"))
-					.ok();
-			}
-		});
-		tokio::spawn({
-			let server = self.clone();
-			async move {
-				server
-					.messenger
-					.publish("watchdog".into(), ())
-					.await
-					.inspect_err(|error| {
-						tracing::error!(?error, "failed to publish the watchdog message");
-					})
 					.ok();
 			}
 		});

--- a/packages/server/src/watchdog.rs
+++ b/packages/server/src/watchdog.rs
@@ -1,5 +1,5 @@
 use {
-	crate::Server,
+	crate::{Server, database},
 	futures::{
 		FutureExt as _, StreamExt as _, TryFutureExt, TryStreamExt, future,
 		stream::FuturesUnordered,
@@ -9,37 +9,67 @@ use {
 	std::{collections::BTreeMap, fmt::Write, pin::pin},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
-	tangram_messenger::prelude::*,
+	tangram_messenger::{BatchConfig, prelude::*},
 };
 
 impl Server {
-	pub async fn watchdog_task(&self, config: &crate::config::Watchdog) -> tg::Result<()> {
+	pub async fn watchdog_task(&self, config: &crate::config::Watchdog) {
+		let expired_processes = tokio::spawn({
+			let server = self.clone();
+			let config = config.clone();
+			async move { server.expired_process_task(&config).await }
+		});
+		let cyclic_processes = tokio::spawn({
+			let server = self.clone();
+			let config = config.clone();
+			async move { server.cyclic_processes_task(&config).await }
+		});
+		match future::select(expired_processes, cyclic_processes).await {
+			future::Either::Left((result, task)) => {
+				if let Err(error) = result {
+					tracing::error!(?error, "watchdog task panicked");
+				}
+				task.await
+					.inspect_err(|error| tracing::error!(?error, "watchdog task panicked"))
+					.ok();
+			},
+			future::Either::Right((result, task)) => {
+				if let Err(error) = result {
+					tracing::error!(?error, "watchdog task panicked");
+				}
+				task.await
+					.inspect_err(|error| tracing::error!(?error, "watchdog task panicked"))
+					.ok();
+			},
+		}
+	}
+
+	async fn expired_process_task(&self, config: &crate::config::Watchdog) {
 		loop {
 			// Finish processes.
-			let expired_future = self
-				.finish_expired_processes(config)
+			let result = self
+				.expired_process_task_inner(config)
 				.inspect_err(
 					|error| tracing::error!(error = %error.trace(), "failed to finish processes"),
-				);
-			let cycle_future = self
-				.finish_cyclic_processes(config)
-				.inspect_err(
-					|error| tracing::error!(error = %error.trace(), "failed to finish processes"),
-				);
-			let result = future::join(expired_future, cycle_future).await;
+				)
+				.await;
 
 			// If an error occurred or no processes were finished, wait to be signaled or for the timeout to expire.
-			if matches!(result, (Err(_), Err(_)) | (Ok(0), Ok(0))) {
-				let stream = self
+			if matches!(result, Err(_) | Ok(0)) {
+				let Ok(stream) = self
 					.messenger
 					.subscribe::<()>("watchdog".into(), None)
 					.await
-					.map_err(|source| {
-						tg::error!(
-							!source,
-							"failed to subscribe to the cancellation message stream"
-						)
-					})?;
+					.inspect_err(|error| {
+						tracing::error!(
+							?error,
+							"failed to subscribe to the watchdog message stream"
+						);
+					})
+				else {
+					tokio::time::sleep(config.interval).await;
+					continue;
+				};
 				let mut stream = pin!(stream);
 				tokio::time::timeout(config.interval, stream.next())
 					.await
@@ -48,7 +78,7 @@ impl Server {
 		}
 	}
 
-	pub(crate) async fn finish_expired_processes(
+	async fn expired_process_task_inner(
 		&self,
 		config: &crate::config::Watchdog,
 	) -> tg::Result<u64> {
@@ -142,47 +172,100 @@ impl Server {
 		Ok(n)
 	}
 
-	async fn finish_cyclic_processes(&self, config: &crate::config::Watchdog) -> tg::Result<u64> {
-		// Get a database connection.
-		let connection = self
+	async fn cyclic_processes_task(&self, config: &crate::config::Watchdog) {
+		// Subscribe to the consumer stream.
+		let Ok(stream) = self
+			.messenger
+			.get_stream("queue".into())
+			.await
+			.inspect_err(|error| tracing::error!(?error, "failed to get the stream"))
+		else {
+			return;
+		};
+		let Ok(consumer) = stream
+			.get_consumer("cycle_detector".into())
+			.await
+			.inspect_err(|error| tracing::error!(?error, "failed to get the consumer"))
+		else {
+			return;
+		};
+		let Ok(stream) = consumer
+			.batch_subscribe::<crate::process::queue::Message>(BatchConfig {
+				max_messages: Some(config.batch_size.to_u64().unwrap()),
+				max_bytes: None,
+				timeout: Some(config.ttl),
+			})
+			.await
+			.inspect_err(|error| tracing::error!(?error, "failed to subscribe"))
+		else {
+			return;
+		};
+		let stream = stream.ready_chunks(config.batch_size);
+		let mut stream = pin!(stream);
+		let mut messages = Vec::with_capacity(config.batch_size);
+		let mut ackers = Vec::with_capacity(config.batch_size);
+		while let Some(chunk) = stream.next().await {
+			messages.clear();
+			ackers.clear();
+			for result in chunk {
+				let Ok(message) = result.inspect_err(|error| {
+					tracing::error!(?error, "error reading from process queue stream");
+				}) else {
+					continue;
+				};
+				let (message, acker) = message.split();
+				messages.push(message);
+				ackers.push(acker);
+			}
+			self.cyclic_processes_task_inner(&messages)
+				.await
+				.inspect_err(|error| tracing::error!(?error, "failed to finish cyclic processes"))
+				.ok();
+			while let Some(acker) = ackers.pop() {
+				acker.ack().await.ok();
+			}
+		}
+	}
+
+	async fn cyclic_processes_task_inner(
+		&self,
+		messages: &[crate::process::queue::Message],
+	) -> tg::Result<()> {
+		let mut connection = self
 			.database
 			.connection()
 			.await
 			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
-		let p = connection.p();
-
-		// Get processes to finish.
-		#[derive(Debug, db::row::Deserialize)]
-		struct Row {
-			#[tangram_database(as = "db::value::FromStr")]
-			process: tg::process::Id,
-
-			#[tangram_database(as = "db::value::FromStr")]
-			child: tg::process::Id,
-		}
-		let statement = formatdoc!(
-			"
-				select process, child
-				from process_children
-				where cycle is null
-				limit {p}1;
-			"
-		);
-		let params = db::params![config.batch_size];
-		let rows = connection
-			.query_all_into::<Row>(statement.into(), params)
+		let transaction = connection
+			.transaction()
 			.await
-			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
+			.map_err(|source| tg::error!(!source, "failed "))?;
+		let results = match &transaction {
+			#[cfg(feature = "postgres")]
+			database::Transaction::Postgres(transaction) => {
+				Self::get_cyclic_processes_postgres(transaction, messages)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to get cyclic processes"))?
+			},
+			#[cfg(feature = "sqlite")]
+			database::Transaction::Sqlite(transaction) => {
+				Self::get_cyclic_processes_sqlite(transaction, messages)
+					.await
+					.map_err(|source| tg::error!(!source, "failed to update parent depths"))?
+			},
+		};
+
+		transaction
+			.commit()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to commit the transaction"))?;
 		drop(connection);
-		let n = rows.len().to_u64().unwrap();
-		rows.into_iter()
-			.map(|row| {
+
+		results
+			.into_iter()
+			.map(|(id, error)| {
 				let server = self.clone();
 				async move {
-					let Some(error) = server.try_detect_cycle(&row.process, &row.child).await?
-					else {
-						return Ok(());
-					};
 					let arg = tg::process::finish::Arg {
 						checksum: None,
 						error: Some(tg::Either::Left(error)),
@@ -191,134 +274,185 @@ impl Server {
 						output: None,
 						remotes: None,
 					};
-					server
-						.finish_process(&row.child, arg)
-						.await
-						.inspect_err(|error| {
-							tracing::error!(?error, "failed to cancel the process");
-						})
-						.ok();
-					Ok::<_, tg::Error>(())
+					server.finish_process(&id, arg).await
 				}
 			})
 			.collect::<FuturesUnordered<_>>()
 			.try_collect::<()>()
 			.await
-			.map_err(|source| tg::error!(!source, "cycle detection failed"))?;
-		Ok(n)
+			.map_err(|source| tg::error!(!source, "failed to finish processes"))?;
+
+		Ok(())
 	}
 
-	async fn try_detect_cycle(
-		&self,
-		parent: &tg::process::Id,
-		child: &tg::process::Id,
-	) -> tg::Result<Option<tg::error::Data>> {
-		let connection = self
-			.database
-			.connection()
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
-		let p = connection.p();
-
-		// Determine if adding this child process creates a cycle.
-		let statement = formatdoc!(
-			"
-			with recursive ancestors as (
-				select {p}1 as id
-				union all
-				select process_children.process as id
-				from ancestors
-				join process_children on ancestors.id = process_children.child
-			)
-			select exists(
-				select 1 from ancestors where id = {p}2
-			);
-			"
-		);
-		let params = db::params![parent.to_string(), child.to_string()];
-		let cycle = connection
-			.query_one_value_into::<bool>(statement.into(), params)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to execute the cycle check"))?;
-
-		// Upgrade to a write connection.
-		drop(connection);
-		let connection = self
-			.database
-			.write_connection()
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
-		let p = connection.p();
-
-		// Mark the edge as forming a cycle.
-		let statement = formatdoc!(
-			"
-				update process_children set cycle = {p}3 where process = {p}1 and child = {p}2;
-			"
-		);
-		let params = db::params![parent.to_string(), child.to_string(), cycle];
-		connection
-			.execute(statement.into(), params)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to perform the query"))?;
-
-		if !cycle {
-			return Ok(None);
+	#[cfg(feature = "postgres")]
+	async fn get_cyclic_processes_postgres(
+		transaction: &db::postgres::Transaction<'_>,
+		messages: &[crate::process::queue::Message],
+	) -> tg::Result<Vec<(tg::process::Id, tg::error::Data)>> {
+		// Build the parameter arrays dynamically.
+		let mut parent_placeholders = Vec::new();
+		let mut child_placeholders = Vec::new();
+		let mut params = Vec::new();
+		let mut idx = 1;
+		for message in messages {
+			let Some(parent) = &message.parent else {
+				continue;
+			};
+			parent_placeholders.push(format!("${idx}"));
+			idx += 1;
+			child_placeholders.push(format!("${idx}"));
+			idx += 1;
+			params.push(db::Value::Text(parent.to_string()));
+			params.push(db::Value::Text(message.process.to_string()));
+		}
+		if parent_placeholders.is_empty() {
+			return Ok(Vec::new());
 		}
 
-		// Construct a good error message by collecting the entire cycle.
-		let mut message = String::from("adding this child process creates a cycle");
-
-		// Try to reconstruct the cycle path by walking from the child through its
-		// descendants until we find a path back to the parent.
-		let statement = formatdoc!(
-			"
-				with recursive reachable (current_process, path) as (
-					select {p}2, {p}2
-
-					union
-
-					select pc.child, r.path || ' ' || pc.child
-					from reachable r
-					join process_children pc on r.current_process = pc.process
-					where r.path not like '%' || pc.child || '%'
-				)
-				select
-					{p}1 || ' ' || path as cycle
-				from reachable
-				where current_process = {p}1
-				limit 1;
-			"
+		// Call the stored function with a single query.
+		#[derive(db::row::Deserialize)]
+		struct Row {
+			process_id: String,
+			cycle_path: Option<String>,
+		}
+		let statement = format!(
+			"select * from get_cyclic_processes(array[{}]::text[], array[{}]::text[]);",
+			parent_placeholders.join(", "),
+			child_placeholders.join(", "),
 		);
-		let params = db::params![parent.to_string(), child.to_string()];
-		let cycle = connection
-			.query_one_value_into::<String>(statement.into(), params)
+		let rows = transaction
+			.query_all_into::<Row>(statement.into(), params)
 			.await
-			.inspect_err(|error| tracing::error!(?error, "failed to get the cycle"))
-			.ok();
+			.map_err(|source| tg::error!(!source, "failed to get cyclic processes"))?;
 
-		// Format the error message.
-		if let Some(cycle) = cycle {
-			let processes = cycle.split(' ').collect::<Vec<_>>();
-			for i in 0..processes.len() - 1 {
-				let parent = processes[i];
-				let child = processes[i + 1];
-				if i == 0 {
-					write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
-				} else {
-					write!(&mut message, "\n{parent} has child {child}").unwrap();
+		// Build the results with formatted error messages.
+		let mut results = Vec::new();
+		for row in rows {
+			let id: tg::process::Id = row
+				.process_id
+				.parse()
+				.map_err(|source| tg::error!(!source, "failed to parse the process id"))?;
+			let mut message = String::from("adding this child process creates a cycle");
+			if let Some(cycle) = row.cycle_path {
+				let processes = cycle.split(' ').collect::<Vec<_>>();
+				for i in 0..processes.len() - 1 {
+					let parent = processes[i];
+					let child = processes[i + 1];
+					if i == 0 {
+						write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
+					} else {
+						write!(&mut message, "\n{parent} has child {child}").unwrap();
+					}
 				}
 			}
+			let error = tg::error::Data {
+				code: None,
+				diagnostics: None,
+				location: None,
+				message: Some(message),
+				source: None,
+				stack: None,
+				values: BTreeMap::new(),
+			};
+			results.push((id, error));
 		}
-		let error = tg::error::Data {
-			code: None,
-			diagnostics: None,
-			location: None,
-			message: Some(message),
-			source: None,
-			stack: None,
-			values: BTreeMap::new(),
-		};
-		Ok(Some(error))
+		Ok(results)
+	}
+
+	#[cfg(feature = "sqlite")]
+	async fn get_cyclic_processes_sqlite(
+		transaction: &db::sqlite::Transaction<'_>,
+		messages: &[crate::process::queue::Message],
+	) -> tg::Result<Vec<(tg::process::Id, tg::error::Data)>> {
+		let mut results = Vec::new();
+		let p = transaction.p();
+
+		for message in messages {
+			let Some(parent) = &message.parent else {
+				continue;
+			};
+			let child = &message.process;
+			let params = db::params![parent.to_string(), child.to_string()];
+			let statement = formatdoc!(
+				"
+					with recursive ancestors as (
+						select {p}1 as id
+						union all
+						select process_children.process as id
+						from ancestors
+						join process_children on ancestors.id = process_children.child
+					)
+					select exists(
+						select 1 from ancestors where id = {p}2
+					);
+				"
+			);
+			let cycle = transaction
+				.query_one_value_into::<bool>(statement.into(), params)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to execute the cycle check"))?;
+
+			if !cycle {
+				continue;
+			}
+
+			// Construct a good error message by collecting the entire cycle.
+			let mut message = String::from("adding this child process creates a cycle");
+
+			// Try to reconstruct the cycle path by walking from the child through its
+			// descendants until we find a path back to the parent.
+			let statement = formatdoc!(
+				"
+					with recursive reachable (current_process, path) as (
+						select {p}2, {p}2
+
+						union
+
+						select pc.child, r.path || ' ' || pc.child
+						from reachable r
+						join process_children pc on r.current_process = pc.process
+						where r.path not like '%' || pc.child || '%'
+					)
+					select
+						{p}1 || ' ' || path as cycle
+					from reachable
+					where current_process = {p}1
+					limit 1;
+				"
+			);
+			let params = db::params![parent.to_string(), child.to_string()];
+			let cycle = transaction
+				.query_one_value_into::<String>(statement.into(), params)
+				.await
+				.inspect_err(|error| tracing::error!(?error, "failed to get the cycle"))
+				.ok();
+
+			// Format the error message.
+			if let Some(cycle) = cycle {
+				let processes = cycle.split(' ').collect::<Vec<_>>();
+				for i in 0..processes.len() - 1 {
+					let parent = processes[i];
+					let child = processes[i + 1];
+					if i == 0 {
+						write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
+					} else {
+						write!(&mut message, "\n{parent} has child {child}").unwrap();
+					}
+				}
+			}
+			let error = tg::error::Data {
+				code: None,
+				diagnostics: None,
+				location: None,
+				message: Some(message),
+				source: None,
+				stack: None,
+				values: BTreeMap::new(),
+			};
+			results.push((child.clone(), error));
+		}
+
+		Ok(results)
 	}
 }

--- a/packages/server/src/watchdog.rs
+++ b/packages/server/src/watchdog.rs
@@ -1,9 +1,12 @@
 use {
 	crate::Server,
-	futures::{FutureExt as _, StreamExt as _, stream::FuturesUnordered},
+	futures::{
+		FutureExt as _, StreamExt as _, TryFutureExt, TryStreamExt, future,
+		stream::FuturesUnordered,
+	},
 	indoc::formatdoc,
 	num::ToPrimitive as _,
-	std::{collections::BTreeMap, pin::pin},
+	std::{collections::BTreeMap, fmt::Write, pin::pin},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
 	tangram_messenger::prelude::*,
@@ -13,12 +16,20 @@ impl Server {
 	pub async fn watchdog_task(&self, config: &crate::config::Watchdog) -> tg::Result<()> {
 		loop {
 			// Finish processes.
-			let result = self.watchdog_task_inner(config).await.inspect_err(
-				|error| tracing::error!(error = %error.trace(), "failed to finish processes"),
-			);
+			let expired_future = self
+				.finish_expired_processes(config)
+				.inspect_err(
+					|error| tracing::error!(error = %error.trace(), "failed to finish processes"),
+				);
+			let cycle_future = self
+				.finish_cyclic_processes(config)
+				.inspect_err(
+					|error| tracing::error!(error = %error.trace(), "failed to finish processes"),
+				);
+			let result = future::join(expired_future, cycle_future).await;
 
 			// If an error occurred or no processes were finished, wait to be signaled or for the timeout to expire.
-			if matches!(result, Err(_) | Ok(0)) {
+			if matches!(result, (Err(_), Err(_)) | (Ok(0), Ok(0))) {
 				let stream = self
 					.messenger
 					.subscribe::<()>("watchdog".into(), None)
@@ -37,7 +48,7 @@ impl Server {
 		}
 	}
 
-	pub(crate) async fn watchdog_task_inner(
+	pub(crate) async fn finish_expired_processes(
 		&self,
 		config: &crate::config::Watchdog,
 	) -> tg::Result<u64> {
@@ -129,5 +140,185 @@ impl Server {
 			.await;
 
 		Ok(n)
+	}
+
+	async fn finish_cyclic_processes(&self, config: &crate::config::Watchdog) -> tg::Result<u64> {
+		// Get a database connection.
+		let connection = self
+			.database
+			.connection()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
+		let p = connection.p();
+
+		// Get processes to finish.
+		#[derive(Debug, db::row::Deserialize)]
+		struct Row {
+			#[tangram_database(as = "db::value::FromStr")]
+			process: tg::process::Id,
+
+			#[tangram_database(as = "db::value::FromStr")]
+			child: tg::process::Id,
+		}
+		let statement = formatdoc!(
+			"
+				select process, child
+				from process_children
+				where cycle is null
+				limit {p}1;
+			"
+		);
+		let params = db::params![config.batch_size];
+		let rows = connection
+			.query_all_into::<Row>(statement.into(), params)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
+		drop(connection);
+		let n = rows.len().to_u64().unwrap();
+		rows.into_iter()
+			.map(|row| {
+				let server = self.clone();
+				async move {
+					let Some(error) = server.try_detect_cycle(&row.process, &row.child).await?
+					else {
+						return Ok(());
+					};
+					let arg = tg::process::finish::Arg {
+						checksum: None,
+						error: Some(tg::Either::Left(error)),
+						exit: 1,
+						local: None,
+						output: None,
+						remotes: None,
+					};
+					server
+						.finish_process(&row.child, arg)
+						.await
+						.inspect_err(|error| {
+							tracing::error!(?error, "failed to cancel the process");
+						})
+						.ok();
+					Ok::<_, tg::Error>(())
+				}
+			})
+			.collect::<FuturesUnordered<_>>()
+			.try_collect::<()>()
+			.await
+			.map_err(|source| tg::error!(!source, "cycle detection failed"))?;
+		Ok(n)
+	}
+
+	async fn try_detect_cycle(
+		&self,
+		parent: &tg::process::Id,
+		child: &tg::process::Id,
+	) -> tg::Result<Option<tg::error::Data>> {
+		let connection = self
+			.database
+			.connection()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
+		let p = connection.p();
+
+		// Determine if adding this child process creates a cycle.
+		let statement = formatdoc!(
+			"
+			with recursive ancestors as (
+				select {p}1 as id
+				union all
+				select process_children.process as id
+				from ancestors
+				join process_children on ancestors.id = process_children.child
+			)
+			select exists(
+				select 1 from ancestors where id = {p}2
+			);
+			"
+		);
+		let params = db::params![parent.to_string(), child.to_string()];
+		let cycle = connection
+			.query_one_value_into::<bool>(statement.into(), params)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to execute the cycle check"))?;
+
+		// Upgrade to a write connection.
+		drop(connection);
+		let connection = self
+			.database
+			.write_connection()
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get a database connection"))?;
+		let p = connection.p();
+
+		// Mark the edge as forming a cycle.
+		let statement = formatdoc!(
+			"
+				update process_children set cycle = {p}3 where process = {p}1 and child = {p}2;
+			"
+		);
+		let params = db::params![parent.to_string(), child.to_string(), cycle];
+		connection
+			.execute(statement.into(), params)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to perform the query"))?;
+
+		if !cycle {
+			return Ok(None);
+		}
+
+		// Construct a good error message by collecting the entire cycle.
+		let mut message = String::from("adding this child process creates a cycle");
+
+		// Try to reconstruct the cycle path by walking from the child through its
+		// descendants until we find a path back to the parent.
+		let statement = formatdoc!(
+			"
+				with recursive reachable (current_process, path) as (
+					select {p}2, {p}2
+
+					union
+
+					select pc.child, r.path || ' ' || pc.child
+					from reachable r
+					join process_children pc on r.current_process = pc.process
+					where r.path not like '%' || pc.child || '%'
+				)
+				select
+					{p}1 || ' ' || path as cycle
+				from reachable
+				where current_process = {p}1
+				limit 1;
+			"
+		);
+		let params = db::params![parent.to_string(), child.to_string()];
+		let cycle = connection
+			.query_one_value_into::<String>(statement.into(), params)
+			.await
+			.inspect_err(|error| tracing::error!(?error, "failed to get the cycle"))
+			.ok();
+
+		// Format the error message.
+		if let Some(cycle) = cycle {
+			let processes = cycle.split(' ').collect::<Vec<_>>();
+			for i in 0..processes.len() - 1 {
+				let parent = processes[i];
+				let child = processes[i + 1];
+				if i == 0 {
+					write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
+				} else {
+					write!(&mut message, "\n{parent} has child {child}").unwrap();
+				}
+			}
+		}
+		let error = tg::error::Data {
+			code: None,
+			diagnostics: None,
+			location: None,
+			message: Some(message),
+			source: None,
+			stack: None,
+			values: BTreeMap::new(),
+		};
+		Ok(Some(error))
 	}
 }

--- a/packages/server/src/watchdog.rs
+++ b/packages/server/src/watchdog.rs
@@ -6,25 +6,30 @@ use {
 	},
 	indoc::formatdoc,
 	num::ToPrimitive as _,
-	std::{collections::BTreeMap, fmt::Write, pin::pin},
+	std::{collections::BTreeMap, pin::pin},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
 	tangram_messenger::{BatchConfig, prelude::*},
 };
+
+#[cfg(feature = "postgres")]
+mod postgres;
+#[cfg(feature = "sqlite")]
+mod sqlite;
 
 impl Server {
 	pub async fn watchdog_task(&self, config: &crate::config::Watchdog) {
 		let expired_processes = tokio::spawn({
 			let server = self.clone();
 			let config = config.clone();
-			async move { server.expired_process_task(&config).await }
+			async move { server.watchdog_heartbeat_task(&config).await }
 		});
-		let cyclic_processes = tokio::spawn({
+		let process_cycles = tokio::spawn({
 			let server = self.clone();
 			let config = config.clone();
-			async move { server.cyclic_processes_task(&config).await }
+			async move { server.watchdog_cycle_task(&config).await }
 		});
-		match future::select(expired_processes, cyclic_processes).await {
+		match future::select(expired_processes, process_cycles).await {
 			future::Either::Left((result, task)) => {
 				if let Err(error) = result {
 					tracing::error!(?error, "watchdog task panicked");
@@ -44,11 +49,11 @@ impl Server {
 		}
 	}
 
-	async fn expired_process_task(&self, config: &crate::config::Watchdog) {
+	async fn watchdog_heartbeat_task(&self, config: &crate::config::Watchdog) {
 		loop {
 			// Finish processes.
 			let result = self
-				.expired_process_task_inner(config)
+				.watchdog_heartbeat_task_inner(config)
 				.inspect_err(
 					|error| tracing::error!(error = %error.trace(), "failed to finish processes"),
 				)
@@ -78,7 +83,7 @@ impl Server {
 		}
 	}
 
-	async fn expired_process_task_inner(
+	async fn watchdog_heartbeat_task_inner(
 		&self,
 		config: &crate::config::Watchdog,
 	) -> tg::Result<u64> {
@@ -172,7 +177,7 @@ impl Server {
 		Ok(n)
 	}
 
-	async fn cyclic_processes_task(&self, config: &crate::config::Watchdog) {
+	async fn watchdog_cycle_task(&self, config: &crate::config::Watchdog) {
 		// Subscribe to the consumer stream.
 		let Ok(stream) = self
 			.messenger
@@ -183,7 +188,7 @@ impl Server {
 			return;
 		};
 		let Ok(consumer) = stream
-			.get_consumer("cycle_detector".into())
+			.get_consumer("watchdog".into())
 			.await
 			.inspect_err(|error| tracing::error!(?error, "failed to get the consumer"))
 		else {
@@ -217,9 +222,9 @@ impl Server {
 				messages.push(message);
 				ackers.push(acker);
 			}
-			self.cyclic_processes_task_inner(&messages)
+			self.watchdog_cycle_task_inner(&messages)
 				.await
-				.inspect_err(|error| tracing::error!(?error, "failed to finish cyclic processes"))
+				.inspect_err(|error| tracing::error!(?error, "failed to finish process cycles"))
 				.ok();
 			while let Some(acker) = ackers.pop() {
 				acker.ack().await.ok();
@@ -227,7 +232,7 @@ impl Server {
 		}
 	}
 
-	async fn cyclic_processes_task_inner(
+	async fn watchdog_cycle_task_inner(
 		&self,
 		messages: &[crate::process::queue::Message],
 	) -> tg::Result<()> {
@@ -239,19 +244,19 @@ impl Server {
 		let transaction = connection
 			.transaction()
 			.await
-			.map_err(|source| tg::error!(!source, "failed "))?;
+			.map_err(|source| tg::error!(!source, "failed to begin a transaction"))?;
 		let results = match &transaction {
 			#[cfg(feature = "postgres")]
 			database::Transaction::Postgres(transaction) => {
-				Self::get_cyclic_processes_postgres(transaction, messages)
+				Self::get_process_cycles_postgres(transaction, messages)
 					.await
-					.map_err(|source| tg::error!(!source, "failed to get cyclic processes"))?
+					.map_err(|source| tg::error!(!source, "failed to get process cycles"))?
 			},
 			#[cfg(feature = "sqlite")]
 			database::Transaction::Sqlite(transaction) => {
-				Self::get_cyclic_processes_sqlite(transaction, messages)
+				Self::get_process_cycles_sqlite(transaction, messages)
 					.await
-					.map_err(|source| tg::error!(!source, "failed to update parent depths"))?
+					.map_err(|source| tg::error!(!source, "failed to get process cycles"))?
 			},
 		};
 
@@ -283,176 +288,5 @@ impl Server {
 			.map_err(|source| tg::error!(!source, "failed to finish processes"))?;
 
 		Ok(())
-	}
-
-	#[cfg(feature = "postgres")]
-	async fn get_cyclic_processes_postgres(
-		transaction: &db::postgres::Transaction<'_>,
-		messages: &[crate::process::queue::Message],
-	) -> tg::Result<Vec<(tg::process::Id, tg::error::Data)>> {
-		// Build the parameter arrays dynamically.
-		let mut parent_placeholders = Vec::new();
-		let mut child_placeholders = Vec::new();
-		let mut params = Vec::new();
-		let mut idx = 1;
-		for message in messages {
-			let Some(parent) = &message.parent else {
-				continue;
-			};
-			parent_placeholders.push(format!("${idx}"));
-			idx += 1;
-			child_placeholders.push(format!("${idx}"));
-			idx += 1;
-			params.push(db::Value::Text(parent.to_string()));
-			params.push(db::Value::Text(message.process.to_string()));
-		}
-		if parent_placeholders.is_empty() {
-			return Ok(Vec::new());
-		}
-
-		// Call the stored function with a single query.
-		#[derive(db::row::Deserialize)]
-		struct Row {
-			process_id: String,
-			cycle_path: Option<String>,
-		}
-		let statement = format!(
-			"select * from get_cyclic_processes(array[{}]::text[], array[{}]::text[]);",
-			parent_placeholders.join(", "),
-			child_placeholders.join(", "),
-		);
-		let rows = transaction
-			.query_all_into::<Row>(statement.into(), params)
-			.await
-			.map_err(|source| tg::error!(!source, "failed to get cyclic processes"))?;
-
-		// Build the results with formatted error messages.
-		let mut results = Vec::new();
-		for row in rows {
-			let id: tg::process::Id = row
-				.process_id
-				.parse()
-				.map_err(|source| tg::error!(!source, "failed to parse the process id"))?;
-			let mut message = String::from("adding this child process creates a cycle");
-			if let Some(cycle) = row.cycle_path {
-				let processes = cycle.split(' ').collect::<Vec<_>>();
-				for i in 0..processes.len() - 1 {
-					let parent = processes[i];
-					let child = processes[i + 1];
-					if i == 0 {
-						write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
-					} else {
-						write!(&mut message, "\n{parent} has child {child}").unwrap();
-					}
-				}
-			}
-			let error = tg::error::Data {
-				code: None,
-				diagnostics: None,
-				location: None,
-				message: Some(message),
-				source: None,
-				stack: None,
-				values: BTreeMap::new(),
-			};
-			results.push((id, error));
-		}
-		Ok(results)
-	}
-
-	#[cfg(feature = "sqlite")]
-	async fn get_cyclic_processes_sqlite(
-		transaction: &db::sqlite::Transaction<'_>,
-		messages: &[crate::process::queue::Message],
-	) -> tg::Result<Vec<(tg::process::Id, tg::error::Data)>> {
-		let mut results = Vec::new();
-		let p = transaction.p();
-
-		for message in messages {
-			let Some(parent) = &message.parent else {
-				continue;
-			};
-			let child = &message.process;
-			let params = db::params![parent.to_string(), child.to_string()];
-			let statement = formatdoc!(
-				"
-					with recursive ancestors as (
-						select {p}1 as id
-						union all
-						select process_children.process as id
-						from ancestors
-						join process_children on ancestors.id = process_children.child
-					)
-					select exists(
-						select 1 from ancestors where id = {p}2
-					);
-				"
-			);
-			let cycle = transaction
-				.query_one_value_into::<bool>(statement.into(), params)
-				.await
-				.map_err(|source| tg::error!(!source, "failed to execute the cycle check"))?;
-
-			if !cycle {
-				continue;
-			}
-
-			// Construct a good error message by collecting the entire cycle.
-			let mut message = String::from("adding this child process creates a cycle");
-
-			// Try to reconstruct the cycle path by walking from the child through its
-			// descendants until we find a path back to the parent.
-			let statement = formatdoc!(
-				"
-					with recursive reachable (current_process, path) as (
-						select {p}2, {p}2
-
-						union
-
-						select pc.child, r.path || ' ' || pc.child
-						from reachable r
-						join process_children pc on r.current_process = pc.process
-						where r.path not like '%' || pc.child || '%'
-					)
-					select
-						{p}1 || ' ' || path as cycle
-					from reachable
-					where current_process = {p}1
-					limit 1;
-				"
-			);
-			let params = db::params![parent.to_string(), child.to_string()];
-			let cycle = transaction
-				.query_one_value_into::<String>(statement.into(), params)
-				.await
-				.inspect_err(|error| tracing::error!(?error, "failed to get the cycle"))
-				.ok();
-
-			// Format the error message.
-			if let Some(cycle) = cycle {
-				let processes = cycle.split(' ').collect::<Vec<_>>();
-				for i in 0..processes.len() - 1 {
-					let parent = processes[i];
-					let child = processes[i + 1];
-					if i == 0 {
-						write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
-					} else {
-						write!(&mut message, "\n{parent} has child {child}").unwrap();
-					}
-				}
-			}
-			let error = tg::error::Data {
-				code: None,
-				diagnostics: None,
-				location: None,
-				message: Some(message),
-				source: None,
-				stack: None,
-				values: BTreeMap::new(),
-			};
-			results.push((child.clone(), error));
-		}
-
-		Ok(results)
 	}
 }

--- a/packages/server/src/watchdog/postgres.rs
+++ b/packages/server/src/watchdog/postgres.rs
@@ -1,0 +1,82 @@
+use {
+	crate::Server,
+	std::{collections::BTreeMap, fmt::Write},
+	tangram_client::prelude::*,
+	tangram_database::{self as db, prelude::*},
+};
+
+impl Server {
+	pub(super) async fn get_process_cycles_postgres(
+		transaction: &db::postgres::Transaction<'_>,
+		messages: &[crate::process::queue::Message],
+	) -> tg::Result<Vec<(tg::process::Id, tg::error::Data)>> {
+		// Build the parameter arrays dynamically.
+		let mut parent_placeholders = Vec::new();
+		let mut child_placeholders = Vec::new();
+		let mut params = Vec::new();
+		let mut index = 1;
+		for message in messages {
+			let Some(parent) = &message.parent else {
+				continue;
+			};
+			parent_placeholders.push(format!("${index}"));
+			index += 1;
+			child_placeholders.push(format!("${index}"));
+			index += 1;
+			params.push(db::Value::Text(parent.to_string()));
+			params.push(db::Value::Text(message.process.to_string()));
+		}
+		if parent_placeholders.is_empty() {
+			return Ok(Vec::new());
+		}
+
+		// Call the stored function with a single query.
+		#[derive(db::row::Deserialize)]
+		struct Row {
+			process_id: String,
+			cycle_path: Option<String>,
+		}
+		let statement = format!(
+			"select * from get_process_cycles(array[{}]::text[], array[{}]::text[]);",
+			parent_placeholders.join(", "),
+			child_placeholders.join(", "),
+		);
+		let rows = transaction
+			.query_all_into::<Row>(statement.into(), params)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to get process cycles"))?;
+
+		// Build the results with formatted error messages.
+		let mut results = Vec::new();
+		for row in rows {
+			let id: tg::process::Id = row
+				.process_id
+				.parse()
+				.map_err(|source| tg::error!(!source, "failed to parse the process id"))?;
+			let mut message = String::from("adding this child process creates a cycle");
+			if let Some(cycle) = row.cycle_path {
+				let processes = cycle.split(' ').collect::<Vec<_>>();
+				for i in 0..processes.len() - 1 {
+					let parent = processes[i];
+					let child = processes[i + 1];
+					if i == 0 {
+						write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
+					} else {
+						write!(&mut message, "\n{parent} has child {child}").unwrap();
+					}
+				}
+			}
+			let error = tg::error::Data {
+				code: None,
+				diagnostics: None,
+				location: None,
+				message: Some(message),
+				source: None,
+				stack: None,
+				values: BTreeMap::new(),
+			};
+			results.push((id, error));
+		}
+		Ok(results)
+	}
+}

--- a/packages/server/src/watchdog/sqlite.rs
+++ b/packages/server/src/watchdog/sqlite.rs
@@ -1,0 +1,104 @@
+use {
+	crate::Server,
+	indoc::formatdoc,
+	std::{collections::BTreeMap, fmt::Write},
+	tangram_client::prelude::*,
+	tangram_database::{self as db, prelude::*},
+};
+
+impl Server {
+	pub(super) async fn get_process_cycles_sqlite(
+		transaction: &db::sqlite::Transaction<'_>,
+		messages: &[crate::process::queue::Message],
+	) -> tg::Result<Vec<(tg::process::Id, tg::error::Data)>> {
+		let mut results = Vec::new();
+		let p = transaction.p();
+
+		for message in messages {
+			let Some(parent) = &message.parent else {
+				continue;
+			};
+			let child = &message.process;
+			let params = db::params![parent.to_string(), child.to_string()];
+			let statement = formatdoc!(
+				"
+					with recursive ancestors as (
+						select {p}1 as id
+						union
+						select process_children.process as id
+						from ancestors
+						join process_children on ancestors.id = process_children.child
+					)
+					select exists(
+						select 1 from ancestors where id = {p}2
+					);
+				"
+			);
+			let cycle = transaction
+				.query_one_value_into::<bool>(statement.into(), params)
+				.await
+				.map_err(|source| tg::error!(!source, "failed to execute the cycle check"))?;
+
+			if !cycle {
+				continue;
+			}
+
+			// Construct a good error message by collecting the entire cycle.
+			let mut message = String::from("adding this child process creates a cycle");
+
+			// Try to reconstruct the cycle path by walking from the child through its
+			// descendants until we find a path back to the parent.
+			let statement = formatdoc!(
+				"
+					with recursive reachable (current_process, path) as (
+						select {p}2, {p}2
+
+						union
+
+						select pc.child, r.path || ' ' || pc.child
+						from reachable r
+						join process_children pc on r.current_process = pc.process
+						where r.path not like '%' || pc.child || '%'
+					)
+					select
+						{p}1 || ' ' || path as cycle
+					from reachable
+					where current_process = {p}1
+					limit 1;
+				"
+			);
+			let params = db::params![parent.to_string(), child.to_string()];
+			let cycle = transaction
+				.query_one_value_into::<String>(statement.into(), params)
+				.await
+				.inspect_err(|error| tracing::error!(?error, "failed to get the cycle"))
+				.ok();
+
+			// Format the error message.
+			if let Some(cycle) = cycle {
+				let processes = cycle.split(' ').collect::<Vec<_>>();
+				for i in 0..processes.len() - 1 {
+					let parent = processes[i];
+					let child = processes[i + 1];
+					if i == 0 {
+						write!(&mut message, "\n{parent} tried to add child {child}").unwrap();
+					} else {
+						write!(&mut message, "\n{parent} has child {child}").unwrap();
+					}
+				}
+			}
+			let error = tg::error::Data {
+				code: None,
+				diagnostics: None,
+				location: None,
+				message: Some(message),
+				source: None,
+				stack: None,
+				values: BTreeMap::new(),
+			};
+			results.push((child.clone(), error));
+		}
+
+		Ok(results)
+	}
+}

--- a/scripts/cloud/init.nu
+++ b/scripts/cloud/init.nu
@@ -6,6 +6,7 @@ nats consumer create finalize finalize --deliver all --max-pending 1000000 --pul
 
 nats stream create queue --discard new --retention work --subjects  queue --defaults
 nats consumer create queue queue --deliver all --max-pending 1000000 --pull --defaults
+nats consumer create queue cycle_detector --deliver all --max-pending 1000000 --pull --defaults
 
 cqlsh -e r#'create keyspace store with replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1 };'#
 cqlsh -k store -f packages/store/src/scylla.cql

--- a/scripts/cloud/init.nu
+++ b/scripts/cloud/init.nu
@@ -6,7 +6,7 @@ nats consumer create finalize finalize --deliver all --max-pending 1000000 --pul
 
 nats stream create queue --discard new --retention work --subjects  queue --defaults
 nats consumer create queue queue --deliver all --max-pending 1000000 --pull --defaults
-nats consumer create queue cycle_detector --deliver all --max-pending 1000000 --pull --defaults
+nats consumer create queue watchdog --deliver all --max-pending 1000000 --pull --defaults
 
 cqlsh -e r#'create keyspace store with replication = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 1 };'#
 cqlsh -k store -f packages/store/src/scylla.cql


### PR DESCRIPTION
- move cycle detection to the watchdog
- (fix) allow update_parent_depth to handle cycles in the process graph

Resolves #770