### PR TITLE
fix(auth): delete_grant for objects only requires the creator to match, not admin

### DIFF
--- a/packages/cli/tests/grants/object_grant_isolation.nu
+++ b/packages/cli/tests/grants/object_grant_isolation.nu
@@ -1,0 +1,36 @@
+use ../../test.nu *
+
+# A subtree grant on one file confers neither its parent directory nor its sibling files.
+
+let remote = spawn --cloud --name remote --config { authentication: true }
+
+let alice = tg --url $remote.url login --verbose alice | from json
+let eve = tg --url $remote.url login --verbose eve | from json
+
+let alice_local = spawn --name alice-local --config {
+	remotes: { default: { url: $remote.url, token: $alice.token } },
+}
+
+# Alice stores a private directory with two files.
+let directory = tg --url $alice_local.url put 'tg.directory({ "a.txt": tg.file("aaa"), "b.txt": tg.file("bbb") })' | str trim
+tg --url $alice_local.url index
+let children = tg --url $alice_local.url children $directory | from json
+let granted_file = $children | get 0
+let sibling_file = $children | get 1
+tg --url $alice_local.url push --lazy $directory
+tg --url $remote.url index
+
+# Alice grants Eve the subtree of one file only.
+tg --url $remote.url --token $alice.token grant $eve.user.id object_subtree $granted_file | ignore
+
+# Eve can read the granted file.
+let granted = tg --url $remote.url --token $eve.token get $granted_file | complete
+success $granted "Eve should read the file she was granted."
+
+# Eve cannot climb to the parent directory.
+let parent = tg --url $remote.url --token $eve.token get $directory | complete
+failure $parent "the grant should not confer the parent directory."
+
+# Eve cannot reach the sibling file.
+let sibling = tg --url $remote.url --token $eve.token get $sibling_file | complete
+failure $sibling "the grant should not confer a sibling file."

--- a/packages/cli/tests/grants/object_revoke_foreign_grant.nu
+++ b/packages/cli/tests/grants/object_revoke_foreign_grant.nu
@@ -1,0 +1,30 @@
+use ../../test.nu *
+
+# A principal who can read an object cannot revoke a grant another principal created on it; only the creator may revoke.
+
+let remote = spawn --cloud --name remote --config { authentication: true }
+
+let alice = tg --url $remote.url login --verbose alice | from json
+let bob = tg --url $remote.url login --verbose bob | from json
+let eve = tg --url $remote.url login --verbose eve | from json
+
+let alice_local = spawn --name alice-local --config {
+	remotes: { default: { url: $remote.url, token: $alice.token } },
+}
+
+# Alice stores a private file and grants both Bob and Eve the subtree.
+let directory = tg --url $alice_local.url put 'tg.directory({ "hello.txt": tg.file("hello") })' | str trim
+tg --url $alice_local.url index
+let file = tg --url $alice_local.url children $directory | from json | get 0
+tg --url $alice_local.url push --lazy $file
+tg --url $remote.url index
+tg --url $remote.url --token $alice.token grant $bob.user.id object_subtree $file | ignore
+tg --url $remote.url --token $alice.token grant $eve.user.id object_subtree $file | ignore
+
+# Eve can read the file, but she did not create Bob's grant, so she cannot revoke it.
+let output = tg --url $remote.url --token $eve.token revoke $bob.user.id object_subtree $file | complete
+failure $output "Eve should not revoke a grant she did not create."
+
+# Bob's grant survives, so he retains access.
+let bob_read = tg --url $remote.url --token $bob.token get $file | complete
+success $bob_read "Bob should retain access after Eve's failed revoke."

--- a/packages/cli/tests/grants/object_revoke_removes_access.nu
+++ b/packages/cli/tests/grants/object_revoke_removes_access.nu
@@ -1,0 +1,32 @@
+use ../../test.nu *
+
+# Revoking an object grant should succeed and remove the grantee's access.
+
+let remote = spawn --cloud --name remote --config { authentication: true }
+
+let alice = tg --url $remote.url login --verbose alice | from json
+let bob = tg --url $remote.url login --verbose bob | from json
+
+let alice_local = spawn --name alice-local --config {
+	remotes: { default: { url: $remote.url, token: $alice.token } },
+}
+
+# Alice stores a private file on the remote and grants Bob the subtree.
+let directory = tg --url $alice_local.url put 'tg.directory({ "hello.txt": tg.file("hello") })' | str trim
+tg --url $alice_local.url index
+let file = tg --url $alice_local.url children $directory | from json | get 0
+tg --url $alice_local.url push --lazy $file
+tg --url $remote.url index
+tg --url $remote.url --token $alice.token grant $bob.user.id object_subtree $file | ignore
+
+# Bob can read the file while the grant is in effect.
+let granted = tg --url $remote.url --token $bob.token get $file | complete
+success $granted "Bob should read the file while the grant is in effect."
+
+# Revoking an object grant should succeed rather than fail because admin is invalid on an object resource.
+let revoked = tg --url $remote.url --token $alice.token revoke $bob.user.id object_subtree $file | complete
+success $revoked "revoking an object grant should succeed."
+
+# After revocation Bob can no longer read the file.
+let denied = tg --url $remote.url --token $bob.token get $file | complete
+failure $denied "Bob should lose access after the grant is revoked."

