### PR TITLE
index/authorize: reuse subtree authorization for nested entries

### DIFF
--- a/packages/cli/tests/grants/process_output_reused_nested_entry.nu
+++ b/packages/cli/tests/grants/process_output_reused_nested_entry.nu
@@ -1,0 +1,28 @@
+use ../../test.nu *
+
+# A build produces a deep directory, and the output reuses one of its deep entries nested inside
+# another directory. The reused entry is external and carries only an ancestor token whose resource
+# is the original directory, not the entry. Building this output must authorize it as a subtree.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			let directory = await tg.build(createDirectory).then(tg.Directory.expect);
+			let entries = await directory.entries;
+			let child = entries["child"];
+			return tg.directory({ wrap: tg.directory({ reused: child }) });
+		}
+
+		export function createDirectory() {
+			let directory = tg.directory({ leaf: tg.file("hi") });
+			for (let i = 0; i < 20; i++) {
+				directory = tg.directory({ child: directory });
+			}
+			return directory;
+		}
+	',
+}
+let out = tg build $path | complete
+success $out "reusing a deep directory entry nested in a new output should authorize as subtree"

--- a/packages/index/src/fdb/authorize.rs
+++ b/packages/index/src/fdb/authorize.rs
@@ -659,7 +659,7 @@ impl Index {
 				if children.is_empty() {
 					continue;
 				}
-				if depth == 1
+				if depth >= 1
 					&& Self::authorize_permission_with_transaction_inner(
 						context,
 						&resource,

--- a/packages/index/src/lmdb/authorize.rs
+++ b/packages/index/src/lmdb/authorize.rs
@@ -554,7 +554,7 @@ impl Index {
 			if children.is_empty() {
 				continue;
 			}
-			if depth == root_depth + 1
+			if depth > root_depth
 				&& Self::authorize_permission_with_transaction_inner(
 					context,
 					&resource,


### PR DESCRIPTION
The previous test/fix only catches children one level deep, nesting the reused child one level deeper still failed. This change makes the reuse correct at any depth.