### PR TITLE
fix(builtin): skip PAX global header

### DIFF
--- a/packages/builtin/src/extract.rs
+++ b/packages/builtin/src/extract.rs
@@ -177,6 +177,9 @@ pub(crate) async fn extract_tar(
 	while let Some(entry) = entries.next().await {
 		let mut entry =
 			entry.map_err(|source| tg::error!(!source, "failed to read the archive entry"))?;
+		if entry.header().entry_type().is_pax_global_extensions() {
+			continue;
+		}
 		let path = entry
 			.path()
 			.map_err(|source| tg::error!(!source, "failed to read the archive entry path"))?;


### PR DESCRIPTION
The extract code was refactored to manually traverse entries instead of calling `unpack`. This code should be updated to skip the PAX global header if found, matching the previous behavior: https://github.com/astral-sh/tokio-tar/blob/1add8c834ad4dc46f0c0ac56845d23742f6a45c8/src/entry.rs#L744-L749

In practice, this caused issues with archives that had this header, which we extract and expect to contain a single entry. They would instead extract with this metadata materialized as a file in the directory.