### PR TITLE
fix(builtin): surface failed builtin builds instead of swallowing them

### DIFF
--- a/packages/builtin/src/archive.rs
+++ b/packages/builtin/src/archive.rs
@@ -19,7 +19,7 @@ pub(crate) async fn archive<H>(
 	_env: tg::value::data::Map,
 	_executable: tg::command::data::Executable,
 	logger: crate::Logger,
-) -> tg::Result<crate::Output>
+) -> tg::Result<tg::Value>
 where
 	H: tg::Handle,
 {
@@ -107,13 +107,6 @@ where
 
 	let output = blob.into();
 
-	let output = crate::Output {
-		checksum: None,
-		error: None,
-		exit: 0,
-		output: Some(output),
-	};
-
 	Ok(output)
 }
 
@@ -179,7 +172,7 @@ where
 
 	// Join the futures.
 	let blob = match future::join(archive_future, blob_future).await {
-		(_, Ok(blob)) => blob,
+		(Ok(()), Ok(blob)) => blob,
 		(Err(error), _) | (_, Err(error)) => {
 			return Err(tg::error!(
 				!error,
@@ -309,7 +302,7 @@ where
 
 	// Join the futures.
 	let blob = match future::join(archive_future, blob_future).await {
-		(_, Ok(blob)) => blob,
+		(Ok(()), Ok(blob)) => blob,
 		(Err(error), _) | (_, Err(error)) => {
 			return Err(tg::error!(
 				!error,

--- a/packages/builtin/src/bundle.rs
+++ b/packages/builtin/src/bundle.rs
@@ -13,7 +13,7 @@ pub(crate) async fn bundle<H>(
 	_env: tg::value::data::Map,
 	_executable: tg::command::data::Executable,
 	_logger: crate::Logger,
-) -> tg::Result<crate::Output>
+) -> tg::Result<tg::Value>
 where
 	H: tg::Handle,
 {
@@ -34,12 +34,6 @@ where
 	// If there are no dependencies, then return the artifact.
 	if dependencies.is_empty() {
 		let output = artifact.into();
-		let output = crate::Output {
-			checksum: None,
-			error: None,
-			exit: 0,
-			output: Some(output),
-		};
 		return Ok(output);
 	}
 
@@ -86,13 +80,6 @@ where
 		.await?
 		.build();
 	let output = output.into();
-
-	let output = crate::Output {
-		checksum: None,
-		error: None,
-		exit: 0,
-		output: Some(output),
-	};
 
 	Ok(output)
 }

--- a/packages/builtin/src/checksum.rs
+++ b/packages/builtin/src/checksum.rs
@@ -19,7 +19,7 @@ pub(crate) async fn checksum<H>(
 	_env: tg::value::data::Map,
 	_executable: tg::command::data::Executable,
 	logger: crate::Logger,
-) -> tg::Result<crate::Output>
+) -> tg::Result<tg::Value>
 where
 	H: tg::Handle,
 {
@@ -49,13 +49,6 @@ where
 	};
 
 	let output = checksum.to_string().into();
-
-	let output = crate::Output {
-		checksum: None,
-		error: None,
-		exit: 0,
-		output: Some(output),
-	};
 
 	Ok(output)
 }

--- a/packages/builtin/src/compress.rs
+++ b/packages/builtin/src/compress.rs
@@ -14,7 +14,7 @@ pub(crate) async fn compress<H>(
 	_env: tg::value::data::Map,
 	_executable: tg::command::data::Executable,
 	logger: crate::Logger,
-) -> tg::Result<crate::Output>
+) -> tg::Result<tg::Value>
 where
 	H: tg::Handle,
 {
@@ -115,13 +115,6 @@ where
 		tg::File::with_contents(blob).into()
 	} else {
 		blob.into()
-	};
-
-	let output = crate::Output {
-		checksum: None,
-		error: None,
-		exit: 0,
-		output: Some(output),
 	};
 
 	Ok(output)

--- a/packages/builtin/src/decompress.rs
+++ b/packages/builtin/src/decompress.rs
@@ -15,7 +15,7 @@ pub(crate) async fn decompress<H>(
 	_env: tg::value::data::Map,
 	_executable: tg::command::data::Executable,
 	logger: crate::Logger,
-) -> tg::Result<crate::Output>
+) -> tg::Result<tg::Value>
 where
 	H: tg::Handle,
 {
@@ -116,13 +116,6 @@ where
 		tg::File::with_contents(blob).into()
 	} else {
 		blob.into()
-	};
-
-	let output = crate::Output {
-		checksum: None,
-		error: None,
-		exit: 0,
-		output: Some(output),
 	};
 
 	Ok(output)

--- a/packages/builtin/src/download.rs
+++ b/packages/builtin/src/download.rs
@@ -26,7 +26,7 @@ pub(crate) async fn download<H>(
 	_executable: tg::command::data::Executable,
 	logger: crate::Logger,
 	temp_path: Option<&Path>,
-) -> tg::Result<crate::Output>
+) -> tg::Result<(tg::Value, Option<tg::Checksum>)>
 where
 	H: tg::Handle,
 {
@@ -260,12 +260,5 @@ where
 		_ => artifact.into(),
 	};
 
-	let output = crate::Output {
-		checksum,
-		error: None,
-		exit: 0,
-		output: Some(output),
-	};
-
-	Ok(output)
+	Ok((output, checksum))
 }

--- a/packages/builtin/src/extract.rs
+++ b/packages/builtin/src/extract.rs
@@ -24,7 +24,7 @@ pub(crate) async fn extract<H>(
 	_executable: tg::command::data::Executable,
 	logger: crate::Logger,
 	temp_path: Option<&Path>,
-) -> tg::Result<crate::Output>
+) -> tg::Result<tg::Value>
 where
 	H: tg::Handle,
 {
@@ -144,13 +144,6 @@ where
 	.await?;
 
 	let output = artifact.into();
-
-	let output = crate::Output {
-		checksum: None,
-		error: None,
-		exit: 0,
-		output: Some(output),
-	};
 
 	Ok(output)
 }

