### PR TITLE
refactor(cli): add clap IDs for fields in flattened structs

### DIFF
--- a/packages/cli/src/checkin.rs
+++ b/packages/cli/src/checkin.rs
@@ -33,11 +33,11 @@ pub struct Options {
 	pub cache_pointers: CachePointers,
 
 	/// Check in the artifact more quickly by allowing it to be destroyed.
-	#[arg(long)]
+	#[arg(id = "checkin.destructive", long = "destructive")]
 	pub destructive: bool,
 
 	/// Check in the artifact determnistically.
-	#[arg(long)]
+	#[arg(id = "checkin.deterministic", long = "deterministic")]
 	pub deterministic: bool,
 
 	#[command(flatten)]
@@ -47,11 +47,11 @@ pub struct Options {
 	pub lock: Lock,
 
 	/// If this flag is set, the lock will not be updated.
-	#[arg(long)]
+	#[arg(id = "checkin.locked", long = "locked")]
 	pub locked: bool,
 
 	/// Treat the provided path as the root path.
-	#[arg(long)]
+	#[arg(id = "checkin.root", long = "root")]
 	pub root: bool,
 
 	#[command(flatten)]
@@ -66,16 +66,20 @@ pub struct Options {
 	#[command(flatten)]
 	pub unsolved_dependencies: UnsolvedDependencies,
 
-	#[arg(long)]
+	#[arg(id = "checkin.watch", long = "watch")]
 	pub watch: bool,
 }
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct TagTtl {
-	#[arg(long = "tag-ttl", overrides_with = "no_tag_ttl", value_parser = humantime::parse_duration)]
+	#[arg(id = "checkin.tag_ttl.tag_ttl", long = "tag-ttl", overrides_with = "checkin.tag_ttl.no_tag_ttl", value_parser = humantime::parse_duration)]
 	pub tag_ttl: Option<Duration>,
 
-	#[arg(long = "no-tag-ttl", overrides_with = "tag_ttl")]
+	#[arg(
+		id = "checkin.tag_ttl.no_tag_ttl",
+		long = "no-tag-ttl",
+		overrides_with = "checkin.tag_ttl.tag_ttl"
+	)]
 	pub no_tag_ttl: bool,
 }
 
@@ -90,18 +94,20 @@ pub struct Solve {
 	/// Whether to solve dependencies
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.solve.solve",
+		long = "solve",
 		num_args = 0..=1,
-		overrides_with = "no_solve",
+		overrides_with = "checkin.solve.no_solve",
 		require_equals = true,
 	)]
 	solve: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.solve.no_solve",
+		long = "no-solve",
 		num_args = 0..=1,
-		overrides_with = "solve",
+		overrides_with = "checkin.solve.solve",
 		require_equals = true,
 	)]
 	no_solve: Option<bool>,
@@ -118,18 +124,20 @@ pub struct Ignore {
 	/// Whether to use ignore files.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.ignore.ignore",
+		long = "ignore",
 		num_args = 0..=1,
-		overrides_with = "no_ignore",
+		overrides_with = "checkin.ignore.no_ignore",
 		require_equals = true,
 	)]
 	ignore: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.ignore.no_ignore",
+		long = "no-ignore",
 		num_args = 0..=1,
-		overrides_with = "ignore",
+		overrides_with = "checkin.ignore.ignore",
 		require_equals = true,
 	)]
 	no_ignore: Option<bool>,
@@ -146,18 +154,20 @@ pub struct SourceDependencies {
 	/// Whether to use source dependencies.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.source_dependencies.source_dependencies",
+		long = "source-dependencies",
 		num_args = 0..=1,
-		overrides_with = "no_source_dependencies",
+		overrides_with = "checkin.source_dependencies.no_source_dependencies",
 		require_equals = true,
 	)]
 	source_dependencies: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.source_dependencies.no_source_dependencies",
+		long = "no-source-dependencies",
 		num_args = 0..=1,
-		overrides_with = "source_dependencies",
+		overrides_with = "checkin.source_dependencies.source_dependencies",
 		require_equals = true,
 	)]
 	no_source_dependencies: Option<bool>,
