### PR TITLE
fix(auth): attempting a grant on a resource a principal cannot see does not reveal whether it exists

### DIFF
--- a/packages/cli/tests/grants/create_no_existence_oracle.nu
+++ b/packages/cli/tests/grants/create_no_existence_oracle.nu
@@ -1,0 +1,26 @@
+use ../../test.nu *
+
+# Attempting to grant on a resource the actor cannot see does not reveal whether it exists.
+
+let server = spawn --config { authentication: true }
+
+def current_token [] {
+	open $env.TANGRAM_CONFIG | get token
+}
+
+tg user login alice
+let alice = current_token
+let eve_user = tg user login eve | from json
+let eve = current_token
+
+# Alice owns a resource that eve has no access to.
+tg --token $alice group create secret
+
+# Granting on the invisible-but-existing resource fails the same way as a nonexistent one.
+let existing = tg --token $eve grant $eve_user.id read secret | complete
+failure $existing "an adversary should not be able to grant on a resource she cannot see"
+assert ($existing.stderr | str contains "failed to find the resource") "the error must not reveal that the resource exists"
+
+let missing = tg --token $eve grant $eve_user.id read does-not-exist | complete
+failure $missing "granting on a nonexistent resource should fail"
+assert ($missing.stderr | str contains "failed to find the resource") "a nonexistent resource should report not found"

--- a/packages/server/src/grant.rs
+++ b/packages/server/src/grant.rs
@@ -20,6 +20,7 @@ impl Session {
 		{
 			return Err(tg::error!("failed to find the resource"));
 		}
+
 		// Creating a grant requires admin permission on the resource.
 		if self
 			.authorize(arg.resource.clone(), tg::grant::Permission::Admin)

--- a/packages/server/src/grant.rs
+++ b/packages/server/src/grant.rs
@@ -13,13 +13,19 @@ use {
 
 impl Session {
 	pub(crate) async fn create_grant(&self, arg: tg::grant::create::Arg) -> tg::Result<tg::Grant> {
-		match self
-			.authorize(arg.resource.clone(), tg::grant::Permission::Admin)
-			.await?
+		// The resource is not found without read permission, so creating a grant does not reveal whether a resource the actor cannot see exists.
+		if self
+			.authorize(arg.resource.clone(), tg::grant::Permission::Read)
+			.await? != Some(true)
 		{
-			None => return Err(tg::error!("failed to find the resource")),
-			Some(false) => return Err(tg::error!("unauthorized")),
-			Some(true) => (),
+			return Err(tg::error!("failed to find the resource"));
+		}
+		// Creating a grant requires admin permission on the resource.
+		if self
+			.authorize(arg.resource.clone(), tg::grant::Permission::Admin)
+			.await? != Some(true)
+		{
+			return Err(tg::error!("unauthorized"));
 		}
 		let session = self.clone();
 		let (grant, batch) = self


### PR DESCRIPTION
Currently, attempting to create a grant on a resource that does not exist but that you should not have access for reveals the object does not exist. This check fails to authorize first, obscuring this information.