### PR TITLE
fix(server): correctly produce artifact/path symlinks from output checkin

### DIFF
--- a/packages/cli/tests/build/sandbox_symlink_artifact_reference.nu
+++ b/packages/cli/tests/build/sandbox_symlink_artifact_reference.nu
@@ -1,0 +1,20 @@
+use ../../test.nu *
+
+let server = spawn --busybox
+
+let path = artifact {
+	tangram.ts: '
+		import busybox from "busybox";
+		export default async () => {
+			const file = tg.file("hello from artifact");
+			return await tg.build`mkdir ${tg.output} && ln -s ${file} ${tg.output}/link`.env(tg.build(busybox));
+		};
+	'
+}
+
+let id = tg build $path
+let object = tg object get --blobs --depth=inf --pretty $id
+snapshot --name object $object
+
+tg cache $id
+snapshot --name cache --path ($server.directory | path join "artifacts" | path join ($id | str trim))

--- a/packages/cli/tests/build/sandbox_symlink_artifact_reference/cache.snapshot
+++ b/packages/cli/tests/build/sandbox_symlink_artifact_reference/cache.snapshot
@@ -1,0 +1,9 @@
+{
+  "kind": "directory",
+  "entries": {
+    "link": {
+      "kind": "symlink",
+      "path": "../fil_016v4jk5zqc9neeshx69mak5wf1nez6js2qadw87g90846w8fzjk20"
+    }
+  }
+}

--- a/packages/cli/tests/build/sandbox_symlink_artifact_reference/object.snapshot
+++ b/packages/cli/tests/build/sandbox_symlink_artifact_reference/object.snapshot
@@ -1,0 +1,7 @@
+tg.directory({
+  "link": tg.symlink({
+    "artifact": tg.file({
+      "contents": tg.blob("hello from artifact"),
+    }),
+  }),
+})

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -257,13 +257,15 @@ impl Server {
 			return Err(tg::error!("ignore is forbidden for destructive checkins"));
 		}
 
-		// Try to find the artifacts path.
+		// Try to find the artifacts path. Fall back to the server's artifacts directory for sandboxed processes.
 		let artifacts_path = root.join(".tangram/artifacts");
 		let artifacts_path = if tokio::fs::try_exists(&artifacts_path)
 			.await
 			.is_ok_and(|exists| exists)
 		{
 			Some(artifacts_path)
+		} else if process.is_some() {
+			Some(self.artifacts_path())
 		} else {
 			None
 		};

--- a/packages/server/src/context.rs
+++ b/packages/server/src/context.rs
@@ -17,6 +17,7 @@ pub struct Process {
 
 #[derive(Clone, Debug)]
 pub struct Paths {
+	pub server_guest: PathBuf,
 	pub server_host: PathBuf,
 	pub output_guest: PathBuf,
 	pub output_host: PathBuf,
@@ -30,6 +31,8 @@ impl Process {
 		};
 		if let Ok(path) = path.strip_prefix(&path_map.output_guest) {
 			path_map.output_host.join(path)
+		} else if let Ok(path) = path.strip_prefix(&path_map.server_guest) {
+			path_map.server_host.join(path)
 		} else {
 			path_map
 				.root_host
@@ -46,7 +49,7 @@ impl Process {
 			paths.output_guest.join(suffix)
 		} else if path.starts_with(&paths.server_host) {
 			let suffix = path.strip_prefix(&paths.server_host).unwrap();
-			PathBuf::from("/.tangram").join(suffix)
+			paths.server_guest.join(suffix)
 		} else {
 			let suffix = path.strip_prefix(&paths.root_host).map_err(|error| {
 				tg::error!(source = error, "cannot map path outside of host root")

--- a/packages/server/src/handle.rs
+++ b/packages/server/src/handle.rs
@@ -253,7 +253,6 @@ impl tg::Handle for Server {
 }
 
 #[derive(Clone)]
-#[cfg_attr(not(feature = "js"), expect(dead_code))]
 pub struct ServerWithContext(pub Server, pub Context);
 
 impl tg::Handle for ServerWithContext {


### PR DESCRIPTION
Currently, symlinks in output directories which point to the absolute path of the sandbox artifact directory were failing to produce artifact/path symlinks, instead retaining only the path, causing broken symlinks. This change uses the path remapping from the proxy and rewrites symlinks during destructive checkin such that they produce correct objects and cache entries.