### PR TITLE
fix(server/run/sandbox): drop dequeue future prior to finish_sandbox

### DIFF
--- a/packages/cli/tests/run/sandbox_dequeue_finish_deadlock.nu
+++ b/packages/cli/tests/run/sandbox_dequeue_finish_deadlock.nu
@@ -1,0 +1,26 @@
+use ../../test.nu *
+
+# Reproduces an async deadlock between an in-flight dequeue_sandbox_process and finish_sandbox.
+
+let server = spawn --config {
+	runner: {
+		concurrency: 4,
+	},
+}
+
+# Many short-lived sandboxed children.
+let parent = artifact {
+	tangram.ts: '
+		export default async () => {
+			const children = [];
+			for (let i = 0; i < 256; i++) {
+				children.push(tg.run`true ${i.toString()}`.sandbox());
+			}
+			await Promise.allSettled(children);
+			return "done";
+		};
+	',
+}
+
+let output = timeout 15s tg build $parent | complete
+success $output "fan-out build should not deadlock between dequeue_sandbox_process and finish_sandbox"

--- a/packages/server/src/run/sandbox.rs
+++ b/packages/server/src/run/sandbox.rs
@@ -191,6 +191,7 @@ impl Server {
 		// Start dequeueing a process.
 		let mut dequeue = self.dequeue_sandbox_process(id, &location).boxed();
 
+		let mut timer_fired = false;
 		loop {
 			let timer_future = timer.as_mut().map_or_else(
 				|| future::pending().left_future(),
@@ -234,16 +235,23 @@ impl Server {
 					}
 				},
 
-				// If the timer fires, then finish the sandbox and break.
+				// If the timer fires, prepare to finish the sandbox and break.
 				() = timer_future => {
-					let arg = tg::sandbox::finish::Arg {
-						error: None,
-						location: Some(location.clone().into()),
-					};
-					self.finish_sandbox(id, arg).await?;
+					timer_fired = true;
 					break;
 				},
 			}
+		}
+
+		drop(dequeue);
+
+		// If the timer fired, finish the sandbox.
+		if timer_fired {
+			let arg = tg::sandbox::finish::Arg {
+				error: None,
+				location: Some(location.clone().into()),
+			};
+			self.finish_sandbox(id, arg).await?;
 		}
 
 		// Stop and await the process tasks.

--- a/packages/server/src/run/sandbox.rs
+++ b/packages/server/src/run/sandbox.rs
@@ -191,7 +191,7 @@ impl Server {
 		// Start dequeueing a process.
 		let mut dequeue = self.dequeue_sandbox_process(id, &location).boxed();
 
-		let mut timer_fired = false;
+		let mut finish = false;
 		loop {
 			let timer_future = timer.as_mut().map_or_else(
 				|| future::pending().left_future(),
@@ -235,18 +235,19 @@ impl Server {
 					}
 				},
 
-				// If the timer fires, prepare to finish the sandbox and break.
+				// If the timer fires, then break and finish the sandbox.
 				() = timer_future => {
-					timer_fired = true;
+					finish = true;
 					break;
 				},
 			}
 		}
 
+		// Drop the dequeue future.
 		drop(dequeue);
 
-		// If the timer fired, finish the sandbox.
-		if timer_fired {
+		// Finish.
+		if finish {
 			let arg = tg::sandbox::finish::Arg {
 				error: None,
 				location: Some(location.clone().into()),


### PR DESCRIPTION
This fixes a deadlock in which the timer branch of the `select!` fires immediately while another writer holds a guard. We’ve asked to dequeue a sandbox process, but immediately hit the timer_fired branch, which now awaits `finish_sandbox`, in contention with the `dequeue` future. When the other writer releases the guard, the dequeue future gets the guard first, but is never polled. The guard now sits in the dequeue future’s oneshot, meaning `finish_sandbox` can never complete. By explicitly dropping this future, we ensure the receiver is dropped, and the guard goes to `finish_sandbox`.