@@ -176,15 +186,20 @@ pub struct Lock {
 	/// Whether to write the lock. Use `--lock=auto` to reuse an existing lock kind or prefer a lockattr for files. Use `--lock=file` to write a lockfile, and `--lock=attr` to write a lockattr. `auto` is the default if not specified.
 	#[arg(
 		default_missing_value = "auto",
-		long,
+		id = "checkin.lock.lock",
+		long = "lock",
 		num_args = 0..=1,
-		overrides_with = "no_lock",
+		overrides_with = "checkin.lock.no_lock",
 		require_equals = true,
 	)]
 	lock: Option<tg::checkin::Lock>,
 
 	/// Disable writing the lock.
-	#[arg(long, overrides_with = "lock")]
+	#[arg(
+		id = "checkin.lock.no_lock",
+		long = "no-lock",
+		overrides_with = "checkin.lock.lock"
+	)]
 	no_lock: bool,
 }
 
@@ -203,18 +218,20 @@ pub struct UnsolvedDependencies {
 	/// Whether to allow unsolved dependencies.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.unsolved_dependencies.unsolved_dependencies",
+		long = "unsolved-dependencies",
 		num_args = 0..=1,
-		overrides_with = "no_unsolved_dependencies",
+		overrides_with = "checkin.unsolved_dependencies.no_unsolved_dependencies",
 		require_equals = true,
 	)]
 	unsolved_dependencies: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.unsolved_dependencies.no_unsolved_dependencies",
+		long = "no-unsolved-dependencies",
 		num_args = 0..=1,
-		overrides_with = "unsolved_dependencies",
+		overrides_with = "checkin.unsolved_dependencies.unsolved_dependencies",
 		require_equals = true,
 	)]
 	no_unsolved_dependencies: Option<bool>,
@@ -233,18 +250,20 @@ pub struct CachePointers {
 	/// Whether to create cache pointers.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.cache_pointers.cache_pointers",
+		long = "cache-pointers",
 		num_args = 0..=1,
-		overrides_with = "no_cache_pointers",
+		overrides_with = "checkin.cache_pointers.no_cache_pointers",
 		require_equals = true,
 	)]
 	cache_pointers: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkin.cache_pointers.no_cache_pointers",
+		long = "no-cache-pointers",
 		num_args = 0..=1,
-		overrides_with = "cache_pointers",
+		overrides_with = "checkin.cache_pointers.cache_pointers",
 		require_equals = true,
 	)]
 	no_cache_pointers: Option<bool>,

--- a/packages/cli/src/checkout.rs
+++ b/packages/cli/src/checkout.rs
@@ -33,18 +33,20 @@ pub struct Dependencies {
 	/// Whether to check out the artifact's dependencies.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkout.dependencies.dependencies",
+		long = "dependencies",
 		num_args = 0..=1,
-		overrides_with = "no_dependencies",
+		overrides_with = "checkout.dependencies.no_dependencies",
 		require_equals = true,
 	)]
 	dependencies: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "checkout.dependencies.no_dependencies",
+		long = "no-dependencies",
 		num_args = 0..=1,
-		overrides_with = "dependencies",
+		overrides_with = "checkout.dependencies.dependencies",
 		require_equals = true,
 	)]
 	no_dependencies: Option<bool>,
@@ -63,15 +65,20 @@ pub struct Lock {
 	/// Whether to write the lock. Use `--lock=auto` to reuse an existing lock kind or prefer a lockattr for files. Use `--lock=file` to write a lockfile, and `--lock=attr` to write a lockattr. `auto` is the default if not specified.
 	#[arg(
 		default_missing_value = "auto",
-		long,
+		id = "checkout.lock.lock",
+		long = "lock",
 		num_args = 0..=1,
-		overrides_with = "no_lock",
+		overrides_with = "checkout.lock.no_lock",
 		require_equals = true,
 	)]
 	lock: Option<tg::checkout::Lock>,
 
 	/// Disable writing the lock.
-	#[arg(long, overrides_with = "lock")]
+	#[arg(
+		id = "checkout.lock.no_lock",
+		long = "no-lock",
+		overrides_with = "checkout.lock.lock"
+	)]
 	no_lock: bool,
 }
 

