### PR TITLE
feat(server/checkin): improve progress reporting

### DIFF
--- a/packages/server/src/checkin/blob.rs
+++ b/packages/server/src/checkin/blob.rs
@@ -60,7 +60,7 @@ impl Session {
 
 		let cache_pointers = arg.options.cache_pointers;
 		let blobs = stream::iter(nodes)
-			.map(|(index, path, size)| {
+			.map(|(index, path, _)| {
 				let progress = progress.clone();
 				let session = self.clone();
 				async move {
@@ -78,7 +78,7 @@ impl Session {
 								})
 							};
 							session
-								.write_inner_sync(file, destination.as_ref())
+								.write_inner_sync(file, destination.as_ref(), &progress)
 								.map_err(
 									|error| tg::error!(!error, path = %path.display(), "failed to create the blob"),
 								)
@@ -86,9 +86,6 @@ impl Session {
 					})
 					.await
 					.map_err(|error| tg::error!(!error, "the blob task panicked"))??;
-					if let Some(size) = size {
-						progress.increment("bytes", size);
-					}
 					Ok::<_, tg::Error>((index, blob))
 				}
 			})

--- a/packages/server/src/checkin/cache.rs
+++ b/packages/server/src/checkin/cache.rs
@@ -5,6 +5,7 @@ use {
 		temp::Temp,
 	},
 	futures::stream::{self, StreamExt as _, TryStreamExt as _},
+	num::ToPrimitive,
 	std::{
 		collections::BTreeSet,
 		os::unix::fs::PermissionsExt as _,
@@ -69,11 +70,11 @@ impl Session {
 
 			// Start the progress indicator.
 			progress.spinner("copying", "copying");
-			let total = files.iter().map(|(_, _, _, size)| size).sum::<u64>();
+			let total = files.len().to_u64().unwrap();
 			progress.start(
-				"bytes".to_owned(),
-				"bytes".to_owned(),
-				tg::progress::IndicatorFormat::Bytes,
+				"files".to_owned(),
+				"files".to_owned(),
+				tg::progress::IndicatorFormat::Normal,
 				Some(0),
 				Some(total),
 			);
@@ -83,18 +84,17 @@ impl Session {
 				.batches(self.server.config.checkin.cache.batch_size)
 				.map(|batch| {
 					let session = self.clone();
-					let batch_bytes: u64 = batch.iter().map(|(_, _, _, size)| size).sum();
 					let batch: Vec<_> = batch
 						.into_iter()
 						.map(|(path, metadata, id, _)| (path, metadata, id))
 						.collect();
 					async move {
-						tokio::task::spawn_blocking(move || session.checkin_cache_inner(batch))
-							.await
-							.map_err(|error| {
-								tg::error!(!error, "the checkin cache task panicked")
-							})??;
-						progress.increment("bytes", batch_bytes);
+						let progress = progress.clone();
+						tokio::task::spawn_blocking(move || {
+							session.checkin_cache_inner(batch, &progress)
+						})
+						.await
+						.map_err(|error| tg::error!(!error, "the checkin cache task panicked"))??;
 						Ok::<_, tg::Error>(())
 					}
 				})
@@ -107,7 +107,7 @@ impl Session {
 				.map_err(|error| tg::error!(!error, "the checkin cache task failed"))?;
 
 			progress.finish("copying");
-			progress.finish("bytes");
+			progress.finish("files");
 		}
 		Ok(())
 	}
@@ -232,6 +232,7 @@ impl Session {
 	fn checkin_cache_inner(
 		&self,
 		batch: Vec<(PathBuf, std::fs::Metadata, tg::object::Id)>,
+		progress: &crate::progress::Handle<super::TaskOutput>,
 	) -> tg::Result<()> {
 		for (path, metadata, id) in batch {
 			// If the file is already cached, then continue.
@@ -284,6 +285,8 @@ impl Session {
 					|error| tg::error!(!error, path = %dst.display(), "failed to set the modified time"),
 				)?;
 			}
+
+			progress.increment("files", 1);
 		}
 
 		Ok(())

--- a/packages/server/src/checkin/cache.rs
+++ b/packages/server/src/checkin/cache.rs
@@ -70,13 +70,21 @@ impl Session {
 
 			// Start the progress indicator.
 			progress.spinner("copying", "copying");
-			let total = files.len().to_u64().unwrap();
+			let files_total = files.len().to_u64().unwrap();
+			let bytes_total = files.iter().map(|(_, _, _, size)| size).sum();
 			progress.start(
 				"files".to_owned(),
 				"files".to_owned(),
 				tg::progress::IndicatorFormat::Normal,
 				Some(0),
-				Some(total),
+				Some(files_total),
+			);
+			progress.start(
+				"bytes".to_owned(),
+				"bytes".to_owned(),
+				tg::progress::IndicatorFormat::Bytes,
+				Some(0),
+				Some(bytes_total),
 			);
 
 			let batches = files
@@ -84,10 +92,6 @@ impl Session {
 				.batches(self.server.config.checkin.cache.batch_size)
 				.map(|batch| {
 					let session = self.clone();
-					let batch: Vec<_> = batch
-						.into_iter()
-						.map(|(path, metadata, id, _)| (path, metadata, id))
-						.collect();
 					async move {
 						let progress = progress.clone();
 						tokio::task::spawn_blocking(move || {
@@ -108,6 +112,7 @@ impl Session {
 
 			progress.finish("copying");
 			progress.finish("files");
+			progress.finish("bytes");
 		}
 		Ok(())
 	}
@@ -231,10 +236,10 @@ impl Session {
 
 	fn checkin_cache_inner(
 		&self,
-		batch: Vec<(PathBuf, std::fs::Metadata, tg::object::Id)>,
+		batch: Vec<(PathBuf, std::fs::Metadata, tg::object::Id, u64)>,
 		progress: &crate::progress::Handle<super::TaskOutput>,
 	) -> tg::Result<()> {
-		for (path, metadata, id) in batch {
+		for (path, metadata, id, size) in batch {
 			// If the file is already cached, then continue.
 			let cache_path = self.server.cache_path().join(id.to_string());
 			if cache_path.exists() {
@@ -287,6 +292,7 @@ impl Session {
 			}
 
 			progress.increment("files", 1);
+			progress.increment("bytes", size);
 		}
 
 		Ok(())

--- a/packages/server/src/write.rs
+++ b/packages/server/src/write.rs
@@ -220,6 +220,7 @@ impl Session {
 		&self,
 		mut reader: impl Read,
 		destination: Option<&Destination>,
+		progress: &crate::progress::Handle<crate::checkin::TaskOutput>,
 	) -> tg::Result<Output> {
 		let principal = self.write_principal();
 
@@ -276,7 +277,7 @@ impl Session {
 						.map_err(|error| tg::error!(!error, "failed to store the leaf"))?;
 				},
 			}
-
+			progress.increment("bytes", chunk.length.to_u64().unwrap());
 			blobs.push(blob);
 		}
 


### PR DESCRIPTION
- Increment progress when hashing bytes per chunk instead of per file.
- Change progress counter for non-destructive copies to track files instead of bytes.

Resolves #903