### PR TITLE
fix(server): reject a path option on a process reference with a clear error

### DIFF
--- a/packages/cli/tests/get/process_path_option.nu
+++ b/packages/cli/tests/get/process_path_option.nu
@@ -1,0 +1,14 @@
+use ../../test.nu *
+
+# A process reference with a path option fails because processes do not contain paths.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: 'export default () => tg.file("contents");',
+}
+let spawned = tg build --detach --verbose $path | from json
+
+let output = tg get $"($spawned.process)?path=foo" | complete
+failure $output
+assert ($output.stderr | str contains "cannot get path in process") "the error should mention the path option"

--- a/packages/server/src/get.rs
+++ b/packages/server/src/get.rs
@@ -42,6 +42,9 @@ impl Session {
 		id: &tg::Id,
 		options: &tg::reference::Options,
 	) -> tg::Result<BoxStream<'static, tg::Result<tg::progress::Event<Option<tg::get::Output>>>>> {
+		if id.kind() == tg::id::Kind::Process && options.path.is_some() {
+			return Err(tg::error!("cannot get path in process"));
+		}
 		let referent = tg::Referent::with_item(tg::get::Item::Id(id.clone()));
 		let output = tg::get::Output { referent };
 		let output = self
@@ -335,6 +338,9 @@ impl Session {
 				output.referent.item = tg::get::Item::Pointer(pointer.clone());
 				output.referent.options.path = Some(get.to_owned());
 				Ok(Some(output))
+			},
+			tg::get::Item::Id(id) if id.kind() == tg::id::Kind::Process => {
+				Err(tg::error!("cannot get path in process"))
 			},
 			tg::get::Item::Id(_) => Err(tg::error!("unexpected reference get option")),
 		}


### PR DESCRIPTION
On main, `tg get <pcs_id>?path=foo` succeeds if the process exists. This should probably error with a clear message.