--- a/packages/cli/src/children.rs
+++ b/packages/cli/src/children.rs
@@ -20,10 +20,14 @@ pub struct Args {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Timeout {
-	#[arg(long, overrides_with = "no_timeout", value_parser = humantime::parse_duration)]
+	#[arg(id = "children.timeout.timeout", long = "timeout", overrides_with = "children.timeout.no_timeout", value_parser = humantime::parse_duration)]
 	pub timeout: Option<Duration>,
 
-	#[arg(long, overrides_with = "timeout")]
+	#[arg(
+		id = "children.timeout.no_timeout",
+		long = "no-timeout",
+		overrides_with = "children.timeout.timeout"
+	)]
 	pub no_timeout: bool,
 }
 

--- a/packages/cli/src/get.rs
+++ b/packages/cli/src/get.rs
@@ -35,10 +35,10 @@ pub struct Args {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Ttl {
-	#[arg(long, overrides_with = "no_ttl", value_parser = humantime::parse_duration)]
+	#[arg(id = "get.ttl.ttl", long = "ttl", overrides_with = "get.ttl.no_ttl", value_parser = humantime::parse_duration)]
 	pub ttl: Option<Duration>,
 
-	#[arg(long, overrides_with = "ttl")]
+	#[arg(id = "get.ttl.no_ttl", long = "no-ttl", overrides_with = "get.ttl.ttl")]
 	pub no_ttl: bool,
 }
 

--- a/packages/cli/src/list.rs
+++ b/packages/cli/src/list.rs
@@ -34,35 +34,49 @@ pub struct Args {
 pub struct Entries {
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "list.entries.groups",
+		long = "groups",
 		num_args = 0..=1,
-		overrides_with = "no_groups",
+		overrides_with = "list.entries.no_groups",
 		require_equals = true,
 	)]
 	groups: Option<bool>,
 
-	#[arg(long, overrides_with = "groups")]
+	#[arg(
+		id = "list.entries.no_groups",
+		long = "no-groups",
+		overrides_with = "list.entries.groups"
+	)]
 	no_groups: bool,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "list.entries.tags",
+		long = "tags",
 		num_args = 0..=1,
-		overrides_with = "no_tags",
+		overrides_with = "list.entries.no_tags",
 		require_equals = true,
 	)]
 	tags: Option<bool>,
 
-	#[arg(long, overrides_with = "tags")]
+	#[arg(
+		id = "list.entries.no_tags",
+		long = "no-tags",
+		overrides_with = "list.entries.tags"
+	)]
 	no_tags: bool,
 }
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Ttl {
-	#[arg(long, overrides_with = "no_ttl", value_parser = humantime::parse_duration)]
+	#[arg(id = "list.ttl.ttl", long = "ttl", overrides_with = "list.ttl.no_ttl", value_parser = humantime::parse_duration)]
 	pub ttl: Option<Duration>,
 
-	#[arg(long, overrides_with = "ttl")]
+	#[arg(
+		id = "list.ttl.no_ttl",
+		long = "no-ttl",
+		overrides_with = "list.ttl.ttl"
+	)]
 	pub no_ttl: bool,
 }
 

--- a/packages/cli/src/location.rs
+++ b/packages/cli/src/location.rs
@@ -4,21 +4,23 @@ use tangram_client::prelude::*;
 pub struct Args {
 	/// Use the local server.
 	#[arg(
-		conflicts_with_all = ["location"],
+		conflicts_with_all = ["location.location"],
 		default_missing_value = "true",
-		long,
+		id = "location.local",
+		long = "local",
 		num_args = 0..=1,
 		require_equals = true,
 	)]
 	local: Option<bool>,
 
-	#[arg(long)]
+	#[arg(id = "location.location", long = "location")]
 	location: Option<tg::location::Arg>,
 
 	/// Use the specified remotes. Pass --remote for the default remote, --remote=false for no remotes, or --remote=<name>[,<name>...] for specific remotes. Can be specified multiple times or comma-separated.
 	#[arg(
-		conflicts_with_all = ["location"],
+		conflicts_with_all = ["location.location"],
 		default_missing_value = "true",
