### PR TITLE
feat(build): allow tsgo and esbuild to respect NODE_PATH if set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6596,6 +6596,7 @@ dependencies = [
  "bytes",
  "data-encoding",
  "futures",
+ "indoc",
  "num",
  "rquickjs",
  "scopeguard",

--- a/packages/compiler/Cargo.toml
+++ b/packages/compiler/Cargo.toml
@@ -19,6 +19,7 @@ typescript = ["dep:tangram_v8", "dep:v8"]
 [build-dependencies]
 data-encoding = { workspace = true }
 glob = { workspace = true }
+indoc = { workspace = true }
 scopeguard = { workspace = true }
 serde_json = { workspace = true }
 v8 = { workspace = true, optional = true }

--- a/packages/js/Cargo.toml
+++ b/packages/js/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 
 [build-dependencies]
 data-encoding = { workspace = true }
+indoc = { workspace = true }
 rquickjs = { workspace = true, optional = true }
 scopeguard = { workspace = true }
 serde_json = { workspace = true }

--- a/tangram.ts
+++ b/tangram.ts
@@ -58,11 +58,11 @@ export const build = async (...args: std.Args<Arg>) => {
 		});
 	}
 
-	// Merge the pre-built node_modules into the source.
+	// Build node_modules and set NODE_PATH for esbuild and build scripts.
 	const nodeModulesArtifact = nodeModules(build);
-	const sourceWithNodeModules = tg.directory(source_, nodeModulesArtifact);
 	envs.push({
 		NODE_PATH: tg`${nodeModulesArtifact}/node_modules`,
+		PATH: tg.Mutation.suffix(tg`${nodeModulesArtifact}/node_modules/.bin`, ":"),
 	});
 
 	// Configure features.
@@ -108,7 +108,7 @@ export const build = async (...args: std.Args<Arg>) => {
 		pre,
 		proxy,
 		sdk,
-		source: sourceWithNodeModules,
+		source: source_,
 		useCargoVendor: true,
 	});
 


### PR DESCRIPTION
In the case where `NODE_PATH` is set, extend the tsconfig.json files and esbuild command env to use that location instead of requiring an in-source `node_modules` folder. If this variable is not present, the current logic is unmodified.

Additionally, update the `tangram.ts` to not merge the `node_modules` directory with the Tangram source.