### PR TITLE
feat: add 'cached' field to process spawn output and process children

### DIFF
--- a/packages/cli/src/build.rs
+++ b/packages/cli/src/build.rs
@@ -119,7 +119,13 @@ impl Cli {
 			// Spawn the view task.
 			let view_task = {
 				let handle = handle.clone();
-				let root = process.clone().map(crate::viewer::Item::Process);
+				let root = process.clone().map(|process| {
+					let process = crate::viewer::Process {
+						cached: output.cached,
+						process,
+					};
+					crate::viewer::Item::Process(process)
+				});
 				let task = Task::spawn_blocking(move |stop| -> tg::Result<()> {
 					let local_set = tokio::task::LocalSet::new();
 					let runtime = tokio::runtime::Builder::new_current_thread()

--- a/packages/cli/src/run.rs
+++ b/packages/cli/src/run.rs
@@ -111,7 +111,12 @@ impl Cli {
 				// Spawn the view task.
 				let view_task = {
 					let handle = handle.clone();
-					let root = process.clone().map(crate::viewer::Item::Process);
+					let root = process.clone().map(|process| {
+						crate::viewer::Item::Process(crate::viewer::Process {
+							cached: output.cached,
+							process,
+						})
+					});
 					let task = Task::spawn_blocking(move |stop| -> tg::Result<()> {
 						let local_set = tokio::task::LocalSet::new();
 						let runtime = tokio::runtime::Builder::new_current_thread()

--- a/packages/cli/src/shell/common.rs
+++ b/packages/cli/src/shell/common.rs
@@ -311,7 +311,13 @@ impl Cli {
 		} else {
 			let view_task = {
 				let handle = handle.clone();
-				let root = process.clone().map(crate::viewer::Item::Process);
+				let root = process.clone().map(|process| {
+					let process = crate::viewer::Process {
+						cached: output.cached,
+						process,
+					};
+					crate::viewer::Item::Process(process)
+				});
 				let task = Task::spawn_blocking(move |stop| -> tg::Result<()> {
 					let local_set = tokio::task::LocalSet::new();
 					let runtime = tokio::runtime::Builder::new_current_thread()

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -86,7 +86,10 @@ impl Cli {
 						return Err(tg::error!(reference = %args.reference, "expected an object"));
 					},
 					(tg::Either::Right(process), Kind::Value) => {
-						crate::viewer::Item::Process(process.clone())
+						crate::viewer::Item::Process(crate::viewer::Process {
+							cached: false,
+							process: process.clone(),
+						})
 					},
 					(_, Kind::Tag) => unreachable!(),
 				};

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -44,13 +44,19 @@ pub type UpdateReceiver<H> = std::sync::mpsc::Receiver<Box<dyn FnOnce(&mut Viewe
 #[derive(Clone, Debug, derive_more::TryUnwrap)]
 pub enum Item {
 	Package(Package),
-	Process(tg::Process),
+	Process(Process),
 	Tag(tg::tag::Pattern),
 	Value(tg::Value),
 }
 
 #[derive(Clone, Debug)]
 pub struct Package(pub tg::Object);
+
+#[derive(Clone, Debug)]
+pub struct Process {
+	pub cached: bool,
+	pub process: tg::Process,
+}
 
 #[derive(Clone, Debug)]
 pub struct Options {

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -117,6 +117,7 @@ impl Drop for UpdateGuard {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Indicator {
+	Cached,
 	Created,
 	Enqueued,
 	Dequeued,
@@ -127,9 +128,9 @@ pub enum Indicator {
 	Error,
 }
 
-type NodeUpdateSender = std::sync::mpsc::Sender<Box<dyn FnOnce(Rc<RefCell<Node>>)>>;
+type NodeUpdateSender = std::sync::mpsc::Sender<Box<dyn FnOnce(Rc<RefCell<Node>>) + Send>>;
 
-type NodeUpdateReceiver = std::sync::mpsc::Receiver<Box<dyn FnOnce(Rc<RefCell<Node>>)>>;
+type NodeUpdateReceiver = std::sync::mpsc::Receiver<Box<dyn FnOnce(Rc<RefCell<Node>>) + Send>>;
 
 #[derive(Debug)]
 pub struct Display {
@@ -212,7 +213,7 @@ where
 				.insert(NodeID::Package(package.0.id())),
 			Some(Item::Process(process)) if options.expand_processes => expanded_nodes
 				.borrow_mut()
-				.insert(NodeID::Process(process.id().clone())),
+				.insert(NodeID::Process(process.process.id().clone())),
 			Some(Item::Tag(pattern)) if options.expand_tags => expanded_nodes
 				.borrow_mut()
 				.insert(NodeID::Tag(pattern.to_string())),
@@ -322,6 +323,7 @@ where
 			let mut title = String::new();
 			let indicator = match node.borrow().indicator {
 				None => None,
+				Some(Indicator::Cached) => Some(crossterm::style::Stylize::white('🎯')),
 				Some(Indicator::Created) => Some(crossterm::style::Stylize::blue('⟳')),
 				Some(Indicator::Enqueued) => Some(crossterm::style::Stylize::yellow('⟳')),
 				Some(Indicator::Dequeued) => Some(crossterm::style::Stylize::yellow('•')),
@@ -1397,13 +1399,13 @@ where
 					Some(tg::Either::Left(object)) => {
 						Item::Value(tg::Value::Object(tg::Object::with_id(object)))
 					},
-					Some(tg::Either::Right(process)) => Item::Process(tg::Process::new(
-						process,
-						None,
-						output.remote.clone(),
-						None,
-						None,
-					)),
+					Some(tg::Either::Right(process)) => {
+						let process = crate::viewer::Process {
+							cached: false,
+							process: tg::Process::new(process, None, None, None, None),
+						};
+						Item::Process(process)
+					},
 					None => Item::Tag(tg::tag::Pattern::new(output.tag.to_string())),
 				};
 				if let Item::Tag(_) = item {
@@ -1430,10 +1432,10 @@ where
 	async fn expand_process(
 		handle: &H,
 		counter: UpdateCounter,
-		referent: tg::Referent<tg::Process>,
+		referent: tg::Referent<crate::viewer::Process>,
 		update_sender: NodeUpdateSender,
 	) -> tg::Result<()> {
-		let process = referent.item.clone();
+		let process = referent.item.process.clone();
 
 		// Create the log task.
 		let log_task = Task::spawn_local({
@@ -1484,33 +1486,41 @@ where
 			})
 			.unwrap();
 
-		// Get the output.
-		let output = handle
-			.get_process(process.id())
-			.await?
-			.data
-			.output
-			.map(tg::Value::try_from)
-			.transpose()?;
-		if let Some(output) = output {
+		tokio::task::spawn({
 			let handle = handle.clone();
-			let update = move |node: Rc<RefCell<Node>>| {
-				let output = Self::create_node(
-					&handle,
-					&node,
-					Some("output".into()),
-					Some(tg::Referent::with_item(Item::Value(output))),
-				);
-				node.borrow_mut().children.push(output);
-			};
-			update_sender.send(Box::new(update)).unwrap();
-		}
+			let process = process.clone();
+			let update_sender = update_sender.clone();
+			async move {
+				let Ok(wait) = process
+					.wait(&handle, tg::process::wait::Arg::default())
+					.await
+				else {
+					return;
+				};
+				if let Some(output) = wait.output {
+					let handle = handle.clone();
+					let update = move |node: Rc<RefCell<Node>>| {
+						let output = Self::create_node(
+							&handle,
+							&node,
+							Some("output".into()),
+							Some(tg::Referent::with_item(Item::Value(output))),
+						);
+						node.borrow_mut().children.insert(0, output);
+					};
+					update_sender.send(Box::new(update)).unwrap();
+				}
+			}
+		});
 
 		// Create the children stream.
 		let mut children = process
 			.children(handle, tg::process::children::get::Arg::default())
 			.await?;
-		while let Some(mut child) = children.try_next().await? {
+		while let Some(child) = children.try_next().await? {
+			let cached = child.cached;
+			let mut child = tg::Referent::new(child.process, child.options);
+
 			// Inherit from the referent.
 			child.inherit(&referent);
 
@@ -1530,8 +1540,11 @@ where
 				if node.borrow().options.collapse_process_children && finished {
 					return;
 				}
-				let item = child.clone().map(Item::Process);
-				let child_node = Self::create_node(&handle, &node, None, Some(item));
+				let child = child
+					.clone()
+					.map(|process| crate::viewer::Process { cached, process });
+				let child_node =
+					Self::create_node(&handle, &node, None, Some(child.clone().map(Item::Process)));
 
 				// Create the update task.
 				let update_task = Task::spawn_local({
@@ -1908,7 +1921,7 @@ where
 				.insert(NodeID::Package(package.0.id())),
 			Item::Process(process) if options.expand_processes => expanded_nodes
 				.borrow_mut()
-				.insert(NodeID::Process(process.id().clone())),
+				.insert(NodeID::Process(process.process.id().clone())),
 			Item::Tag(pattern) if options.expand_tags => expanded_nodes
 				.borrow_mut()
 				.insert(NodeID::Tag(pattern.to_string())),
@@ -2070,14 +2083,17 @@ where
 		Ok(())
 	}
 
-	async fn process_title(handle: &H, process: &tg::Referent<tg::Process>) -> Option<String> {
+	async fn process_title(
+		handle: &H,
+		process: &tg::Referent<crate::viewer::Process>,
+	) -> Option<String> {
 		// Use the name if provided.
 		if let Some(name) = process.name() {
 			return Some(name.to_owned());
 		}
 
 		// Get the original commands' executable.
-		let command = process.item.command(handle).await.ok()?.clone();
+		let command = process.item.process.command(handle).await.ok()?.clone();
 		let executable = command.executable(handle).await.ok()?.clone();
 
 		// Handle paths.
@@ -2114,7 +2130,7 @@ where
 	async fn process_update_task(
 		handle: &H,
 		counter: UpdateCounter,
-		process: &tg::Referent<tg::Process>,
+		process: &tg::Referent<crate::viewer::Process>,
 		options: &Options,
 		update_sender: NodeUpdateSender,
 	) -> tg::Result<()>
@@ -2132,15 +2148,16 @@ where
 		}
 
 		// Create the status stream.
-		let mut status = process.item.status(handle).await?;
+		let mut status = process.item.process.status(handle).await?;
 		while let Some(status) = status.try_next().await? {
 			let guard = counter.guard();
-			let indicator = match status {
-				tg::process::Status::Created => Indicator::Created,
-				tg::process::Status::Enqueued => Indicator::Enqueued,
-				tg::process::Status::Dequeued => Indicator::Dequeued,
-				tg::process::Status::Started => Indicator::Started,
-				tg::process::Status::Finished => {
+			let indicator = match (process.item.cached, status) {
+				(true, _) => Indicator::Cached,
+				(false, tg::process::Status::Created) => Indicator::Created,
+				(false, tg::process::Status::Enqueued) => Indicator::Enqueued,
+				(false, tg::process::Status::Dequeued) => Indicator::Dequeued,
+				(false, tg::process::Status::Started) => Indicator::Started,
+				(false, tg::process::Status::Finished) => {
 					// Remove the child if necessary.
 					if options.collapse_process_children {
 						let update = move |node: Rc<RefCell<Node>>| {
@@ -2171,7 +2188,7 @@ where
 						return Ok(());
 					}
 
-					let state = process.item.load(handle).await?;
+					let state = process.item.process.load(handle).await?;
 					let failed =
 						state.error.is_some() || state.exit.as_ref().is_some_and(|code| *code != 0);
 					if failed {
@@ -2190,7 +2207,7 @@ where
 		// Check if the process was canceled.
 		let arg = tg::process::get::Arg::default();
 		if handle
-			.try_get_process(process.item.id(), arg)
+			.try_get_process(process.item.process.id(), arg)
 			.await?
 			.and_then(|output| output.data.error)
 			.is_some_and(|error| match error {
@@ -2271,6 +2288,7 @@ where
 
 			let indicator = match node.borrow().indicator {
 				None => None,
+				Some(Indicator::Cached) => Some("🎯".white()),
 				Some(Indicator::Created) => Some("⟳".blue()),
 				Some(Indicator::Enqueued) => Some("⟳".yellow()),
 				Some(Indicator::Dequeued) => Some("•".yellow()),
@@ -2353,7 +2371,7 @@ where
 					let handle = handle.clone();
 					let update = move |viewer: &mut super::Viewer<H>| {
 						if let Some(process) = process {
-							let log = Log::new(&handle, &process);
+							let log = Log::new(&handle, &process.process);
 							viewer.log.replace(log);
 						} else {
 							viewer.log.take();
@@ -2368,7 +2386,7 @@ where
 					async move {
 						match referent.item {
 							Item::Process(process) => handle
-								.get_process(process.id())
+								.get_process(process.process.id())
 								.and_then(async |output: tg::process::get::Output| {
 									#[derive(serde::Serialize)]
 									struct ProcessData {
@@ -2377,7 +2395,7 @@ where
 									}
 									let metadata = handle
 										.try_get_process_metadata(
-											process.id(),
+											process.process.id(),
 											tg::process::metadata::Arg::default(),
 										)
 										.await?;
@@ -2527,7 +2545,7 @@ where
 		let contents = match referent.item() {
 			Item::Package(package) => package.0.id().to_string(),
 			Item::Tag(tag) => tag.to_string(),
-			Item::Process(process) => process.id().to_string(),
+			Item::Process(process) => process.process.id().to_string(),
 			Item::Value(value) => {
 				if let tg::Value::Object(object) = value {
 					Self::object_id(object)

--- a/packages/cli/tests/build/errors.nu
+++ b/packages/cli/tests/build/errors.nu
@@ -25,7 +25,7 @@ let process = tg get $process_id | from json
 
 # Get error IDs from parent and child processes.
 let parent_error = $process.error
-let child_id = $process.children | first | get item
+let child_id = $process.children | first | get process
 let child = tg get $child_id | from json
 let child_error = $child.error
 

--- a/packages/cli/tests/get_process_children.nu
+++ b/packages/cli/tests/get_process_children.nu
@@ -1,0 +1,42 @@
+
+use ../test.nu *
+let server = spawn
+let path = artifact {
+	tangram.ts: r#'
+		export const foo = () => "foo";
+		export const bar = () => "bar";
+		export default async () => {
+			return [
+				await tg.build(foo).named("foo"),
+				await tg.build(bar).named("bar")
+			]
+		};
+	'#
+}
+let output = tg build $"($path)#foo" | complete
+success $output
+snapshot $output.stdout '
+	"foo"
+
+'
+
+let process = tg build -dv $path | from json
+let output = tg wait $process.process
+snapshot $output '{"exit":0,"output":["foo","bar"]}'
+
+let children = tg process children $process.process | from json
+
+let foo = $children | get 0 | update process 'PROCESS'
+snapshot $foo '
+	cached: true
+	options: name: foo
+	process: PROCESS
+
+'
+
+let bar = $children | get 1 | update process 'PROCESS'
+snapshot $bar '
+	options: name: bar
+	process: PROCESS
+
+'

--- a/packages/cli/tests/push/process.nu
+++ b/packages/cli/tests/push/process.nu
@@ -44,14 +44,14 @@ export def test [path: string, ...args] {
 	# Confirm children are present if --recursive.
 	if "--recursive" in $args {
 		for child in $children {
-			tg -u $remote.url get $child.item
+			tg -u $remote.url get $child.process
 		}
 	}
 
 	# Confirm children commands are present if --recursive and --commands.
 	if "--commands" in $args and "--recursive" in $args {
 		for child in $children {
-			let output = tg -u $remote.url get $child.item | from json
+			let output = tg -u $remote.url get $child.process | from json
 			tg -u $remote.url get $output.command --pretty
 		}
 	}
@@ -59,7 +59,7 @@ export def test [path: string, ...args] {
 	# Confirm children output is present if --recursive.
 	if "--recursive" in $args {
 		for child in $children {
-			let output = tg get $child.item | from json
+			let output = tg get $child.process | from json
 			if (($output.output | describe) | str starts-with 'record') {
 				if $output.output.kind == "object" {
 					tg -u $remote.url get $output.output.value --pretty

--- a/packages/cli/tests/push/process_intermediate_missing_remote_has_subtree.nu
+++ b/packages/cli/tests/push/process_intermediate_missing_remote_has_subtree.nu
@@ -51,7 +51,7 @@ def test [...args] {
 	let children_a = $process_a_data.children
 
 	# Get process B (first child of A).
-	let process_b_id = $children_a | get 0 | get item
+	let process_b_id = $children_a | get 0 | get process
 	let process_b_data = tg -u $source.url get $process_b_id | from json
 	let command_b_id = $process_b_data.command
 	let output_b_id = $process_b_data.output.value
@@ -59,7 +59,7 @@ def test [...args] {
 	let children_b = $process_b_data.children
 
 	# Get process C (first child of B).
-	let process_c_id = $children_b | get 0 | get item
+	let process_c_id = $children_b | get 0 | get process
 	let process_c_data = tg -u $source.url get $process_c_id | from json
 	let command_c_id = $process_c_data.command
 	let output_c_id = $process_c_data.output.value
@@ -67,7 +67,7 @@ def test [...args] {
 	let children_c = $process_c_data.children
 
 	# Get process D (first child of C).
-	let process_d_id = $children_c | get 0 | get item
+	let process_d_id = $children_c | get 0 | get process
 	let process_d_data = tg -u $source.url get $process_d_id | from json
 	let command_d_id = $process_d_data.command
 	let output_d_id = $process_d_data.output.value

--- a/packages/cli/tests/push/process_mixed_missing_many.nu
+++ b/packages/cli/tests/push/process_mixed_missing_many.nu
@@ -102,7 +102,7 @@ def test [...args] {
 	let child_count = $children | length
 	for i in 0..<$child_count {
 		let child = $children | get $i
-		let child_id = $child.item
+		let child_id = $child.process
 		let child_data = tg -u $source.url get $child_id | from json
 		let child_command_id = $child_data.command
 		let child_output_id = $child_data.output.value

--- a/packages/cli/tests/push/process_recursive_then_commands.nu
+++ b/packages/cli/tests/push/process_recursive_then_commands.nu
@@ -5,7 +5,7 @@ def collect_commands [process_id: string] {
 	let process = tg get $process_id | from json
 	mut commands = [$process.command]
 	for child in $process.children {
-		$commands = $commands | append (collect_commands $child.item)
+		$commands = $commands | append (collect_commands $child.process)
 	}
 	$commands
 }

--- a/packages/cli/tests/tree/double_build.nu
+++ b/packages/cli/tests/tree/double_build.nu
@@ -25,8 +25,8 @@ let output = tg view $id --mode inline --expand-processes --depth 2
 
 snapshot $output '
 	✓ fil_01g1t9dmfw9v9arvs2k8e3x6zt69gpx993gbw8tw5jgpzqzptxt8fg#default
-	├╴command: cmd_01vcrs5cx1wx85xj9yqa546kxq2h2w5td5p52dsscy745zgak3eycg
 	├╴output: 42
+	├╴command: cmd_01vcrs5cx1wx85xj9yqa546kxq2h2w5td5p52dsscy745zgak3eycg
 	├╴✓ ../b.tg.ts#default
 	└╴✓ fil_01sa3pyv7baf50x2ymmvy7p41zqnmmv8gp1fq5z3mq60ps8vcfxa30#default
 '

--- a/packages/client/src/process/children/get.rs
+++ b/packages/client/src/process/children/get.rs
@@ -36,7 +36,7 @@ pub enum Event {
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct Chunk {
 	pub position: u64,
-	pub data: Vec<tg::Referent<tg::process::Id>>,
+	pub data: Vec<tg::process::data::Child>,
 }
 
 impl tg::Process {
@@ -44,7 +44,7 @@ impl tg::Process {
 		&self,
 		handle: &H,
 		arg: tg::process::children::get::Arg,
-	) -> tg::Result<impl Stream<Item = tg::Result<tg::Referent<Self>>> + Send + 'static>
+	) -> tg::Result<impl Stream<Item = tg::Result<tg::process::state::Child>> + Send + 'static>
 	where
 		H: tg::Handle,
 	{
@@ -57,7 +57,9 @@ impl tg::Process {
 		&self,
 		handle: &H,
 		arg: tg::process::children::get::Arg,
-	) -> tg::Result<Option<impl Stream<Item = tg::Result<tg::Referent<Self>>> + Send + 'static>>
+	) -> tg::Result<
+		Option<impl Stream<Item = tg::Result<tg::process::state::Child>> + Send + 'static>,
+	>
 	where
 		H: tg::Handle,
 	{
@@ -71,9 +73,7 @@ impl tg::Process {
 							chunk
 								.data
 								.into_iter()
-								.map(|referent| {
-									referent.map(|id| tg::Process::new(id, None, None, None, None))
-								})
+								.map(tg::process::state::Child::from)
 								.map(Ok),
 						)
 					})

--- a/packages/client/src/process/data.rs
+++ b/packages/client/src/process/data.rs
@@ -24,7 +24,7 @@ pub struct Data {
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[tangram_serialize(id = 2, default, skip_serializing_if = "Option::is_none")]
-	pub children: Option<Vec<tg::Referent<tg::process::Id>>>,
+	pub children: Option<Vec<tg::process::data::Child>>,
 
 	#[tangram_serialize(id = 3)]
 	pub command: tg::command::Id,
@@ -101,6 +101,25 @@ pub struct Data {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[tangram_serialize(id = 21, default, skip_serializing_if = "Option::is_none")]
 	pub stdout: Option<tg::process::Stdio>,
+}
+
+#[derive(
+	Clone,
+	Debug,
+	serde::Deserialize,
+	serde::Serialize,
+	tangram_serialize::Deserialize,
+	tangram_serialize::Serialize,
+)]
+
+pub struct Child {
+	#[tangram_serialize(id = 1)]
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub cached: bool,
+	#[tangram_serialize(id = 2)]
+	pub process: tg::process::Id,
+	#[tangram_serialize(id = 3)]
+	pub options: tg::referent::Options,
 }
 
 #[derive(

--- a/packages/client/src/process/spawn.rs
+++ b/packages/client/src/process/spawn.rs
@@ -48,6 +48,9 @@ pub struct Arg {
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Output {
+	#[serde(default, skip_serializing_if = "is_false")]
+	pub cached: bool,
+
 	pub process: tg::process::Id,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]

--- a/packages/client/src/process/state.rs
+++ b/packages/client/src/process/state.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 pub struct State {
 	pub actual_checksum: Option<tg::Checksum>,
 	pub cacheable: bool,
-	pub children: Option<Vec<tg::Referent<tg::Process>>>,
+	pub children: Option<Vec<Child>>,
 	pub command: tg::Command,
 	pub created_at: i64,
 	pub dequeued_at: Option<i64>,
@@ -25,18 +25,22 @@ pub struct State {
 	pub stdout: Option<tg::process::Stdio>,
 }
 
+#[derive(Clone, Debug)]
+pub struct Child {
+	pub cached: bool,
+	pub process: tg::Process,
+	pub options: tg::referent::Options,
+}
+
 impl TryFrom<tg::process::Data> for tg::process::State {
 	type Error = tg::Error;
 
 	fn try_from(value: tg::process::Data) -> Result<Self, Self::Error> {
 		let actual_checksum = value.actual_checksum;
 		let cacheable = value.cacheable;
-		let children = value.children.map(|children| {
-			children
-				.into_iter()
-				.map(|referent| referent.map(|id| tg::Process::new(id, None, None, None, None)))
-				.collect()
-		});
+		let children = value
+			.children
+			.map(|children| children.into_iter().map(|child| child.into()).collect());
 		let command = tg::Command::with_id(value.command);
 		let created_at = value.created_at;
 		let dequeued_at = value.dequeued_at;
@@ -87,5 +91,15 @@ impl TryFrom<tg::process::Data> for tg::process::State {
 			stdin,
 			stdout,
 		})
+	}
+}
+
+impl From<tg::process::data::Child> for Child {
+	fn from(value: tg::process::data::Child) -> Self {
+		Self {
+			cached: value.cached,
+			process: tg::Process::new(value.process, None, None, None, None),
+			options: value.options,
+		}
 	}
 }

--- a/packages/clients/js/src/handle.ts
+++ b/packages/clients/js/src/handle.ts
@@ -40,6 +40,7 @@ export namespace Handle {
 	};
 
 	export type SpawnOutput = {
+		cached: boolean,
 		process: tg.Process.Id;
 		remote: string | undefined;
 		token: string | undefined;

--- a/packages/server/src/database/postgres.sql
+++ b/packages/server/src/database/postgres.sql
@@ -89,6 +89,7 @@ create index process_tokens_token_index on process_tokens (token);
 
 create table process_children (
 	process text not null,
+	cached int8 not null,
 	child text not null,
 	position int8 not null,
 	options text,

--- a/packages/server/src/database/sqlite.sql
+++ b/packages/server/src/database/sqlite.sql
@@ -49,6 +49,7 @@ create index process_tokens_token_index on process_tokens (token);
 
 create table process_children (
 	process text not null,
+	cached integer not null,
 	child text not null,
 	options text,
 	position integer not null,

--- a/packages/server/src/process/children/get.rs
+++ b/packages/server/src/process/children/get.rs
@@ -248,6 +248,7 @@ impl Server {
 		// Get the children.
 		#[derive(db::row::Deserialize)]
 		struct Row {
+			cached: bool,
 			#[tangram_database(as = "db::value::FromStr")]
 			child: tg::process::Id,
 			#[tangram_database(as = "db::value::Json<tg::referent::Options>")]
@@ -256,7 +257,7 @@ impl Server {
 		let p = connection.p();
 		let statement = formatdoc!(
 			"
-				select child, options
+				select cached, child, options
 				from process_children
 				where process = {p}1
 				order by position
@@ -270,8 +271,9 @@ impl Server {
 			.await
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?
 			.into_iter()
-			.map(|row| tg::Referent {
-				item: row.child,
+			.map(|row| tg::process::data::Child {
+				cached: row.cached,
+				process: row.child,
 				options: row.options,
 			})
 			.collect();

--- a/packages/server/src/process/finalize.rs
+++ b/packages/server/src/process/finalize.rs
@@ -183,7 +183,7 @@ impl Server {
 			.as_ref()
 			.ok_or_else(|| tg::error!("expected the children to be set"))?
 			.iter()
-			.map(|referent| referent.item.clone())
+			.map(|child| child.process.clone())
 			.collect();
 		let put_process_arg = tangram_index::PutProcessArg {
 			children,

--- a/packages/server/src/process/get/postgres.rs
+++ b/packages/server/src/process/get/postgres.rs
@@ -26,8 +26,8 @@ impl Server {
 			#[tangram_database(as = "Option<db::postgres::value::FromStr>")]
 			actual_checksum: Option<tg::Checksum>,
 			cacheable: Option<bool>,
-			#[tangram_database(as = "Option<Vec<db::postgres::value::FromStr>>")]
-			children: Option<Vec<tg::Referent<tg::process::Id>>>,
+			#[tangram_database(as = "Option<db::value::Json<Vec<tg::process::data::Child>>>")]
+			children: Option<Vec<tg::process::data::Child>>,
 			#[tangram_database(as = "Option<db::postgres::value::FromStr>")]
 			command: Option<tg::command::Id>,
 			created_at: Option<i64>,
@@ -64,7 +64,7 @@ impl Server {
 					processes.id,
 					actual_checksum,
 					cacheable,
-					(select coalesce(array_agg(child), '{}') from process_children where process = ids.id) as children,
+					(select coalesce(json_agg(json_build_object('cached', cached::bool, 'process', child, 'options', options::json) order by position), '[]'::json) from process_children where process = ids.id) as children,
 					command,
 					created_at,
 					dequeued_at,

--- a/packages/server/src/process/get/sqlite.rs
+++ b/packages/server/src/process/get/sqlite.rs
@@ -187,12 +187,13 @@ impl Server {
 		// Get the children.
 		#[derive(db::sqlite::row::Deserialize)]
 		struct ChildRow {
+			cached: bool,
 			child: String,
 			options: db::value::Json<tg::referent::Options>,
 		}
 		let statement = indoc!(
 			"
-				select child, options
+				select cached, child, options
 				from process_children
 				where process = ?1;
 			"
@@ -210,13 +211,17 @@ impl Server {
 		{
 			let child_row = <ChildRow as db::sqlite::row::Deserialize>::deserialize(child_row)
 				.map_err(|source| tg::error!(!source, "failed to deserialize the row"))?;
-			let item = child_row
+			let cached = child_row.cached;
+			let process = child_row
 				.child
 				.parse()
 				.map_err(|source| tg::error!(!source, %id, "failed to parse the child id"))?;
 			let options = child_row.options.0;
-			let referent = tg::Referent { item, options };
-			children.push(referent);
+			children.push(tg::process::data::Child {
+				cached,
+				process,
+				options,
+			});
 		}
 
 		let data = tg::process::Data {

--- a/packages/server/src/process/list/postgres.rs
+++ b/packages/server/src/process/list/postgres.rs
@@ -22,8 +22,8 @@ impl Server {
 			#[tangram_database(as = "Option<db::postgres::value::FromStr>")]
 			actual_checksum: Option<tg::Checksum>,
 			cacheable: bool,
-			#[tangram_database(as = "Vec<db::postgres::value::FromStr>")]
-			children: Vec<tg::Referent<tg::process::Id>>,
+			#[tangram_database(as = "Option<db::value::Json<Vec<tg::process::data::Child>>>")]
+			children: Option<Vec<tg::process::data::Child>>,
 			#[tangram_database(as = "db::postgres::value::FromStr")]
 			command: tg::command::Id,
 			created_at: i64,
@@ -60,7 +60,7 @@ impl Server {
 					processes.id,
 					actual_checksum,
 					cacheable,
-					(select coalesce(array_agg(child), '{}') from process_children where process = processes.id) as children,
+					(select coalesce(json_agg(json_build_object('cached', cached::bool, 'process', child, 'options', options::json) order by position), '[]'::json) from process_children where process = processes.id) as children,
 					command,
 					created_at,
 					dequeued_at,
@@ -115,7 +115,7 @@ impl Server {
 				let data = tg::process::Data {
 					actual_checksum: row.actual_checksum,
 					cacheable: row.cacheable,
-					children: Some(row.children),
+					children: row.children,
 					command: row.command,
 					created_at: row.created_at,
 					dequeued_at: row.dequeued_at,

--- a/packages/server/src/process/list/sqlite.rs
+++ b/packages/server/src/process/list/sqlite.rs
@@ -110,13 +110,14 @@ impl Server {
 			// Get the children for this process.
 			#[derive(db::sqlite::row::Deserialize)]
 			struct ChildRow {
+				cached: bool,
 				#[tangram_database(as = "db::sqlite::value::FromStr")]
 				child: tg::process::Id,
 				options: db::value::Json<tg::referent::Options>,
 			}
 			let statement = indoc!(
 				"
-					select child, options
+					select cached, child, options
 					from process_children
 					where process = ?1;
 				"
@@ -134,11 +135,12 @@ impl Server {
 			{
 				let child_row = <ChildRow as db::sqlite::row::Deserialize>::deserialize(child_row)
 					.map_err(|source| tg::error!(!source, "failed to deserialize the row"))?;
-				let referent = tg::Referent {
-					item: child_row.child,
+				let child = tg::process::data::Child {
+					cached: child_row.cached,
+					process: child_row.child,
 					options: child_row.options.0,
 				};
-				children.push(referent);
+				children.push(child);
 			}
 
 			let error = row

--- a/packages/server/src/process/put.rs
+++ b/packages/server/src/process/put.rs
@@ -64,7 +64,7 @@ impl Server {
 			.as_ref()
 			.ok_or_else(|| tg::error!("expected the children to be set"))?
 			.iter()
-			.map(|referent| referent.item.clone())
+			.map(|child| child.process.clone())
 			.collect();
 		let command = std::iter::once((
 			arg.data.command.clone().into(),

--- a/packages/server/src/process/put/postgres.rs
+++ b/packages/server/src/process/put/postgres.rs
@@ -231,6 +231,7 @@ impl Server {
 		// Collect all children from all processes.
 		let mut child_processes = Vec::new();
 		let mut child_positions = Vec::new();
+		let mut child_cached = Vec::new();
 		let mut child_ids = Vec::new();
 		let mut child_options = Vec::new();
 
@@ -239,8 +240,9 @@ impl Server {
 				for (position, child) in children.iter().enumerate() {
 					child_processes.push(id.to_string());
 					child_positions.push(position.to_i64().unwrap());
-					child_ids.push(child.item.to_string());
-					child_options.push(serde_json::to_string(child.options()).unwrap());
+					child_cached.push(child.cached);
+					child_ids.push(child.process.to_string());
+					child_options.push(serde_json::to_string(&child.options).unwrap());
 				}
 			}
 		}
@@ -249,8 +251,8 @@ impl Server {
 		if !child_processes.is_empty() {
 			let statement = indoc!(
 				"
-					insert into process_children (process, position, child, options)
-					select unnest($1::text[]), unnest($2::int8[]), unnest($3::text[]), unnest($4::text[])
+					insert into process_children (process, position, cached, child, options)
+					select unnest($1::text[]), unnest($2::int8[]), unnest($3::int8[]), unnest($4::text[]), unnest($5::text[])
 					on conflict (process, child) do nothing;
 				"
 			);
@@ -260,6 +262,7 @@ impl Server {
 					&[
 						&child_processes,
 						&child_positions,
+						&child_cached,
 						&child_ids,
 						&child_options,
 					],

--- a/packages/server/src/process/put/sqlite.rs
+++ b/packages/server/src/process/put/sqlite.rs
@@ -211,8 +211,8 @@ impl Server {
 				for (position, child) in children.iter().enumerate() {
 					let params = sqlite::params![
 						id.to_string(),
-						child.cached,
 						position.to_i64().unwrap(),
+						child.cached,
 						child.process.to_string(),
 						serde_json::to_string(&child.options).unwrap(),
 					];

--- a/packages/server/src/process/put/sqlite.rs
+++ b/packages/server/src/process/put/sqlite.rs
@@ -149,8 +149,8 @@ impl Server {
 		// Prepare the children insert statement.
 		let children_statement = indoc!(
 			"
-				insert into process_children (process, position, child, options)
-				values (?1, ?2, ?3, ?4)
+				insert into process_children (process, position, cached, child, options)
+				values (?1, ?2, ?3, ?4, ?5)
 				on conflict (process, child) do nothing;
 			"
 		);
@@ -211,9 +211,10 @@ impl Server {
 				for (position, child) in children.iter().enumerate() {
 					let params = sqlite::params![
 						id.to_string(),
+						child.cached,
 						position.to_i64().unwrap(),
-						child.item.to_string(),
-						serde_json::to_string(child.options()).unwrap(),
+						child.process.to_string(),
+						serde_json::to_string(&child.options).unwrap(),
 					];
 					children_stmt
 						.execute(params)

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -15,6 +15,7 @@ use {
 
 #[derive(derive_more::Debug)]
 struct LocalOutput {
+	cached: bool,
 	id: tg::process::Id,
 	#[debug(ignore)]
 	permit: Option<ProcessPermit>,
@@ -261,6 +262,7 @@ impl Server {
 				if let Some(wait) = result? {
 					let output = output.unwrap();
 					tg::process::spawn::Output {
+						cached: output.cached,
 						process: output.id,
 						remote: None,
 						token: output.token,
@@ -296,6 +298,7 @@ impl Server {
 						return Ok(None);
 					};
 					tg::process::spawn::Output {
+						cached: output.cached,
 						process: output.id,
 						remote: None,
 						token: output.token,
@@ -310,6 +313,7 @@ impl Server {
 		{
 			self.add_process_child(
 				parent,
+				output.cached,
 				&output.process,
 				&arg.command.options,
 				output.token.as_ref(),
@@ -463,6 +467,7 @@ impl Server {
 		};
 
 		Ok(Some(LocalOutput {
+			cached: true,
 			id,
 			permit: None,
 			status,
@@ -554,8 +559,8 @@ impl Server {
 		// Insert the process children.
 		let statement = formatdoc!(
 			"
-				insert into process_children (process, position, child, options)
-				select process, position, child, options from process_children where process = {p}1;
+				insert into process_children (process, position, cached, child, options)
+				select process, position, cached, child, options from process_children where process = {p}1;
 			"
 		);
 		let params = db::params![id.to_string()];
@@ -689,6 +694,7 @@ impl Server {
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
 		Ok(Some(LocalOutput {
+			cached: true,
 			id,
 			permit: None,
 			status,
@@ -862,6 +868,7 @@ impl Server {
 			.map_err(|source| tg::error!(!source, "failed to execute the statement"))?;
 
 		Ok(LocalOutput {
+			cached: false,
 			id,
 			permit,
 			status,
@@ -924,6 +931,7 @@ impl Server {
 	async fn add_process_child(
 		&self,
 		parent: &tg::process::Id,
+		cached: bool,
 		child: &tg::process::Id,
 		options: &tg::referent::Options,
 		token: Option<&String>,
@@ -942,11 +950,18 @@ impl Server {
 			.map_err(|source| tg::error!(!source, "failed to begin a transaction"))?;
 
 		// Add the process as a child.
-		self.add_process_child_with_transaction(&transaction, parent, child, options, token)
-			.await
-			.map_err(
-				|source| tg::error!(!source, %parent, %child, "failed to add the process as a child"),
-			)?;
+		self.add_process_child_with_transaction(
+			&transaction,
+			parent,
+			cached,
+			child,
+			options,
+			token,
+		)
+		.await
+		.map_err(
+			|source| tg::error!(!source, %parent, %child, "failed to add the process as a child"),
+		)?;
 
 		// Commit the transaction.
 		transaction
@@ -967,6 +982,7 @@ impl Server {
 		&self,
 		transaction: &database::Transaction<'_>,
 		parent: &tg::process::Id,
+		cached: bool,
 		child: &tg::process::Id,
 		options: &tg::referent::Options,
 		token: Option<&String>,
@@ -1042,13 +1058,14 @@ impl Server {
 		// Add the child to the database.
 		let statement = formatdoc!(
 			"
-				insert into process_children (process, position, child, options, token)
-				values ({p}1, (select coalesce(max(position) + 1, 0) from process_children where process = {p}1), {p}2, {p}3, {p}4)
+				insert into process_children (process, position, cached, child, options, token)
+				values ({p}1, (select coalesce(max(position) + 1, 0) from process_children where process = {p}1), {p}2, {p}3, {p}4, {p}5)
 				on conflict (process, child) do nothing;
 			"
 		);
 		let params = db::params![
 			parent.to_string(),
+			cached,
 			child.to_string(),
 			db::value::Json(options),
 			token

--- a/packages/server/src/sync/get/queue.rs
+++ b/packages/server/src/sync/get/queue.rs
@@ -345,10 +345,10 @@ impl Server {
 				|| (state.arg.outputs && !stored.is_some_and(|stored| stored.subtree_output)))
 			&& let Some(children) = &data.children
 		{
-			for referent in children {
+			for child in children {
 				state.queue.enqueue_process(ProcessItem {
 					parent: Some(id.clone()),
-					id: referent.item.clone(),
+					id: child.process.clone(),
 					eager: state.arg.eager,
 				});
 			}

--- a/packages/server/src/sync/graph.rs
+++ b/packages/server/src/sync/graph.rs
@@ -224,7 +224,7 @@ impl Graph {
 				children
 					.iter()
 					.map(|child| {
-						let child_entry = self.nodes.entry(child.item.clone().into());
+						let child_entry = self.nodes.entry(child.process.clone().into());
 						let child_index = child_entry.index();
 						let child_node =
 							child_entry.or_insert_with(|| Node::Process(ProcessNode::default()));

--- a/packages/server/src/sync/put/store.rs
+++ b/packages/server/src/sync/put/store.rs
@@ -204,7 +204,7 @@ impl Server {
 					.iter()
 					.map(|child| crate::sync::queue::ProcessItem {
 						parent: Some(item.id.clone()),
-						id: child.item.clone(),
+						id: child.process.clone(),
 						eager: item.eager,
 					});
 				state.queue.enqueue_processes(items);


### PR DESCRIPTION
- added a field to inform callers when process spawns are cache hits
- changed signature of process `children` APIs to return a `Child` struct
- added the `cached` field to postgres/sqlite databases and child put/get queries
- updated viewer to display when a process is cached