+		id = "location.remotes",
 		long = "remotes",
 		num_args = 0..=1,
 		require_equals = true,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -129,11 +129,21 @@ struct Args {
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Remotes {
 	/// Override the `remotes` key in the config.
-	#[arg(conflicts_with = "no_remotes", long, short, value_delimiter = ',')]
+	#[arg(
+		conflicts_with = "main.remotes.no_remotes",
+		id = "main.remotes.remotes",
+		long = "remotes",
+		short = 'r',
+		value_delimiter = ','
+	)]
 	remotes: Option<Vec<String>>,
 
 	/// Override the `remotes` key in the config.
-	#[arg(conflicts_with = "remotes", long)]
+	#[arg(
+		conflicts_with = "main.remotes.remotes",
+		id = "main.remotes.no_remotes",
+		long = "no-remotes"
+	)]
 	no_remotes: bool,
 }
 
@@ -153,19 +163,21 @@ struct Quiet {
 	/// Whether to show progress and other helpful information.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "main.quiet.quiet",
+		long = "quiet",
 		num_args = 0..=1,
-		overrides_with = "no_quiet",
+		overrides_with = "main.quiet.no_quiet",
 		require_equals = true,
-		short,
+		short = 'q',
 	)]
 	quiet: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "main.quiet.no_quiet",
+		long = "no-quiet",
 		num_args = 0..=1,
-		overrides_with = "quiet",
+		overrides_with = "main.quiet.quiet",
 		require_equals = true,
 	)]
 	no_quiet: Option<bool>,

--- a/packages/cli/src/print.rs
+++ b/packages/cli/src/print.rs
@@ -14,15 +14,15 @@ const INDENTATION: &str = "  ";
 #[group(skip)]
 pub struct Options {
 	/// Whether to print blobs in the value.
-	#[arg(long)]
+	#[arg(id = "print.blobs", long = "blobs")]
 	pub blobs: bool,
 
 	/// The depth with which to print the value.
-	#[arg(long)]
+	#[arg(id = "print.depth", long = "depth")]
 	pub depth: Option<Depth>,
 
 	/// Whether to pretty print the value.
-	#[arg(long)]
+	#[arg(id = "print.pretty", long = "pretty")]
 	pub pretty: bool,
 }
 

--- a/packages/cli/src/process/children.rs
+++ b/packages/cli/src/process/children.rs
@@ -33,10 +33,14 @@ pub struct Args {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Timeout {
-	#[arg(long, overrides_with = "no_timeout", value_parser = humantime::parse_duration)]
+	#[arg(id = "children.timeout.timeout", long = "timeout", overrides_with = "children.timeout.no_timeout", value_parser = humantime::parse_duration)]
 	pub timeout: Option<Duration>,
 
-	#[arg(long, overrides_with = "timeout")]
+	#[arg(
+		id = "children.timeout.no_timeout",
+		long = "no-timeout",
+		overrides_with = "children.timeout.timeout"
+	)]
 	pub no_timeout: bool,
 }
 

--- a/packages/cli/src/process/run.rs
+++ b/packages/cli/src/process/run.rs
@@ -21,15 +21,24 @@ pub struct Args {
 pub struct Options {
 	/// Whether to check out the output.
 	#[expect(clippy::option_option)]
-	#[arg(long, require_equals = true, short)]
+	#[arg(
+		id = "run.checkout",
+		long = "checkout",
+		require_equals = true,
+		short = 'c'
+	)]
 	pub checkout: Option<Option<PathBuf>>,
 
 	/// Whether to overwrite an existing file system object at the path.
-	#[arg(long, requires = "checkout")]
+	#[arg(
+		id = "run.checkout_force",
+		long = "checkout-force",
+		requires = "run.checkout"
+	)]
 	pub checkout_force: bool,
 
 	/// If this flag is set, then exit immediately instead of waiting for the process to finish.
-	#[arg(long, short)]
+	#[arg(id = "run.detach", long = "detach", short = 'd')]
 	pub detach: bool,
 
 	#[command(flatten)]
