### PR TITLE
fix(auth): sandbox ownership assignment auth

### DIFF
--- a/packages/cli/tests/grants/sandbox_owner_requires_permission_foreign_user.nu
+++ b/packages/cli/tests/grants/sandbox_owner_requires_permission_foreign_user.nu
@@ -1,0 +1,12 @@
+use ../../test.nu *
+
+# Creating a sandbox owned by another user requires write on that user, so an unrelated user must not assign them as owner.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+let bob = tg login --verbose bob | from json
+
+# Alice has no write on Bob, so she must not be able to assign Bob as the owner of a new sandbox.
+let create = tg --token $alice.token sandbox create --owner $bob.user.id --no-network | complete
+failure $create "Alice must not create a sandbox owned by a user she cannot write"

--- a/packages/cli/tests/grants/sandbox_owner_requires_permission_unjoined_group.nu
+++ b/packages/cli/tests/grants/sandbox_owner_requires_permission_unjoined_group.nu
@@ -1,0 +1,16 @@
+use ../../test.nu *
+
+# Creating a sandbox owned by a group requires write on that group, so read access to it is not enough to claim it as owner.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+let bob = tg login --verbose bob | from json
+
+# Bob owns a group and grants Alice only read on it, so Alice can resolve it but cannot write it.
+tg --token $bob.token group create secret
+tg --token $bob.token grant $alice.user.id read secret
+
+# Read on the group is not enough to claim it as a sandbox owner.
+let create = tg --token $alice.token sandbox create --owner secret --no-network | complete
+failure $create "Alice must not create a sandbox owned by a group she can only read"

--- a/packages/cli/tests/grants/sandbox_owner_root_rejected.nu
+++ b/packages/cli/tests/grants/sandbox_owner_root_rejected.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# A non-root user must not create a sandbox owned by root.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+
+# Alice cannot act as root, so she must not claim root as a sandbox owner.
+let create = tg --token $alice.token sandbox create --owner root --no-network | complete
+failure $create "Alice must not create a sandbox owned by root"

--- a/packages/cli/tests/grants/sandbox_owner_root_without_auth.nu
+++ b/packages/cli/tests/grants/sandbox_owner_root_without_auth.nu
@@ -1,0 +1,9 @@
+use ../../test.nu *
+
+# With authentication disabled, the root principal may create a sandbox owned by root.
+
+let server = spawn
+
+let sandbox = tg sandbox create --owner root --no-network | str trim
+let data = tg sandbox get $sandbox | from json
+assert equal $data.owner "root" "a root principal should create a root-owned sandbox when authentication is disabled"

--- a/packages/cli/tests/grants/sandbox_owner_self.nu
+++ b/packages/cli/tests/grants/sandbox_owner_self.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# A user may explicitly name themselves as the owner of a sandbox they create.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+
+let sandbox = tg --token $alice.token sandbox create --owner $alice.user.id --no-network | str trim
+let data = tg --token $alice.token sandbox get $sandbox | from json
+assert equal $data.owner $alice.user.id "a user should be able to name themselves as the owner"

--- a/packages/cli/tests/grants/sandbox_process_owner_requires_permission.nu
+++ b/packages/cli/tests/grants/sandbox_process_owner_requires_permission.nu
@@ -1,0 +1,21 @@
+use ../../test.nu *
+
+# Building a process with a group owner requires write on that group, so read access alone is not enough.
+
+let server = spawn --config { authentication: true }
+
+let alice = tg login --verbose alice | from json
+let bob = tg login --verbose bob | from json
+let eve = tg login --verbose eve | from json
+
+tg --token $alice.token group create team
+tg --token $alice.token group members add team $bob.user.id
+tg --token $alice.token grant $eve.user.id read team
+
+let path = artifact { tangram.ts: 'export default () => tg.file("process-owner-assignment")' }
+
+# Bob, a member, may build a process owned by the team.
+success (tg --token $bob.token build --detach --owner team $path | complete) "a member should build a process owned by their group"
+
+# Eve can resolve the team but only has read, so she must not assign it as the owner.
+failure (tg --token $eve.token build --detach --owner team $path | complete) "read on the owning group must not allow building a process owned by it"

--- a/packages/index/src/fdb/authorize.rs
+++ b/packages/index/src/fdb/authorize.rs
@@ -128,7 +128,10 @@ impl Index {
 				outputs.push(None);
 				continue;
 			};
-			crate::authorize::validate(&id, arg.permissions)?;
+			if crate::authorize::validate(&id, arg.permissions).is_err() {
+				outputs.push(None);
+				continue;
+			}
 			if matches!(principal, tg::Principal::Root) {
 				outputs.push(Some(crate::authorize::Output {
 					permissions: arg.permissions,

--- a/packages/index/src/lmdb/authorize.rs
+++ b/packages/index/src/lmdb/authorize.rs
@@ -104,7 +104,10 @@ impl Index {
 						outputs.push(None);
 						continue;
 					};
-					crate::authorize::validate(&id, arg.permissions)?;
+					if crate::authorize::validate(&id, arg.permissions).is_err() {
+						outputs.push(None);
+						continue;
+					}
 					if matches!(principal, tg::Principal::Root) {
 						outputs.push(Some(crate::authorize::Output {
 							permissions: arg.permissions,

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -127,6 +127,25 @@ impl Session {
 		Ok(outputs)
 	}
 
+	pub(crate) async fn authorize_owner(&self, owner: Option<&tg::Principal>) -> tg::Result<()> {
+		let Some(owner) = owner else {
+			return Ok(());
+		};
+		let authorized = match owner.to_id() {
+			Some(id) => {
+				let permission = Self::write_permission_for_resource(&id)?;
+				self.authorize(tg::grant::Resource::Id(id), permission)
+					.await?
+					.is_some_and(|permissions| permissions.contains(permission))
+			},
+			None => matches!(self.context.principal, tg::Principal::Root),
+		};
+		if !authorized {
+			return Err(tg::error!("unauthorized"));
+		}
+		Ok(())
+	}
+
 	pub(crate) fn authorize_token(
 		&self,
 		resource: &tg::grant::Resource,

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -164,6 +164,11 @@ impl Session {
 			&& arg.stderr.is_log()
 			&& tty.is_none();
 
+		// Authorize assigning the sandbox owner.
+		if let Some(tg::Either::Left(sandbox)) = &arg.sandbox {
+			self.authorize_owner(sandbox.owner.as_ref()).await?;
+		}
+
 		// Get or create a local process in the process store.
 		let session = self.clone();
 		let mut output = self

--- a/packages/server/src/sandbox/create.rs
+++ b/packages/server/src/sandbox/create.rs
@@ -58,6 +58,7 @@ impl Session {
 		if matches!(self.context.principal, tg::Principal::Anonymous) {
 			return Err(tg::error!("unauthorized"));
 		}
+		self.authorize_owner(arg.owner.as_ref()).await?;
 		arg = Self::normalize_sandbox_create_arg(arg)?;
 		let id = tg::sandbox::Id::new();
 		let creator = self.context.principal.clone();


### PR DESCRIPTION
Authorizes the owner during sandbox creation and process spawning.

Additionally, convert a `validate` failure to a denial rather than a server error, since the permission's kind does not apply to the resource, and it cannot be held. This fixes a regression from the per-resource permission change with `--owner <org>`. Because `validate` was a hard error, `resolve_owner` failed in `try_get_group`, instead of falling through to `try_get_organization`.