### PR TITLE
fix(cli): report the resolved referent in the get info message

### DIFF
--- a/packages/cli/src/get.rs
+++ b/packages/cli/src/get.rs
@@ -59,7 +59,7 @@ impl Cli {
 			..Default::default()
 		};
 		let referent = self.get_reference_with_arg(&args.reference, arg).await?;
-		self.print_info_message(&args.reference.to_string());
+		self.print_info_message(&referent.to_string());
 		match referent.item {
 			tg::get::Item::Id(id) => match id.kind() {
 				tg::id::Kind::Blob

--- a/packages/cli/tests/get/relative_path_referent.nu
+++ b/packages/cli/tests/get/relative_path_referent.nu
@@ -1,0 +1,25 @@
+use ../../test.nu *
+
+# Getting a relative reference reports the resolved path relative to the working directory; an absolute reference reports it absolute.
+
+let server = spawn
+
+let pkg = artifact {
+	tangram.ts: 'export default () => tg.file("rel");',
+}
+let parent = $pkg | path dirname
+let name = $pkg | path basename
+
+let output = with-env { TANGRAM_QUIET: "false" } { do --env { cd $parent; tg get $"./($name)" | complete } }
+success $output
+snapshot $output.stderr '
+	info dir_01rvv5xmnmngm4xsyeg848w049fnsdf9vz9gqd2sgfqgwqqah13sgg?path=artifact
+
+'
+
+let output = with-env { TANGRAM_QUIET: "false" } { tg get $pkg | complete }
+success $output
+snapshot ($output.stderr | redact $parent) '
+	info dir_01rvv5xmnmngm4xsyeg848w049fnsdf9vz9gqd2sgfqgwqqah13sgg?path=<path>/artifact
+
+'

--- a/packages/cli/tests/object/get_by_id_with_path.nu
+++ b/packages/cli/tests/object/get_by_id_with_path.nu
@@ -26,6 +26,6 @@ snapshot $output.stdout '
 
 '
 snapshot $output.stderr '
-	info dir_0141ez1f9wny9knjrbegp3gnx9z4am8fa9ww584xbv64fm8azg1g80?get=foo/bar/file.txt
+	info fil_0161g41yea30wb48ta1dt778xfgfxrm09e1p1dznezech34e27tp60?id=dir_0141ez1f9wny9knjrbegp3gnx9z4am8fa9ww584xbv64fm8azg1g80&path=foo/bar/file.txt
 
 '

--- a/packages/cli/tests/object/get_by_tag_with_path.nu
+++ b/packages/cli/tests/object/get_by_tag_with_path.nu
@@ -28,6 +28,6 @@ snapshot $output.stdout '
 
 '
 snapshot $output.stderr '
-	info test?get=foo/bar/file.txt
+	info fil_0161g41yea30wb48ta1dt778xfgfxrm09e1p1dznezech34e27tp60?id=dir_0141ez1f9wny9knjrbegp3gnx9z4am8fa9ww584xbv64fm8azg1g80&path=foo/bar/file.txt&tag=test
 
 '


### PR DESCRIPTION
This is a judgment call.

Currently, `tg get` will provide an info line reporting on the operation.  When using an indirect referent, like a tag or a `?get=` subpath, it could be useful to instead see the resolved referent in this line.

Before:

```
$ tg get 'test?get=foo/bar/file.txt'
info test?get=foo/bar/file.txt
```

After:

```
$ tg get 'test?get=foo/bar/file.txt'
info fil_0161g4…?id=dir_0141ez…&path=foo/bar/file.txt&tag=test
```

It may be useful for debugging a failure to see what was resolved, instead of just echoing back the indirect reference the user provided.

For a direct ID, there is no change in behavior.