@@ -39,11 +48,11 @@ pub struct Options {
 	pub spawn: crate::process::spawn::Options,
 
 	/// Print the full spawn output instead of just the process ID.
-	#[arg(long, short)]
+	#[arg(id = "run.verbose", long = "verbose", short = 'v')]
 	pub verbose: bool,
 
 	/// The view to display if the process's stdio is not attached.
-	#[arg(long)]
+	#[arg(id = "run.view", long = "view")]
 	pub view: Option<View>,
 }
 

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -35,6 +35,7 @@ pub struct Options {
 	/// Set arguments as strings.
 	#[arg(
 		action = clap::ArgAction::Append,
+		id = "spawn.arg_strings",
 		long = "arg-string",
 		num_args = 1,
 		short = 'a',
@@ -44,6 +45,7 @@ pub struct Options {
 	/// Set arguments as values.
 	#[arg(
 		action = clap::ArgAction::Append,
+		id = "spawn.arg_values",
 		long = "arg-value",
 		num_args = 1,
 		short = 'A',
@@ -51,13 +53,14 @@ pub struct Options {
 	pub arg_values: Vec<String>,
 
 	/// If this flag is set, then build the specified target and run its output.
-	#[arg(long, short)]
+	#[arg(id = "spawn.build", long = "build", short = 'b')]
 	pub build: bool,
 
 	/// Set this flag to true to require a cached process. Set this flag to false to require a new process to be created. Omit this flag to use a cached process if possible, and create a new process if not.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "spawn.cached",
+		long = "cached",
 		num_args = 0..=1,
 		require_equals = true,
 	)]
@@ -67,11 +70,11 @@ pub struct Options {
 	pub checkin: crate::checkin::Options,
 
 	/// The output's expected checksum.
-	#[arg(long)]
+	#[arg(id = "spawn.checksum", long = "checksum")]
 	pub checksum: Option<tg::Checksum>,
 
 	/// Set the working directory for the process.
-	#[arg(long, short = 'C')]
+	#[arg(id = "spawn.cwd", long = "cwd", short = 'C')]
 	pub cwd: Option<PathBuf>,
 
 	#[command(flatten)]
@@ -80,6 +83,7 @@ pub struct Options {
 	/// Set environment variables as strings.
 	#[arg(
 		action = clap::ArgAction::Append,
+		id = "spawn.env_strings",
 		long = "env-string",
 		num_args = 1,
 		short = 'e',
@@ -89,6 +93,7 @@ pub struct Options {
 	/// Set environment variables as values.
 	#[arg(
 		action = clap::ArgAction::Append,
+		id = "spawn.env_values",
 		long = "env-value",
 		num_args = 1,
 		short = 'E',
@@ -96,37 +101,37 @@ pub struct Options {
 	pub env_values: Vec<String>,
 
 	/// The executable to run.
-	#[arg(long, short = 'x')]
+	#[arg(id = "spawn.executable", long = "executable", short = 'x')]
 	pub executable: Option<tg::command::data::Executable>,
 
 	/// Set the host.
-	#[arg(long)]
+	#[arg(id = "spawn.host", long = "host")]
 	pub host: Option<String>,
 
 	#[command(flatten)]
 	pub location: crate::location::Args,
 
 	/// Whether to retry failed processes.
-	#[arg(long)]
+	#[arg(id = "spawn.retry", long = "retry")]
 	pub retry: bool,
 
 	#[command(flatten)]
 	pub sandbox: Sandbox,
 
 	/// Set the stderr mode.
-	#[arg(long)]
+	#[arg(id = "spawn.stderr", long = "stderr")]
 	pub stderr: Option<tg::process::Stdio>,
 
 	/// Set the stdin mode.
-	#[arg(long)]
+	#[arg(id = "spawn.stdin", long = "stdin")]
 	pub stdin: Option<tg::process::Stdio>,
 
 	/// Set the stdout mode.
-	#[arg(long)]
+	#[arg(id = "spawn.stdout", long = "stdout")]
 	pub stdout: Option<tg::process::Stdio>,
 
 	/// Tag the process.
-	#[arg(long)]
+	#[arg(id = "spawn.tag", long = "tag")]
 	pub tag: Option<tg::Specifier>,
 
 	#[command(flatten)]
@@ -135,17 +140,18 @@ pub struct Options {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Debug {
-	#[arg(long = "debug")]
+	#[arg(id = "spawn.debug.enabled", long = "debug")]
 	enabled: bool,
 
-	#[arg(long = "debug-addr")]
+	#[arg(id = "spawn.debug.addr", long = "debug-addr")]
 	addr: Option<std::net::SocketAddr>,
 
 	#[arg(long = "debug-mode", id = "spawn.debug.mode")]
 	mode: Option<tg::process::debug::Mode>,
 
 	#[arg(
-		long,
+		id = "spawn.debug.inspect",
+		long = "inspect",
 		default_missing_value = "127.0.0.1:9229",
 		num_args = 0..=1,
 		require_equals = true,
@@ -154,7 +160,8 @@ pub struct Debug {
 	inspect: Option<std::net::SocketAddr>,
 
 	#[arg(
-		long,
+		id = "spawn.debug.inspect_brk",
+		long = "inspect-brk",
 		default_missing_value = "127.0.0.1:9229",
 		num_args = 0..=1,
 		require_equals = true,
@@ -163,7 +170,8 @@ pub struct Debug {
 	inspect_brk: Option<std::net::SocketAddr>,
 
 	#[arg(
-		long,
+		id = "spawn.debug.inspect_wait",
+		long = "inspect-wait",
 		default_missing_value = "127.0.0.1:9229",
 		num_args = 0..=1,
 		require_equals = true,
@@ -221,20 +229,20 @@ pub struct Sandbox {
 	/// Whether to sandbox the process, or an existing sandbox to use.
 	#[arg(
 		default_missing_value = "true",
-		id = "sandbox",
+		id = "spawn.sandbox.value",
 		long = "sandbox",
 		num_args = 0..=1,
-		overrides_with = "no_sandbox",
+		overrides_with = "spawn.sandbox.disabled",
 		require_equals = true,
 	)]
 	value: Option<tg::Either<bool, tg::sandbox::Id>>,
 
 	#[arg(
 		default_missing_value = "true",
-		id = "no_sandbox",
+		id = "spawn.sandbox.disabled",
 		long = "no-sandbox",
 		num_args = 0..=1,
-		overrides_with = "sandbox",
+		overrides_with = "spawn.sandbox.value",
 		require_equals = true,
 	)]
 	disabled: Option<bool>,
@@ -270,10 +278,14 @@ impl Sandbox {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Ttl {
-	#[arg(long, overrides_with = "no_ttl", value_parser = humantime::parse_duration)]
+	#[arg(id = "spawn.sandbox.ttl.ttl", long = "ttl", overrides_with = "spawn.sandbox.ttl.no_ttl", value_parser = humantime::parse_duration)]
 	pub ttl: Option<Duration>,
 
-	#[arg(long, overrides_with = "ttl")]
+	#[arg(
+		id = "spawn.sandbox.ttl.no_ttl",
+		long = "no-ttl",
+		overrides_with = "spawn.sandbox.ttl.ttl"
+	)]
 	pub no_ttl: bool,
 }
 
@@ -292,9 +304,10 @@ pub struct Tty {
 	/// Whether to allocate a tty for the process. Optionally set the size as rows,cols.
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "spawn.tty.tty",
+		long = "tty",
 		num_args = 0..=1,
-		overrides_with = "no_tty",
+		overrides_with = "spawn.tty.no_tty",
 		require_equals = true,
 		value_name = "ROWS,COLS",
 	)]
@@ -302,9 +315,10 @@ pub struct Tty {
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "spawn.tty.no_tty",
+		long = "no-tty",
 		num_args = 0..=1,
-		overrides_with = "tty",
+		overrides_with = "spawn.tty.tty",
 		require_equals = true,
 	)]
 	pub(crate) no_tty: Option<bool>,

--- a/packages/cli/src/process/status.rs
+++ b/packages/cli/src/process/status.rs
@@ -19,10 +19,14 @@ pub struct Args {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Timeout {
-	#[arg(long, overrides_with = "no_timeout", value_parser = humantime::parse_duration)]
+	#[arg(id = "status.timeout.timeout", long = "timeout", overrides_with = "status.timeout.no_timeout", value_parser = humantime::parse_duration)]
 	pub timeout: Option<Duration>,
 
-	#[arg(long, overrides_with = "timeout")]
+	#[arg(
+		id = "status.timeout.no_timeout",
+		long = "no-timeout",
+		overrides_with = "status.timeout.timeout"
+	)]
 	pub no_timeout: bool,
 }
 

--- a/packages/cli/src/process/stdio/read.rs
+++ b/packages/cli/src/process/stdio/read.rs
@@ -32,10 +32,14 @@ pub struct Args {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Timeout {
-	#[arg(long, overrides_with = "no_timeout", value_parser = humantime::parse_duration)]
+	#[arg(id = "read.timeout.timeout", long = "timeout", overrides_with = "read.timeout.no_timeout", value_parser = humantime::parse_duration)]
 	pub timeout: Option<Duration>,
 
-	#[arg(long, overrides_with = "timeout")]
+	#[arg(
+		id = "read.timeout.no_timeout",
+		long = "no-timeout",
+		overrides_with = "read.timeout.timeout"
+	)]
 	pub no_timeout: bool,
 }
 

--- a/packages/cli/src/push.rs
+++ b/packages/cli/src/push.rs
@@ -39,18 +39,20 @@ pub struct Args {
 pub struct Eager {
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "push.eager.eager",
+		long = "eager",
 		num_args = 0..=1,
-		overrides_with = "lazy",
+		overrides_with = "push.eager.lazy",
 		require_equals = true,
 	)]
 	eager: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "push.eager.lazy",
+		long = "lazy",
 		num_args = 0..=1,
-		overrides_with = "eager",
+		overrides_with = "push.eager.eager",
 		require_equals = true,
 	)]
 	lazy: Option<bool>,
