### PR TITLE
fix(clients/js): retain undefined as null in toData

### DIFF
--- a/packages/cli/tests/build/command_undefined_map_arg_object_id.nu
+++ b/packages/cli/tests/build/command_undefined_map_arg_object_id.nu
@@ -1,0 +1,37 @@
+use ../../test.nu *
+
+# A command argument map with an undefined entry must round-trip through the
+# object store. The id is computed locally (keeping the entry as null) while the
+# object is sent as JSON (which drops undefined keys), so storing validates
+# id == hash(bytes) and a divergence throws "invalid object id".
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: r#'
+		export function f() {
+			return "ok";
+		}
+		export default async function () {
+			// Construct a command whose argument is a map with an undefined entry.
+			let command = await tg.command(f, { a: undefined });
+
+			// Store it. A mismatch between the local id and the wire bytes fails
+			// here with "invalid object id".
+			let id = await command.store();
+
+			// Load it back and assert the undefined entry survived.
+			let args = await tg.Command.withId(id).args;
+			tg.assert(args.length === 1, "the argument was dropped");
+			let arg = args[0];
+			tg.assert(
+				typeof arg === "object" && arg !== null && "a" in arg,
+				"the undefined map entry was dropped",
+			);
+
+			return "ok";
+		}
+	'#
+}
+
+success (tg build $path | complete) "an undefined map entry must round-trip through the object store"

--- a/packages/clients/js/src/process.ts
+++ b/packages/clients/js/src/process.ts
@@ -1290,7 +1290,7 @@ export namespace Process {
 			if (data.log !== undefined && typeof data.log !== "string") {
 				data.log = data.log.id;
 			}
-			if (data.output !== undefined) {
+			if ("output" in data) {
 				tg.Value.Data.removeTokens(data.output);
 			}
 			return data;

--- a/packages/clients/js/src/resolve.ts
+++ b/packages/clients/js/src/resolve.ts
@@ -18,6 +18,7 @@ export type Unresolved<T extends tg.Value> = tg.MaybePromise<
 		? UnresolvedCommand<A, O>
 		: T extends
 					| undefined
+					| null
 					| boolean
 					| number
 					| string
@@ -46,6 +47,7 @@ type UnresolvedCommand<A extends Array<tg.Value>, O extends tg.Value> =
 type UnresolvedWithoutCommand<T extends tg.Value> = tg.MaybePromise<
 	T extends
 		| undefined
+		| null
 		| boolean
 		| number
 		| string
@@ -81,6 +83,7 @@ export type Resolved<T extends tg.Unresolved<tg.Value>> =
 			? tg.Command<tg.ResolvedArgs<A>, tg.ResolvedReturnValue<O>>
 			: T extends
 						| undefined
+						| null
 						| boolean
 						| number
 						| string
@@ -105,7 +108,7 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 		visited: im.Set<object>,
 	): Promise<Resolved<T>> => {
 		value = await value;
-		if (typeof value === "object") {
+		if (typeof value === "object" && value !== null) {
 			if (visited.has(value)) {
 				throw new Error("cycle detected");
 			}
@@ -114,6 +117,7 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 		let output: Resolved<T>;
 		if (
 			value === undefined ||
+			value === null ||
 			typeof value === "boolean" ||
 			typeof value === "number" ||
 			typeof value === "string" ||
@@ -147,7 +151,7 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 		} else {
 			throw new Error("invalid value to resolve");
 		}
-		if (typeof value === "object") {
+		if (typeof value === "object" && value !== null) {
 			visited = visited.delete(value);
 		}
 		return output;

--- a/packages/clients/js/src/util.ts
+++ b/packages/clients/js/src/util.ts
@@ -18,6 +18,7 @@ export type MaybeMutationMap<
 
 export type ValueOrMaybeMutationMap<T extends tg.Value = tg.Value> = T extends
 	| undefined
+	| null
 	| boolean
 	| number
 	| string

--- a/packages/clients/js/src/value.ts
+++ b/packages/clients/js/src/value.ts
@@ -39,8 +39,9 @@ export namespace Value {
 	};
 
 	export let toData = (value: Value): Data => {
-		if (
-			typeof value === "undefined" ||
+		if (value === undefined) {
+			return null;
+		} else if (
 			typeof value === "boolean" ||
 			typeof value === "number" ||
 			typeof value === "string"

--- a/packages/clients/js/src/value.ts
+++ b/packages/clients/js/src/value.ts
@@ -7,6 +7,7 @@ import {
 /** The union of all types that can be used as the input or output of Tangram commands. */
 export type Value =
 	| undefined
+	| null
 	| boolean
 	| number
 	| string
@@ -39,7 +40,7 @@ export namespace Value {
 	};
 
 	export let toData = (value: Value): Data => {
-		if (value === undefined) {
+		if (value === undefined || value === null) {
 			return null;
 		} else if (
 			typeof value === "boolean" ||
@@ -75,7 +76,6 @@ export namespace Value {
 		if (data === null) {
 			return undefined;
 		} else if (
-			typeof data === "undefined" ||
 			typeof data === "boolean" ||
 			typeof data === "number" ||
 			typeof data === "string"
@@ -119,6 +119,7 @@ export namespace Value {
 	export let is = (value: unknown): value is Value => {
 		return (
 			value === undefined ||
+			value === null ||
 			typeof value === "boolean" ||
 			typeof value === "number" ||
 			typeof value === "string" ||
@@ -272,7 +273,6 @@ export namespace Value {
 
 	export type Data =
 		| null
-		| undefined
 		| boolean
 		| number
 		| string
@@ -288,7 +288,6 @@ export namespace Value {
 		export let children = (data: tg.Value.Data): Array<tg.Object.Id> => {
 			if (
 				data === null ||
-				typeof data === "undefined" ||
 				typeof data === "boolean" ||
 				typeof data === "number" ||
 				typeof data === "string"

--- a/packages/js/src/start.ts
+++ b/packages/js/src/start.ts
@@ -24,9 +24,9 @@ export let start = async (): Promise<tg.Value.Data> => {
 	}
 	let namespace = await import(specifier, { with: attributes });
 
-	// If there is no export, then return undefined.
+	// If there is no export, then return null.
 	if (export_ === undefined) {
-		return undefined;
+		return null;
 	}
 
 	// Call the export.


### PR DESCRIPTION
Retain `undefined` as `null` in `tg.Value.toData`, mirroring `fromData`.