### PR TITLE
fix(spawn): authorize the spawner to read the command's objects

### DIFF
--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -583,10 +583,12 @@ impl Cli {
 
 		// Create the command builder.
 		let mut command_env = None;
+		let mut command_options = None;
 		let mut command = match referent.item.clone() {
 			tg::graph::Edge::Object(tg::Object::Command(command)) => {
 				let object = command.object_with_handle(&client).await?;
 				command_env = Some(object.env.clone());
+				command_options = Some(referent.options.clone());
 				tg::Command::builder()
 					.host(object.host.clone())
 					.executable(object.executable.clone())
@@ -903,6 +905,9 @@ impl Cli {
 			args: command.args.clone(),
 			cached: options.cached,
 			checksum: options.checksum,
+			command: command_options.map(|options| {
+				tg::Referent::new(tg::Command::with_object(command.clone()), options)
+			}),
 			cwd: command.cwd.clone(),
 			debug: debug.map(tg::Either::Right),
 			env: command.env.clone(),

--- a/packages/cli/tests/grants/checksum_requires_read.nu
+++ b/packages/cli/tests/grants/checksum_requires_read.nu
@@ -1,0 +1,17 @@
+use ../../test.nu *
+
+# A principal who cannot read a private file must not be able to checksum it, since checksumming reads its bytes.
+
+let server = spawn --config { authentication: { providers: { insecure: true } } }
+let alice = tg login --verbose alice | from json
+let eve = tg login --verbose eve | from json
+
+# Alice stores a private file; Eve cannot read it.
+let secret = tg --token $alice.token put 'tg.file("checksumsecret")' | str trim
+tg index
+let before = tg --token $eve.token get $secret | complete
+failure $before "Eve should not read Alice's private file before the exploit."
+
+# Eve must not be able to checksum a file she cannot read.
+let exploit = tg --token $eve.token checksum $secret | complete
+failure $exploit "Eve must not checksum a private file she cannot read."

--- a/packages/clients/js/src/process/spawn.ts
+++ b/packages/clients/js/src/process/spawn.ts
@@ -58,6 +58,9 @@ export let spawnArg = async (
 		} else {
 			command_ = arg.command;
 		}
+		if (command_ !== undefined) {
+			options.token ??= command_.state.token;
+		}
 	}
 	if ("name" in arg) {
 		options.name = arg.name;

--- a/packages/clients/rust/src/process/spawn.rs
+++ b/packages/clients/rust/src/process/spawn.rs
@@ -125,6 +125,9 @@ where
 	let mut options = tg::referent::Options::default();
 	if let Some(command) = arg.command {
 		options = command.options;
+		if options.token.is_none() {
+			options.token = command.item.state().token();
+		}
 		command_.replace(command.item);
 	}
 	if let Some(name) = arg.name {

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -145,24 +145,7 @@ impl Session {
 		arg: tg::process::spawn::Arg,
 		parent_sandbox: Option<tg::sandbox::Id>,
 	) -> tg::Result<Option<tg::process::spawn::Output>> {
-		let tty = match arg.tty.as_ref() {
-			None => None,
-			Some(tty) => Some(
-				tty.as_ref()
-					.right()
-					.copied()
-					.ok_or_else(|| tg::error!("invalid tty"))?,
-			),
-		};
-
-		// Get the host.
-		let command_ = tg::Command::with_id(arg.command.item.clone());
-		let host = command_
-			.host_with_handle(self)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to get the command host"))?
-			.to_string();
-
+		// Authorize the command.
 		let permission =
 			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
 		if !self
@@ -172,6 +155,14 @@ impl Session {
 		{
 			return Err(tg::error!("unauthorized"));
 		}
+
+		// Get the host.
+		let command_ = tg::Command::with_id(arg.command.item.clone());
+		let host = command_
+			.host_with_handle(self)
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the command host"))?
+			.to_string();
 
 		// Determine if the process is cacheable.
 		let cacheable = if let Some(tg::Either::Left(sandbox)) = &arg.sandbox {
@@ -184,7 +175,7 @@ impl Session {
 			&& arg.stdin.is_null()
 			&& arg.stdout.is_log()
 			&& arg.stderr.is_log()
-			&& tty.is_none();
+			&& arg.tty.is_none();
 
 		// Authorize assigning the sandbox owner.
 		if let Some(tg::Either::Left(sandbox)) = &arg.sandbox {

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -163,6 +163,16 @@ impl Session {
 			.map_err(|error| tg::error!(!error, "failed to get the command host"))?
 			.to_string();
 
+		let permission =
+			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
+		if !self
+			.authorize(tg::object::Id::from(arg.command.item.clone()), permission)
+			.await?
+			.is_some_and(|permissions| permissions.contains(permission))
+		{
+			return Err(tg::error!("unauthorized"));
+		}
+
 		// Determine if the process is cacheable.
 		let cacheable = if let Some(tg::Either::Left(sandbox)) = &arg.sandbox {
 			sandbox.mounts.is_empty() && sandbox.network.is_none()

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -148,8 +148,14 @@ impl Session {
 		// Authorize the command.
 		let permission =
 			tg::grant::Permission::Object(tg::grant::permission::object::Permission::Subtree);
+		let command = tg::object::Id::from(arg.command.item.clone());
+		let command = if let Some(token) = arg.command.options.token.clone() {
+			tg::Either::Right(tg::WithToken { id: command, token })
+		} else {
+			tg::Either::Left(command)
+		};
 		if !self
-			.authorize(tg::object::Id::from(arg.command.item.clone()), permission)
+			.authorize(command, permission)
 			.await?
 			.is_some_and(|permissions| permissions.contains(permission))
 		{


### PR DESCRIPTION
Add a missing authorization check for the command subtree in spawn, closing a leak where it was possible to `tg checksum` a file you could not `tg get`, via the spawned builtin. We already gated commands that you yourself built, but this scenario allowed you to place an object you cannot read into a command as an argument, which was missed. 