### PR TITLE
fix(js): prevent errors from generated modules

### DIFF
--- a/packages/cli/tests/check/import_with_type_directory.nu
+++ b/packages/cli/tests/check/import_with_type_directory.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		import file from "." with { type: "directory" };
+	'
+}
+
+tg check $path

--- a/packages/js/src/tangram.d.ts
+++ b/packages/js/src/tangram.d.ts
@@ -2,15 +2,10 @@
 
 // oxlint-disable no-unused-private-class-members
 
-declare interface ImportAttributes {
-	path?: string;
-}
-
 declare interface ImportMeta {
 	module: tg.Module;
 }
 
-// @ts-expect-error
 declare let console: {
 	/** Write to stdout. */
 	log: (...args: Array<unknown>) => void;

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -15,5 +15,4 @@
 		"types": [],
 		"verbatimModuleSyntax": true,
 	},
-	"exclude": ["./src/tangram.d.ts"],
 }

--- a/packages/server/src/module/load.rs
+++ b/packages/server/src/module/load.rs
@@ -1,5 +1,6 @@
 use {
 	crate::{Server, context::Context},
+	indoc::formatdoc,
 	tangram_client::prelude::*,
 	tangram_http::{body::Boxed as BoxBody, request::Ext as _},
 };
@@ -100,16 +101,29 @@ impl Server {
 				let text = match item {
 					tg::module::data::Item::Edge(edge) => match edge {
 						tg::graph::data::Edge::Pointer(pointer) => {
-							format!(
-								r#"export default tg.{class}.withPointer(tg.Graph.Pointer.fromDataString("{pointer}"));"#
+							formatdoc!(
+								r#"
+									// @ts-nocheck
+									export default tg.{class}.withPointer(tg.Graph.Pointer.fromDataString("{pointer}")) as tg.{class};
+								"#
 							)
 						},
 						tg::graph::data::Edge::Object(object) => {
-							format!(r#"export default tg.{class}.withId("{object}");"#)
+							formatdoc!(
+								r#"
+									// @ts-nocheck
+									export default tg.{class}.withId("{object}") as tg.{class};
+								"#
+							)
 						},
 					},
 					tg::module::data::Item::Path(_) => {
-						r"export default undefined as unknown as tg.{class};".to_owned()
+						formatdoc!(
+							r"
+								// @ts-nocheck
+								export default undefined as tg.{class};
+							"
+						)
 					},
 				};
 				Ok(tg::module::load::Output { text })


### PR DESCRIPTION
Without these declarations, present in the implementation but not the `d.ts`, running `tg check .` in the tangram repo produced the following diagnostics:
```
error Property 'withPointer' does not exist on type 'typeof Directory'.
error Property 'fromDataString' does not exist on type 'typeof Pointer'.
error an error occurred
-> type checking failed
   internal:packages/cli/src/check.rs:60:15
```
Adding them allows this command to return a clean typecheck.