### PR TITLE
fix(server): do not materialize root grants

### DIFF
--- a/packages/cli/tests/index/zzz_grant_scan_compounding.nu
+++ b/packages/cli/tests/index/zzz_grant_scan_compounding.nu
@@ -1,0 +1,56 @@
+use ../../test.nu *
+
+# Identical builds should cost the same. Here each is slower than the last, because the indexer
+# propagates every grant across an object's entire ancestry, and that cost is super-linear in the
+# grants already accumulated on a shared object. The template combines the two conditions that
+# trigger the blow-up:
+#   1. `shared` returns a constant, so its outputs are identical content-addressed objects in every
+#      build — a fixed set of shared objects the builds keep re-granting.
+#   2. `wrap` embeds a per-build salt, so nothing caches: every build re-runs and wraps those shared
+#      objects in fresh parents, adding one more grant and one more ancestor to each.
+# Every grant write fans out one visibility entry per ancestor (packages/index/src/lmdb/grant/put.rs),
+# so ten identical builds compound; a constant-cost indexer keeps their times flat. This is the
+# pathology behind the multi-minute std build "hang".
+
+let server = spawn --config { tokio_single_threaded: false, v8_thread_pool_size: 8 }
+
+let template = '
+export function shared(i: number) { return i; }
+export function wrap(w: number) {
+	let _ = __SALT__;
+	let children = [];
+	for (let i = 0; i < 8; i++) { children.push(tg.build(shared, i)); }
+	return Promise.all(children).then(() => w);
+}
+export default async function () {
+	let wrappers = [];
+	for (let w = 0; w < 16; w++) { wrappers.push(tg.build(wrap, w)); }
+	await Promise.all(wrappers);
+	return "done";
+}
+'
+
+# Build the same graph ten times, salting only the wrappers, and time each build end to end.
+mut rows = []
+for trial in 0..<10 {
+	let src = ($template | str replace --all "__SALT__" ($trial | into string))
+	let path = (artifact { tangram.ts: $src })
+	let t0 = (date now)
+	let out = (tg build $path | complete)
+	let ns = (((date now) - $t0) | into int)
+	$rows = ($rows | append { trial: $trial, secs: ($ns / 1_000_000_000 | math round -p 2), exit: $out.exit_code, ns: $ns })
+}
+print ($rows | select trial secs exit)
+
+# The timing is only meaningful if every build completed.
+let failed = ($rows | where exit != 0)
+assert (($failed | length) == 0) $"($failed | length) of 10 builds failed"
+
+# Compare slowest to fastest, not an absolute time, so the bound is machine-independent: a
+# constant-cost indexer keeps the ratio near one; super-linear grant propagation makes it grow.
+let fastest = ($rows | get ns | math min)
+let slowest = ($rows | get ns | math max)
+let ratio = ($slowest / $fastest)
+let ratio_rounded = ($ratio | math round -p 2)
+print $"fastest=(($fastest / 1_000_000_000) | math round -p 2)s slowest=(($slowest / 1_000_000_000) | math round -p 2)s ratio=($ratio_rounded)x"
+assert ($ratio < 2.5) $"identical builds compounded ($ratio_rounded)x: grant propagation is super-linear in the grants accumulated on the shared objects"

