### PR TITLE
fix(clients/js): correct null asymmetry

### DIFF
--- a/packages/cli/tests/build/command_undefined_map_arg_child_process.nu
+++ b/packages/cli/tests/build/command_undefined_map_arg_child_process.nu
@@ -1,0 +1,18 @@
+use ../../test.nu *
+
+# A command argument map with an undefined entry must round-trip into a child process without crashing when the process deserializes its arguments.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: r#'
+		export const inner = (arg: { a?: string }) => {
+			return "ok";
+		};
+		export default async () => {
+			return await tg.build(inner, { a: undefined });
+		};
+	'#
+}
+
+success (tg build $path | complete) "a map arg with an undefined entry must round-trip into a child process"

--- a/packages/js/src/quickjs/serde/serializer.rs
+++ b/packages/js/src/quickjs/serde/serializer.rs
@@ -158,7 +158,7 @@ impl<'js> serde::Serializer for Serializer<'js> {
 	}
 
 	fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-		Ok(qjs::Value::new_undefined(self.ctx))
+		Ok(qjs::Value::new_null(self.ctx))
 	}
 
 	fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {

--- a/packages/v8/src/serde/serializer.rs
+++ b/packages/v8/src/serde/serializer.rs
@@ -149,7 +149,7 @@ impl<'a, 's, 'p> serde::Serializer for Serializer<'a, 's, 'p> {
 	}
 
 	fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-		Ok(v8::undefined(self.scope).into())
+		Ok(v8::null(self.scope).into())
 	}
 
 	fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {


### PR DESCRIPTION
Correct asymmetry introduced in #936 - unit must serialize as null, not undefined.