### PR TITLE
fix(checkin): authorize the caller before minting a cache-path token

### DIFF
--- a/packages/cli/tests/grants/checkin_cache_path_requires_auth.nu
+++ b/packages/cli/tests/grants/checkin_cache_path_requires_auth.nu
@@ -1,0 +1,19 @@
+use ../../test.nu *
+
+# Checking in a cache path must authorize the caller on the named artifact: the cache-path branch mints an object subtree grant token for the artifact id in the path, so a principal who cannot read that artifact must not be able to check it in and obtain a read capability for it.
+
+let dir = mktemp -d
+let server = spawn --directory $dir --config { authentication: { providers: { insecure: true } } }
+let alice = tg login --verbose alice | from json
+let eve = tg login --verbose eve | from json
+
+# Alice stores a private artifact; Eve cannot read it.
+let secret = tg --token $alice.token put 'tg.file("topsecret-checkin")' | str trim
+tg index
+let before = tg --token $eve.token get $secret | complete
+failure $before "Eve should not read Alice's private artifact before the exploit."
+
+# Eve checks in the server's cache path for Alice's artifact id. This must be denied, since
+# checkin_cache_path mints an object_subtree grant token for the id without authorizing the caller.
+let exploit = tg --token $eve.token checkin $"($dir)/artifacts/($secret)" | complete
+failure $exploit "Eve must not check in an artifact she cannot read and mint a read token for it."

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -254,7 +254,6 @@ impl Session {
 			.parse()
 			.map_err(|error| tg::error!(!error, "failed to parse the artifact id"))?;
 
-		// Authorize the caller to read the artifact before minting a token for it.
 		let resource = tg::grant::Resource::Id(id.clone().into());
 		let permission =
 			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
@@ -272,6 +271,7 @@ impl Session {
 			let output = tg::checkin::Output { artifact };
 			return Ok(output);
 		}
+
 		let subpath = path.components().skip(1).collect::<PathBuf>();
 		let artifact = tg::Artifact::with_id(id);
 		let directory = artifact
@@ -282,10 +282,12 @@ impl Session {
 			.get_with_handle(self, subpath)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to get the artifact from the cache"))?;
+
 		let id = artifact.id();
 		let mut referent = tg::Referent::with_item(id);
 		referent.options.token = self.create_artifact_token(&referent.item)?;
 		let output = tg::checkin::Output { artifact: referent };
+
 		Ok(output)
 	}
 

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -241,7 +241,7 @@ impl Session {
 	}
 
 	async fn checkin_cache_path(&self, path: &Path) -> tg::Result<tg::checkin::Output> {
-		let id = path
+		let id: tg::artifact::Id = path
 			.components()
 			.next()
 			.map(|component| {
@@ -253,6 +253,19 @@ impl Session {
 			.ok_or_else(|| tg::error!("cannot check in the cache directory"))??
 			.parse()
 			.map_err(|error| tg::error!(!error, "failed to parse the artifact id"))?;
+
+		// Authorize the caller to read the artifact before minting a token for it.
+		let resource = tg::grant::Resource::Id(id.clone().into());
+		let permission =
+			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
+		if !self
+			.authorize(resource, permission)
+			.await?
+			.is_some_and(|permissions| permissions.contains(permission))
+		{
+			return Err(tg::error!("unauthorized"));
+		}
+
 		if path.components().count() == 1 {
 			let mut artifact = tg::Referent::with_item(id);
 			artifact.options.token = self.create_artifact_token(&artifact.item)?;

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -241,7 +241,7 @@ impl Session {
 	}
 
 	async fn checkin_cache_path(&self, path: &Path) -> tg::Result<tg::checkin::Output> {
-		let id: tg::artifact::Id = path
+		let id = path
 			.components()
 			.next()
 			.map(|component| {
@@ -251,7 +251,7 @@ impl Session {
 				name.to_str().ok_or_else(|| tg::error!("non-utf8 path"))
 			})
 			.ok_or_else(|| tg::error!("cannot check in the cache directory"))??
-			.parse()
+			.parse::<tg::artifact::Id>()
 			.map_err(|error| tg::error!(!error, "failed to parse the artifact id"))?;
 
 		let resource = tg::grant::Resource::Id(id.clone().into());


### PR DESCRIPTION
Adds a missing authorization check when checking in from the cache path to prevent receiving a token the user should not have.