### PR TITLE
fix(auth): authorize process output

### DIFF
--- a/packages/cli/tests/grants/process_output_foreign_object_nested.nu
+++ b/packages/cli/tests/grants/process_output_foreign_object_nested.nu
@@ -1,0 +1,28 @@
+use ../../test.nu *
+
+# A process cannot leak a private object by nesting it in its output: building a directory that references tg.File.withId of a file the builder cannot read must not grant the builder read access to that file.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+let eve = tg login --verbose eve | from json
+
+# Alice builds a private file.
+let alice_path = artifact { tangram.ts: 'export default () => tg.file("topsecret")' }
+let alice_process = tg --token $alice.token build --detach $alice_path | str trim
+let file = (tg --token $alice.token wait $alice_process | from json).output.value
+
+# Eve cannot read Alice's private file.
+let denied = tg --token $eve.token get $file | complete
+failure $denied "Eve should not read Alice's private file before the exploit."
+
+# Eve builds a process whose output is a directory that nests Alice's private file, referenced by id.
+let source = 'export default () => tg.directory({ "leak": tg.File.withId("FILE_ID") })' | str replace "FILE_ID" $file
+let eve_path = artifact { tangram.ts: $source }
+let eve_process = tg --token $eve.token build --detach $eve_path | str trim
+tg --token $eve.token wait $eve_process
+
+# Eve must not gain read access to Alice's private file by nesting it in her process output.
+let leaked = tg --token $eve.token get $file | complete
+failure $leaked "Eve must not read Alice's private file after nesting it in her process output."
+assert ($leaked.stderr | str contains "failed to load the object") "the private file should remain masked."

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -129,6 +129,46 @@ impl Session {
 			}
 		}
 
