### PR TITLE
fix(sandbox): use client mode in sandbox, add overlay root path map

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -390,6 +390,9 @@ fn main() -> std::process::ExitCode {
 			..
 		} => Mode::Client,
 
+		// When running inside a sandbox process, use client mode.
+		_ if std::env::var_os("TANGRAM_PROCESS").is_some() => Mode::Client,
+
 		_ => args.mode.unwrap_or_default(),
 	};
 
@@ -518,7 +521,8 @@ impl Cli {
 			Mode::Server => tg::Either::Right(self.server().boxed().await?),
 		};
 
-		if self.health.is_none() {
+		// Skip the health check when running inside a sandbox process.
+		if self.health.is_none() && std::env::var_os("TANGRAM_PROCESS").is_none() {
 			let arg = tg::health::Arg {
 				fields: Some(vec!["diagnostics".to_owned()]),
 			};
@@ -662,8 +666,13 @@ impl Cli {
 				max_retries: retry.max_retries,
 			});
 
+		// Get the process.
+		let process = std::env::var("TANGRAM_PROCESS")
+			.ok()
+			.and_then(|value| value.parse().ok());
+
 		// Create the client.
-		tg::Client::new(url, Some(version()), token, None, reconnect, retry)
+		tg::Client::new(url, Some(version()), token, process, reconnect, retry)
 	}
 
 	async fn server(&self) -> tg::Result<Server> {

--- a/packages/cli/tests/build/sandbox_checkin_overlay_root.nu
+++ b/packages/cli/tests/build/sandbox_checkin_overlay_root.nu
@@ -1,0 +1,21 @@
+use ../../test.nu *
+
+# Test that a sandboxed process can check in a file created on the overlay root.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			return tg.build`
+					echo "hello from overlay" > /overlay_test.txt
+					tangram checkin /overlay_test.txt > ${tg.output}
+				`;
+		}
+	',
+}
+
+let output = tg build $path
+let checkin_id = tg read $output | str trim
+let contents = tg read $checkin_id | str trim
+snapshot $contents 'hello from overlay'

--- a/packages/sandbox/src/root.rs
+++ b/packages/sandbox/src/root.rs
@@ -65,6 +65,12 @@ impl Sandbox {
 				(self.guest_output_path(), self.host_output_path()),
 				(self.guest_artifacts_path(), self.0.artifacts_path.clone()),
 			]);
+			if matches!(self.0.isolation, tg::sandbox::Isolation::Container) {
+				path_maps.push((
+					PathBuf::from("/"),
+					Self::host_upper_path_from_root(&self.0.path),
+				));
+			}
 			Self::map_path(
 				path,
 				path_maps
@@ -124,6 +130,12 @@ impl Sandbox {
 				(self.host_output_path(), self.guest_output_path()),
 				(self.0.artifacts_path.clone(), self.guest_artifacts_path()),
 			]);
+			if matches!(self.0.isolation, tg::sandbox::Isolation::Container) {
+				path_maps.push((
+					Self::host_upper_path_from_root(&self.0.path),
+					PathBuf::from("/"),
+				));
+			}
 			Self::map_path(
 				path,
 				path_maps


### PR DESCRIPTION
This PR adds a test asserting we can `tangram checkin` inside a sandbox, which fails without the changes implemented:

- Set client mode when TANGRAM_PROCESS is set, skip health check
- Add host_to_guest mapping branch for the overlay root.