### PR TITLE
feat(cli): group, organization aliases for owner

### DIFF
--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -840,7 +840,7 @@ impl Cli {
 				Some(tg::process::SandboxArg::Id(id))
 			} else {
 				let owner = self
-					.resolve_owner(&client, options.sandbox.arg.owner.clone())
+					.resolve_owner(&client, options.sandbox.arg.owner_selector()?)
 					.await?;
 				Some(tg::process::SandboxArg::Arg(
 					tg::process::SandboxCreateArg {

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -840,7 +840,7 @@ impl Cli {
 				Some(tg::process::SandboxArg::Id(id))
 			} else {
 				let owner = self
-					.resolve_owner(&client, options.sandbox.arg.owner_selector()?)
+					.resolve_owner(&client, options.sandbox.arg.owner.clone())
 					.await?;
 				Some(tg::process::SandboxArg::Arg(
 					tg::process::SandboxCreateArg {

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -840,7 +840,7 @@ impl Cli {
 				Some(tg::process::SandboxArg::Id(id))
 			} else {
 				let owner = self
-					.resolve_owner(&client, options.sandbox.arg.owner.clone())
+					.resolve_owner(&client, &options.sandbox.arg.owner)
 					.await?;
 				Some(tg::process::SandboxArg::Arg(
 					tg::process::SandboxCreateArg {
@@ -853,7 +853,6 @@ impl Cli {
 						network,
 						owner,
 						ttl: Some(options.sandbox.ttl.get()),
-						user: options.sandbox.arg.user.clone(),
 					},
 				))
 			}

--- a/packages/cli/src/sandbox.rs
+++ b/packages/cli/src/sandbox.rs
@@ -46,9 +46,6 @@ pub struct Options {
 	#[arg(id = "sandbox.cpu", long = "cpu")]
 	pub cpu: Option<u64>,
 
-	#[arg(id = "sandbox.group", long = "group", conflicts_with_all = ["sandbox.organization", "sandbox.owner"])]
-	pub group: Option<tg::principal::Selector>,
-
 	#[arg(id = "sandbox.hostname", long = "hostname")]
 	pub hostname: Option<String>,
 
@@ -64,10 +61,7 @@ pub struct Options {
 	#[clap(flatten)]
 	pub network: Network,
 
-	#[arg(id = "sandbox.organization", long = "organization", conflicts_with_all = ["sandbox.group", "sandbox.owner"])]
-	pub organization: Option<tg::principal::Selector>,
-
-	#[arg(id = "sandbox.owner", long = "owner", conflicts_with_all = ["sandbox.group", "sandbox.organization"])]
+	#[arg(id = "sandbox.owner", long = "owner")]
 	pub owner: Option<tg::principal::Selector>,
 
 	#[arg(action = clap::ArgAction::Append, id = "sandbox.ports", long = "port", num_args = 1, short = 'p')]
@@ -102,14 +96,6 @@ pub struct Network {
 	no_network: bool,
 }
 
-/// The kind of principal an owner selector must resolve to.
-#[derive(Clone, Copy, Debug)]
-pub enum OwnerKind {
-	Any,
-	Group,
-	Organization,
-}
-
 impl Network {
 	pub fn with_network(network: tg::sandbox::Network) -> Self {
 		Self {
@@ -139,32 +125,14 @@ fn parse_network(s: &str) -> tg::Result<tg::sandbox::Network> {
 impl Options {
 	pub fn is_empty(&self) -> bool {
 		self.cpu.is_none()
-			&& self.group.is_none()
 			&& self.hostname.is_none()
 			&& self.isolation.is_none()
 			&& self.memory.is_none()
 			&& self.mounts.is_empty()
 			&& self.network.get().is_none()
-			&& self.organization.is_none()
 			&& self.owner.is_none()
 			&& self.ports.is_empty()
 			&& self.user.is_none()
-	}
-
-	/// Combine the owner, group, and organization options into a single selector and the
-	/// kind of principal it must resolve to.
-	pub fn owner_selector(&self) -> tg::Result<Option<(tg::principal::Selector, OwnerKind)>> {
-		match (&self.owner, &self.group, &self.organization) {
-			(None, None, None) => Ok(None),
-			(Some(owner), None, None) => Ok(Some((owner.clone(), OwnerKind::Any))),
-			(None, Some(group), None) => Ok(Some((group.clone(), OwnerKind::Group))),
-			(None, None, Some(organization)) => {
-				Ok(Some((organization.clone(), OwnerKind::Organization)))
-			},
-			_ => Err(tg::error!(
-				"only one of the owner, group, or organization options may be provided"
-			)),
-		}
 	}
 }
 
@@ -172,83 +140,49 @@ impl Cli {
 	pub async fn resolve_owner(
 		&self,
 		client: &tg::Client,
-		owner: Option<(tg::principal::Selector, OwnerKind)>,
+		owner: Option<tg::principal::Selector>,
 	) -> tg::Result<Option<tg::Principal>> {
-		let Some((selector, kind)) = owner else {
+		let Some(owner) = owner else {
 			return Ok(None);
 		};
-		let owner = match selector {
-			tg::principal::Selector::Principal(principal) => {
-				let principal = match principal {
-					tg::grant::Principal::Group(id) => tg::Principal::Group(id),
-					tg::grant::Principal::Organization(id) => tg::Principal::Organization(id),
-					tg::grant::Principal::Process(id) => tg::Principal::Process(id),
-					tg::grant::Principal::Public => {
-						return Err(tg::error!("invalid sandbox owner"));
-					},
-					tg::grant::Principal::Root => tg::Principal::Root,
-					tg::grant::Principal::Runner => tg::Principal::Runner,
-					tg::grant::Principal::Sandbox(id) => tg::Principal::Sandbox(id),
-					tg::grant::Principal::User(id) => tg::Principal::User(id),
-				};
-				match kind {
-					OwnerKind::Group if !matches!(principal, tg::Principal::Group(_)) => {
-						return Err(tg::error!("the owner is not a group"));
-					},
-					OwnerKind::Organization
-						if !matches!(principal, tg::Principal::Organization(_)) =>
-					{
-						return Err(tg::error!("the owner is not an organization"));
-					},
-					_ => {},
-				}
-				principal
-			},
-			tg::principal::Selector::Specifier(specifier) => match kind {
-				OwnerKind::Group => {
-					let selector = tg::Selector::Specifier(specifier);
-					let group = client
-						.try_get_group(&selector, tg::group::get::Arg::default())
-						.await?
-						.ok_or_else(|| tg::error!("failed to resolve the owner as a group"))?;
-					tg::Principal::Group(group.id)
+		let owner = match owner {
+			tg::principal::Selector::Principal(principal) => match principal {
+				tg::grant::Principal::Group(id) => tg::Principal::Group(id),
+				tg::grant::Principal::Organization(id) => tg::Principal::Organization(id),
+				tg::grant::Principal::Process(id) => tg::Principal::Process(id),
+				tg::grant::Principal::Public => {
+					return Err(tg::error!("invalid sandbox owner"));
 				},
-				OwnerKind::Organization => {
-					let selector = tg::Selector::Specifier(specifier);
-					let organization = client
+				tg::grant::Principal::Root => tg::Principal::Root,
+				tg::grant::Principal::Runner => tg::Principal::Runner,
+				tg::grant::Principal::Sandbox(id) => tg::Principal::Sandbox(id),
+				tg::grant::Principal::User(id) => tg::Principal::User(id),
+			},
+			tg::principal::Selector::Specifier(specifier) => {
+				let selector = tg::Selector::Specifier(specifier.clone());
+				if let Some(group) = client
+					.try_get_group(&selector, tg::group::get::Arg::default())
+					.await?
+				{
+					tg::Principal::Group(group.id)
+				} else {
+					let selector = tg::Selector::Specifier(specifier.clone());
+					if let Some(organization) = client
 						.try_get_organization(&selector, tg::organization::get::Arg::default())
 						.await?
-						.ok_or_else(|| {
-							tg::error!("failed to resolve the owner as an organization")
-						})?;
-					tg::Principal::Organization(organization.id)
-				},
-				OwnerKind::Any => {
-					let selector = tg::Selector::Specifier(specifier.clone());
-					if let Some(group) = client
-						.try_get_group(&selector, tg::group::get::Arg::default())
-						.await?
 					{
-						tg::Principal::Group(group.id)
+						tg::Principal::Organization(organization.id)
 					} else {
-						let selector = tg::Selector::Specifier(specifier.clone());
-						if let Some(organization) = client
-							.try_get_organization(&selector, tg::organization::get::Arg::default())
+						let selector = tg::Selector::Specifier(specifier);
+						let Some(user) = client
+							.try_get_user(&selector, tg::user::get::Arg::default())
 							.await?
-						{
-							tg::Principal::Organization(organization.id)
-						} else {
-							let selector = tg::Selector::Specifier(specifier);
-							let Some(user) = client
-								.try_get_user(&selector, tg::user::get::Arg::default())
-								.await?
-							else {
-								return Err(tg::error!("failed to resolve the sandbox owner"));
-							};
-							tg::Principal::User(user.id)
-						}
+						else {
+							return Err(tg::error!("failed to resolve the sandbox owner"));
+						};
+						tg::Principal::User(user.id)
 					}
-				},
+				}
 			},
 		};
 		Ok(Some(owner))

--- a/packages/cli/src/sandbox.rs
+++ b/packages/cli/src/sandbox.rs
@@ -61,7 +61,7 @@ pub struct Options {
 	#[clap(flatten)]
 	pub network: Network,
 
-	#[arg(id = "sandbox.owner", long = "owner")]
+	#[arg(id = "sandbox.owner", long = "owner", visible_aliases = ["group", "organization"])]
 	pub owner: Option<tg::principal::Selector>,
 
 	#[arg(action = clap::ArgAction::Append, id = "sandbox.ports", long = "port", num_args = 1, short = 'p')]

--- a/packages/cli/src/sandbox.rs
+++ b/packages/cli/src/sandbox.rs
@@ -46,6 +46,9 @@ pub struct Options {
 	#[arg(id = "sandbox.cpu", long = "cpu")]
 	pub cpu: Option<u64>,
 
+	#[arg(id = "sandbox.group", long = "group", conflicts_with_all = ["sandbox.organization", "sandbox.owner"])]
+	pub group: Option<tg::principal::Selector>,
+
 	#[arg(id = "sandbox.hostname", long = "hostname")]
 	pub hostname: Option<String>,
 
@@ -61,7 +64,10 @@ pub struct Options {
 	#[clap(flatten)]
 	pub network: Network,
 
-	#[arg(id = "sandbox.owner", long = "owner", visible_aliases = ["group", "organization"])]
+	#[arg(id = "sandbox.organization", long = "organization", conflicts_with_all = ["sandbox.group", "sandbox.owner"])]
+	pub organization: Option<tg::principal::Selector>,
+
+	#[arg(id = "sandbox.owner", long = "owner", conflicts_with_all = ["sandbox.group", "sandbox.organization"])]
 	pub owner: Option<tg::principal::Selector>,
 
 	#[arg(action = clap::ArgAction::Append, id = "sandbox.ports", long = "port", num_args = 1, short = 'p')]
@@ -96,6 +102,14 @@ pub struct Network {
 	no_network: bool,
 }
 
+/// The kind of principal an owner selector must resolve to.
+#[derive(Clone, Copy, Debug)]
+pub enum OwnerKind {
+	Any,
+	Group,
+	Organization,
+}
+
 impl Network {
 	pub fn with_network(network: tg::sandbox::Network) -> Self {
 		Self {
@@ -125,14 +139,32 @@ fn parse_network(s: &str) -> tg::Result<tg::sandbox::Network> {
 impl Options {
 	pub fn is_empty(&self) -> bool {
 		self.cpu.is_none()
+			&& self.group.is_none()
 			&& self.hostname.is_none()
 			&& self.isolation.is_none()
 			&& self.memory.is_none()
 			&& self.mounts.is_empty()
 			&& self.network.get().is_none()
+			&& self.organization.is_none()
 			&& self.owner.is_none()
 			&& self.ports.is_empty()
 			&& self.user.is_none()
+	}
+
+	/// Combine the owner, group, and organization options into a single selector and the
+	/// kind of principal it must resolve to.
+	pub fn owner_selector(&self) -> tg::Result<Option<(tg::principal::Selector, OwnerKind)>> {
+		match (&self.owner, &self.group, &self.organization) {
+			(None, None, None) => Ok(None),
+			(Some(owner), None, None) => Ok(Some((owner.clone(), OwnerKind::Any))),
+			(None, Some(group), None) => Ok(Some((group.clone(), OwnerKind::Group))),
+			(None, None, Some(organization)) => {
+				Ok(Some((organization.clone(), OwnerKind::Organization)))
+			},
+			_ => Err(tg::error!(
+				"only one of the owner, group, or organization options may be provided"
+			)),
+		}
 	}
 }
 
@@ -140,49 +172,83 @@ impl Cli {
 	pub async fn resolve_owner(
 		&self,
 		client: &tg::Client,
-		owner: Option<tg::principal::Selector>,
+		owner: Option<(tg::principal::Selector, OwnerKind)>,
 	) -> tg::Result<Option<tg::Principal>> {
-		let Some(owner) = owner else {
+		let Some((selector, kind)) = owner else {
 			return Ok(None);
 		};
-		let owner = match owner {
-			tg::principal::Selector::Principal(principal) => match principal {
-				tg::grant::Principal::Group(id) => tg::Principal::Group(id),
-				tg::grant::Principal::Organization(id) => tg::Principal::Organization(id),
-				tg::grant::Principal::Process(id) => tg::Principal::Process(id),
-				tg::grant::Principal::Public => {
-					return Err(tg::error!("invalid sandbox owner"));
-				},
-				tg::grant::Principal::Root => tg::Principal::Root,
-				tg::grant::Principal::Runner => tg::Principal::Runner,
-				tg::grant::Principal::Sandbox(id) => tg::Principal::Sandbox(id),
-				tg::grant::Principal::User(id) => tg::Principal::User(id),
+		let owner = match selector {
+			tg::principal::Selector::Principal(principal) => {
+				let principal = match principal {
+					tg::grant::Principal::Group(id) => tg::Principal::Group(id),
+					tg::grant::Principal::Organization(id) => tg::Principal::Organization(id),
+					tg::grant::Principal::Process(id) => tg::Principal::Process(id),
+					tg::grant::Principal::Public => {
+						return Err(tg::error!("invalid sandbox owner"));
+					},
+					tg::grant::Principal::Root => tg::Principal::Root,
+					tg::grant::Principal::Runner => tg::Principal::Runner,
+					tg::grant::Principal::Sandbox(id) => tg::Principal::Sandbox(id),
+					tg::grant::Principal::User(id) => tg::Principal::User(id),
+				};
+				match kind {
+					OwnerKind::Group if !matches!(principal, tg::Principal::Group(_)) => {
+						return Err(tg::error!("the owner is not a group"));
+					},
+					OwnerKind::Organization
+						if !matches!(principal, tg::Principal::Organization(_)) =>
+					{
+						return Err(tg::error!("the owner is not an organization"));
+					},
+					_ => {},
+				}
+				principal
 			},
-			tg::principal::Selector::Specifier(specifier) => {
-				let selector = tg::Selector::Specifier(specifier.clone());
-				if let Some(group) = client
-					.try_get_group(&selector, tg::group::get::Arg::default())
-					.await?
-				{
+			tg::principal::Selector::Specifier(specifier) => match kind {
+				OwnerKind::Group => {
+					let selector = tg::Selector::Specifier(specifier);
+					let group = client
+						.try_get_group(&selector, tg::group::get::Arg::default())
+						.await?
+						.ok_or_else(|| tg::error!("failed to resolve the owner as a group"))?;
 					tg::Principal::Group(group.id)
-				} else {
-					let selector = tg::Selector::Specifier(specifier.clone());
-					if let Some(organization) = client
+				},
+				OwnerKind::Organization => {
+					let selector = tg::Selector::Specifier(specifier);
+					let organization = client
 						.try_get_organization(&selector, tg::organization::get::Arg::default())
 						.await?
+						.ok_or_else(|| {
+							tg::error!("failed to resolve the owner as an organization")
+						})?;
+					tg::Principal::Organization(organization.id)
+				},
+				OwnerKind::Any => {
+					let selector = tg::Selector::Specifier(specifier.clone());
+					if let Some(group) = client
+						.try_get_group(&selector, tg::group::get::Arg::default())
+						.await?
 					{
-						tg::Principal::Organization(organization.id)
+						tg::Principal::Group(group.id)
 					} else {
-						let selector = tg::Selector::Specifier(specifier);
-						let Some(user) = client
-							.try_get_user(&selector, tg::user::get::Arg::default())
+						let selector = tg::Selector::Specifier(specifier.clone());
+						if let Some(organization) = client
+							.try_get_organization(&selector, tg::organization::get::Arg::default())
 							.await?
-						else {
-							return Err(tg::error!("failed to resolve the sandbox owner"));
-						};
-						tg::Principal::User(user.id)
+						{
+							tg::Principal::Organization(organization.id)
+						} else {
+							let selector = tg::Selector::Specifier(specifier);
+							let Some(user) = client
+								.try_get_user(&selector, tg::user::get::Arg::default())
+								.await?
+							else {
+								return Err(tg::error!("failed to resolve the sandbox owner"));
+							};
+							tg::Principal::User(user.id)
+						}
 					}
-				}
+				},
 			},
 		};
 		Ok(Some(owner))

--- a/packages/cli/src/sandbox.rs
+++ b/packages/cli/src/sandbox.rs
@@ -1,4 +1,4 @@
-use {crate::Cli, tangram_client::prelude::*};
+use {crate::Cli, tangram_client::prelude::*, tangram_futures::stream::TryExt as _};
 
 #[cfg(target_os = "linux")]
 pub mod container;
@@ -61,14 +61,11 @@ pub struct Options {
 	#[clap(flatten)]
 	pub network: Network,
 
-	#[arg(id = "sandbox.owner", long = "owner")]
-	pub owner: Option<tg::principal::Selector>,
+	#[clap(flatten)]
+	pub owner: Owner,
 
 	#[arg(action = clap::ArgAction::Append, id = "sandbox.ports", long = "port", num_args = 1, short = 'p')]
 	pub ports: Vec<tg::sandbox::Port>,
-
-	#[arg(id = "sandbox.user", long = "user")]
-	pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, clap::Args)]
@@ -94,6 +91,21 @@ pub struct Network {
 		require_equals = true,
 	)]
 	no_network: bool,
+}
+
+#[derive(Clone, Debug, Default, clap::Args)]
+pub struct Owner {
+	#[arg(id = "sandbox.owner.value", long = "owner", conflicts_with_all = ["sandbox.owner.user", "sandbox.owner.group", "sandbox.owner.organization"])]
+	value: Option<tg::principal::Selector>,
+
+	#[arg(id = "sandbox.owner.user", long = "user", conflicts_with_all = ["sandbox.owner.value", "sandbox.owner.group", "sandbox.owner.organization"])]
+	user: Option<tg::principal::Selector>,
+
+	#[arg(id = "sandbox.owner.group", long = "group", conflicts_with_all = ["sandbox.owner.value", "sandbox.owner.user", "sandbox.owner.organization"])]
+	group: Option<tg::principal::Selector>,
+
+	#[arg(alias = "org", id = "sandbox.owner.organization", long = "organization", conflicts_with_all = ["sandbox.owner.value", "sandbox.owner.user", "sandbox.owner.group"])]
+	organization: Option<tg::principal::Selector>,
 }
 
 impl Network {
@@ -130,9 +142,17 @@ impl Options {
 			&& self.memory.is_none()
 			&& self.mounts.is_empty()
 			&& self.network.get().is_none()
-			&& self.owner.is_none()
+			&& self.owner.is_empty()
 			&& self.ports.is_empty()
+	}
+}
+
+impl Owner {
+	pub fn is_empty(&self) -> bool {
+		self.value.is_none()
 			&& self.user.is_none()
+			&& self.group.is_none()
+			&& self.organization.is_none()
 	}
 }
 
@@ -140,52 +160,251 @@ impl Cli {
 	pub async fn resolve_owner(
 		&self,
 		client: &tg::Client,
-		owner: Option<tg::principal::Selector>,
+		owner: &Owner,
 	) -> tg::Result<Option<tg::Principal>> {
-		let Some(owner) = owner else {
-			return Ok(None);
-		};
-		let owner = match owner {
-			tg::principal::Selector::Principal(principal) => match principal {
-				tg::grant::Principal::Group(id) => tg::Principal::Group(id),
-				tg::grant::Principal::Organization(id) => tg::Principal::Organization(id),
-				tg::grant::Principal::Process(id) => tg::Principal::Process(id),
-				tg::grant::Principal::Public => {
-					return Err(tg::error!("invalid sandbox owner"));
-				},
-				tg::grant::Principal::Root => tg::Principal::Root,
-				tg::grant::Principal::Runner => tg::Principal::Runner,
-				tg::grant::Principal::Sandbox(id) => tg::Principal::Sandbox(id),
-				tg::grant::Principal::User(id) => tg::Principal::User(id),
+		if let Some(owner) = owner.value.clone() {
+			Ok(Some(self.resolve_any_owner(client, owner).await?))
+		} else if let Some(user) = owner.user.clone() {
+			Ok(Some(self.resolve_user_owner(client, user).await?))
+		} else if let Some(group) = owner.group.clone() {
+			Ok(Some(self.resolve_group_owner(client, group).await?))
+		} else if let Some(organization) = owner.organization.clone() {
+			Ok(Some(
+				self.resolve_organization_owner(client, organization)
+					.await?,
+			))
+		} else {
+			Ok(None)
+		}
+	}
+
+	async fn resolve_any_owner(
+		&self,
+		client: &tg::Client,
+		owner: tg::principal::Selector,
+	) -> tg::Result<tg::Principal> {
+		match owner {
+			tg::principal::Selector::Principal(principal) => {
+				Self::resolve_owner_principal(principal)
 			},
 			tg::principal::Selector::Specifier(specifier) => {
-				let selector = tg::Selector::Specifier(specifier.clone());
-				if let Some(group) = client
+				self.resolve_any_owner_specifier(client, specifier).await
+			},
+		}
+	}
+
+	async fn resolve_user_owner(
+		&self,
+		client: &tg::Client,
+		owner: tg::principal::Selector,
+	) -> tg::Result<tg::Principal> {
+		match owner {
+			tg::principal::Selector::Principal(principal) => {
+				let principal = Self::resolve_owner_principal(principal)?;
+				if !matches!(principal, tg::Principal::User(_)) {
+					return Err(tg::error!("the owner is not a user"));
+				}
+				Ok(principal)
+			},
+			tg::principal::Selector::Specifier(specifier) => self
+				.resolve_user_owner_specifier(client, specifier)
+				.await?
+				.ok_or_else(|| tg::error!("failed to resolve the owner as a user")),
+		}
+	}
+
+	async fn resolve_group_owner(
+		&self,
+		client: &tg::Client,
+		owner: tg::principal::Selector,
+	) -> tg::Result<tg::Principal> {
+		match owner {
+			tg::principal::Selector::Principal(principal) => {
+				let principal = Self::resolve_owner_principal(principal)?;
+				if !matches!(principal, tg::Principal::Group(_)) {
+					return Err(tg::error!("the owner is not a group"));
+				}
+				Ok(principal)
+			},
+			tg::principal::Selector::Specifier(specifier) => self
+				.resolve_group_owner_specifier(client, specifier)
+				.await?
+				.ok_or_else(|| tg::error!("failed to resolve the owner as a group")),
+		}
+	}
+
+	async fn resolve_organization_owner(
+		&self,
+		client: &tg::Client,
+		owner: tg::principal::Selector,
+	) -> tg::Result<tg::Principal> {
+		match owner {
+			tg::principal::Selector::Principal(principal) => {
+				let principal = Self::resolve_owner_principal(principal)?;
+				if !matches!(principal, tg::Principal::Organization(_)) {
+					return Err(tg::error!("the owner is not an organization"));
+				}
+				Ok(principal)
+			},
+			tg::principal::Selector::Specifier(specifier) => self
+				.resolve_organization_owner_specifier(client, specifier)
+				.await?
+				.ok_or_else(|| tg::error!("failed to resolve the owner as an organization")),
+		}
+	}
+
+	fn resolve_owner_principal(principal: tg::grant::Principal) -> tg::Result<tg::Principal> {
+		let principal = match principal {
+			tg::grant::Principal::Group(id) => tg::Principal::Group(id),
+			tg::grant::Principal::Organization(id) => tg::Principal::Organization(id),
+			tg::grant::Principal::Process(id) => tg::Principal::Process(id),
+			tg::grant::Principal::Public => {
+				return Err(tg::error!("invalid sandbox owner"));
+			},
+			tg::grant::Principal::Root => tg::Principal::Root,
+			tg::grant::Principal::Runner => tg::Principal::Runner,
+			tg::grant::Principal::Sandbox(id) => tg::Principal::Sandbox(id),
+			tg::grant::Principal::User(id) => tg::Principal::User(id),
+		};
+		Ok(principal)
+	}
+
+	async fn resolve_any_owner_specifier(
+		&self,
+		client: &tg::Client,
+		specifier: tg::Specifier,
+	) -> tg::Result<tg::Principal> {
+		let Some(kind) = self
+			.try_resolve_owner_specifier_kind(client, specifier.clone())
+			.await?
+		else {
+			return Err(tg::error!("failed to resolve the sandbox owner"));
+		};
+		match kind {
+			tg::id::Kind::Group => {
+				let selector = tg::Selector::Specifier(specifier);
+				let group = client
 					.try_get_group(&selector, tg::group::get::Arg::default())
 					.await?
-				{
-					tg::Principal::Group(group.id)
-				} else {
-					let selector = tg::Selector::Specifier(specifier.clone());
-					if let Some(organization) = client
-						.try_get_organization(&selector, tg::organization::get::Arg::default())
-						.await?
-					{
-						tg::Principal::Organization(organization.id)
-					} else {
-						let selector = tg::Selector::Specifier(specifier);
-						let Some(user) = client
-							.try_get_user(&selector, tg::user::get::Arg::default())
-							.await?
-						else {
-							return Err(tg::error!("failed to resolve the sandbox owner"));
-						};
-						tg::Principal::User(user.id)
-					}
-				}
+					.ok_or_else(|| tg::error!("failed to resolve the sandbox owner"))?;
+				Ok(tg::Principal::Group(group.id))
 			},
+			tg::id::Kind::Organization => {
+				let selector = tg::Selector::Specifier(specifier);
+				let organization = client
+					.try_get_organization(&selector, tg::organization::get::Arg::default())
+					.await?
+					.ok_or_else(|| tg::error!("failed to resolve the sandbox owner"))?;
+				Ok(tg::Principal::Organization(organization.id))
+			},
+			tg::id::Kind::User => {
+				let selector = tg::Selector::Specifier(specifier);
+				let user = client
+					.try_get_user(&selector, tg::user::get::Arg::default())
+					.await?
+					.ok_or_else(|| tg::error!("failed to resolve the sandbox owner"))?;
+				Ok(tg::Principal::User(user.id))
+			},
+			_ => Err(tg::error!("failed to resolve the sandbox owner")),
+		}
+	}
+
+	async fn try_resolve_owner_specifier_kind(
+		&self,
+		client: &tg::Client,
+		specifier: tg::Specifier,
+	) -> tg::Result<Option<tg::id::Kind>> {
+		let reference = tg::Reference::with_item(tg::reference::Item::Specifier(specifier.into()));
+		let stream = client.try_get(&reference, tg::get::Arg::default()).await?;
+		let stream = std::pin::pin!(stream);
+		let Some(event) = stream.try_last().await? else {
+			return Ok(None);
 		};
-		Ok(Some(owner))
+		let Some(output) = event
+			.try_unwrap_output()
+			.ok()
+			.ok_or_else(|| tg::error!("expected the output"))?
+		else {
+			return Ok(None);
+		};
+		let referent = output.referent;
+		let id = referent
+			.item
+			.try_unwrap_id()
+			.map_err(|_| tg::error!("failed to resolve the sandbox owner"))?;
+		Ok(Some(id.kind()))
+	}
+
+	async fn try_resolve_owner_specifier_as_kind(
+		&self,
+		client: &tg::Client,
+		specifier: tg::Specifier,
+		kind: tg::id::Kind,
+	) -> tg::Result<Option<tg::Specifier>> {
+		let Some(actual) = self
+			.try_resolve_owner_specifier_kind(client, specifier.clone())
+			.await?
+		else {
+			return Ok(None);
+		};
+		if actual != kind {
+			return Ok(None);
+		}
+		Ok(Some(specifier))
+	}
+
+	async fn resolve_user_owner_specifier(
+		&self,
+		client: &tg::Client,
+		specifier: tg::Specifier,
+	) -> tg::Result<Option<tg::Principal>> {
+		let Some(specifier) = self
+			.try_resolve_owner_specifier_as_kind(client, specifier, tg::id::Kind::User)
+			.await?
+		else {
+			return Ok(None);
+		};
+		let selector = tg::Selector::Specifier(specifier);
+		let user = client
+			.try_get_user(&selector, tg::user::get::Arg::default())
+			.await?;
+		Ok(user.map(|user| tg::Principal::User(user.id)))
+	}
+
+	async fn resolve_group_owner_specifier(
+		&self,
+		client: &tg::Client,
+		specifier: tg::Specifier,
+	) -> tg::Result<Option<tg::Principal>> {
+		let Some(specifier) = self
+			.try_resolve_owner_specifier_as_kind(client, specifier, tg::id::Kind::Group)
+			.await?
+		else {
+			return Ok(None);
+		};
+		let selector = tg::Selector::Specifier(specifier);
+		let group = client
+			.try_get_group(&selector, tg::group::get::Arg::default())
+			.await?;
+		Ok(group.map(|group| tg::Principal::Group(group.id)))
+	}
+
+	async fn resolve_organization_owner_specifier(
+		&self,
+		client: &tg::Client,
+		specifier: tg::Specifier,
+	) -> tg::Result<Option<tg::Principal>> {
+		let Some(specifier) = self
+			.try_resolve_owner_specifier_as_kind(client, specifier, tg::id::Kind::Organization)
+			.await?
+		else {
+			return Ok(None);
+		};
+		let selector = tg::Selector::Specifier(specifier);
+		let organization = client
+			.try_get_organization(&selector, tg::organization::get::Arg::default())
+			.await?;
+		Ok(organization.map(|organization| tg::Principal::Organization(organization.id)))
 	}
 
 	pub async fn command_sandbox(&mut self, args: Args) -> tg::Result<()> {

--- a/packages/cli/src/sandbox/create.rs
+++ b/packages/cli/src/sandbox/create.rs
@@ -36,11 +36,9 @@ impl Ttl {
 impl Cli {
 	pub async fn command_sandbox_create(&mut self, args: Args) -> tg::Result<()> {
 		let client = self.client().await?;
-		let owner = self
-			.resolve_owner(&client, args.arg.owner_selector()?)
-			.await?;
 		let ports = args.arg.ports;
 		let network = crate::sandbox::normalize_network(&args.arg.network, ports)?;
+		let owner = self.resolve_owner(&client, args.arg.owner).await?;
 		let arg = tg::sandbox::create::Arg {
 			cpu: args.arg.cpu,
 			hostname: args.arg.hostname,

--- a/packages/cli/src/sandbox/create.rs
+++ b/packages/cli/src/sandbox/create.rs
@@ -38,7 +38,7 @@ impl Cli {
 		let client = self.client().await?;
 		let ports = args.arg.ports;
 		let network = crate::sandbox::normalize_network(&args.arg.network, ports)?;
-		let owner = self.resolve_owner(&client, args.arg.owner).await?;
+		let owner = self.resolve_owner(&client, &args.arg.owner).await?;
 		let arg = tg::sandbox::create::Arg {
 			cpu: args.arg.cpu,
 			hostname: args.arg.hostname,
@@ -49,7 +49,6 @@ impl Cli {
 			network,
 			owner,
 			ttl: args.ttl.get(),
-			user: args.arg.user,
 		};
 		let output = client
 			.create_sandbox(arg)

--- a/packages/cli/src/sandbox/create.rs
+++ b/packages/cli/src/sandbox/create.rs
@@ -36,9 +36,11 @@ impl Ttl {
 impl Cli {
 	pub async fn command_sandbox_create(&mut self, args: Args) -> tg::Result<()> {
 		let client = self.client().await?;
+		let owner = self
+			.resolve_owner(&client, args.arg.owner_selector()?)
+			.await?;
 		let ports = args.arg.ports;
 		let network = crate::sandbox::normalize_network(&args.arg.network, ports)?;
-		let owner = self.resolve_owner(&client, args.arg.owner).await?;
 		let arg = tg::sandbox::create::Arg {
 			cpu: args.arg.cpu,
 			hostname: args.arg.hostname,

--- a/packages/cli/src/sandbox/vm/run.rs
+++ b/packages/cli/src/sandbox/vm/run.rs
@@ -84,9 +84,6 @@ pub struct Args {
 
 	#[arg(long)]
 	pub url: tangram_uri::Uri,
-
-	#[arg(long)]
-	pub user: Option<String>,
 }
 
 impl Cli {
@@ -118,7 +115,6 @@ impl Cli {
 			snapshot_memory: args.snapshot_memory,
 			tangram_path: args.tangram_path,
 			url: args.url,
-			user: args.user,
 		};
 		tangram_sandbox::vm::run::run(&arg)
 	}

--- a/packages/cli/tests/grants/sandbox_group_alias_requires_group.nu
+++ b/packages/cli/tests/grants/sandbox_group_alias_requires_group.nu
@@ -1,0 +1,37 @@
+use ../../test.nu *
+
+# The --group owner alias resolves only a group; an organization or a user is rejected.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+let bob = tg login --verbose bob | from json
+
+tg --token $alice.token group create team
+tg --token $alice.token grant $bob.user.id write team
+tg --token $alice.token organization create acme
+
+let team = tg --token $bob.token group get team | from json
+
+# A group resolves and is stored as the owner.
+let sandbox = tg --token $bob.token sandbox create --group team --no-network | str trim
+let data = tg --token $bob.token sandbox get $sandbox | from json
+assert equal $data.owner $team.id "the --group alias should resolve a group owner"
+
+# An organization is not a group, so --group must reject it.
+let organization = tg --token $bob.token sandbox create --group acme --no-network | complete
+failure $organization "--group must reject an organization"
+snapshot ($organization.stderr | redact) '
+	error an error occurred
+	-> failed to resolve the owner as a group
+
+'
+
+# A user is not a group, so --group must reject it.
+let user = tg --token $bob.token sandbox create --group $alice.user.id --no-network | complete
+failure $user "--group must reject a user"
+snapshot ($user.stderr | redact) '
+	error an error occurred
+	-> the owner is not a group
+
+'

--- a/packages/cli/tests/grants/sandbox_organization_alias_requires_organization.nu
+++ b/packages/cli/tests/grants/sandbox_organization_alias_requires_organization.nu
@@ -1,0 +1,37 @@
+use ../../test.nu *
+
+# The --organization owner alias resolves only an organization; a group or a user is rejected.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+let bob = tg login --verbose bob | from json
+
+tg --token $alice.token organization create acme
+tg --token $alice.token organization members add acme $bob.user.id
+tg --token $alice.token group create team
+
+let acme = tg --token $bob.token organization get acme | from json
+
+# An organization resolves and is stored as the owner.
+let sandbox = tg --token $bob.token sandbox create --organization acme --no-network | str trim
+let data = tg --token $bob.token sandbox get $sandbox | from json
+assert equal $data.owner $acme.id "the --organization alias should resolve an organization owner"
+
+# A group is not an organization, so --organization must reject it.
+let group = tg --token $bob.token sandbox create --organization team --no-network | complete
+failure $group "--organization must reject a group"
+snapshot ($group.stderr | redact) '
+	error an error occurred
+	-> failed to resolve the owner as an organization
+
+'
+
+# A user is not an organization, so --organization must reject it.
+let user = tg --token $bob.token sandbox create --organization $alice.user.id --no-network | complete
+failure $user "--organization must reject a user"
+snapshot ($user.stderr | redact) '
+	error an error occurred
+	-> the owner is not an organization
+
+'

--- a/packages/cli/tests/grants/sandbox_owner_alias_conflicts.nu
+++ b/packages/cli/tests/grants/sandbox_owner_alias_conflicts.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# At most one of the owner, group, and organization options may be provided.
+# At most one of the owner, user, group, and organization options may be provided.
 
 let server = spawn --config { authentication: true }
 
@@ -9,3 +9,4 @@ let alice = tg login --verbose alice | from json
 # Providing two owner selectors at once is a usage error.
 failure (tg --token $alice.token sandbox create --owner team --group team --no-network | complete) "--owner and --group must conflict"
 failure (tg --token $alice.token sandbox create --group team --organization team --no-network | complete) "--group and --organization must conflict"
+failure (tg --token $alice.token sandbox create --org team --user team --no-network | complete) "--org and --user must conflict"

--- a/packages/cli/tests/grants/sandbox_owner_alias_conflicts.nu
+++ b/packages/cli/tests/grants/sandbox_owner_alias_conflicts.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# At most one of the owner, group, and organization options may be provided.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+
+# Providing two owner selectors at once is a usage error.
+failure (tg --token $alice.token sandbox create --owner team --group team --no-network | complete) "--owner and --group must conflict"
+failure (tg --token $alice.token sandbox create --group team --organization team --no-network | complete) "--group and --organization must conflict"

--- a/packages/cli/tests/grants/sandbox_owner_grant_revoked.nu
+++ b/packages/cli/tests/grants/sandbox_owner_grant_revoked.nu
@@ -10,7 +10,7 @@ let carol = tg login --verbose carol | from json
 
 tg --token $alice.token group create team
 tg --token $alice.token grant $bob.user.id write team
-let sandbox = tg --token $bob.token sandbox create --owner team --no-network | str trim
+let sandbox = tg --token $bob.token sandbox create --group team --no-network | str trim
 
 tg --token $alice.token grant $carol.user.id write team
 success (tg --token $carol.token sandbox get $sandbox | complete) "Carol should get the sandbox while she has write on the team"

--- a/packages/cli/tests/grants/sandbox_owner_member_grant_revoke_insufficient.nu
+++ b/packages/cli/tests/grants/sandbox_owner_member_grant_revoke_insufficient.nu
@@ -9,7 +9,7 @@ let bob = tg login --verbose bob | from json
 
 tg --token $alice.token group create team
 tg --token $alice.token group members add team $bob.user.id
-let sandbox = tg --token $bob.token sandbox create --owner team --no-network | str trim
+let sandbox = tg --token $bob.token sandbox create --group team --no-network | str trim
 success (tg --token $bob.token sandbox get $sandbox | complete) "Bob should get the team-owned sandbox while a member"
 
 # Deleting the write grant created when Bob joined leaves his membership intact, so dynamic membership still authorizes him.

--- a/packages/cli/tests/grants/sandbox_owner_membership_granted_after_create.nu
+++ b/packages/cli/tests/grants/sandbox_owner_membership_granted_after_create.nu
@@ -11,7 +11,7 @@ let carol = tg login --verbose carol | from json
 tg --token $alice.token group create team
 tg --token $alice.token group members add team $bob.user.id
 
-let sandbox = tg --token $bob.token sandbox create --owner team --no-network | str trim
+let sandbox = tg --token $bob.token sandbox create --group team --no-network | str trim
 
 # Carol is not yet a member, so she cannot access the team-owned sandbox.
 failure (tg --token $carol.token sandbox get $sandbox | complete) "Carol must not get the sandbox before joining the team"

--- a/packages/cli/tests/grants/sandbox_owner_membership_revoked.nu
+++ b/packages/cli/tests/grants/sandbox_owner_membership_revoked.nu
@@ -12,7 +12,7 @@ tg --token $alice.token group create team
 tg --token $alice.token group members add team $bob.user.id
 
 let team = tg --token $bob.token group get team | from json
-let sandbox = tg --token $bob.token sandbox create --owner team --no-network | str trim
+let sandbox = tg --token $bob.token sandbox create --group team --no-network | str trim
 
 let data = tg --token $bob.token sandbox get $sandbox | from json
 assert equal $data.owner $team.id "the sandbox should be owned by the team"

--- a/packages/cli/tests/grants/sandbox_owner_organization_membership_revoked.nu
+++ b/packages/cli/tests/grants/sandbox_owner_organization_membership_revoked.nu
@@ -12,7 +12,7 @@ tg --token $alice.token organization create acme
 tg --token $alice.token organization members add acme $bob.user.id
 
 let acme = tg --token $bob.token organization get acme | from json
-let sandbox = tg --token $bob.token sandbox create --owner acme --no-network | str trim
+let sandbox = tg --token $bob.token sandbox create --organization acme --no-network | str trim
 
 let data = tg --token $bob.token sandbox get $sandbox | from json
 assert equal $data.owner $acme.id "the sandbox should be owned by the organization"

--- a/packages/cli/tests/grants/sandbox_owner_organization_nested_group.nu
+++ b/packages/cli/tests/grants/sandbox_owner_organization_nested_group.nu
@@ -14,7 +14,7 @@ tg --token $alice.token group members add team $bob.user.id
 let team = tg --token $alice.token group get team | from json
 tg --token $alice.token organization members add acme $team.id
 
-let sandbox = tg --token $alice.token sandbox create --owner acme --no-network | str trim
+let sandbox = tg --token $alice.token sandbox create --organization acme --no-network | str trim
 
 # Bob is a member of the team, and the team belongs to the organization, so he reaches the organization-owned sandbox transitively.
 success (tg --token $bob.token sandbox get $sandbox | complete) "a member of a group in the organization should reach the organization-owned sandbox"

--- a/packages/cli/tests/grants/sandbox_owner_write_grant_confers_access.nu
+++ b/packages/cli/tests/grants/sandbox_owner_write_grant_confers_access.nu
@@ -11,7 +11,7 @@ let dave = tg login --verbose dave | from json
 
 tg --token $alice.token group create team
 tg --token $alice.token grant $bob.user.id write team
-let sandbox = tg --token $bob.token sandbox create --owner team --no-network | str trim
+let sandbox = tg --token $bob.token sandbox create --group team --no-network | str trim
 
 # A write grant on the owner confers access.
 tg --token $alice.token grant $carol.user.id write team

--- a/packages/cli/tests/grants/sandbox_process_group_visibility.nu
+++ b/packages/cli/tests/grants/sandbox_process_group_visibility.nu
@@ -19,7 +19,7 @@ let private = tg --token $bob.token build --detach $private_path | str trim
 tg --token $bob.token wait $private | complete | ignore
 
 let team_path = artifact { tangram.ts: 'export default function () { return tg.file("group-visibility-team"); }' }
-let process = tg --token $bob.token build --detach --owner team $team_path | str trim
+let process = tg --token $bob.token build --detach --group team $team_path | str trim
 tg --token $bob.token wait $process | complete | ignore
 
 # Carol, a member, can read the team-owned process but not Bob's private process; Eve, an outsider, can read neither.

--- a/packages/cli/tests/grants/sandbox_process_visibility_revoked.nu
+++ b/packages/cli/tests/grants/sandbox_process_visibility_revoked.nu
@@ -14,7 +14,7 @@ tg --token $alice.token group members add team $carol.user.id
 
 # Bob builds a process whose sandbox is owned by the team; the process record's visibility follows the team-owned sandbox.
 let path = artifact { tangram.ts: 'export default function () { return tg.file("revoked-visibility-team"); }' }
-let process = tg --token $bob.token build --detach --owner team $path | str trim
+let process = tg --token $bob.token build --detach --group team $path | str trim
 tg --token $bob.token wait $process | complete | ignore
 
 # Carol, a member, can read the team-owned process.

--- a/packages/clients/rust/src/process.rs
+++ b/packages/clients/rust/src/process.rs
@@ -131,7 +131,6 @@ pub struct SandboxCreateArg {
 	pub network: Option<tg::sandbox::Network>,
 	pub owner: Option<tg::Principal>,
 	pub ttl: Option<Option<Duration>>,
-	pub user: Option<String>,
 }
 
 impl<O> Process<O> {

--- a/packages/clients/rust/src/process/spawn.rs
+++ b/packages/clients/rust/src/process/spawn.rs
@@ -1177,7 +1177,6 @@ fn normalize_sandbox(
 				network,
 				owner: arg.owner.clone(),
 				ttl: Some(Duration::ZERO),
-				user: None,
 			};
 			Ok(Some(tg::Either::Left(sandbox)))
 		},
@@ -1197,7 +1196,6 @@ fn normalize_sandbox_create_arg(
 		network: sandbox.network,
 		owner: sandbox.owner,
 		ttl: sandbox.ttl.unwrap_or(Some(Duration::ZERO)),
-		user: sandbox.user,
 	}
 }
 

--- a/packages/clients/rust/src/sandbox/create.rs
+++ b/packages/clients/rust/src/sandbox/create.rs
@@ -35,9 +35,6 @@ pub struct Arg {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[serde_as(as = "Option<DurationSecondsWithFrac>")]
 	pub ttl: Option<Duration>,
-
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub user: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/packages/clients/rust/src/sandbox/get.rs
+++ b/packages/clients/rust/src/sandbox/get.rs
@@ -49,9 +49,6 @@ pub struct Output {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[serde_as(as = "Option<DurationSecondsWithFrac>")]
 	pub ttl: Option<Duration>,
-
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub user: Option<String>,
 }
 
 impl tg::Session {

--- a/packages/clients/rust/src/sandbox/list.rs
+++ b/packages/clients/rust/src/sandbox/list.rs
@@ -46,9 +46,6 @@ pub struct Item {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[serde_as(as = "Option<DurationSecondsWithFrac>")]
 	pub ttl: Option<Duration>,
-
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub user: Option<String>,
 }
 
 impl tg::Session {

--- a/packages/sandbox/src/container/spawn.rs
+++ b/packages/sandbox/src/container/spawn.rs
@@ -57,7 +57,7 @@ pub(crate) async fn spawn(
 		_ => None,
 	};
 	prepare_sandbox_directory(&arg.path)?;
-	let user = prepare_etc_files(&arg.path, network.as_deref(), arg.user.as_deref(), &arg.dns)?;
+	let user = prepare_etc_files(&arg.path, network.as_deref(), &arg.dns)?;
 	let upper_path = Sandbox::host_upper_path_from_root(&arg.path);
 	for mount in &arg.mounts {
 		crate::container::root::ensure_mount_target(&arg.rootfs_path, &upper_path, mount)?;
@@ -274,10 +274,9 @@ fn prepare_sandbox_directory(sandbox_path: &Path) -> tg::Result<()> {
 fn prepare_etc_files(
 	sandbox_path: &Path,
 	network: Option<&crate::network::Network>,
-	user: Option<&str>,
 	dns: &[Ipv4Addr],
 ) -> tg::Result<User> {
-	let user = resolve_user(user)?;
+	let user = resolve_user(None)?;
 	let passwd = render_passwd(&user);
 	std::fs::write(Sandbox::host_passwd_path_from_root(sandbox_path), passwd)
 		.map_err(|error| tg::error!(!error, "failed to write /etc/passwd"))?;

--- a/packages/sandbox/src/lib.rs
+++ b/packages/sandbox/src/lib.rs
@@ -99,7 +99,6 @@ pub struct Arg {
 	pub tangram_path: PathBuf,
 	pub tangram_socket_path: Option<PathBuf>,
 	pub token: Option<String>,
-	pub user: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Default, derive_more::Display, derive_more::FromStr)]
@@ -687,17 +686,10 @@ fn validate_resources(
 }
 
 fn validate_options(arg: &Arg) -> tg::Result<()> {
-	if matches!(arg.isolation, Isolation::Seatbelt(_)) {
-		if arg.hostname.is_some() {
-			return Err(tg::error!(
-				"setting a hostname is not supported with seatbelt isolation"
-			));
-		}
-		if arg.user.is_some() {
-			return Err(tg::error!(
-				"setting a user is not supported with seatbelt isolation"
-			));
-		}
+	if matches!(arg.isolation, Isolation::Seatbelt(_)) && arg.hostname.is_some() {
+		return Err(tg::error!(
+			"setting a hostname is not supported with seatbelt isolation"
+		));
 	}
 	Ok(())
 }

--- a/packages/sandbox/src/vm/run.rs
+++ b/packages/sandbox/src/vm/run.rs
@@ -78,7 +78,6 @@ pub struct Arg {
 	pub snapshot_memory: u64,
 	pub tangram_path: PathBuf,
 	pub url: tangram_uri::Uri,
-	pub user: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -199,7 +198,7 @@ pub fn run(arg: &Arg) -> tg::Result<ExitCode> {
 	}
 
 	tracing::trace!("sandbox directory: {}", arg.path.display());
-	let user = resolve_user(arg.user.as_deref())?;
+	let user = resolve_user(None)?;
 	prepare_sandbox_directory(&arg.path)?;
 	prepare_etc_files(&arg.path, &user)?;
 

--- a/packages/sandbox/src/vm/spawn.rs
+++ b/packages/sandbox/src/vm/spawn.rs
@@ -102,9 +102,6 @@ pub(crate) fn spawn(
 	if let Some(memory) = arg.memory {
 		command.arg("--memory").arg(memory.to_string());
 	}
-	if let Some(user) = &arg.user {
-		command.arg("--user").arg(user);
-	}
 	for mount in &arg.mounts {
 		command.arg("--mount").arg(mount.to_string());
 	}

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -1492,7 +1492,7 @@ impl Session {
 		let id = tg::sandbox::Id::new();
 		let creator = &Some(self.context.principal.to_string());
 		let statement = formatdoc!(
-			r#"
+			r"
 				insert into sandboxes (
 					id,
 					cpu,
@@ -1507,8 +1507,7 @@ impl Session {
 					owner,
 					started_at,
 					status,
-					ttl,
-					"user"
+					ttl
 				)
 				values (
 					{p}1,
@@ -1524,10 +1523,9 @@ impl Session {
 					{p}11,
 					{p}12,
 					{p}13,
-					{p}14,
-					{p}15
+					{p}14
 				);
-			"#
+			"
 		);
 		let now = time::OffsetDateTime::now_utc().unix_timestamp();
 		let heartbeat_at = (status == tg::sandbox::Status::Started).then_some(now);
@@ -1538,7 +1536,6 @@ impl Session {
 			arg.cpu,
 			arg.memory,
 			arg.hostname.as_deref(),
-			arg.user.as_deref(),
 		)?;
 		let cpu = arg
 			.cpu
@@ -1567,7 +1564,6 @@ impl Session {
 			started_at,
 			status.to_string(),
 			db::value::DurationSeconds(ttl),
-			arg.user.clone(),
 		];
 		let result = transaction.execute(statement.into(), params).await;
 		crate::database::retry!(result, "failed to execute the statement");

--- a/packages/server/src/process/store/postgres.sql
+++ b/packages/server/src/process/store/postgres.sql
@@ -13,8 +13,7 @@ create table sandboxes (
 	owner text,
 	started_at int8,
 	status text not null,
-	ttl int8,
-	"user" text
+	ttl int8
 );
 
 create index sandboxes_heartbeat_at_index on sandboxes (heartbeat_at) where status = 'started';

--- a/packages/server/src/process/store/sqlite.sql
+++ b/packages/server/src/process/store/sqlite.sql
@@ -13,8 +13,7 @@ create table sandboxes (
 	owner text,
 	started_at integer,
 	status text not null,
-	ttl integer,
-	"user" text
+	ttl integer
 );
 
 create index sandboxes_heartbeat_at_index on sandboxes (heartbeat_at) where status = 'started';

--- a/packages/server/src/run/sandbox.rs
+++ b/packages/server/src/run/sandbox.rs
@@ -275,7 +275,6 @@ impl Session {
 			tangram_path: self.server.tangram_path.clone(),
 			tangram_socket_path,
 			token: token.clone(),
-			user: state.user.clone(),
 		};
 		let sandbox = tangram_sandbox::Sandbox::new(arg)
 			.await

--- a/packages/server/src/sandbox.rs
+++ b/packages/server/src/sandbox.rs
@@ -143,7 +143,6 @@ impl Server {
 		cpu: Option<u64>,
 		memory: Option<u64>,
 		hostname: Option<&str>,
-		user: Option<&str>,
 	) -> tg::Result<()> {
 		if cpu == Some(0) {
 			return Err(tg::error!("sandbox cpu must be greater than zero"));
@@ -158,17 +157,10 @@ impl Server {
 				"sandbox cpu and memory are not supported with seatbelt isolation"
 			));
 		}
-		if matches!(isolation, tangram_sandbox::Isolation::Seatbelt(_)) {
-			if hostname.is_some() {
-				return Err(tg::error!(
-					"setting a hostname is not supported with seatbelt isolation"
-				));
-			}
-			if user.is_some() {
-				return Err(tg::error!(
-					"setting a user is not supported with seatbelt isolation"
-				));
-			}
+		if matches!(isolation, tangram_sandbox::Isolation::Seatbelt(_)) && hostname.is_some() {
+			return Err(tg::error!(
+				"setting a hostname is not supported with seatbelt isolation"
+			));
 		}
 		Ok(())
 	}

--- a/packages/server/src/sandbox/create.rs
+++ b/packages/server/src/sandbox/create.rs
@@ -73,7 +73,6 @@ impl Session {
 			arg.cpu,
 			arg.memory,
 			arg.hostname.as_deref(),
-			arg.user.as_deref(),
 		)?;
 		let cpu = arg
 			.cpu
@@ -132,7 +131,7 @@ impl Session {
 	) -> tg::Result<ControlFlow<(), crate::database::Error>> {
 		let p = transaction.p();
 		let statement = formatdoc!(
-			r#"
+			r"
 				insert into sandboxes (
 					id,
 					cpu,
@@ -145,8 +144,7 @@ impl Session {
 					network,
 					owner,
 					status,
-					ttl,
-					"user"
+					ttl
 				)
 				values (
 					{p}1,
@@ -160,10 +158,9 @@ impl Session {
 					{p}9,
 					{p}10,
 					{p}11,
-					{p}12,
-					{p}13
+					{p}12
 				);
-			"#
+			"
 		);
 		let params = db::params![
 			arg.id.to_string(),
@@ -178,7 +175,6 @@ impl Session {
 			arg.owner.as_ref().map(ToString::to_string),
 			tg::sandbox::Status::Created.to_string(),
 			db::value::DurationSeconds(arg.ttl),
-			arg.arg.user,
 		];
 		let result = transaction.execute(statement.into(), params).await;
 		crate::database::retry!(result, "failed to execute the statement");

--- a/packages/server/src/sandbox/get.rs
+++ b/packages/server/src/sandbox/get.rs
@@ -83,7 +83,6 @@ impl Session {
 			status: tg::sandbox::Status,
 			#[tangram_database(as = "Option<db::value::DurationSeconds>")]
 			ttl: Option<std::time::Duration>,
-			user: Option<String>,
 		}
 		let connection = self
 			.server
@@ -93,7 +92,7 @@ impl Session {
 			.map_err(|error| tg::error!(!error, "failed to get a database connection"))?;
 		let p = connection.p();
 		let statement = formatdoc!(
-			r#"
+			r"
 				select
 					cpu,
 					creator,
@@ -104,11 +103,10 @@ impl Session {
 					network,
 					owner,
 					status,
-					ttl,
-					"user" as user
+					ttl
 				from sandboxes
 				where id = {p}1;
-			"#
+			"
 		);
 		let params = db::params![id.to_string()];
 		let row = connection
@@ -145,7 +143,6 @@ impl Session {
 					owner: Some(row.owner.unwrap_or(tg::Principal::Root)),
 					status: row.status,
 					ttl: row.ttl,
-					user: row.user,
 				})
 			})
 			.transpose()?;

--- a/packages/server/src/sandbox/list.rs
+++ b/packages/server/src/sandbox/list.rs
@@ -60,7 +60,6 @@ impl Session {
 			status: tg::sandbox::Status,
 			#[tangram_database(as = "Option<db::value::DurationSeconds>")]
 			ttl: Option<std::time::Duration>,
-			user: Option<String>,
 		}
 		let connection = self
 			.server
@@ -69,12 +68,12 @@ impl Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to get a process store connection"))?;
 		let statement = formatdoc!(
-			r#"
-				select id, cpu, hostname, memory, mounts, network, owner, status, ttl, "user" as user
+			r"
+				select id, cpu, hostname, memory, mounts, network, owner, status, ttl
 				from sandboxes
 				where status != 'destroyed'
 				order by created_at;
-			"#
+			"
 		);
 		let params = db::params![];
 		let rows = connection
@@ -102,7 +101,6 @@ impl Session {
 					owner: Some(row.owner.unwrap_or(tg::Principal::Root)),
 					status: row.status,
 					ttl: row.ttl,
-					user: row.user,
 				})
 			})
 			.collect::<tg::Result<Vec<tg::sandbox::list::Item>>>()?;


### PR DESCRIPTION
Adds `--group` and `--organization` CLI args for setting owners that validate the specific variant of owner.

A simple clap alias would allow, for example, `--organization <my_org>` to confusingly set the owner to a *group* named `my_org` if one existed, or similarly, `--group <user>` or `--group <org>`. This change instead splits the arguments, makes them mutually exclusive, and validates the variant.

`--owner` still uses the same logic as before, checking for a group, then user, then organization.