### PR TITLE
fix(auth): reject duplicate creation of auth entities instead of idempotent operations

### DIFF
--- a/packages/cli/tests/grants/create_duplicate.nu
+++ b/packages/cli/tests/grants/create_duplicate.nu
@@ -1,0 +1,20 @@
+use ../../test.nu *
+
+# Creating a grant that already exists fails.
+
+let server = spawn --config { authentication: true }
+
+def current_token [] {
+	open $env.TANGRAM_CONFIG | get token
+}
+
+tg user login alice
+let alice = current_token
+let bob_user = tg user login bob | from json
+
+tg --token $alice group create team
+tg --token $alice grant $bob_user.id read team
+
+let output = tg --token $alice grant $bob_user.id read team | complete
+failure $output "creating a grant that already exists should fail"
+assert ($output.stderr | str contains "already") "the error should report that the grant already exists"

--- a/packages/cli/tests/group/members_add_duplicate.nu
+++ b/packages/cli/tests/group/members_add_duplicate.nu
@@ -1,0 +1,20 @@
+use ../../test.nu *
+
+# Adding a member that is already in the group fails because the membership already exists.
+
+let server = spawn --config { authentication: true }
+
+def current_token [] {
+	open $env.TANGRAM_CONFIG | get token
+}
+
+tg user login alice
+let alice = current_token
+let bob_user = tg user login bob | from json
+
+tg --token $alice group create team
+tg --token $alice group members add team $bob_user.id
+
+let output = tg --token $alice group members add team $bob_user.id | complete
+failure $output "adding a member that already exists should fail"
+assert ($output.stderr | str contains "already") "the error should report that the membership already exists"

--- a/packages/cli/tests/organization/create_duplicate.nu
+++ b/packages/cli/tests/organization/create_duplicate.nu
@@ -1,0 +1,18 @@
+use ../../test.nu *
+
+# Creating an organization whose specifier is already in use fails with a clear error.
+
+let server = spawn --config { authentication: true }
+
+def current_token [] {
+	open $env.TANGRAM_CONFIG | get token
+}
+
+tg user login alice
+let alice = current_token
+
+tg --token $alice organization create acme
+
+let output = tg --token $alice organization create acme | complete
+failure $output "a duplicate organization should be rejected"
+assert ($output.stderr | str contains "already in use") "the error should mention that the specifier is already in use"

--- a/packages/cli/tests/organization/members_add_duplicate.nu
+++ b/packages/cli/tests/organization/members_add_duplicate.nu
@@ -1,0 +1,20 @@
+use ../../test.nu *
+
+# Adding a member that is already in the organization fails because the membership already exists.
+
+let server = spawn --config { authentication: true }
+
+def current_token [] {
+	open $env.TANGRAM_CONFIG | get token
+}
+
+tg user login alice
+let alice = current_token
+let bob_user = tg user login bob | from json
+
+tg --token $alice organization create acme
+tg --token $alice organization members add acme $bob_user.id
+
+let output = tg --token $alice organization members add acme $bob_user.id | complete
+failure $output "adding a member that already exists should fail"
+assert ($output.stderr | str contains "already") "the error should report that the membership already exists"

--- a/packages/server/src/grant.rs
+++ b/packages/server/src/grant.rs
@@ -30,9 +30,12 @@ impl Session {
 				let session = session.clone();
 				async move {
 					let mut batch = tangram_index::batch::Arg::default();
-					let grant = session
+					let (grant, inserted) = session
 						.create_grant_with_transaction(transaction, arg, &mut batch)
 						.await?;
+					if !inserted {
+						return Err(tg::error!("the grant already exists").into());
+					}
 					Ok::<_, crate::database::Error>(ControlFlow::Break((grant, batch)))
 				}
 				.boxed()
@@ -89,7 +92,7 @@ impl Session {
 		transaction: &crate::database::Transaction<'_>,
 		arg: tg::grant::create::Arg,
 		batch: &mut tangram_index::batch::Arg,
-	) -> tg::Result<tg::Grant> {
+	) -> tg::Result<(tg::Grant, bool)> {
 		let resource = Self::resolve_resource_with_transaction(transaction, &arg.resource)
 			.await?
 			.ok_or_else(|| tg::error!("failed to find the resource"))?;
@@ -145,13 +148,16 @@ impl Session {
 				)
 				.await
 				.map_err(|error| tg::error!(!error, "failed to execute the statement"))?;
-			return Ok(tg::Grant {
-				created_at: row.created_at,
-				creator: row.creator,
-				permission: arg.permission,
-				principal,
-				resource,
-			});
+			return Ok((
+				tg::Grant {
+					created_at: row.created_at,
+					creator: row.creator,
+					permission: arg.permission,
+					principal,
+					resource,
+				},
+				false,
+			));
 		}
 		batch.put_grants.push(tangram_index::grant::put::Arg {
 			created_at,
@@ -161,13 +167,16 @@ impl Session {
 			principal: principal.clone(),
 			resource: resource.clone(),
 		});
-		Ok(tg::Grant {
-			created_at,
-			creator,
-			permission: arg.permission,
-			principal,
-			resource,
-		})
+		Ok((
+			tg::Grant {
+				created_at,
+				creator,
+				permission: arg.permission,
+				principal,
+				resource,
+			},
+			true,
+		))
 	}
 
 	pub(crate) async fn delete_grant_with_transaction(

--- a/packages/server/src/group/members/add.rs
+++ b/packages/server/src/group/members/add.rs
@@ -125,7 +125,7 @@ impl Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to execute the statement"))?;
 		if inserted == 0 {
-			return Ok(());
+			return Err(tg::error!("the member is already in the group"));
 		}
 		batch
 			.put_group_members

--- a/packages/server/src/organization/create.rs
+++ b/packages/server/src/organization/create.rs
@@ -84,6 +84,12 @@ impl Session {
 		if arg.specifier.components().count() != 1 {
 			return Err(tg::error!("invalid organization specifier"));
 		}
+		if Self::try_get_node_by_specifier_with_transaction(transaction, &arg.specifier)
+			.await?
+			.is_some()
+		{
+			return Err(tg::error!("specifier is already in use"));
+		}
 		let id = tg::organization::Id::new();
 		let node = Self::create_node_with_transaction(
 			transaction,

--- a/packages/server/src/organization/members/add.rs
+++ b/packages/server/src/organization/members/add.rs
@@ -134,7 +134,7 @@ impl Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to execute the statement"))?;
 		if inserted == 0 {
-			return Ok(());
+			return Err(tg::error!("the member is already in the organization"));
 		}
 		batch
 			.put_organization_members


### PR DESCRIPTION
On main, adding a grant or a member that already exists succeeds, and simply doesn't mutate any state. Instead, this PR causes these operations to fail with an error informing the user the same entity already exists.