### PR TITLE
fix(test): support busybox under authentication

### DIFF
--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -1109,8 +1109,15 @@ export def --env spawn [
 			export default env;
 		';
 		$source | save ($path | path join 'tangram.ts')
-		tg check $path
-		tg -c ($config_path) tag 'busybox' $path
+		if ($config.authentication? | default false) {
+			# Under authentication, tag busybox as a user and grant public access to it.
+			let user = tg -c ($config_path) login --verbose busyboxer | from json
+			tg -c ($config_path) --token ($user.token) tag 'busybox' $path
+			tg -c ($config_path) --token ($user.token) grant public tag_read 'busybox'
+		} else {
+			tg check $path
+			tg -c ($config_path) tag 'busybox' $path
+		}
 		rm -rf $path
 	}
 

--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -1110,7 +1110,6 @@ export def --env spawn [
 		';
 		$source | save ($path | path join 'tangram.ts')
 		if ($config.authentication? | default false) {
-			# Under authentication, tag busybox as a user and grant public access to it.
 			let user = tg -c ($config_path) login --verbose busyboxer | from json
 			tg -c ($config_path) --token ($user.token) tag 'busybox' $path
 			tg -c ($config_path) --token ($user.token) grant public tag_read 'busybox'

--- a/packages/cli/tests/grants/busybox_authentication.nu
+++ b/packages/cli/tests/grants/busybox_authentication.nu
@@ -1,0 +1,17 @@
+use ../../test.nu *
+
+# A user can build a package that depends on busybox under authentication.
+
+let server = spawn --busybox --config { authentication: true }
+let alice = tg login --verbose alice | from json
+
+let path = artifact {
+	tangram.ts: '
+		import busybox from "busybox";
+		export default async function () {
+			return tg.run`mkdir -p $TANGRAM_OUTPUT && echo hello > $TANGRAM_OUTPUT/message.txt`.env(tg.build(busybox));
+		}
+	',
+}
+
+success (tg --token $alice.token build $path | complete) "using busybox under authentication must work"


### PR DESCRIPTION
The test harness needs to explicitly set the `busybox` tag to public for use with `{ authentication: true }` in tests.