### PR TITLE
fix(server): consistently use aws_lc_rs

### DIFF
--- a/packages/server/src/http.rs
+++ b/packages/server/src/http.rs
@@ -454,7 +454,7 @@ impl Server {
 		};
 
 		let mut config = rustls::ServerConfig::builder_with_provider(std::sync::Arc::new(
-			rustls::crypto::ring::default_provider(),
+			rustls::crypto::aws_lc_rs::default_provider(),
 		))
 		.with_safe_default_protocol_versions()
 		.map_err(|error| tg::error!(!error, "failed to create the tls config"))?


### PR DESCRIPTION
Use the aws_lc_rs provider instead of ring, matching rest of codebase.