### PR TITLE
fix(sandbox): macos root mount, home var

### DIFF
--- a/packages/sandbox/src/seatbelt/spawn.rs
+++ b/packages/sandbox/src/seatbelt/spawn.rs
@@ -215,28 +215,17 @@ fn create_sandbox_profile(arg: &crate::Arg) -> CString {
 			(allow file-read* process-exec
 				(subpath "{}"))
 
-			;; Allow reading and writing to the sandbox paths.
+			;; Allow reading and writing to the sandbox socket files.
 			(allow file-read* file-write* file-write-create file-write-mode
 				file-write-unlink file-link
 				(literal "{}")
 				(literal "{}"))
-			(allow file-read* file-write* file-write-create file-write-mode
-				file-write-unlink file-link process-exec
-				(subpath "{}")
-				(subpath "{}")
-				(subpath "{}"))
 		"#,
 		arg.tangram_path.display(),
 		arg.rootfs_path.join("lib").display(),
 		arg.rootfs_path.join("bin").display(),
 		Sandbox::host_tangram_socket_path_from_root(&arg.path).display(),
 		Sandbox::host_listen_path_from_root(&arg.path).display(),
-		Sandbox::host_tangram_socket_path_from_root(&arg.path).display(),
-		Sandbox::host_output_path_from_root(&arg.path).display(),
-		Sandbox::host_scratch_path_from_root(&arg.path)
-			.parent()
-			.unwrap()
-			.display(),
 	)
 	.unwrap();
 
@@ -319,7 +308,12 @@ fn create_sandbox_profile(arg: &crate::Arg) -> CString {
 		.unwrap();
 	}
 
