### PR TITLE
fix(cli): only create log task in viewer if process stdio is logged

### DIFF
--- a/packages/cli/src/process/run.rs
+++ b/packages/cli/src/process/run.rs
@@ -181,6 +181,7 @@ impl Cli {
 					.map_err(|error| tg::error!(!error, "failed to create the tokio runtime"))?;
 				local_set.block_on(&runtime, async move {
 					let viewer_options = crate::viewer::Options {
+						attached: true,
 						collapse_process_children: true,
 						depth: None,
 						expand_groups: false,

--- a/packages/cli/src/view.rs
+++ b/packages/cli/src/view.rs
@@ -198,6 +198,7 @@ impl Cli {
 			local_set
 				.block_on(&runtime, async move {
 					let options = crate::viewer::Options {
+						attached: false,
 						collapse_process_children: args.collapse_process_children,
 						depth: args.depth,
 						expand_groups: args.expand_tags,

--- a/packages/cli/src/viewer.rs
+++ b/packages/cli/src/viewer.rs
@@ -55,6 +55,7 @@ pub struct Package(pub tg::Object);
 
 #[derive(Clone, Debug)]
 pub struct Options {
+	pub attached: bool,
 	pub collapse_process_children: bool,
 	pub depth: Option<u32>,
 	pub expand_groups: bool,

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -227,7 +227,8 @@ impl Tree {
 				let update_sender = update_sender.clone();
 				let guard = counter.guard();
 				let task = Task::spawn_local(|_| async move {
-					Self::expand_task(&client, counter.clone(), referent, update_sender).await;
+					Self::expand_task(&client, counter.clone(), referent, update_sender, false)
+						.await;
 					drop(guard);
 				});
 				Some(task)
@@ -392,6 +393,7 @@ impl Tree {
 		if matches!(node.expanded, Some(true) | None) {
 			return;
 		}
+		let force_log = node.depth == 0 && node.options.attached;
 		let children_task = Task::spawn_local({
 			let counter = self.counter.clone();
 			let guard = counter.guard();
@@ -399,7 +401,7 @@ impl Tree {
 			let update_sender = node.update_sender.clone();
 			let referent = referent.clone();
 			move |_| async move {
-				Self::expand_task(&client, counter, referent, update_sender).await;
+				Self::expand_task(&client, counter, referent, update_sender, force_log).await;
 				drop(guard);
 			}
 		});
@@ -1411,16 +1413,19 @@ impl Tree {
 		counter: UpdateCounter,
 		referent: tg::Referent<tg::Process>,
 		update_sender: NodeUpdateSender,
+		force_log: bool,
 	) -> tg::Result<()> {
 		let process = referent.item.clone();
 
-		// Create the log task, but only if the process's stdio is logged. Reading
-		// a piped or tty stream here would destructively consume it, stealing the
-		// data from the process that spawned it and is reading it through a pipe.
-		let logged = match process.load_with_handle(client).await {
-			Ok(state) => state.log.is_some() || state.stdout.is_log() || state.stderr.is_log(),
-			Err(_) => false,
-		};
+		// Create the log task, but only if the process's stdio is logged or this is
+		// the attached root process. Reading a piped or tty stream of a descendant
+		// process would destructively consume it, stealing the data from the
+		// process that spawned it and is reading it through a pipe.
+		let logged = force_log
+			|| match process.load_with_handle(client).await {
+				Ok(state) => state.log.is_some() || state.stdout.is_log() || state.stderr.is_log(),
+				Err(_) => false,
+			};
 		if logged {
 			let log_task = Task::spawn_local({
 				let process = process.clone();
@@ -1679,11 +1684,19 @@ impl Tree {
 		counter: UpdateCounter,
 		referent: tg::Referent<Item>,
 		update_sender: NodeUpdateSender,
+		force_log: bool,
 	) {
 		let result = match referent.item() {
 			Item::Process(process) => {
 				let referent = referent.clone().map(|_| process.clone());
-				Self::expand_process(client, counter.clone(), referent, update_sender.clone()).await
+				Self::expand_process(
+					client,
+					counter.clone(),
+					referent,
+					update_sender.clone(),
+					force_log,
+				)
+				.await
 			},
 			Item::Value(value) => {
 				Self::expand_value(
@@ -1950,8 +1963,9 @@ impl Tree {
 			let client = client.clone();
 			let referent = referent.clone();
 			let update_sender = update_sender.clone();
-			let task: Task<()> = Task::spawn_local(|_| async move {
-				Self::expand_task(&client, counter, referent, update_sender).await;
+			let force_log = options.attached;
+			let task: Task<()> = Task::spawn_local(move |_| async move {
+				Self::expand_task(&client, counter, referent, update_sender, force_log).await;
 				drop(guard);
 			});
 			Some(task)

--- a/packages/cli/src/viewer/tree.rs
+++ b/packages/cli/src/viewer/tree.rs
@@ -1414,23 +1414,31 @@ impl Tree {
 	) -> tg::Result<()> {
 		let process = referent.item.clone();
 
-		// Create the log task.
-		let log_task = Task::spawn_local({
-			let process = process.clone();
-			let client = client.clone();
-			let guard = counter.guard();
-			let update_sender = update_sender.clone();
-			|_| async move {
-				Self::process_log_task(&client, process, update_sender)
-					.await
-					.ok();
-				drop(guard);
-			}
-		});
-		let update = move |node: Rc<RefCell<Node>>| {
-			node.borrow_mut().log_task.replace(log_task);
+		// Create the log task, but only if the process's stdio is logged. Reading
+		// a piped or tty stream here would destructively consume it, stealing the
+		// data from the process that spawned it and is reading it through a pipe.
+		let logged = match process.load_with_handle(client).await {
+			Ok(state) => state.log.is_some() || state.stdout.is_log() || state.stderr.is_log(),
+			Err(_) => false,
 		};
-		update_sender.send(Box::new(update)).ok();
+		if logged {
+			let log_task = Task::spawn_local({
+				let process = process.clone();
+				let client = client.clone();
+				let guard = counter.guard();
+				let update_sender = update_sender.clone();
+				|_| async move {
+					Self::process_log_task(&client, process, update_sender)
+						.await
+						.ok();
+					drop(guard);
+				}
+			});
+			let update = move |node: Rc<RefCell<Node>>| {
+				node.borrow_mut().log_task.replace(log_task);
+			};
+			update_sender.send(Box::new(update)).ok();
+		}
 
 		let command = process.command_with_handle(client).await?;
 		let value = tg::Value::Object(command.clone().into());

--- a/packages/cli/tests/js/process/nested_pipe_repro.nu
+++ b/packages/cli/tests/js/process/nested_pipe_repro.nu
@@ -1,0 +1,26 @@
+use ../../../test.nu *
+
+# Minimal, deterministic reproduction of the nested-sandbox pipe data-loss bug.
+#
+# A sandboxed parent (tg build) spawns a sandboxed child, pipes its stdout, and
+# reads it. The child's stdout is lost: readAll returns 0 bytes instead of 2,
+# even though the child exits 0.
+#
+# The bug requires BOTH levels of sandboxing:
+#   - parent sandboxed:  run via `tg build` (not `tg run`)
+#   - child sandboxed:   `.sandbox()` on the spawn
+# Drop either one and the read succeeds. This is the mechanism behind the flaky
+# js/process/stdio_read_all.nu and stdio_write_all.nu.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			let child = await tg.spawn`printf hi`.stdout("pipe").sandbox();
+			return (await child.stdout.readAll()).length;
+		};
+	'
+}
+
+assert ((tg build $path | from json) == 2) "nested-sandbox pipe read lost the child stdout"


### PR DESCRIPTION
Fixes an apparent issue where stdio in a nested sandbox with piped stdio can get lost.