@@ -67,9 +69,10 @@ pub struct Outputs {
 	#[arg(
 		alias = "output",
 		default_missing_value = "true",
-		long,
+		id = "push.outputs.outputs",
+		long = "outputs",
 		num_args = 0..=1,
-		overrides_with = "no_outputs",
+		overrides_with = "push.outputs.no_outputs",
 		require_equals = true,
 	)]
 	outputs: Option<bool>,
@@ -77,9 +80,10 @@ pub struct Outputs {
 	#[arg(
 		alias = "no-output",
 		default_missing_value = "true",
-		long,
+		id = "push.outputs.no_outputs",
+		long = "no-outputs",
 		num_args = 0..=1,
-		overrides_with = "outputs",
+		overrides_with = "push.outputs.outputs",
 		require_equals = true,
 	)]
 	no_outputs: Option<bool>,

--- a/packages/cli/src/sandbox.rs
+++ b/packages/cli/src/sandbox.rs
@@ -43,28 +43,28 @@ pub enum Command {
 #[derive(Clone, Debug, Default, clap::Args)]
 #[group(skip)]
 pub struct Options {
-	#[arg(long)]
+	#[arg(id = "sandbox.cpu", long = "cpu")]
 	pub cpu: Option<u64>,
 
-	#[arg(long)]
+	#[arg(id = "sandbox.hostname", long = "hostname")]
 	pub hostname: Option<String>,
 
-	#[arg(long)]
+	#[arg(id = "sandbox.isolation", long = "isolation")]
 	pub isolation: Option<tg::sandbox::Isolation>,
 
-	#[arg(long)]
+	#[arg(id = "sandbox.memory", long = "memory")]
 	pub memory: Option<u64>,
 
-	#[arg(action = clap::ArgAction::Append, long = "mount", num_args = 1, short)]
+	#[arg(action = clap::ArgAction::Append, id = "sandbox.mounts", long = "mount", num_args = 1, short = 'm')]
 	pub mounts: Vec<tg::sandbox::Mount>,
 
 	#[clap(flatten)]
 	pub network: Network,
 
-	#[arg(action = clap::ArgAction::Append, long = "port", num_args = 1, short = 'p')]
+	#[arg(action = clap::ArgAction::Append, id = "sandbox.ports", long = "port", num_args = 1, short = 'p')]
 	pub ports: Vec<tg::sandbox::Port>,
 
-	#[arg(long)]
+	#[arg(id = "sandbox.user", long = "user")]
 	pub user: Option<String>,
 }
 
@@ -73,9 +73,10 @@ pub struct Network {
 	/// Enable networking.
 	#[arg(
 		default_missing_value = "",
-		long,
+		id = "sandbox.network.network",
+		long = "network",
 		num_args = 0..=1,
-		overrides_with = "no_network",
+		overrides_with = "sandbox.network.no_network",
 		require_equals = true,
 		value_parser = parse_network,
 	)]
