### PR TITLE
fix(cli): accept a file as input to compress and decompress

### DIFF
--- a/packages/cli/src/compress.rs
+++ b/packages/cli/src/compress.rs
@@ -5,7 +5,7 @@ use {crate::Cli, futures::FutureExt as _, tangram_client::prelude::*};
 #[group(skip)]
 pub struct Args {
 	#[arg(index = 1)]
-	pub blob: tg::blob::Id,
+	pub input: tg::Either<tg::blob::Id, tg::file::Id>,
 
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
@@ -17,9 +17,12 @@ pub struct Args {
 impl Cli {
 	pub async fn command_compress(&mut self, args: Args) -> tg::Result<()> {
 		let client = self.client().await?;
-		let blob = tg::Blob::with_id(args.blob);
+		let input = match args.input {
+			tg::Either::Left(id) => tg::Either::Left(tg::Blob::with_id(id)),
+			tg::Either::Right(id) => tg::Either::Right(tg::File::with_id(id)),
+		};
 		let format = args.format;
-		let command = tg::builtin::compress_command(&blob, format);
+		let command = tg::builtin::compress_command(input, format);
 		let command = command
 			.store_with_handle(&client)
 			.await

--- a/packages/cli/src/decompress.rs
+++ b/packages/cli/src/decompress.rs
@@ -5,7 +5,7 @@ use {crate::Cli, futures::FutureExt as _, tangram_client::prelude::*};
 #[group(skip)]
 pub struct Args {
 	#[arg(index = 1)]
-	pub blob: tg::blob::Id,
+	pub input: tg::Either<tg::blob::Id, tg::file::Id>,
 
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
@@ -14,8 +14,11 @@ pub struct Args {
 impl Cli {
 	pub async fn command_decompress(&mut self, args: Args) -> tg::Result<()> {
 		let client = self.client().await?;
-		let blob = tg::Blob::with_id(args.blob);
-		let command = tg::builtin::decompress_command(&blob);
+		let input = match args.input {
+			tg::Either::Left(id) => tg::Either::Left(tg::Blob::with_id(id)),
+			tg::Either::Right(id) => tg::Either::Right(tg::File::with_id(id)),
+		};
+		let command = tg::builtin::decompress_command(input);
 		let command = command
 			.store_with_handle(&client)
 			.await

--- a/packages/cli/tests/compress/file_input.nu
+++ b/packages/cli/tests/compress/file_input.nu
@@ -1,0 +1,15 @@
+use ../../test.nu *
+
+# Compressing and decompressing a file roundtrips to the original file, as documented by both commands.
+
+let server = spawn
+
+let file_id = tg put 'tg.file("contents")' | str trim
+assert ($file_id | str starts-with "fil_") "the put should return a file id"
+
+let compressed = tg compress --format gz $file_id | str trim
+assert ($compressed | str starts-with "fil_") "the compressed output should be a file"
+assert ($compressed != $file_id) "the compressed file should differ from the original"
+
+let decompressed = tg decompress $compressed | str trim
+assert equal $decompressed $file_id "the decompressed file should equal the original"

--- a/packages/clients/rust/src/builtin.rs
+++ b/packages/clients/rust/src/builtin.rs
@@ -240,9 +240,12 @@ where
 }
 
 #[must_use]
-pub fn compress_command(input: &tg::Blob, format: tg::CompressionFormat) -> tg::Command {
+pub fn compress_command(
+	input: tg::Either<tg::Blob, tg::File>,
+	format: tg::CompressionFormat,
+) -> tg::Command {
 	let host = "builtin";
-	let args = vec![input.clone().into(), format.to_string().into()];
+	let args = vec![input.into(), format.to_string().into()];
 	let executable = tg::command::Executable::Path(tg::command::PathExecutable {
 		path: "compress".into(),
 	});
@@ -277,9 +280,9 @@ where
 }
 
 #[must_use]
-pub fn decompress_command(input: &tg::Blob) -> tg::Command {
+pub fn decompress_command(input: tg::Either<tg::Blob, tg::File>) -> tg::Command {
 	let host = "builtin";
-	let args = vec![input.clone().into()];
+	let args = vec![input.into()];
 	let executable = tg::command::Executable::Path(tg::command::PathExecutable {
 		path: "decompress".into(),
 	});


### PR DESCRIPTION
The CLI `compress` and `decompress` commands now accept either a file or a blob, matching the documented functionality and already-existing internal feature set.