### PR TITLE
fix(cli): resolve the clap id collision

### DIFF
--- a/packages/cli/src/download.rs
+++ b/packages/cli/src/download.rs
@@ -10,7 +10,7 @@ pub struct Args {
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
 
-	#[arg(long)]
+	#[arg(long = "mode", id = "download_mode")]
 	pub mode: Option<tg::DownloadMode>,
 
 	#[arg(index = 1)]

--- a/packages/cli/src/download.rs
+++ b/packages/cli/src/download.rs
@@ -10,7 +10,7 @@ pub struct Args {
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
 
-	#[arg(long = "mode", id = "download_mode")]
+	#[arg(long)]
 	pub mode: Option<tg::DownloadMode>,
 
 	#[arg(index = 1)]

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -141,7 +141,7 @@ pub struct Debug {
 	#[arg(long = "debug-addr")]
 	addr: Option<std::net::SocketAddr>,
 
-	#[arg(long = "debug-mode")]
+	#[arg(long = "debug-mode", id = "debug_mode")]
 	mode: Option<tg::process::debug::Mode>,
 
 	#[arg(

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -141,7 +141,7 @@ pub struct Debug {
 	#[arg(long = "debug-addr")]
 	addr: Option<std::net::SocketAddr>,
 
-	#[arg(long = "debug-mode", id = "debug_mode")]
+	#[arg(long = "debug-mode", id = "spawn.debug.mode")]
 	mode: Option<tg::process::debug::Mode>,
 
 	#[arg(

--- a/packages/cli/tests/download/basic.nu
+++ b/packages/cli/tests/download/basic.nu
@@ -1,0 +1,14 @@
+use ../../test.nu *
+
+# Downloading a URL with a wildcard checksum returns a blob with the downloaded contents.
+
+skip_if_offline
+
+let server = spawn
+
+let output = tg download "http://www.example.com" --checksum sha256:any | complete
+success $output
+assert ($output.stdout | str trim | str starts-with "blb_") "the download should return a blob id"
+
+let contents = tg read ($output.stdout | str trim)
+assert ($contents | str contains "Example Domain") "the blob should contain the downloaded page"

--- a/packages/cli/tests/download/default_checksum_requires_match.nu
+++ b/packages/cli/tests/download/default_checksum_requires_match.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# Downloading a URL without a checksum fails, because the default checksum matches nothing and the caller must opt in with a wildcard.
+
+skip_if_offline
+
+let server = spawn
+
+let output = tg download "http://www.example.com" | complete
+failure $output
+assert ($output.stderr | str contains "checksum mismatch") "the download should fail because no checksum was provided"


### PR DESCRIPTION
The download subcommand's `mode` field resulted in a clap ID that conflicts with the `mode` field in the spawn options in [`packages/cli/src/process/spawn.rs`](https://github.com/tangramdotdev/tangram/blob/4820cc1fcf3973ed5bb0835d1e58dc280a7c68a7/packages/cli/src/process/spawn.rs#L145). Adding an explicit ID for the download mode resolves the conflict.