### PR TITLE
fix(sandbox): cleanup tempdir on cache hit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6945,7 +6945,7 @@ dependencies = [
  "tangram_client",
  "tangram_futures",
  "tangram_uri",
- "tempfile",
+ "tangram_util",
  "tokio",
  "tokio-util",
 ]
@@ -7052,7 +7052,6 @@ dependencies = [
  "tangram_serialize",
  "tangram_uri",
  "tangram_util",
- "tempfile",
  "time",
  "tokio",
  "tokio-rustls",
@@ -7196,7 +7195,6 @@ dependencies = [
  "indoc",
  "pretty_assertions",
  "tangram_util",
- "tempfile",
  "tokio",
 ]
 
@@ -7243,8 +7241,8 @@ dependencies = [
  "tangram_client",
  "tangram_compiler",
  "tangram_futures",
+ "tangram_util",
  "tangram_v8",
- "tempfile",
  "tokio",
  "tokio-util",
  "toml",
@@ -7265,7 +7263,7 @@ dependencies = [
  "num",
  "tangram_client",
  "tangram_serialize",
- "tempfile",
+ "tangram_util",
  "tokio",
 ]
 
@@ -7301,7 +7299,7 @@ dependencies = [
  "serde_json",
  "tangram_client",
  "tangram_serialize",
- "tempfile",
+ "tangram_util",
  "tokio",
 ]
 
@@ -7330,7 +7328,6 @@ dependencies = [
  "tangram_http",
  "tangram_uri",
  "tangram_util",
- "tempfile",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7454,6 +7451,7 @@ version = "0.0.0"
 dependencies = [
  "bytes",
  "data-encoding",
+ "data-encoding-macro",
  "derive_more",
  "fnv",
  "futures",
@@ -7470,6 +7468,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
  "xattr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,6 @@ sha2 = "0.11"
 smallvec = "1"
 sourcemap = "9"
 syn = { version = "2", features = ["full"] }
-tempfile = "3"
 sync_wrapper = "1"
 tangram_builtin = { path = "packages/builtin" }
 tangram_client = { path = "packages/clients/rust" }

--- a/packages/builtin/Cargo.toml
+++ b/packages/builtin/Cargo.toml
@@ -27,7 +27,7 @@ num = { workspace = true }
 reqwest = { workspace = true }
 tangram_client = { workspace = true }
 tangram_futures = { workspace = true }
-tempfile = { workspace = true }
+tangram_util = { workspace = true }
 tangram_uri = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/packages/builtin/src/download.rs
+++ b/packages/builtin/src/download.rs
@@ -156,10 +156,12 @@ where
 	};
 
 	// Download.
-	let temp_path = temp_path.map_or_else(std::env::temp_dir, ToOwned::to_owned);
-	let mut temp = tempfile::TempDir::new_in(&temp_path)
+	let temp = temp_path
+		.map_or_else(tangram_util::fs::Temp::new, tangram_util::fs::Temp::new_in)
 		.map_err(|source| tg::error!(!source, "failed to create the temp directory"))?;
-	temp.disable_cleanup(true);
+	tokio::fs::create_dir(temp.path())
+		.await
+		.map_err(|source| tg::error!(!source, "failed to create the temp directory"))?;
 	let path = match mode {
 		Mode::Raw => {
 			let path = temp.path().join("file");
@@ -198,10 +200,10 @@ where
 		Mode::Extract(format, compression) => {
 			match format {
 				tg::ArchiveFormat::Tar => {
-					super::extract::extract_tar(&temp, &mut reader, compression).await?;
+					super::extract::extract_tar(temp.path(), &mut reader, compression).await?;
 				},
 				tg::ArchiveFormat::Zip => {
-					super::extract::extract_zip(&temp, &mut reader).await?;
+					super::extract::extract_zip(temp.path(), &mut reader).await?;
 				},
 			}
 			temp.path().to_owned()

--- a/packages/builtin/src/extract.rs
+++ b/packages/builtin/src/extract.rs
@@ -94,17 +94,20 @@ where
 	});
 
 	// Create a temp.
-	let temp_path = temp_path.map_or_else(std::env::temp_dir, ToOwned::to_owned);
-	let temp = tempfile::TempDir::new_in(&temp_path)
+	let temp = temp_path
+		.map_or_else(tangram_util::fs::Temp::new, tangram_util::fs::Temp::new_in)
+		.map_err(|source| tg::error!(!source, "failed to create the temp directory"))?;
+	tokio::fs::create_dir(temp.path())
+		.await
 		.map_err(|source| tg::error!(!source, "failed to create the temp directory"))?;
 
 	// Extract to the temp.
 	match format {
 		tg::ArchiveFormat::Tar => {
-			extract_tar(&temp, &mut reader, compression).await?;
+			extract_tar(temp.path(), &mut reader, compression).await?;
 		},
 		tg::ArchiveFormat::Zip => {
-			extract_zip(&temp, &mut reader).await?;
+			extract_zip(temp.path(), &mut reader).await?;
 		},
 	}
 
@@ -153,7 +156,7 @@ where
 }
 
 pub(crate) async fn extract_tar(
-	temp: &tempfile::TempDir,
+	temp: &Path,
 	reader: &mut (impl tokio::io::AsyncBufRead + Send + Unpin + 'static),
 	compression: Option<tg::CompressionFormat>,
 ) -> tg::Result<()> {
@@ -185,7 +188,7 @@ pub(crate) async fn extract_tar(
 		let path = entry
 			.path()
 			.map_err(|source| tg::error!(!source, "failed to read the archive entry path"))?;
-		let path = resolve_tar_entry_path(temp.path(), &path)?;
+		let path = resolve_tar_entry_path(temp, &path)?;
 		let kind = entry.header().entry_type();
 
 		if kind.is_dir() {
@@ -216,7 +219,7 @@ pub(crate) async fn extract_tar(
 				.link_name()
 				.map_err(|source| tg::error!(!source, "failed to read hard link target"))?
 				.ok_or_else(|| tg::error!("expected the entry to have a hard link target"))?;
-			let target = resolve_tar_entry_path(temp.path(), &target)?;
+			let target = resolve_tar_entry_path(temp, &target)?;
 			tokio::fs::hard_link(&target, &path)
 				.await
 				.map_err(|source| tg::error!(!source, "failed to create the hard link"))?;
@@ -266,7 +269,7 @@ fn resolve_tar_entry_path(root: &Path, path: &Path) -> tg::Result<PathBuf> {
 }
 
 pub(crate) async fn extract_zip(
-	temp: &tempfile::TempDir,
+	temp: &Path,
 	reader: &mut (impl tokio::io::AsyncBufRead + Send + Unpin + 'static),
 ) -> tg::Result<()> {
 	// Create the reader.
@@ -293,7 +296,7 @@ pub(crate) async fn extract_zip(
 			.filename()
 			.as_str()
 			.map_err(|source| tg::error!(!source, "failed to get the entry filename"))?;
-		let path = temp.path().join(filename);
+		let path = temp.join(filename);
 
 		// Check if the entry is a directory.
 		let is_dir = entry_reader

--- a/packages/cli/tests/run/unsandboxed_cleanup_output_cache_collision.nu
+++ b/packages/cli/tests/run/unsandboxed_cleanup_output_cache_collision.nu
@@ -1,0 +1,24 @@
+use ../../test.nu *
+
+# Two unsandboxed processes produce the same output artifact. The second run's
+# cache rename fails with AlreadyExists, leaving the tempdir source in place
+# with 0o555 permissions, causing tempdir cleanup to fail with EACCES.
+# The nested directory structure is required - flat output can be cleaned up.
+
+let server = spawn --busybox
+
+let path = artifact {
+	tangram.ts: '
+		import busybox from "busybox";
+		export let a = () =>
+			tg.run`mkdir -p ${tg.output}/sub && printf hello > ${tg.output}/sub/msg`
+				.env({ VARIANT: "a" }).env(tg.build(busybox));
+		export let b = () =>
+			tg.run`mkdir -p ${tg.output}/sub && printf hello > ${tg.output}/sub/msg`
+				.env({ VARIANT: "b" }).env(tg.build(busybox));
+	',
+}
+
+tg build ($path + '#a')
+let output = tg build ($path + '#b') | complete
+success $output

--- a/packages/clients/js/src/process.ts
+++ b/packages/clients/js/src/process.ts
@@ -382,8 +382,8 @@ export class Process<O extends tg.Value = tg.Value> {
 		}
 
 		let id = tg.handle.processId();
-		let tempDir = await tg.host.mkdtemp();
-		let outputPath = tg.path.join(tempDir, id);
+		let tempPath = await tg.host.mkdtemp();
+		let outputPath = tg.path.join(tempPath, id);
 		let artifacts = await checkoutArtifacts(command);
 		let env = await renderEnv(command.env, artifacts, outputPath);
 		let { args, executable } = renderCommand(command, artifacts, outputPath);
@@ -416,7 +416,7 @@ export class Process<O extends tg.Value = tg.Value> {
 				stdin,
 				stdout,
 			},
-			tempDir,
+			tempPath,
 			outputPath,
 		);
 		return new tg.Process<O>({
@@ -439,7 +439,7 @@ export class Process<O extends tg.Value = tg.Value> {
 			stdin: tg.Process.Stdio.Writer;
 			stdout: tg.Process.Stdio.Reader;
 		},
-		tempDir: string,
+		tempPath: string,
 		outputPath: string,
 	): Promise<tg.Process.Wait> {
 		let wait: tg.Process.Wait | undefined;
@@ -501,7 +501,7 @@ export class Process<O extends tg.Value = tg.Value> {
 			for (let name of ["stdin", "stdout", "stderr"] as const) {
 				await stdio[name].close();
 			}
-			await tg.host.remove(tempDir);
+			await tg.host.remove(tempPath);
 		} catch (error) {
 			if (waitError === undefined) {
 				waitError = error;

--- a/packages/clients/rust/Cargo.toml
+++ b/packages/clients/rust/Cargo.toml
@@ -61,7 +61,6 @@ tangram_http = { workspace = true }
 tangram_serialize = { workspace = true }
 tangram_uri = { workspace = true }
 tangram_util = { workspace = true }
-tempfile = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true, optional = true }

--- a/packages/clients/rust/src/process/spawn.rs
+++ b/packages/clients/rust/src/process/spawn.rs
@@ -16,7 +16,6 @@ use {
 	tangram_futures::stream::TryExt as _,
 	tangram_http::{request::builder::Ext as _, response::Ext as _},
 	tangram_util::serde::{CommaSeparatedString, is_default, is_false},
-	tempfile::TempDir,
 };
 
 #[serde_as]
@@ -353,7 +352,10 @@ impl<O: 'static> tg::Process<O> {
 		}
 
 		let id = tg::process::Id::new();
-		let temp = TempDir::new()
+		let temp = tangram_util::fs::Temp::new()
+			.map_err(|source| tg::error!(!source, "failed to create a temp directory"))?;
+		tokio::fs::create_dir(temp.path())
+			.await
 			.map_err(|source| tg::error!(!source, "failed to create a temp directory"))?;
 		let output_path = temp.path().join(id.to_string());
 		let artifacts = checkout_artifacts(handle, &command).await?;
@@ -444,7 +446,7 @@ impl<O: 'static> tg::Process<O> {
 		handle: H,
 		mut child: tokio::process::Child,
 		output_path: PathBuf,
-		_temp: TempDir,
+		_temp: tangram_util::fs::Temp,
 	) -> tg::Result<tg::process::wait::Output>
 	where
 		H: tg::Handle,

--- a/packages/ignore/Cargo.toml
+++ b/packages/ignore/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 indoc = { workspace = true }
 pretty_assertions = { workspace = true }
 tangram_util = { workspace = true }
-tempfile = { workspace = true }
 
 [dependencies]
 derive_more = { workspace = true }

--- a/packages/ignore/src/tests.rs
+++ b/packages/ignore/src/tests.rs
@@ -7,7 +7,8 @@ use {
 
 #[tokio::test]
 async fn test() {
-	let temp = tempfile::TempDir::new().unwrap();
+	let temp = tangram_util::fs::Temp::new().unwrap();
+	std::fs::create_dir(temp.path()).unwrap();
 	let root = temp.path().join("root");
 	let artifact = Artifact::from(util::directory! {
 		".DS_Store" => util::file!(""),

--- a/packages/js/Cargo.toml
+++ b/packages/js/Cargo.toml
@@ -47,8 +47,8 @@ sync_wrapper = { workspace = true }
 tangram_client = { workspace = true }
 tangram_compiler = { workspace = true }
 tangram_futures = { workspace = true }
+tangram_util = { workspace = true }
 tangram_v8 = { workspace = true, optional = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 toml = { workspace = true }

--- a/packages/js/src/host.rs
+++ b/packages/js/src/host.rs
@@ -212,9 +212,12 @@ impl Host {
 	}
 
 	pub async fn mkdtemp(&self) -> tg::Result<String> {
-		let path = tempfile::tempdir()
-			.map_err(|source| tg::error!(!source, "failed to create a temp directory"))?
-			.keep();
+		let path = tangram_util::fs::Temp::new()
+			.map_err(|source| tg::error!(!source, "failed to create a temp directory"))?;
+		tokio::fs::create_dir(path.path())
+			.await
+			.map_err(|source| tg::error!(!source, "failed to create a temp directory"))?;
+		let path = path.into_path();
 		let path = path
 			.into_os_string()
 			.into_string()
@@ -267,25 +270,9 @@ impl Host {
 	}
 
 	pub async fn remove(&self, path: String) -> tg::Result<()> {
-		let path = PathBuf::from(path);
-		let metadata = match tokio::fs::symlink_metadata(&path).await {
-			Ok(metadata) => metadata,
-			Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-			Err(source) => {
-				return Err(
-					tg::error!(!source, path = %path.display(), "failed to read the path metadata"),
-				);
-			},
-		};
-		if metadata.is_dir() {
-			tokio::fs::remove_dir_all(&path).await.map_err(
-				|source| tg::error!(!source, path = %path.display(), "failed to remove the directory"),
-			)?;
-		} else {
-			tokio::fs::remove_file(&path).await.map_err(
-				|source| tg::error!(!source, path = %path.display(), "failed to remove the file"),
-			)?;
-		}
+		tangram_util::fs::remove(&path)
+			.await
+			.map_err(|source| tg::error!(!source, %path, "failed to remove"))?;
 		Ok(())
 	}
 

--- a/packages/sandbox/Cargo.toml
+++ b/packages/sandbox/Cargo.toml
@@ -41,7 +41,6 @@ tangram_futures = { workspace = true }
 tangram_http = { workspace = true }
 tangram_uri = { workspace = true }
 tangram_util = { workspace = true }
-tempfile = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }

--- a/packages/sandbox/src/container/run.rs
+++ b/packages/sandbox/src/container/run.rs
@@ -9,7 +9,6 @@ use {
 		process::ExitCode,
 	},
 	tangram_client::prelude::*,
-	tempfile::TempDir,
 };
 
 #[derive(Clone, Debug)]
@@ -151,7 +150,7 @@ fn child_main(
 	exec_command(arg)
 }
 
-fn prepare_root(arg: &Arg) -> tg::Result<Option<TempDir>> {
+fn prepare_root(arg: &Arg) -> tg::Result<Option<tangram_util::fs::Temp>> {
 	if !arg
 		.overlays
 		.iter()
@@ -159,9 +158,9 @@ fn prepare_root(arg: &Arg) -> tg::Result<Option<TempDir>> {
 	{
 		return Ok(None);
 	}
-	let path = tempfile::Builder::new()
-		.prefix("tg-sandbox-run.")
-		.tempdir()
+	let path = tangram_util::fs::Temp::new()
+		.map_err(|source| tg::error!(!source, "failed to create the scratch path"))?;
+	std::fs::create_dir(path.path())
 		.map_err(|source| tg::error!(!source, "failed to create the scratch path"))?;
 	let root = path.path().join("root");
 	std::fs::remove_dir_all(&root).ok();

--- a/packages/server/src/checkin/cache.rs
+++ b/packages/server/src/checkin/cache.rs
@@ -142,7 +142,12 @@ impl Server {
 					|source| tg::error!(!source, path = %dst.display(), "failed to set permissions"),
 				)?;
 		}
-		if !done {
+		if done {
+			// Cache entry already exists, so remove the source from tempdir to avoid cleanup failure.
+			tangram_util::fs::remove(src).await.map_err(
+				|source| tg::error!(!source, path = %src.display(), "failed to remove the source"),
+			)?;
+		} else {
 			let epoch = filetime::FileTime::from_system_time(std::time::SystemTime::UNIX_EPOCH);
 			filetime::set_symlink_file_times(&dst, epoch, epoch).map_err(
 				|source| tg::error!(!source, path = %dst.display(), "failed to set the modified time"),

--- a/packages/server/src/checkin/cache.rs
+++ b/packages/server/src/checkin/cache.rs
@@ -142,12 +142,7 @@ impl Server {
 					|source| tg::error!(!source, path = %dst.display(), "failed to set permissions"),
 				)?;
 		}
-		if done {
-			// Cache entry already exists, so remove the source from tempdir to avoid cleanup failure.
-			tangram_util::fs::remove(src).await.map_err(
-				|source| tg::error!(!source, path = %src.display(), "failed to remove the source"),
-			)?;
-		} else {
+		if !done {
 			let epoch = filetime::FileTime::from_system_time(std::time::SystemTime::UNIX_EPOCH);
 			filetime::set_symlink_file_times(&dst, epoch, epoch).map_err(
 				|source| tg::error!(!source, path = %dst.display(), "failed to set the modified time"),

--- a/packages/stores/log/Cargo.toml
+++ b/packages/stores/log/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 workspace = true
 
 [dev-dependencies]
-tempfile = { workspace = true }
+tangram_util = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/packages/stores/log/src/lmdb.rs
+++ b/packages/stores/log/src/lmdb.rs
@@ -643,10 +643,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_put_and_read_log_single_chunk() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -689,10 +690,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_put_and_read_log_multiple_chunks() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -741,10 +743,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_read_log_across_chunk_boundaries() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -817,10 +820,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_read_log_combined_stream() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -896,10 +900,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_delete_log_removes_all_chunks() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -965,10 +970,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_try_get_log_length() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -1040,10 +1046,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_read_log_at_end_returns_empty() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();
@@ -1074,10 +1081,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_read_log_nonexistent_process() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 		let process = tg::process::Id::new();

--- a/packages/stores/object/Cargo.toml
+++ b/packages/stores/object/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 workspace = true
 
 [dev-dependencies]
-tempfile = { workspace = true }
+tangram_util = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/packages/stores/object/src/lmdb.rs
+++ b/packages/stores/object/src/lmdb.rs
@@ -580,10 +580,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_put_and_get_object() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 
@@ -616,10 +617,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_put_object_without_bytes_then_with_bytes() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 
@@ -674,10 +676,11 @@ mod tests {
 	#[test]
 	fn test_put_and_get_object_sync() {
 		// This test mimics what the server does using sync functions.
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 
@@ -709,10 +712,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_put_batch_and_get_object() {
-		let temp_dir = tempfile::tempdir().unwrap();
+		let temp = tangram_util::fs::Temp::new().unwrap();
+		std::fs::create_dir(temp.path()).unwrap();
 		let config = Config {
 			map_size: 1024 * 1024 * 10,
-			path: temp_dir.path().join("test.lmdb"),
+			path: temp.path().join("test.lmdb"),
 		};
 		let store = Store::new(&config).unwrap();
 

--- a/packages/util/Cargo.toml
+++ b/packages/util/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 bytes = { workspace = true }
 data-encoding = { workspace = true }
+data-encoding-macro = { workspace = true }
 derive_more = { workspace = true }
 fnv = { workspace = true }
 futures = { workspace = true }
@@ -35,4 +36,5 @@ tangram_futures = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tracing = { workspace = true }
+uuid = { workspace = true }
 xattr = { workspace = true }

--- a/packages/util/src/fs.rs
+++ b/packages/util/src/fs.rs
@@ -6,6 +6,66 @@ use {
 	},
 };
 
+#[derive(Debug)]
+pub struct Temp {
+	path: Option<PathBuf>,
+	preserve: bool,
+}
+
+impl Temp {
+	pub fn new() -> std::io::Result<Self> {
+		Self::new_in(std::env::temp_dir())
+	}
+
+	pub fn new_in(path: impl AsRef<Path>) -> std::io::Result<Self> {
+		const ENCODING: data_encoding::Encoding = data_encoding_macro::new_encoding! {
+			symbols: "0123456789abcdefghjkmnpqrstvwxyz",
+		};
+		let id = uuid::Uuid::now_v7();
+		let id = ENCODING.encode(&id.into_bytes());
+		let path = path.as_ref().join(id);
+		Ok(Self {
+			path: Some(path),
+			preserve: false,
+		})
+	}
+
+	#[must_use]
+	pub fn preserve(mut self, preserve: bool) -> Self {
+		self.preserve = preserve;
+		self
+	}
+
+	#[must_use]
+	pub fn path(&self) -> &Path {
+		self.path
+			.as_deref()
+			.expect("expected the temp path to exist")
+	}
+
+	#[must_use]
+	pub fn into_path(mut self) -> PathBuf {
+		self.path.take().expect("expected the temp path to exist")
+	}
+}
+
+impl AsRef<Path> for Temp {
+	fn as_ref(&self) -> &Path {
+		self.path()
+	}
+}
+
+impl Drop for Temp {
+	fn drop(&mut self) {
+		if self.preserve {
+			return;
+		}
+		if let Some(path) = self.path.take() {
+			remove_sync(&path).ok();
+		}
+	}
+}
+
 pub async fn canonicalize_parent(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
 	let path = std::path::absolute(path)?;
 	let Some(parent) = path.parent() else {
@@ -101,8 +161,6 @@ pub fn remove_sync(path: impl AsRef<Path>) -> std::io::Result<()> {
 }
 
 /// Rename a file or directory atomically, failing if the destination already exists.
-///
-/// Uses `renameatx_np` with `RENAME_EXCL` on macOS and `renameat2` with `RENAME_NOREPLACE` on Linux.
 pub fn rename_noreplace_sync(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
 	// #[cfg(target_os = "macos")]
 	// {
@@ -147,8 +205,6 @@ pub fn rename_noreplace_sync(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> st
 }
 
 /// Rename a file or directory atomically, failing if the destination already exists.
-///
-/// Uses `renameatx_np` with `RENAME_EXCL` on macOS and `renameat2` with `RENAME_NOREPLACE` on Linux.
 pub async fn rename_noreplace(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
 	let src = src.as_ref().to_owned();
 	let dst = dst.as_ref().to_owned();


### PR DESCRIPTION
When a process runs that produces an identical output to a previously cached artifact, the current implementation leaves the original tempdir in place, but `checkin_fixup` has set the permissions to read-only. This causes the later cleanup step to fail with EACCESS. The fix is to remove the sourcedir in the event the cache entry already exists in 

This PR includes a test which erorrs on main and passes with this fix.