### PR TITLE
fix(cancel): error when cancelling a finished process

### DIFF
--- a/packages/cli/tests/build/cancel_finished_invalid_token.nu
+++ b/packages/cli/tests/build/cancel_finished_invalid_token.nu
@@ -1,0 +1,17 @@
+use ../../test.nu *
+
+# Cancelling a finished process with an invalid lease token fails with an already-finished error.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default () => "Hello, World!";
+	'
+}
+let process = tg build --detach --verbose $path | from json
+tg wait $process.process
+
+let output = tg cancel $process.process invalidtoken | complete
+failure $output
+assert ($output.stderr | str contains 'the process is already finished') "the error should mention the finished process"

--- a/packages/cli/tests/build/cancel_finished_valid_token.nu
+++ b/packages/cli/tests/build/cancel_finished_valid_token.nu
@@ -1,0 +1,17 @@
+use ../../test.nu *
+
+# Cancelling a finished process with its lease token fails with an already-finished error.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default () => "Hello, World!";
+	'
+}
+let process = tg build --detach --verbose $path | from json
+tg wait $process.process
+
+let output = tg cancel $process.process $process.lease | complete
+failure $output
+assert ($output.stderr | str contains 'the process is already finished') "the error should mention the finished process"

--- a/packages/cli/tests/build/cancel_token_reuse.nu
+++ b/packages/cli/tests/build/cancel_token_reuse.nu
@@ -1,0 +1,23 @@
+use ../../test.nu *
+
+# A lease token that was used to cancel a process cannot be used to cancel it again.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			while (true) {
+				await tg.sleep(1);
+			}
+		};
+	'
+}
+let process = tg build --detach --verbose $path | from json
+
+tg cancel $process.process $process.lease
+tg wait $process.process
+
+let output = tg cancel $process.process $process.lease | complete
+failure $output
+assert ($output.stderr | str contains 'the process is already finished') "the error should mention the finished process"

--- a/packages/cli/tests/build/cancel_token_reuse_running.nu
+++ b/packages/cli/tests/build/cancel_token_reuse_running.nu
@@ -1,0 +1,31 @@
+use ../../test.nu *
+
+# A lease token that was already used to cancel cannot be reused while the process is still running.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			while (true) {
+				await tg.sleep(1);
+			}
+		};
+	'
+}
+
+# Two detached builds of the same module deduplicate to one process with distinct leases.
+let first = tg build --detach --verbose $path | from json
+let second = tg build --detach --verbose $path | from json
+assert equal $second.process $first.process "the builds should deduplicate to one process"
+
+# Cancel the first lease. The second lease keeps the process running.
+tg cancel $first.process $first.lease
+
+# Reusing the first token fails because the lease no longer exists.
+let output = tg cancel $first.process $first.lease | complete
+failure $output
+assert ($output.stderr | str contains 'the process lease was not found') "the error should mention the missing lease"
+
+tg cancel $second.process $second.lease
+tg wait $second.process

--- a/packages/server/src/process/cancel.rs
+++ b/packages/server/src/process/cancel.rs
@@ -102,6 +102,10 @@ impl Session {
 			return Ok(ControlFlow::Break(None));
 		};
 
+		if status.is_finished() {
+			return Err(tg::error!("the process is already finished"));
+		}
+
 		let p = transaction.p();
 		let statement = formatdoc!(
 			r"
@@ -113,7 +117,7 @@ impl Session {
 		let result = transaction.execute(statement.into(), params).await;
 		let deleted = crate::database::retry!(result, "failed to execute the statement");
 
-		if deleted == 0 && !status.is_finished() {
+		if deleted == 0 {
 			return Err(tg::error!("the process lease was not found"));
 		}
 


### PR DESCRIPTION
Ensure the server errors when canceling a finished process.

Additionally, test these cases:

Process finished error path:
- Process finished, token invalid (process finished error)
- Process finished, token valid (process finished error)
- Process finished, token valid but reused (process finished error)

Lease not found:
- Two leases on the same process, valid token used twice (lease not found on reuse attempt)