-	for mount in &arg.mounts {
+	let sandbox_root_mount = tg::sandbox::Mount {
+		source: arg.path.clone(),
+		target: arg.path.clone(),
+		readonly: false,
+	};
+	for mount in std::iter::once(&sandbox_root_mount).chain(arg.mounts.iter()) {
 		if mount.readonly {
 			let path = &mount.source;
 			writedoc!(

--- a/packages/sandbox/src/seatbelt/spawn.rs
+++ b/packages/sandbox/src/seatbelt/spawn.rs
@@ -258,19 +258,56 @@ fn create_sandbox_profile(arg: &crate::Arg) -> CString {
 	}
 
 	if let Some(home_path) = &home_path {
-		let cf_user_text_encoding = home_path.join(".CFUserTextEncoding");
 		writedoc!(
 			profile,
 			r"
-				;; Allow CoreFoundation to read the user locale metadata.
-				(allow file-read* file-test-existence
-					(literal {})
-					(literal {}))
+				;; Allow read-only access to the user's home directory so tools such
+				;; as cargo/libgit2 (reading $HOME/.gitconfig), rustup toolchains,
+				;; and CoreFoundation (.CFUserTextEncoding) work inside the sandbox.
+				(allow file-read* file-map-executable file-test-existence
+					(subpath {}))
 			",
 			escape(home_path.as_os_str().as_bytes()),
-			escape(cf_user_text_encoding.as_os_str().as_bytes()),
 		)
 		.unwrap();
+		for ancestor in home_path
+			.ancestors()
+			.skip(1)
+			.take_while(|path| *path != Path::new("/"))
+		{
+			writedoc!(
+				profile,
+				r"
+					(allow file-read-metadata
+						(literal {}))
+				",
+				escape(ancestor.as_os_str().as_bytes()),
+			)
+			.unwrap();
+		}
+		// Hard-deny well-known credential stores under $HOME. Seatbelt uses
+		// last-matching-rule semantics, so these override the allow above.
+		// List matches OpenCode's default secret roots.
+		for secret in [
+			".ssh",
+			".gnupg",
+			".aws",
+			".azure",
+			".config/gcloud",
+			".netrc",
+			".npmrc",
+		] {
+			let path = home_path.join(secret);
+			writedoc!(
+				profile,
+				r"
+					(deny file-read* file-read-metadata file-map-executable
+						(subpath {}))
+				",
+				escape(path.as_os_str().as_bytes()),
+			)
+			.unwrap();
+		}
 	}
 
 	if arg.network {

--- a/packages/sandbox/src/seatbelt/spawn.rs
+++ b/packages/sandbox/src/seatbelt/spawn.rs
@@ -261,9 +261,6 @@ fn create_sandbox_profile(arg: &crate::Arg) -> CString {
 		writedoc!(
 			profile,
 			r"
-				;; Allow read-only access to the user's home directory so tools such
-				;; as cargo/libgit2 (reading $HOME/.gitconfig), rustup toolchains,
-				;; and CoreFoundation (.CFUserTextEncoding) work inside the sandbox.
 				(allow file-read* file-map-executable file-test-existence
 					(subpath {}))
 			",
@@ -285,9 +282,6 @@ fn create_sandbox_profile(arg: &crate::Arg) -> CString {
 			)
 			.unwrap();
 		}
-		// Hard-deny well-known credential stores under $HOME. Seatbelt uses
-		// last-matching-rule semantics, so these override the allow above.
-		// List matches OpenCode's default secret roots.
 		for secret in [
 			".ssh",
 			".gnupg",

--- a/packages/sandbox/src/server/spawn/darwin.rs
+++ b/packages/sandbox/src/server/spawn/darwin.rs
@@ -6,9 +6,14 @@ pub fn prepare_command_for_spawn(
 	library_paths: &[std::path::PathBuf],
 ) -> tg::Result<()> {
 	if !command.env.contains_key("HOME") {
-		let home = std::env::var("HOME")
-			.map_err(|source| tg::error!(!source, "failed to get the home directory"))?;
-		command.env.insert("HOME".to_owned(), home);
+		// Use `/root` to match the Linux container default. The seatbelt
+		// sandbox does not chroot, so the host's `$HOME` (typically under
+		// `/Users`) is visible but denied by the profile; tools that stat
+		// `$HOME/.gitconfig` (for example libgit2 via `cargo`) then see
+		// `EPERM` instead of `ENOENT` and treat the config as invalid. A
+		// path that does not exist on the host under a granted subtree
+		// produces `ENOENT`, which is the expected "no config" signal.
+		command.env.insert("HOME".to_owned(), "/root".to_owned());
 	}
 	let mut paths = Vec::new();
 	if let Some(wrapper_directory) = tangram_wrapper_directory(library_paths) {

--- a/packages/sandbox/src/server/spawn/darwin.rs
+++ b/packages/sandbox/src/server/spawn/darwin.rs
@@ -6,14 +6,9 @@ pub fn prepare_command_for_spawn(
 	library_paths: &[std::path::PathBuf],
 ) -> tg::Result<()> {
 	if !command.env.contains_key("HOME") {
-		// Use `/root` to match the Linux container default. The seatbelt
-		// sandbox does not chroot, so the host's `$HOME` (typically under
-		// `/Users`) is visible but denied by the profile; tools that stat
-		// `$HOME/.gitconfig` (for example libgit2 via `cargo`) then see
-		// `EPERM` instead of `ENOENT` and treat the config as invalid. A
-		// path that does not exist on the host under a granted subtree
-		// produces `ENOENT`, which is the expected "no config" signal.
-		command.env.insert("HOME".to_owned(), "/root".to_owned());
+		let home = std::env::var("HOME")
+			.map_err(|source| tg::error!(!source, "failed to get the home directory"))?;
+		command.env.insert("HOME".to_owned(), home);
 	}
 	let mut paths = Vec::new();
 	if let Some(wrapper_directory) = tangram_wrapper_directory(library_paths) {


### PR DESCRIPTION
Fixes two outstanding issues with the macOS sandbox implementation:

1. The sandbox root mount was handled like other user mounts prior to the refactor, which allowed permissions like `file-read-metadata path-ancestors {}`, which is required for operations like chdir. This adds the root mount to the list of mounts so it is handled consistently.

1. Setting HOME to the user's home is problematic because this directory is not visible to the sandbox. This causes tools that attempt to read from $HOME to fail in unexpected ways. The current fix sets it to `/root` to exactly match Linux.