### PR TITLE
fix(clients/js): restore types to pre-generation API

### DIFF
--- a/packages/clients/js/src/args.ts
+++ b/packages/clients/js/src/args.ts
@@ -58,7 +58,7 @@ export namespace Args {
 										tg.Artifact.is(value) ||
 										typeof value === "string",
 								);
-								mutation = await tg.Mutation.prefix<tg.Template.Arg>(value);
+								mutation = await tg.Mutation.prefix(value);
 								break;
 							case "suffix":
 								tg.assert(
@@ -66,7 +66,7 @@ export namespace Args {
 										tg.Artifact.is(value) ||
 										typeof value === "string",
 								);
-								mutation = await tg.Mutation.suffix<tg.Template.Arg>(value);
+								mutation = await tg.Mutation.suffix(value);
 								break;
 							case "merge":
 								mutation = await tg.Mutation.merge(value);

--- a/packages/clients/js/src/mutation.ts
+++ b/packages/clients/js/src/mutation.ts
@@ -98,8 +98,8 @@ export class Mutation<T extends tg.Value = tg.Value> {
 	}
 
 	/** Create a prefix mutation. */
-	static async prefix<T extends tg.Template.Arg = tg.Template.Arg>(
-		template: tg.Unresolved<T>,
+	static async prefix(
+		template: tg.Unresolved<tg.Template.Arg>,
 		separator?: string | undefined,
 	): Promise<tg.Mutation<tg.Template>> {
 		return new tg.Mutation({
@@ -110,8 +110,8 @@ export class Mutation<T extends tg.Value = tg.Value> {
 	}
 
 	/** Create a suffix mutation. */
-	static async suffix<T extends tg.Template.Arg = tg.Template.Arg>(
-		template: tg.Unresolved<T>,
+	static async suffix(
+		template: tg.Unresolved<tg.Template.Arg>,
 		separator?: string | undefined,
 	): Promise<tg.Mutation<tg.Template>> {
 		return new tg.Mutation({

--- a/packages/clients/js/src/symlink.ts
+++ b/packages/clients/js/src/symlink.ts
@@ -1,7 +1,9 @@
 import * as tg from "./index.ts";
 
 /** Create a symlink. */
-export let symlink = async (arg: tg.Symlink.Arg): Promise<tg.Symlink> => {
+export let symlink = async (
+	arg: tg.Unresolved<tg.Symlink.Arg>,
+): Promise<tg.Symlink> => {
 	return await tg.Symlink.new(arg);
 };
 


### PR DESCRIPTION
Fix some small errors in the now-generated tangram.d.ts:

- `tg.symlink` should take an unresolved arg
- `prefix`/`suffix` hardcode their return type to `Mutation<Template>` instead of retaining `T`, so generic is not useful.

The behavior now matches the public API defined in the hand-written `d.ts`.