### PR TITLE
fix(cli): tg init creates nested parent directories

### DIFF
--- a/packages/cli/src/init.rs
+++ b/packages/cli/src/init.rs
@@ -10,15 +10,15 @@ pub struct Args {
 
 impl Cli {
 	pub async fn command_init(&mut self, args: Args) -> tg::Result<()> {
-		// Canonicalize the path's parent.
-		let path = tangram_util::fs::canonicalize_parent(&args.path)
+		// Create the directory.
+		tokio::fs::create_dir_all(&args.path).await.map_err(
+			|error| tg::error!(!error, path = ?args.path, "failed to create the directory"),
+		)?;
+
+		// Canonicalize the path.
+		let path = tokio::fs::canonicalize(&args.path)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to canonicalize the path"))?;
-
-		// Create the directory.
-		tokio::fs::create_dir_all(&path)
-			.await
-			.map_err(|error| tg::error!(!error, ?path, "failed to create the directory"))?;
 
 		// Check if there is already a root module for the path.
 		for name in tg::module::ROOT_MODULE_FILE_NAMES {

--- a/packages/cli/tests/init/nested_path.nu
+++ b/packages/cli/tests/init/nested_path.nu
@@ -1,9 +1,12 @@
 use ../../test.nu *
 
-# Initializing a nested path whose parent does not exist fails because only the final component is created.
+# Initializing a nested path whose parent does not exist creates the full directory chain.
 
 let dir = mktemp --directory
+let path = $dir | path join "a" "b"
 
-let output = tg init ($dir | path join "a" "b") | complete
-failure $output
-assert ($output.stderr | str contains "failed to canonicalize the path") "the error should mention the path"
+let output = tg init $path | complete
+success $output
+
+assert ($path | path exists) "the nested directory should be created"
+assert (($path | path join tangram.ts) | path exists) "the scaffold should be created"


### PR DESCRIPTION
On main, `tg init` currently fails if parent directories do not yet exist. This change creates the full path first.