### PR TITLE
fix(sandbox/macos): canonicalize current_exe path

### DIFF
--- a/packages/util/src/env.rs
+++ b/packages/util/src/env.rs
@@ -11,7 +11,8 @@ pub fn current_exe() -> std::io::Result<PathBuf> {
 		let path = OsStr::from_bytes(path);
 		PathBuf::from(path)
 	} else {
-		std::fs::canonicalize(&path)?
+		path
 	};
+	let path = std::fs::canonicalize(path)?;
 	Ok(path)
 }

--- a/packages/util/src/env.rs
+++ b/packages/util/src/env.rs
@@ -11,7 +11,7 @@ pub fn current_exe() -> std::io::Result<PathBuf> {
 		let path = OsStr::from_bytes(path);
 		PathBuf::from(path)
 	} else {
-		path
+		std::fs::canonicalize(&path)?
 	};
 	Ok(path)
 }


### PR DESCRIPTION
Canonicalize the current_exe path on macOS. The `std::env::current_exe()` function uses `_NSGetExecutablePath`, which does not follow symlinks. This results in a seatbelt profile rule that does not match when `tangram` is executed through a symlink:

```
(allow file-read* process-exec
      (literal "{tangram_path}"))
```

This path is the symlink, not the actual binary.  When we actually exec, seatbelt resolves the symlink, and that path no longer matches the profile rule.

  This results in an EPERM when starting sandboxes:

```
-> failed to execute the command
   internal:packages/sandbox/src/seatbelt/run.rs:71:6
-> Operation not permitted (os error 1)
```

Canonicalizing this path to the real executable resolves this mismatch and matches our intent. This behavior now matches the behavior on Linux, which uses `/proc/self/exe` for `std::env::current_exe()`, which does follow symlinks.