@@ -83,9 +84,10 @@ pub struct Network {
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "sandbox.network.no_network",
+		long = "no-network",
 		num_args = 0..=1,
-		overrides_with = "network",
+		overrides_with = "sandbox.network.network",
 		require_equals = true,
 	)]
 	no_network: bool,

--- a/packages/cli/src/sandbox/create.rs
+++ b/packages/cli/src/sandbox/create.rs
@@ -16,10 +16,14 @@ pub struct Args {
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct Ttl {
-	#[arg(long, overrides_with = "no_ttl", value_parser = humantime::parse_duration)]
+	#[arg(id = "create.ttl.ttl", long = "ttl", overrides_with = "create.ttl.no_ttl", value_parser = humantime::parse_duration)]
 	pub ttl: Option<Duration>,
 
-	#[arg(long, overrides_with = "ttl")]
+	#[arg(
+		id = "create.ttl.no_ttl",
+		long = "no-ttl",
+		overrides_with = "create.ttl.ttl"
+	)]
 	pub no_ttl: bool,
 }
 

--- a/packages/cli/src/sandbox/serve.rs
+++ b/packages/cli/src/sandbox/serve.rs
@@ -24,18 +24,20 @@ pub struct Args {
 pub struct Listen {
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "serve.listen.connect",
+		long = "connect",
 		num_args = 0..=1,
-		overrides_with = "listen",
+		overrides_with = "serve.listen.listen",
 		require_equals = true,
 	)]
 	connect: Option<bool>,
 
 	#[arg(
 		default_missing_value = "true",