--- a/packages/builtin/src/lib.rs
+++ b/packages/builtin/src/lib.rs
@@ -1,9 +1,9 @@
 use {
 	self::{
-		archive::archive, bundle::bundle, checksum::checksum, compress::compress,
-		decompress::decompress, download::download, extract::extract,
+		archive::archive, bundle::bundle, compress::compress, decompress::decompress,
+		download::download, extract::extract,
 	},
-	futures::{FutureExt as _, TryStreamExt as _, future::BoxFuture},
+	futures::{TryStreamExt as _, future::BoxFuture},
 	std::{path::Path, pin::pin, sync::Arc},
 	tangram_client::prelude::*,
 };
@@ -53,19 +53,41 @@ where
 		_ => return Err(tg::error!("expected the executable to be a path")),
 	};
 
-	let output = match name {
-		"archive" => archive(handle, args, cwd, env, executable, logger).boxed(),
-		"bundle" => bundle(handle, args, cwd, env, executable, logger).boxed(),
-		"checksum" => checksum(handle, args, cwd, env, executable, logger).boxed(),
-		"compress" => compress(handle, args, cwd, env, executable, logger).boxed(),
-		"decompress" => decompress(handle, args, cwd, env, executable, logger).boxed(),
-		"download" => download(handle, args, cwd, env, executable, logger, temp_path).boxed(),
-		"extract" => extract(handle, args, cwd, env, executable, logger, temp_path).boxed(),
+	// Run the builtin. Only download produces a checksum.
+	let mut checksum = None;
+	let result = match name {
+		"archive" => archive(handle, args, cwd, env, executable, logger).await,
+		"bundle" => bundle(handle, args, cwd, env, executable, logger).await,
+		"checksum" => self::checksum::checksum(handle, args, cwd, env, executable, logger).await,
+		"compress" => compress(handle, args, cwd, env, executable, logger).await,
+		"decompress" => decompress(handle, args, cwd, env, executable, logger).await,
+		"download" => download(handle, args, cwd, env, executable, logger, temp_path)
+			.await
+			.map(|(value, download_checksum)| {
+				checksum = download_checksum;
+				value
+			}),
+		"extract" => extract(handle, args, cwd, env, executable, logger, temp_path).await,
 		_ => {
 			return Err(tg::error!("invalid executable"));
 		},
-	}
-	.await?;
+	};
+
+	// An error from a builtin means the build failed, not that the builtin could not run, so record it in the output.
+	let output = match result {
+		Ok(value) => Output {
+			checksum,
+			error: None,
+			exit: 0,
+			output: Some(value),
+		},
+		Err(error) => Output {
+			checksum: None,
+			error: Some(error),
+			exit: 1,
+			output: None,
+		},
+	};
 
 	Ok(output)
 }

--- a/packages/cli/tests/archive/file_dependencies_rejected.nu
+++ b/packages/cli/tests/archive/file_dependencies_rejected.nu
@@ -1,0 +1,13 @@
+use ../../test.nu *
+
+# Archiving a directory that contains a file with dependencies fails instead of producing a truncated archive.
+
+let server = spawn
+
+let dir = tg put 'tg.directory({ "a": tg.file("first"), "z": tg.file({ "contents": tg.blob("x"), "dependencies": { "dep": { "item": tg.file("d") } } }) })' | str trim
+
+let tar_output = tg archive --format tar $dir | complete
+failure $tar_output
+
+let zip_output = tg archive --format zip $dir | complete
+failure $zip_output

