### PR TITLE
fix(server): object batch ancestor subtree token

### DIFF
--- a/packages/cli/tests/grants/process_output_reused_directory_entry.nu
+++ b/packages/cli/tests/grants/process_output_reused_directory_entry.nu
@@ -4,7 +4,6 @@ use ../../test.nu *
 # subtree token) in a new directory output must authorize as subtree. The object-batch
 # advisory check rejects the ancestor token, downgrading the output to a node-only grant
 # that then fails finish once its subtree exceeds the search budget (depth here).
-# Minimal offline analog of std's darwin toolchain overlay reusing `await raw.entries`.
 
 let server = spawn
 

--- a/packages/cli/tests/grants/process_output_reused_directory_entry.nu
+++ b/packages/cli/tests/grants/process_output_reused_directory_entry.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+
+# Reusing a child from a tokened directory's `.entries` (which carries the parent's
+# subtree token) in a new directory output must authorize as subtree. The object-batch
+# advisory check rejects the ancestor token, downgrading the output to a node-only grant
+# that then fails finish once its subtree exceeds the search budget (depth here).
+# Minimal offline analog of std's darwin toolchain overlay reusing `await raw.entries`.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			let raw = await tg.build(makeRaw).then(tg.Directory.expect);
+			let entries = await raw.entries;
+			let child = entries["child"];
+			return tg.directory({ reused: child });
+		}
+		export function makeRaw() {
+			let dir = tg.directory({ leaf: tg.file("hi") });
+			for (let i = 0; i < 18; i++) {
+				dir = tg.directory({ child: dir });
+			}
+			return dir;
+		}
+	',
+}
+let out = tg build $path | complete
+success $out "reusing a tokened directory's entry in a new output should authorize as subtree"

--- a/packages/server/src/object.rs
+++ b/packages/server/src/object.rs
@@ -33,8 +33,21 @@ impl Session {
 				return Ok(false);
 			};
 			let child = advisory_children.get(child).unwrap().clone();
-			if !self.object_token_grants_subtree(child) {
-				return Ok(false);
+			if !self.object_token_grants_subtree(child.clone()) {
+				if !matches!(child, tg::Either::Right(_)) {
+					return Ok(false);
+				}
+				let permission = tg::grant::Permission::Object(
+					tg::grant::permission::object::Permission::Subtree,
+				);
+				let permissions = tg::grant::permission::Set::from_permission(permission);
+				let authorized = self
+					.authorize(child, permissions)
+					.await?
+					.is_some_and(|permissions| permissions.contains(permission));
+				if !authorized {
+					return Ok(false);
+				}
 			}
 		}
 		Ok(true)


### PR DESCRIPTION
Constructing a directory from the .entries() of a tokened directory makes its children carry the parent's token, so the object-batch advisory check rejects them as not an exact match and downgrades the new directory to a node-only grant. We do legitimately have subtree access via the parent's token, but the downgrade only surfaces when the directory is a process output whose subtree exceeds the finish-time subtree-search budget. It then fails with unauthorized.

The fix falls back from the fast token check to the index, which authorizes the child by following its parent chain up to the directory the token covers — confirming, against the object graph, that the child is genuinely within the token's subtree.