--- a/packages/server/src/checkin/index.rs
+++ b/packages/server/src/checkin/index.rs
@@ -65,24 +65,27 @@ impl Session {
 				.as_secs()
 				.to_i64()
 				.unwrap();
-		let put_grant = (!matches!(self.context.principal, tg::Principal::Anonymous))
-			.then(|| {
-				let principal = self.context.principal.clone();
-				let index = graph.paths.get(root).unwrap();
-				let resource = graph.nodes.get(index).unwrap().id.as_ref().unwrap().clone();
-				Ok::<_, tg::Error>(tangram_index::grant::put::Arg {
-					created_at: touched_at,
-					creator: Some(principal.clone()),
-					expires_at: Some(grant_expires_at),
-					permissions: tg::grant::Permission::Object(
-						tg::grant::permission::object::Permission::Subtree,
-					)
-					.into(),
-					principal: principal.try_to_grant_principal()?,
-					resource: resource.into(),
-				})
+		let put_grant = (!matches!(
+			self.context.principal,
+			tg::Principal::Anonymous | tg::Principal::Root
+		))
+		.then(|| {
+			let principal = self.context.principal.clone();
+			let index = graph.paths.get(root).unwrap();
+			let resource = graph.nodes.get(index).unwrap().id.as_ref().unwrap().clone();
+			Ok::<_, tg::Error>(tangram_index::grant::put::Arg {
+				created_at: touched_at,
+				creator: Some(principal.clone()),
+				expires_at: Some(grant_expires_at),
+				permissions: tg::grant::Permission::Object(
+					tg::grant::permission::object::Permission::Subtree,
+				)
+				.into(),
+				principal: principal.try_to_grant_principal()?,
+				resource: resource.into(),
 			})
-			.transpose()?;
+		})
+		.transpose()?;
 
 		// Index.
 		self.server

--- a/packages/server/src/object/batch.rs
+++ b/packages/server/src/object/batch.rs
@@ -53,8 +53,11 @@ impl Session {
 				.unwrap();
 
 		// Store the objects.
-		let principal = (!matches!(self.context.principal, tg::Principal::Anonymous))
-			.then(|| self.context.principal.clone());
+		let principal = (!matches!(
+			self.context.principal,
+			tg::Principal::Anonymous | tg::Principal::Root
+		))
+		.then(|| self.context.principal.clone());
 		let put_args: Vec<_> = arg
 			.objects
 			.iter()

--- a/packages/server/src/object/put.rs
+++ b/packages/server/src/object/put.rs
@@ -117,19 +117,22 @@ impl Session {
 			stored: tangram_index::object::Stored::default(),
 			touched_at: now,
 		};
-		let put_grant = (!matches!(self.context.principal, tg::Principal::Anonymous))
-			.then(|| {
-				let principal = self.context.principal.clone();
-				Ok::<_, tg::Error>(tangram_index::grant::put::Arg {
-					created_at: now,
-					creator: Some(principal.clone()),
-					expires_at: Some(grant_expires_at),
-					permissions: tg::grant::Permission::Object(permission).into(),
-					principal: principal.try_to_grant_principal()?,
-					resource: id.clone().into(),
-				})
+		let put_grant = (!matches!(
+			self.context.principal,
+			tg::Principal::Anonymous | tg::Principal::Root
+		))
+		.then(|| {
+			let principal = self.context.principal.clone();
+			Ok::<_, tg::Error>(tangram_index::grant::put::Arg {
+				created_at: now,
+				creator: Some(principal.clone()),
+				expires_at: Some(grant_expires_at),
+				permissions: tg::grant::Permission::Object(permission).into(),
+				principal: principal.try_to_grant_principal()?,
+				resource: id.clone().into(),
 			})
-			.transpose()?;
+		})
+		.transpose()?;
 		self.server
 			.index_tasks
 			.spawn(|_| {

--- a/packages/server/src/process/put.rs
+++ b/packages/server/src/process/put.rs
@@ -141,22 +141,25 @@ impl Session {
 				.as_secs()
 				.to_i64()
 				.unwrap();
-		let put_grant = (!matches!(self.context.principal, tg::Principal::Anonymous))
-			.then(|| {
-				let principal = self.context.principal.clone();
-				Ok::<_, tg::Error>(tangram_index::grant::put::Arg {
-					created_at: now,
-					creator: Some(principal.clone()),
-					expires_at: Some(grant_expires_at),
-					permissions: tg::grant::Permission::Process(
-						tg::grant::permission::process::Permission::Node,
-					)
-					.into(),
-					principal: principal.try_to_grant_principal()?,
-					resource: id.clone().into(),
-				})
+		let put_grant = (!matches!(
+			self.context.principal,
+			tg::Principal::Anonymous | tg::Principal::Root
+		))
+		.then(|| {
+			let principal = self.context.principal.clone();
+			Ok::<_, tg::Error>(tangram_index::grant::put::Arg {
+				created_at: now,
+				creator: Some(principal.clone()),
+				expires_at: Some(grant_expires_at),
+				permissions: tg::grant::Permission::Process(
+					tg::grant::permission::process::Permission::Node,
+				)
+				.into(),
+				principal: principal.try_to_grant_principal()?,
+				resource: id.clone().into(),
 			})
-			.transpose()?;
+		})
+		.transpose()?;
 		self.server
 			.index_tasks
 			.spawn(|_| {

--- a/packages/server/src/write.rs
+++ b/packages/server/src/write.rs
@@ -499,8 +499,11 @@ impl Session {
 			blob,
 			cache_pointer,
 			touched_at,
-			(!matches!(self.context.principal, tg::Principal::Anonymous))
-				.then_some(&self.context.principal),
+			(!matches!(
+				self.context.principal,
+				tg::Principal::Anonymous | tg::Principal::Root
+			))
+			.then_some(&self.context.principal),
 			grant_expires_at,
 		);
 		self.server


### PR DESCRIPTION
The included test demonstrates a compounding slowdown in authorization due to writing excessive grants.  The included fix bypasses this by skipping Root when materializing these grants, which allows the test to stay flat timing-wise across the builds it runs.

On a local server with authentication disabled, the acting principal is Root, which is authorized for everything by bypass and never reads grants — yet every checkin/object/process write still materialized a Root grant and fanned it out across each object's growing ancestry, making repeated builds over shared objects compound super-linearly (the multi-minute std build "hang"). This extends the grant-write gate to skip Root as well as Anonymous, so those write-only grants are never produced.