+		// A process confers read access on its output objects, so the principal finishing the
+		// process must be able to read every object it is naming as the output. Otherwise a process
+		// could leak a private object by naming it as its output: a process that produces an object
+		// stores it and is thereby granted read access, whereas a process that merely names an
+		// existing object by id stores nothing and holds no grant. The objects are authorized
+		// concurrently.
+		if exit == 0
+			&& let Some(data) = &output
+		{
+			let permission =
+				tg::grant::Permission::Object(tg::grant::permission::object::Permission::Node);
+			let mut objects = std::collections::BTreeSet::new();
+			data.children(&mut objects);
+			let unauthorized = futures::future::try_join_all(objects.into_iter().map(|object| {
+				async move {
+					let resource = tg::grant::Resource::Id(object.clone().into());
+					let authorized = self
+						.authorize(resource, permission)
+						.await?
+						.is_some_and(|permissions| permissions.contains(permission));
+					Ok::<_, tg::Error>((!authorized).then_some(object))
+				}
+			}))
+			.await?
+			.into_iter()
+			.flatten()
+			.next();
+			if let Some(object) = unauthorized {
+				let data = tg::error::Data {
+					message: Some(format!(
+						"the process attempted to output an object it cannot read: {object}"
+					)),
+					..Default::default()
+				};
+				error = Some(tg::Either::Left(data));
+				exit = 1;
+				output = None;
+			}
+		}
+
 		let error_code = match error.as_ref() {
 			Some(tg::Either::Left(data)) => data.code,
 			Some(tg::Either::Right(id)) => {

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -129,13 +129,8 @@ impl Session {
 			}
 		}
 
-		// A process confers read access on the whole subtree of its output, so the principal
-		// finishing the process must be able to read every object reachable from the output.
-		// Otherwise a process could leak a private object by naming it, or by nesting it in a
-		// directory it builds, as its output. An output produced by checking in files holds a
-		// subtree grant and so its whole subtree is readable, whereas an output set by id via the
-		// output xattr only holds a node grant on each object the process produced, so the subtree
-		// is verified by descending into the objects the process can read only at the node level.
+		// Ensure the principal finishing the process can read every object reachable from its
+		// output, so that a process cannot leak a private object by naming it as its output.
 		if exit == 0
 			&& let Some(data) = &output
 		{
@@ -265,10 +260,6 @@ impl Session {
 		Ok(Some(true))
 	}
 
-	/// Find an object reachable from a process output that the principal cannot read, if any. If
-	/// the principal holds a subtree grant on an object, then its whole subtree is readable and the
-	/// search does not descend into it. Otherwise the principal must hold a node grant on the
-	/// object, and the search descends into the object's children.
 	async fn find_unreadable_output_object(
 		&self,
 		roots: std::collections::BTreeSet<tg::object::Id>,

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -129,14 +129,31 @@ impl Session {
 			}
 		}
 
-		// Ensure the principal finishing the process can read every object reachable from its
-		// output, so that a process cannot leak a private object by naming it as its output.
+		// A process confers subtree read access on its output objects, so the principal finishing
+		// the process must hold subtree read access to each object it is naming as the output.
+		// Otherwise a process could leak a private object by naming it as its output.
 		if exit == 0
 			&& let Some(data) = &output
 		{
+			let permission =
+				tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
 			let mut objects = std::collections::BTreeSet::new();
 			data.children(&mut objects);
-			if let Some(object) = self.find_unreadable_output_object(objects).await? {
+			let unauthorized = futures::future::try_join_all(objects.into_iter().map(|object| {
+				async move {
+					let resource = tg::grant::Resource::Id(object.clone().into());
+					let authorized = self
+						.authorize(resource, permission)
+						.await?
+						.is_some_and(|permissions| permissions.contains(permission));
+					Ok::<_, tg::Error>((!authorized).then_some(object))
+				}
+			}))
+			.await?
+			.into_iter()
+			.flatten()
+			.next();
+			if let Some(object) = unauthorized {
 				let data = tg::error::Data {
 					message: Some(format!(
 						"the process attempted to output an object it cannot read: {object}"
@@ -258,45 +275,6 @@ impl Session {
 		self.spawn_process_finish_tasks(&id);
 
 		Ok(Some(true))
-	}
-
-	async fn find_unreadable_output_object(
-		&self,
-		roots: std::collections::BTreeSet<tg::object::Id>,
-	) -> tg::Result<Option<tg::object::Id>> {
-		let node = tg::grant::Permission::Object(tg::grant::permission::object::Permission::Node);
-		let subtree =
-			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
-		let mut seen = std::collections::BTreeSet::new();
-		let mut stack = roots.into_iter().collect::<Vec<_>>();
-		while let Some(id) = stack.pop() {
-			if !seen.insert(id.clone()) {
-				continue;
-			}
-			let resource = tg::grant::Resource::Id(id.clone().into());
-			if self
-				.authorize(resource.clone(), subtree)
-				.await?
-				.is_some_and(|permissions| permissions.contains(subtree))
-			{
-				continue;
-			}
-			if !self
-				.authorize(resource, node)
-				.await?
-				.is_some_and(|permissions| permissions.contains(node))
-			{
-				return Ok(Some(id));
-			}
-			let mut children = std::collections::BTreeSet::new();
-			tg::Object::with_id(id.clone())
-				.data_with_handle(self)
-				.await
-				.map_err(|error| tg::error!(!error, %id, "failed to load the output object"))?
-				.children(&mut children);
-			stack.extend(children);
-		}
-		Ok(None)
 	}
 
 	pub(crate) async fn store_process_error(

--- a/packages/server/src/process/finish.rs
+++ b/packages/server/src/process/finish.rs
@@ -129,34 +129,19 @@ impl Session {
 			}
 		}
 
-		// A process confers read access on its output objects, so the principal finishing the
-		// process must be able to read every object it is naming as the output. Otherwise a process
-		// could leak a private object by naming it as its output: a process that produces an object
-		// stores it and is thereby granted read access, whereas a process that merely names an
-		// existing object by id stores nothing and holds no grant. The objects are authorized
-		// concurrently.
+		// A process confers read access on the whole subtree of its output, so the principal
+		// finishing the process must be able to read every object reachable from the output.
+		// Otherwise a process could leak a private object by naming it, or by nesting it in a
+		// directory it builds, as its output. An output produced by checking in files holds a
+		// subtree grant and so its whole subtree is readable, whereas an output set by id via the
+		// output xattr only holds a node grant on each object the process produced, so the subtree
+		// is verified by descending into the objects the process can read only at the node level.
 		if exit == 0
 			&& let Some(data) = &output
 		{
-			let permission =
-				tg::grant::Permission::Object(tg::grant::permission::object::Permission::Node);
 			let mut objects = std::collections::BTreeSet::new();
 			data.children(&mut objects);
-			let unauthorized = futures::future::try_join_all(objects.into_iter().map(|object| {
-				async move {
-					let resource = tg::grant::Resource::Id(object.clone().into());
-					let authorized = self
-						.authorize(resource, permission)
-						.await?
-						.is_some_and(|permissions| permissions.contains(permission));
-					Ok::<_, tg::Error>((!authorized).then_some(object))
-				}
-			}))
-			.await?
-			.into_iter()
-			.flatten()
-			.next();
-			if let Some(object) = unauthorized {
+			if let Some(object) = self.find_unreadable_output_object(objects).await? {
 				let data = tg::error::Data {
 					message: Some(format!(
 						"the process attempted to output an object it cannot read: {object}"
@@ -278,6 +263,49 @@ impl Session {
 		self.spawn_process_finish_tasks(&id);
 
 		Ok(Some(true))
+	}
+
+	/// Find an object reachable from a process output that the principal cannot read, if any. If
+	/// the principal holds a subtree grant on an object, then its whole subtree is readable and the
+	/// search does not descend into it. Otherwise the principal must hold a node grant on the
+	/// object, and the search descends into the object's children.
+	async fn find_unreadable_output_object(
+		&self,
+		roots: std::collections::BTreeSet<tg::object::Id>,
+	) -> tg::Result<Option<tg::object::Id>> {
+		let node = tg::grant::Permission::Object(tg::grant::permission::object::Permission::Node);
+		let subtree =
+			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
+		let mut seen = std::collections::BTreeSet::new();
+		let mut stack = roots.into_iter().collect::<Vec<_>>();
+		while let Some(id) = stack.pop() {
+			if !seen.insert(id.clone()) {
+				continue;
+			}
+			let resource = tg::grant::Resource::Id(id.clone().into());
+			if self
+				.authorize(resource.clone(), subtree)
+				.await?
+				.is_some_and(|permissions| permissions.contains(subtree))
+			{
+				continue;
+			}
+			if !self
+				.authorize(resource, node)
+				.await?
+				.is_some_and(|permissions| permissions.contains(node))
+			{
+				return Ok(Some(id));
+			}
+			let mut children = std::collections::BTreeSet::new();
+			tg::Object::with_id(id.clone())
+				.data_with_handle(self)
+				.await
+				.map_err(|error| tg::error!(!error, %id, "failed to load the output object"))?
+				.children(&mut children);
+			stack.extend(children);
+		}
+		Ok(None)
 	}
 
 	pub(crate) async fn store_process_error(

--- a/packages/server/src/write.rs
+++ b/packages/server/src/write.rs
@@ -488,6 +488,30 @@ impl Session {
 	) -> tg::Result<()> {
 		let (put_cache_entry_args, put_object_args) =
 			Self::write_index_args(blob, cache_pointer, touched_at);
+		let grant_expires_at = touched_at
+			+ self
+				.server
+				.config
+				.object
+				.grant_time_to_live
+				.as_secs()
+				.to_i64()
+				.unwrap();
+		let put_grant =
+			self.context
+				.principal
+				.clone()
+				.map(|principal| tangram_index::grant::put::Arg {
+					created_at: touched_at,
+					creator: Some(principal.clone()),
+					expires_at: Some(grant_expires_at),
+					permissions: tg::grant::Permission::Object(
+						tg::grant::permission::object::Permission::Node,
+					)
+					.into(),
+					principal: principal.into(),
+					resource: tg::object::Id::from(blob.id.clone()).into(),
+				});
 		self.server
 			.index_tasks
 			.spawn(|_| {
@@ -498,6 +522,7 @@ impl Session {
 						.index
 						.batch(tangram_index::batch::Arg {
 							put_cache_entries: put_cache_entry_args,
+							put_grants: put_grant.map(|arg| vec![arg]).unwrap_or_default(),
 							put_objects: put_object_args,
 							..Default::default()
 						})


### PR DESCRIPTION
Adds authorization to process output during `finish`.

This fix involved two changes:

- When a process sets its output by ID, via JS `withId` or via `user.tangram.output`, the constructed value may reference arbitrary objects. This looks like either `Subtree` on an object, which will hold in the checkin case, as the principal provably created it, or `Node`, and the recursively descending into children. We can always abort if `Subtree` is held, otherwise, we have to descend. If any reachable object is unreadable, fail the process.
- The `blob` write path created objects without the requisite `Node` grant. I mirrored the existing logic in `object/put` to create this grant correctly for the storing principal