### PR TITLE
fix(cli): hold a guard so the output node is always added

### DIFF
--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -1467,7 +1467,10 @@ impl Tree {
 			let client = client.clone();
 			let process = process.clone();
 			let update_sender = update_sender.clone();
+			// Hold a guard so the tree is not considered finished until the output node has been added.
+			let guard = counter.guard();
 			async move {
+				let _guard = guard;
 				let Ok(wait) = process
 					.wait_with_handle(&client, tg::process::wait::Arg::default())
 					.await


### PR DESCRIPTION
Adds a guard ensuring the output node is always added to the tree.  This resolves a race that surfaced in the `tree/command_arg` test. I observed the snapshot failing ~60% of the time. Adding this guard ensures that the tree is never printed before the task's
  `wait_with_handle().await` resolves. The `num_pending` count hits 0, so `is_finished` returns true, before this final node is added. With this addition, this test always passes.