### PR TITLE
fix(test): fix the doc helper for newer nushell

### DIFF
--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -665,16 +665,7 @@ export def doc [string: string] {
 
 	# Extract leading whitespace from each non-empty line.
 	let leading_whitespace = $non_whitespace_lines | each { |line|
-		let chars = $line | split chars
-		mut ws = ""
-		for char in $chars {
-			if $char == "\t" or $char == " " {
-				$ws = $ws + $char
-			} else {
-				break
-			}
-		}
-		$ws
+		$line | split chars | take while { |char| $char == "\t" or $char == " " } | str join
 	}
 
 	# Find the common prefix of all leading whitespace strings.


### PR DESCRIPTION
nushell 0.114.0 updated its type inference and no longer narrows the closure parameter `$line` to `string`. `split chars` has two input-dependent signatures, so without a narrowed input it can't resolve to one, and its result becomes the ambiguous type `oneof<list<string>, list<list<string>>>` which the for loop can't consume.

This appears to be a bug in nushell — our program is obviously correct as written, and is being rejected by their new type inference. It can be mitigated by using the take-while construct instead, which is correct and valid in either version and a little cleaner anyway.