--- a/packages/cli/tests/archive/non_directory_rejected.nu
+++ b/packages/cli/tests/archive/non_directory_rejected.nu
@@ -1,0 +1,13 @@
+use ../../test.nu *
+
+# Archiving an artifact that is not a directory fails instead of producing an unusable archive.
+
+let server = spawn
+
+let file_id = tg put 'tg.file("contents")' | str trim
+
+let tar_output = tg archive --format tar $file_id | complete
+failure $tar_output
+
+let zip_output = tg archive --format zip $file_id | complete
+failure $zip_output

--- a/packages/cli/tests/archive/zip_compression_rejected.nu
+++ b/packages/cli/tests/archive/zip_compression_rejected.nu
@@ -6,12 +6,12 @@ let server = spawn
 
 let dir = tg put 'tg.directory({ "hello.txt": tg.file("hello") })' | str trim
 
-let build = tg archive --format zip --compression gz --detach --verbose $dir | from json
-let wait = tg wait $build.process | from json
-assert equal $wait.exit 1 "the archive process should exit with code 1"
-
-let log = tg log $build.process | complete
-snapshot ($log.stderr | redact) '
+let output = tg archive --format zip --compression gz $dir | complete
+failure $output
+snapshot ($output.stderr | redact | normalize_ids) '
+	error an error occurred
+	-> the process failed
+	   id = <process>
 	-> compression is not supported for zip archives
 
 '

--- a/packages/cli/tests/checksum/file_with_dependencies_fails.nu
+++ b/packages/cli/tests/checksum/file_with_dependencies_fails.nu
@@ -6,13 +6,12 @@ let server = spawn
 
 let dir = tg put 'tg.directory({ "f": tg.file({ "contents": tg.blob("x"), "dependencies": { "dep": { "item": tg.file("d") } } }) })' | str trim
 
-let build = tg checksum --detach --verbose $dir | from json
-let wait = tg wait $build.process | from json
-assert equal $wait.exit 1 "the checksum process should exit with code 1"
-
-let log = tg log $build.process | complete
-snapshot ($log.stderr | redact) '
-	 0 B
+let output = tg checksum $dir | complete
+failure $output
+snapshot ($output.stderr | redact | normalize_ids) '
+	error an error occurred
+	-> the process failed
+	   id = <process>
 	-> cannot checksum a file with dependencies
 
 '

--- a/packages/cli/tests/checksum/symlink_with_artifact_fails.nu
+++ b/packages/cli/tests/checksum/symlink_with_artifact_fails.nu
@@ -6,13 +6,12 @@ let server = spawn
 
 let dir = tg put 'tg.directory({ "link": tg.symlink({ "artifact": tg.file("target") }) })' | str trim
 
-let build = tg checksum --detach --verbose $dir | from json
-let wait = tg wait $build.process | from json
-assert equal $wait.exit 1 "the checksum process should exit with code 1"
-
-let log = tg log $build.process | complete
-snapshot ($log.stderr | redact) '
-	 0 B
+let output = tg checksum $dir | complete
+failure $output
+snapshot ($output.stderr | redact | normalize_ids) '
+	error an error occurred
+	-> the process failed
+	   id = <process>
 	-> cannot checksum a symlink with an artifact
 
 '

--- a/packages/cli/tests/compress/decompress_not_compressed.nu
+++ b/packages/cli/tests/compress/decompress_not_compressed.nu
@@ -1,17 +1,17 @@
 use ../../test.nu *
 
-# Decompressing a blob that is not compressed fails with an invalid compression format error in the process log.
+# Decompressing a blob that is not compressed fails with an invalid compression format error.
 
 let server = spawn
 
 let blob = "hello, world!\n" | tg write
 
-let build = tg decompress --detach --verbose $blob | from json
-let wait = tg wait $build.process | from json
-assert equal $wait.exit 1 "the decompress process should exit with code 1"
-
-let log = tg log $build.process | complete
-snapshot ($log.stderr | redact | normalize_ids) '
+let output = tg decompress $blob | complete
+failure $output
+snapshot ($output.stderr | redact | normalize_ids) '
+	error an error occurred
+	-> the process failed
+	   id = <process>
 	-> invalid compression format
 
 '


### PR DESCRIPTION
Fix two error reporting issues in builtins:

- Correct structure of builtins to pass up errors, instead of only successes
- In `archive.rs`, catch the case where the archive failed, so a failed archive gets reported instead of returning a truncated blob.
- Don't over-assert in tests - instead of process log, snapshot the structured error