-		long,
+		id = "serve.listen.listen",
+		long = "listen",
 		num_args = 0..=1,
-		overrides_with = "connect",
+		overrides_with = "serve.listen.connect",
 		require_equals = true,
 	)]
 	listen: Option<bool>,

--- a/packages/cli/src/tag/put.rs
+++ b/packages/cli/src/tag/put.rs
@@ -7,13 +7,13 @@ pub struct Args {
 	#[command(flatten)]
 	pub checkin: crate::checkin::Options,
 
-	#[arg(long, short)]
+	#[arg(id = "put.force", long = "force", short = 'f')]
 	pub force: bool,
 
 	#[command(flatten)]
 	pub location: crate::location::Args,
 
-	#[arg(long)]
+	#[arg(id = "put.public", long = "public")]
 	pub public: bool,
 
 	#[arg(default_value = ".", index = 2)]

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -73,9 +73,10 @@ pub struct AlternateScreen {
 	#[arg(
 		default_missing_value = "true",
 		hide = true,
-		long,
+		id = "view.alternate_screen.alternate_screen",
+		long = "alternate-screen",
 		num_args = 0..=1,
-		overrides_with = "no_alternate_screen",
+		overrides_with = "view.alternate_screen.no_alternate_screen",
 		require_equals = true,
 	)]
 	alternate_screen: Option<bool>,
@@ -83,9 +84,10 @@ pub struct AlternateScreen {
 	#[arg(
 		default_missing_value = "true",
 		hide = true,
-		long,
+		id = "view.alternate_screen.no_alternate_screen",
+		long = "no-alternate-screen",
 		num_args = 0..=1,
-		overrides_with = "alternate_screen",
+		overrides_with = "view.alternate_screen.alternate_screen",
 		require_equals = true,
 	)]
 	no_alternate_screen: Option<bool>,


### PR DESCRIPTION
Use dot-separated clap IDs for all fields in structs we expect to flatten.