--- a/packages/cli/tests/grants/object_self_grant_persists.nu
+++ b/packages/cli/tests/grants/object_self_grant_persists.nu
@@ -1,0 +1,30 @@
+use ../../test.nu *
+
+# Exercising a grant is akin to cloning the capability, so a principal who re-grants access to themselves retains it even after the granting principal revokes; revocation is not a global kill-switch.
+
+let remote = spawn --cloud --name remote --config { authentication: true }
+
+let alice = tg --url $remote.url login --verbose alice | from json
+let bob = tg --url $remote.url login --verbose bob | from json
+
+let alice_local = spawn --name alice-local --config {
+	remotes: { default: { url: $remote.url, token: $alice.token } },
+}
+
+# Alice stores a private file and grants Bob the subtree.
+let directory = tg --url $alice_local.url put 'tg.directory({ "hello.txt": tg.file("hello") })' | str trim
+tg --url $alice_local.url index
+let file = tg --url $alice_local.url children $directory | from json | get 0
+tg --url $alice_local.url push --lazy $file
+tg --url $remote.url index
+tg --url $remote.url --token $alice.token grant $bob.user.id object_subtree $file | ignore
+
+# While he holds the grant, Bob re-grants the subtree to himself, cloning the capability.
+tg --url $remote.url --token $bob.token grant $bob.user.id object_subtree $file | ignore
+
+# Alice revokes the grant she made to Bob; this removes only her own grant.
+tg --url $remote.url --token $alice.token revoke $bob.user.id object_subtree $file | ignore
+
+# Bob retains access through the grant he made to himself, since a revoke cannot reach a capability another principal already holds.
+let output = tg --url $remote.url --token $bob.token get $file | complete
+success $output "Bob should retain access through his own grant after Alice revokes hers."

--- a/packages/server/src/grant.rs
+++ b/packages/server/src/grant.rs
@@ -85,15 +85,7 @@ impl Session {
 				if tg::object::Id::try_from(id.clone()).is_ok()
 					|| id.kind() == tg::id::Kind::Process =>
 			{
-				// An object or process grant is self-permissioning, so revoking it requires only the permission being revoked, just as creating it does.
-				tangram_index::authorize::validate(id, arg.permissions)?;
-				if self
-					.authorize(arg.resource.clone(), arg.permissions)
-					.await?
-					.is_none_or(|permissions| !permissions.contains(arg.permissions))
-				{
-					return Ok(None);
-				}
+				// A grant on an object or process may be revoked only by its creator, which is enforced by the creator scoping in the transaction, so being able to read the resource confers no power to revoke another principal's grant.
 			},
 			_ => {
 				// Revoking a grant on a user, group, organization, or tag requires admin permission on the resource.

--- a/packages/server/src/grant.rs
+++ b/packages/server/src/grant.rs
@@ -80,11 +80,30 @@ impl Session {
 	}
 
 	pub(crate) async fn delete_grant(&self, arg: tg::grant::delete::Arg) -> tg::Result<Option<()>> {
-		let permission = tg::grant::Permission::Admin;
-		match self.authorize(arg.resource.clone(), permission).await? {
-			None => return Ok(None),
-			Some(permissions) if permissions.contains(permission) => (),
-			Some(_) => return Err(tg::error!("unauthorized")),
+		match &arg.resource {
+			tg::grant::Resource::Id(id)
+				if tg::object::Id::try_from(id.clone()).is_ok()
+					|| id.kind() == tg::id::Kind::Process =>
+			{
+				// An object or process grant is self-permissioning, so revoking it requires only the permission being revoked, just as creating it does.
+				tangram_index::authorize::validate(id, arg.permissions)?;
+				if self
+					.authorize(arg.resource.clone(), arg.permissions)
+					.await?
+					.is_none_or(|permissions| !permissions.contains(arg.permissions))
+				{
+					return Ok(None);
+				}
+			},
+			_ => {
+				// Revoking a grant on a user, group, organization, or tag requires admin permission on the resource.
+				let permission = tg::grant::Permission::Admin;
+				match self.authorize(arg.resource.clone(), permission).await? {
+					None => return Ok(None),
+					Some(permissions) if permissions.contains(permission) => (),
+					Some(_) => return Err(tg::error!("unauthorized")),
+				}
+			},
 		}
 		let session = self.clone();
 		let (output, batch) = self


### PR DESCRIPTION
Revoking an object or process grant 500'd because delete_grant required Admin, which is invalid for those resources. Skip the Admin gate for objects and processes and rely on the transaction's existing creator scoping, so only the grant's creator may revoke it. Grants on users, groups, organizations, and tags are unchanged.