### PR TITLE
fix(builtin): extract empty tars and preserve the zip executable bit

### DIFF
--- a/packages/builtin/src/extract.rs
+++ b/packages/builtin/src/extract.rs
@@ -371,10 +371,11 @@ pub(crate) async fn extract_zip(
 		.await
 		.map_err(|error| tg::error!(!error, "failed to read zip central directory"))?;
 
-	// Get symlinks.
+	// Get the symlinks and executable permissions from the central directory, because the local file headers do not carry the unix permissions.
 	let central_directory: &[u8] = &central_directory;
 	let entry_count = entries.len();
 	let mut symlinks = Vec::new();
+	let mut executables = Vec::new();
 	let mut position = 0;
 	while position + 4 <= central_directory.len() {
 		let signature = u32::from_le_bytes(
@@ -410,6 +411,7 @@ pub(crate) async fn extract_zip(
 		);
 		let permissions = (external_file_attribute >> 16) as u16;
 		symlinks.push(permissions & 0o120_000 == 0o120_000);
+		executables.push(permissions & 0o000_111 != 0);
 		position = position
 			.checked_add(46)
 			.and_then(|position| position.checked_add(filename_length))
@@ -417,26 +419,37 @@ pub(crate) async fn extract_zip(
 			.and_then(|position| position.checked_add(comment_length))
 			.ok_or_else(|| tg::error!("invalid zip central directory"))?;
 	}
-	if symlinks.len() != entry_count {
+	if symlinks.len() != entry_count || executables.len() != entry_count {
 		return Err(tg::error!("invalid zip central directory"));
 	}
 
-	// Apply symlinks.
-	for (path, is_symlink) in entries.iter().zip(symlinks) {
-		if !is_symlink {
+	// Apply the symlinks and executable permissions.
+	for ((path, is_symlink), is_executable) in entries.iter().zip(symlinks).zip(executables) {
+		if is_symlink {
+			let buffer = tokio::fs::read(path)
+				.await
+				.map_err(|error| tg::error!(!error, "failed to read symlink target"))?;
+			let target = std::str::from_utf8(&buffer)
+				.map_err(|error| tg::error!(!error, "symlink target not valid UTF-8"))?;
+			tokio::fs::remove_file(path)
+				.await
+				.map_err(|error| tg::error!(!error, "failed to remove the symlink placeholder"))?;
+			tokio::fs::symlink(target, path)
+				.await
+				.map_err(|error| tg::error!(!error, "failed to create the symlink"))?;
 			continue;
 		}
-		let buffer = tokio::fs::read(path)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to read symlink target"))?;
-		let target = std::str::from_utf8(&buffer)
-			.map_err(|error| tg::error!(!error, "symlink target not valid UTF-8"))?;
-		tokio::fs::remove_file(path)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to remove the symlink placeholder"))?;
-		tokio::fs::symlink(target, path)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to create the symlink"))?;
+		if is_executable {
+			let metadata = tokio::fs::symlink_metadata(path)
+				.await
+				.map_err(|error| tg::error!(!error, "failed to read the entry metadata"))?;
+			if metadata.is_file() {
+				let permissions = std::fs::Permissions::from_mode(0o755);
+				tokio::fs::set_permissions(path, permissions)
+					.await
+					.map_err(|error| tg::error!(!error, "failed to set the permissions"))?;
+			}
+		}
 	}
 
 	Ok(())

--- a/packages/builtin/src/util.rs
+++ b/packages/builtin/src/util.rs
@@ -28,6 +28,13 @@ pub(crate) fn detect_archive_format(
 		return Ok(Some((tg::ArchiveFormat::Tar, None)));
 	}
 
+	// A tar archive with no entries consists of zero-filled end-of-archive blocks. If the first record is entirely zero, then treat the buffer as an empty tar archive.
+	if let Some(block) = bytes.get(0..512)
+		&& block.iter().all(|&byte| byte == 0)
+	{
+		return Ok(Some((tg::ArchiveFormat::Tar, None)));
+	}
+
 	// Otherwise, check for a valid tar checksum by parsing the header record. This is an 8-byte field at offset 148. See <https://en.wikipedia.org/wiki/Tar_(computing)#File_format>: "The checksum is calculated by taking the sum of the unsigned byte values of the header record with the eight checksum bytes taken to be ASCII spaces (decimal value 32). It is stored as a six digit octal number with leading zeroes followed by a NUL and then a space".
 	let position = 148;
 	let length = 8;

--- a/packages/cli/tests/archive/empty_directory_tar_roundtrip.nu
+++ b/packages/cli/tests/archive/empty_directory_tar_roundtrip.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# Archiving and extracting an empty directory as tar roundtrips to the original directory.
+
+let server = spawn
+
+let dir = tg put 'tg.directory({})' | str trim
+
+let blob = tg archive --format tar $dir | str trim
+let extracted = tg extract $blob | str trim
+assert equal $extracted $dir "the extracted directory should equal the original"

--- a/packages/cli/tests/archive/executable_zip_roundtrip.nu
+++ b/packages/cli/tests/archive/executable_zip_roundtrip.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# Archiving and extracting a directory with an executable file as zip preserves the executable bit.
+
+let server = spawn
+
+let dir = tg put 'tg.directory({ "tool": tg.file({ "contents": tg.blob("#!/bin/sh"), "executable": true }) })' | str trim
+
+let blob = tg archive --format zip $dir | str trim
+let extracted = tg extract $blob | str trim
+assert equal $extracted $dir "the extracted directory should equal the original"


### PR DESCRIPTION
Fixes two issues with archives:

- Tar archives of empty directories
- Executable bits in zip archives