### PR TITLE
fix(build): hoisted bun install, feature-gate repl

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -49,6 +49,7 @@ mod push;
 mod put;
 mod read;
 mod remote;
+#[cfg(feature = "js")]
 mod repl;
 mod sandbox;
 mod server;
@@ -257,6 +258,7 @@ enum Command {
 
 	Remote(self::remote::Args),
 
+	#[cfg(feature = "js")]
 	Repl(self::repl::Args),
 
 	#[command(alias = "r")]
@@ -1070,6 +1072,7 @@ impl Cli {
 			Command::Put(args) => self.command_put(args).boxed(),
 			Command::Read(args) => self.command_read(args).boxed(),
 			Command::Remote(args) => self.command_remote(args).boxed(),
+			#[cfg(feature = "js")]
 			Command::Repl(args) => self.command_repl(args).boxed(),
 			Command::Run(args) => self.command_run(args).boxed(),
 			Command::Sandbox(args) => self.command_sandbox(args).boxed(),

--- a/tangram.ts
+++ b/tangram.ts
@@ -200,7 +200,7 @@ export const nodeModules = async (hostArg?: string) => {
 			cp -R ${workspaceSource}/. ${tg.output}
 			chmod -R u+w ${tg.output}
 			cd ${tg.output}
-			bun install --frozen-lockfile || true
+			bun install --frozen-lockfile --linker=hoisted || true
 			mkdir -p packages/js/node_modules/@tangramdotdev
 			ln -sf ../../../../clients/js packages/js/node_modules/@tangramdotdev/client
 		`


### PR DESCRIPTION
Two small fixes:

- add the `js` feature to the repl module
- use hoisted strategy in bun install for sandboxed builds of tangram