### PR TITLE
js: implement retry and reconnect

### DIFF
--- a/packages/cli/src/server/run.rs
+++ b/packages/cli/src/server/run.rs
@@ -65,12 +65,12 @@ impl Cli {
 
 		// Set the URL.
 		if let Some(url) = &self.args.url {
-			config.http = Some(tangram_server::config::Http {
-				listeners: vec![tangram_server::config::HttpListener {
-					url: url.clone(),
-					tls: None,
-				}],
-			});
+			let listener = tangram_server::config::HttpListener {
+				url: url.clone(),
+				tls: None,
+			};
+			let http = config.http.get_or_insert_default();
+			http.listeners = vec![listener];
 		}
 
 		// Set the remotes.

--- a/packages/cli/tests/build/idle_session_empty_body.nu
+++ b/packages/cli/tests/build/idle_session_empty_body.nu
@@ -2,13 +2,13 @@ use ../../test.nu *
 
 # A request sent after the connection's idle timeout must not send an empty body.
 
-let server = spawn
+let server = spawn --config { http: { idle_timeout: 3 } }
 
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
 			await tg.client.write("hello");
-			await tg.sleep(35);
+			await tg.sleep(4);
 			let id = await tg.client.write("world");
 			let text = await tg.Blob.withId(id).text;
 			return `second write round tripped as ${JSON.stringify(text)}`;

--- a/packages/cli/tests/build/idle_session_empty_body.nu
+++ b/packages/cli/tests/build/idle_session_empty_body.nu
@@ -1,0 +1,20 @@
+use ../../test.nu *
+
+# A request sent after the connection's idle timeout must not send an empty body.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			await tg.client.write("hello");
+			await tg.sleep(35);
+			let id = await tg.client.write("world");
+			let text = await tg.Blob.withId(id).text;
+			return `second write round tripped as ${JSON.stringify(text)}`;
+		}
+	'
+}
+
+let output = tg build $path
+snapshot $output '"second write round tripped as \"world\""'

--- a/packages/clients/js/src/client.ts
+++ b/packages/clients/js/src/client.ts
@@ -27,7 +27,22 @@ import { read, tryRead, tryReadStream } from "./client/read.ts";
 import { getSandbox, tryGetSandbox } from "./client/sandbox/get.ts";
 import { write } from "./client/write.ts";
 
+type RetryOptions = {
+	backoff: number;
+	jitter: number;
+	maxDelay: number;
+	maxRetries: number;
+};
+
+let reconnectOptions = defaultRetryOptions();
+let retryOptions = defaultRetryOptions();
+
+class RequestError {
+	constructor(readonly source: unknown) {}
+}
+
 export class Client {
+	#connecting: Promise<tg.Host.Http2.ClientHttp2Session> | null = null;
 	#session: tg.Host.Http2.ClientHttp2Session | null = null;
 
 	arg() {
@@ -230,19 +245,140 @@ export class Client {
 		return write(this, argOrBytes, input);
 	}
 
-	#connect() {
-		if (this.#session !== null) {
+	async send(request: Request): Promise<Response> {
+		try {
+			return await this.#send(request);
+		} catch (error) {
+			throw error instanceof RequestError ? error.source : error;
+		}
+	}
+
+	async sendWithRetry(request: Request): Promise<Response> {
+		if (request.body !== undefined && !request.body.replayable) {
+			throw new Error("cannot retry a request with a streaming body");
+		}
+		try {
+			return await retry(
+				retryOptions,
+				() => this.#send(request),
+				(error) => error instanceof RequestError,
+			);
+		} catch (error) {
+			throw error instanceof RequestError ? error.source : error;
+		}
+	}
+
+	async #send(request: Request): Promise<Response> {
+		let token = tg.process.env.TANGRAM_TOKEN;
+		if (token !== undefined && typeof token !== "string") {
+			throw new Error("invalid TANGRAM_TOKEN");
+		}
+		let headers: tg.Host.Http2.Headers = {
+			...request.headers.toData(),
+			":method": request.method,
+			":path": request.uri.toString(),
+		};
+		if (token !== undefined) {
+			headers = {
+				...headers,
+				authorization: `Bearer ${token}`,
+			};
+		}
+		let session = await this.#connect();
+		try {
+			let body = request.body;
+			let stream = session.request(headers, {
+				endStream: body === undefined,
+			});
+			let response = Response.fromStream(stream);
+			if (body !== undefined) {
+				(async () => {
+					for await (let chunk of body) {
+						stream.write(chunk);
+					}
+					stream.end();
+				})().catch((error) => {
+					stream.destroy(
+						error instanceof Error
+							? error
+							: new Error("failed to write the request body"),
+					);
+				});
+			}
+			return await response;
+		} catch (error) {
+			this.#disconnect(session);
+			session.destroy();
+			throw new RequestError(error);
+		}
+	}
+
+	async #connect() {
+		while (true) {
+			let session = this.#session;
+			if (session !== null) {
+				if (!session.closed) {
+					return session;
+				}
+				this.#disconnect(session);
+				session.destroy();
+			}
+			let connecting = this.#connecting;
+			if (connecting === null) {
+				connecting = retry(reconnectOptions, () => this.#createSession());
+				this.#connecting = connecting;
+			}
+			let nextSession: tg.Host.Http2.ClientHttp2Session;
+			try {
+				nextSession = await connecting;
+			} finally {
+				if (this.#connecting === connecting) {
+					this.#connecting = null;
+				}
+			}
+			if (nextSession.closed) {
+				nextSession.destroy();
+				continue;
+			}
+			if (this.#session === null) {
+				this.#session = nextSession;
+				nextSession.once("close", () => this.#disconnect(nextSession));
+				nextSession.once("error", () => this.#disconnect(nextSession));
+			} else if (this.#session !== nextSession) {
+				nextSession.destroy();
+			}
 			return this.#session;
 		}
+	}
+
+	async #createSession() {
 		let url = tg.process.env.TANGRAM_URL;
 		if (typeof url !== "string") {
 			throw new Error("missing TANGRAM_URL");
 		}
-		let nextSession = tg.host.http2.connect(url);
-		this.#session = nextSession;
-		nextSession.once("close", () => this.#disconnect(nextSession));
-		nextSession.once("error", () => this.#disconnect(nextSession));
-		return nextSession;
+		let session = tg.host.http2.connect(url);
+		try {
+			await new Promise<void>((resolve, reject) => {
+				let cleanup = () => {
+					session.off("connect", onConnect);
+					session.off("error", onError);
+				};
+				let onConnect = () => {
+					cleanup();
+					resolve();
+				};
+				let onError = (error: unknown) => {
+					cleanup();
+					reject(error);
+				};
+				session.once("connect", onConnect);
+				session.once("error", onError);
+			});
+		} catch (error) {
+			session.destroy();
+			throw error;
+		}
+		return session;
 	}
 
 	#disconnect(value?: tg.Host.Http2.ClientHttp2Session) {
@@ -251,55 +387,41 @@ export class Client {
 		}
 		this.#session = null;
 	}
-
-	async send(request: Request): Promise<Response> {
-		let error: unknown;
-		for (let attempt = 0; attempt < 2; attempt++) {
-			let session = this.#connect();
-			try {
-				let token = tg.process.env.TANGRAM_TOKEN;
-				if (token !== undefined && typeof token !== "string") {
-					throw new Error("invalid TANGRAM_TOKEN");
-				}
-				let headers: tg.Host.Http2.Headers = {
-					...request.headers.toData(),
-					":method": request.method,
-					":path": request.uri.toString(),
-				};
-				if (token !== undefined) {
-					headers = {
-						...headers,
-						authorization: `Bearer ${token}`,
-					};
-				}
-				let body = request.body;
-				let stream = session.request(headers, {
-					endStream: body === undefined,
-				});
-				let response = Response.fromStream(stream);
-				if (body !== undefined) {
-					(async () => {
-						for await (let chunk of body) {
-							stream.write(chunk);
-						}
-						stream.end();
-					})().catch((error) => {
-						stream.destroy(
-							error instanceof Error
-								? error
-								: new Error("failed to write the request body"),
-						);
-					});
-				}
-				return await response;
-			} catch (error_) {
-				error = error_;
-				this.#disconnect(session);
-				session.destroy();
-			}
-		}
-		throw error;
-	}
 }
 
 export let client = new Client();
+
+function defaultRetryOptions(): RetryOptions {
+	return {
+		backoff: 0.01,
+		jitter: 0.01,
+		maxDelay: 1,
+		maxRetries: 3,
+	};
+}
+
+async function retry<T>(
+	options: RetryOptions,
+	function_: () => Promise<T>,
+	shouldRetry: (error: unknown) => boolean = () => true,
+) {
+	let error: unknown;
+	for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+		try {
+			return await function_();
+		} catch (error_) {
+			error = error_;
+			if (attempt === options.maxRetries || !shouldRetry(error)) {
+				break;
+			}
+			let multiplier = 2 ** Math.min(attempt + 1, 31);
+			let jitter = Math.random() * options.jitter;
+			let delay = Math.min(
+				options.backoff * multiplier + jitter,
+				options.maxDelay,
+			);
+			await tg.sleep(delay);
+		}
+	}
+	throw error;
+}

--- a/packages/clients/js/src/client/checkin.ts
+++ b/packages/clients/js/src/client/checkin.ts
@@ -106,7 +106,7 @@ export async function checkin(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}

--- a/packages/clients/js/src/client/checkout.ts
+++ b/packages/clients/js/src/client/checkout.ts
@@ -62,7 +62,7 @@ export async function checkout(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}

--- a/packages/clients/js/src/client/object/batch.ts
+++ b/packages/clients/js/src/client/object/batch.ts
@@ -29,7 +29,7 @@ export async function postObjectBatch(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}

--- a/packages/clients/js/src/client/object/get.ts
+++ b/packages/clients/js/src/client/object/get.ts
@@ -27,7 +27,7 @@ export async function tryGetObject(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/object/put.ts
+++ b/packages/clients/js/src/client/object/put.ts
@@ -29,7 +29,7 @@ export async function putObject(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}

--- a/packages/clients/js/src/client/process/get.ts
+++ b/packages/clients/js/src/client/process/get.ts
@@ -52,7 +52,7 @@ export async function tryGetProcess(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/process/put.ts
+++ b/packages/clients/js/src/client/process/put.ts
@@ -38,7 +38,7 @@ export async function putProcess(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}

--- a/packages/clients/js/src/client/process/signal.ts
+++ b/packages/clients/js/src/client/process/signal.ts
@@ -43,7 +43,7 @@ export async function trySignalProcess(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/process/spawn.ts
+++ b/packages/clients/js/src/client/process/spawn.ts
@@ -130,7 +130,7 @@ export async function trySpawnProcess(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}

--- a/packages/clients/js/src/client/process/stdio/read.ts
+++ b/packages/clients/js/src/client/process/stdio/read.ts
@@ -91,7 +91,7 @@ async function readProcessStdioOnce(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/process/tty/put.ts
+++ b/packages/clients/js/src/client/process/tty/put.ts
@@ -36,7 +36,7 @@ export async function trySetProcessTtySize(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/process/wait.ts
+++ b/packages/clients/js/src/client/process/wait.ts
@@ -82,7 +82,7 @@ async function waitProcessOnce(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		throw new Error("failed to find the process");
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/read.ts
+++ b/packages/clients/js/src/client/read.ts
@@ -68,7 +68,7 @@ export async function tryReadStream(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/client/sandbox/get.ts
+++ b/packages/clients/js/src/client/sandbox/get.ts
@@ -37,7 +37,7 @@ export async function tryGetSandbox(
 		uri,
 		headers,
 	});
-	let response = await client.send(request);
+	let response = await client.sendWithRetry(request);
 	if (response.status === 404) {
 		return null;
 	} else if (response.status < 200 || response.status >= 300) {

--- a/packages/clients/js/src/host.ts
+++ b/packages/clients/js/src/host.ts
@@ -125,6 +125,8 @@ export namespace Host {
 
 		export interface ClientHttp2Session {
 			readonly authority: string;
+			readonly closed: boolean;
+			readonly destroyed: boolean;
 			readonly options: ConnectOptions;
 
 			close(callback?: () => void): Promise<void>;

--- a/packages/clients/js/src/http/body.ts
+++ b/packages/clients/js/src/http/body.ts
@@ -1,14 +1,18 @@
 import * as tg from "../index.ts";
 
 export class Body implements AsyncIterable<Uint8Array> {
-	#body: AsyncIterable<Uint8Array>;
+	#body: AsyncIterable<string | Uint8Array>;
+	#replayable: boolean;
 
 	constructor(body?: AsyncIterable<string | Uint8Array>) {
-		this.#body = normalize(body ?? empty());
+		this.#body = body ?? empty();
+		this.#replayable = body === undefined;
 	}
 
 	static bytes(bytes: Uint8Array) {
-		return new Body(single(bytes));
+		let body = new Body(single(bytes));
+		body.#replayable = true;
+		return body;
 	}
 
 	static empty() {
@@ -25,6 +29,10 @@ export class Body implements AsyncIterable<Uint8Array> {
 
 	static text(text: string) {
 		return Body.bytes(tg.encoding.utf8.encode(text));
+	}
+
+	get replayable() {
+		return this.#replayable;
 	}
 
 	async collect() {
@@ -46,7 +54,7 @@ export class Body implements AsyncIterable<Uint8Array> {
 	}
 
 	[Symbol.asyncIterator]() {
-		return this.#body[Symbol.asyncIterator]();
+		return normalize(this.#body)[Symbol.asyncIterator]();
 	}
 }
 
@@ -97,8 +105,12 @@ async function* encodeSse(
 
 async function* empty(): AsyncIterableIterator<Uint8Array> {}
 
-async function* single(value: Uint8Array): AsyncIterableIterator<Uint8Array> {
-	yield value;
+function single(value: Uint8Array): AsyncIterable<Uint8Array> {
+	return {
+		async *[Symbol.asyncIterator]() {
+			yield value;
+		},
+	};
 }
 
 async function* normalize(

--- a/packages/js/src/http2.rs
+++ b/packages/js/src/http2.rs
@@ -20,6 +20,11 @@ use {
 
 type BodyFrame = Result<http_body::Frame<Bytes>, std::io::Error>;
 type RequestBody = StreamBody<ReceiverStream<BodyFrame>>;
+type Handshake = (
+	hyper::client::conn::http2::SendRequest<RequestBody>,
+	mpsc::Sender<SessionEvent>,
+	mpsc::Receiver<SessionEvent>,
+);
 
 #[derive(Default)]
 pub(crate) struct Http2 {
@@ -30,6 +35,8 @@ pub(crate) struct Http2 {
 
 struct Session {
 	authority: String,
+	event_tx: mpsc::Sender<SessionEvent>,
+	events: Mutex<mpsc::Receiver<SessionEvent>>,
 	scheme: String,
 	sender: hyper::client::conn::http2::SendRequest<RequestBody>,
 	streams: DashMap<usize, ()>,
@@ -57,6 +64,13 @@ pub struct RequestOptions {
 
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SessionEvent {
+	Close,
+	Error { message: String },
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum StreamEvent {
 	Close,
 	Data { bytes: Bytes },
@@ -79,8 +93,8 @@ impl Http2 {
 		if let Some(path) = authority.strip_prefix("http+unix://") {
 			let path = unix_path_from_str(path)?;
 			let stream = connect_unix(&path).await?;
-			let sender = handshake(stream).await?;
-			return Ok(self.insert_session("localhost".to_owned(), "http".to_owned(), sender));
+			let handshake = handshake(stream).await?;
+			return Ok(self.insert_session("localhost".to_owned(), "http".to_owned(), handshake));
 		}
 
 		let uri = authority
@@ -89,7 +103,7 @@ impl Http2 {
 		let scheme = uri
 			.scheme_str()
 			.ok_or_else(|| tg::error!("missing a URL scheme"))?;
-		let (authority, scheme, sender) = match scheme {
+		let (authority, scheme, handshake) = match scheme {
 			"http" | "https" => {
 				let host = uri.host().ok_or_else(|| tg::error!("missing a URL host"))?;
 				let port = options
@@ -110,42 +124,50 @@ impl Http2 {
 					host.to_owned()
 				};
 				let stream = connect_tcp(host, port).await?;
-				let sender = if scheme == "https" {
+				let handshake = if scheme == "https" {
 					let stream = connect_tls(host, stream).await?;
 					verify_alpn_protocol(&stream)?;
 					handshake(stream).await?
 				} else {
 					handshake(stream).await?
 				};
-				(authority, scheme.to_owned(), sender)
+				(authority, scheme.to_owned(), handshake)
 			},
 			"http+unix" => {
 				let path = unix_path(&uri)?;
 				let stream = connect_unix(&path).await?;
-				let sender = handshake(stream).await?;
-				("localhost".to_owned(), "http".to_owned(), sender)
+				let handshake = handshake(stream).await?;
+				("localhost".to_owned(), "http".to_owned(), handshake)
 			},
 			_ => return Err(tg::error!("unsupported URL scheme")),
 		};
 
-		Ok(self.insert_session(authority, scheme, sender))
+		Ok(self.insert_session(authority, scheme, handshake))
 	}
 
-	fn insert_session(
-		&self,
-		authority: String,
-		scheme: String,
-		sender: hyper::client::conn::http2::SendRequest<RequestBody>,
-	) -> usize {
+	fn insert_session(&self, authority: String, scheme: String, handshake: Handshake) -> usize {
+		let (sender, event_tx, event_rx) = handshake;
 		let token = self.token();
 		let session = Session {
 			authority,
+			event_tx,
+			events: Mutex::new(event_rx),
 			scheme,
 			sender,
 			streams: DashMap::new(),
 		};
 		self.sessions.insert(token, Arc::new(session));
 		token
+	}
+
+	pub(crate) async fn session_read(&self, session: usize) -> tg::Result<Option<SessionEvent>> {
+		let session = self
+			.sessions
+			.get(&session)
+			.ok_or_else(|| tg::error!("invalid HTTP/2 session"))?
+			.value()
+			.clone();
+		Ok(session.events.lock().await.recv().await)
 	}
 
 	pub(crate) async fn session_request(
@@ -223,7 +245,7 @@ impl Http2 {
 	pub(crate) async fn stream_close(&self, stream: usize) -> tg::Result<()> {
 		if let Some((_token, stream)) = self.streams.remove(&stream) {
 			self.remove_stream_from_session(&stream);
-			stream.close().await;
+			stream.close(None).await;
 		}
 		Ok(())
 	}
@@ -235,7 +257,7 @@ impl Http2 {
 	pub(crate) async fn session_destroy(
 		&self,
 		session: usize,
-		_error: Option<String>,
+		error: Option<String>,
 	) -> tg::Result<()> {
 		let Some((_token, session)) = self.sessions.remove(&session) else {
 			return Ok(());
@@ -247,9 +269,10 @@ impl Http2 {
 			.collect::<Vec<_>>();
 		for stream in streams {
 			if let Some((_token, stream)) = self.streams.remove(&stream) {
-				stream.close().await;
+				stream.close(error.as_deref()).await;
 			}
 		}
+		session.event_tx.try_send(SessionEvent::Close).ok();
 		Ok(())
 	}
 
@@ -265,8 +288,16 @@ impl Http2 {
 }
 
 impl Stream {
-	async fn close(&self) {
+	async fn close(&self, error: Option<&str>) {
 		self.request.lock().await.take();
+		if let Some(message) = error {
+			self.event_tx
+				.send(StreamEvent::Error {
+					message: message.to_owned(),
+				})
+				.await
+				.ok();
+		}
 		self.event_tx.try_send(StreamEvent::Close).ok();
 	}
 }
@@ -334,7 +365,7 @@ fn unix_path_from_str(path: &str) -> tg::Result<PathBuf> {
 	Ok(PathBuf::from(path.as_ref()))
 }
 
-async fn handshake<S>(stream: S) -> tg::Result<hyper::client::conn::http2::SendRequest<RequestBody>>
+async fn handshake<S>(stream: S) -> tg::Result<Handshake>
 where
 	S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
 {
@@ -346,14 +377,24 @@ where
 		.handshake(io)
 		.await
 		.map_err(|error| tg::error!(!error, "failed to perform the HTTP/2 handshake"))?;
-	tokio::spawn(async move {
-		connection.await.ok();
+	let (event_tx, event_rx) = mpsc::channel(1);
+	tokio::spawn({
+		let event_tx = event_tx.clone();
+		async move {
+			let event = match connection.await {
+				Ok(()) => SessionEvent::Close,
+				Err(error) => SessionEvent::Error {
+					message: error.to_string(),
+				},
+			};
+			event_tx.send(event).await.ok();
+		}
 	});
 	sender
 		.ready()
 		.await
 		.map_err(|error| tg::error!(!error, "failed to ready the HTTP/2 sender"))?;
-	Ok(sender)
+	Ok((sender, event_tx, event_rx))
 }
 
 fn verify_alpn_protocol(

--- a/packages/js/src/http2.ts
+++ b/packages/js/src/http2.ts
@@ -8,6 +8,8 @@ type RequestOptions = {
 	endStream?: boolean;
 };
 
+type SessionEvent = { kind: "close" } | { kind: "error"; message: string };
+
 type StreamEvent =
 	| { kind: "close" }
 	| { kind: "data"; bytes: Uint8Array }
@@ -58,6 +60,7 @@ export class ClientHttp2Session extends EventEmitter {
 	#closed = false;
 	#connect: Promise<void>;
 	#destroyed = false;
+	#emittedClose = false;
 	#token: number | null = null;
 
 	constructor(
@@ -68,17 +71,26 @@ export class ClientHttp2Session extends EventEmitter {
 		this.#connect = syscall("http2_connect", authority, options).then(
 			(token) => {
 				this.#token = token;
+				this.#readLoop(token);
 				this.emit("connect", this);
 			},
 			(error) => {
 				this.#closed = true;
 				this.#destroyed = true;
 				this.emit("error", error);
-				this.emit("close");
+				this.#emitClose();
 				throw error;
 			},
 		);
 		this.#connect.catch(() => undefined);
+	}
+
+	get closed() {
+		return this.#closed;
+	}
+
+	get destroyed() {
+		return this.#destroyed;
 	}
 
 	request(headers: Headers, options: RequestOptions = {}) {
@@ -98,7 +110,7 @@ export class ClientHttp2Session extends EventEmitter {
 			let token = await this.#ready();
 			await syscall("http2_session_close", token);
 		} finally {
-			this.emit("close");
+			this.#emitClose();
 		}
 	}
 
@@ -123,7 +135,7 @@ export class ClientHttp2Session extends EventEmitter {
 				if (error !== undefined) {
 					this.emit("error", error);
 				}
-				this.emit("close");
+				this.#emitClose();
 			});
 	}
 
@@ -134,12 +146,48 @@ export class ClientHttp2Session extends EventEmitter {
 		});
 	}
 
+	async #readLoop(token: number) {
+		let error: unknown;
+		try {
+			let event = (await syscall("http2_session_read", token)) as
+				| SessionEvent
+				| null;
+			if (event?.kind === "error") {
+				error = new Error(event.message);
+			}
+		} catch (error_) {
+			error = error_;
+		}
+		if (this.#destroyed) {
+			return;
+		}
+		this.#closed = true;
+		this.#destroyed = true;
+		this.#token = null;
+		let message = error instanceof Error ? error.message : null;
+		await syscall("http2_session_destroy", token, message).catch(
+			() => undefined,
+		);
+		if (error !== undefined) {
+			this.emit("error", error);
+		}
+		this.#emitClose();
+	}
+
 	async #ready() {
 		await this.#connect;
 		if (this.#token === null) {
 			throw new Error("the HTTP/2 session is closed");
 		}
 		return this.#token;
+	}
+
+	#emitClose() {
+		if (this.#emittedClose) {
+			return;
+		}
+		this.#emittedClose = true;
+		this.emit("close");
 	}
 }
 

--- a/packages/js/src/quickjs/syscall.rs
+++ b/packages/js/src/quickjs/syscall.rs
@@ -89,6 +89,7 @@ pub fn syscall<'js>(
 		"http2_session_destroy" => {
 			qjs::Function::new(ctx.clone(), Async(self::http2::session_destroy))
 		},
+		"http2_session_read" => qjs::Function::new(ctx.clone(), Async(self::http2::session_read)),
 		"http2_session_request" => {
 			qjs::Function::new(ctx.clone(), Async(self::http2::session_request))
 		},

--- a/packages/js/src/quickjs/syscall/http2.rs
+++ b/packages/js/src/quickjs/syscall/http2.rs
@@ -15,6 +15,35 @@ pub async fn connect(
 	Result(state.http2.connect(authority, options).await)
 }
 
+pub async fn session_close(ctx: qjs::Ctx<'_>, session: usize) -> Result<()> {
+	let state = ctx.userdata::<StateHandle>().unwrap().clone();
+	Result(state.http2.session_close(session).await)
+}
+
+pub async fn session_destroy(
+	ctx: qjs::Ctx<'_>,
+	session: usize,
+	error: Arg<Option<String>>,
+) -> Result<()> {
+	let state = ctx.userdata::<StateHandle>().unwrap().clone();
+	let Arg(error) = error;
+	Result(state.http2.session_destroy(session, error).await)
+}
+
+pub async fn session_read(
+	ctx: qjs::Ctx<'_>,
+	session: usize,
+) -> Result<Option<Serde<crate::http2::SessionEvent>>> {
+	let state = ctx.userdata::<StateHandle>().unwrap().clone();
+	Result(
+		state
+			.http2
+			.session_read(session)
+			.await
+			.map(|event| event.map(Serde)),
+	)
+}
+
 pub async fn session_request(
 	ctx: qjs::Ctx<'_>,
 	session: usize,
@@ -27,9 +56,9 @@ pub async fn session_request(
 	Result(state.http2.session_request(session, headers, options).await)
 }
 
-pub async fn stream_write(ctx: qjs::Ctx<'_>, stream: usize, bytes: Uint8Array) -> Result<()> {
+pub async fn stream_close(ctx: qjs::Ctx<'_>, stream: usize) -> Result<()> {
 	let state = ctx.userdata::<StateHandle>().unwrap().clone();
-	Result(state.http2.stream_write(stream, bytes.into()).await)
+	Result(state.http2.stream_close(stream).await)
 }
 
 pub async fn stream_end(
@@ -56,22 +85,7 @@ pub async fn stream_read(
 	)
 }
 
-pub async fn stream_close(ctx: qjs::Ctx<'_>, stream: usize) -> Result<()> {
+pub async fn stream_write(ctx: qjs::Ctx<'_>, stream: usize, bytes: Uint8Array) -> Result<()> {
 	let state = ctx.userdata::<StateHandle>().unwrap().clone();
-	Result(state.http2.stream_close(stream).await)
-}
-
-pub async fn session_close(ctx: qjs::Ctx<'_>, session: usize) -> Result<()> {
-	let state = ctx.userdata::<StateHandle>().unwrap().clone();
-	Result(state.http2.session_close(session).await)
-}
-
-pub async fn session_destroy(
-	ctx: qjs::Ctx<'_>,
-	session: usize,
-	error: Arg<Option<String>>,
-) -> Result<()> {
-	let state = ctx.userdata::<StateHandle>().unwrap().clone();
-	let Arg(error) = error;
-	Result(state.http2.session_destroy(session, error).await)
+	Result(state.http2.stream_write(stream, bytes.into()).await)
 }

--- a/packages/js/src/syscall.ts
+++ b/packages/js/src/syscall.ts
@@ -164,6 +164,11 @@ declare global {
 	): Promise<void>;
 
 	function syscall(
+		syscall: "http2_session_read",
+		session: number,
+	): Promise<unknown | null>;
+
+	function syscall(
 		syscall: "http2_session_request",
 		session: number,
 		headers: [string, string][],

--- a/packages/js/src/v8/syscall.rs
+++ b/packages/js/src/v8/syscall.rs
@@ -64,6 +64,7 @@ pub fn syscall<'s>(
 		"http2_connect" => async_(scope, &args, self::http2::connect),
 		"http2_session_close" => async_(scope, &args, self::http2::session_close),
 		"http2_session_destroy" => async_(scope, &args, self::http2::session_destroy),
+		"http2_session_read" => async_(scope, &args, self::http2::session_read),
 		"http2_session_request" => async_(scope, &args, self::http2::session_request),
 		"http2_stream_close" => async_(scope, &args, self::http2::stream_close),
 		"http2_stream_end" => async_(scope, &args, self::http2::stream_end),

--- a/packages/js/src/v8/syscall/http2.rs
+++ b/packages/js/src/v8/syscall/http2.rs
@@ -8,6 +8,28 @@ pub async fn connect(
 	state.http2.connect(authority, options).await
 }
 
+pub async fn session_close(state: Rc<State>, args: (usize,)) -> tg::Result<()> {
+	let (session,) = args;
+	state.http2.session_close(session).await
+}
+
+pub async fn session_destroy(state: Rc<State>, args: (usize, Option<String>)) -> tg::Result<()> {
+	let (session, error) = args;
+	state.http2.session_destroy(session, error).await
+}
+
+pub async fn session_read(
+	state: Rc<State>,
+	args: (usize,),
+) -> tg::Result<Option<Serde<crate::http2::SessionEvent>>> {
+	let (session,) = args;
+	state
+		.http2
+		.session_read(session)
+		.await
+		.map(|event| event.map(Serde))
+}
+
 pub async fn session_request(
 	state: Rc<State>,
 	args: (
@@ -20,9 +42,9 @@ pub async fn session_request(
 	state.http2.session_request(session, headers, options).await
 }
 
-pub async fn stream_write(state: Rc<State>, args: (usize, Bytes)) -> tg::Result<()> {
-	let (stream, bytes) = args;
-	state.http2.stream_write(stream, bytes).await
+pub async fn stream_close(state: Rc<State>, args: (usize,)) -> tg::Result<()> {
+	let (stream,) = args;
+	state.http2.stream_close(stream).await
 }
 
 pub async fn stream_end(state: Rc<State>, args: (usize, Option<Bytes>)) -> tg::Result<()> {
@@ -42,17 +64,7 @@ pub async fn stream_read(
 		.map(|event| event.map(Serde))
 }
 
-pub async fn stream_close(state: Rc<State>, args: (usize,)) -> tg::Result<()> {
-	let (stream,) = args;
-	state.http2.stream_close(stream).await
-}
-
-pub async fn session_close(state: Rc<State>, args: (usize,)) -> tg::Result<()> {
-	let (session,) = args;
-	state.http2.session_close(session).await
-}
-
-pub async fn session_destroy(state: Rc<State>, args: (usize, Option<String>)) -> tg::Result<()> {
-	let (session, error) = args;
-	state.http2.session_destroy(session, error).await
+pub async fn stream_write(state: Rc<State>, args: (usize, Bytes)) -> tg::Result<()> {
+	let (stream, bytes) = args;
+	state.http2.stream_write(stream, bytes).await
 }

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -336,9 +336,13 @@ pub struct TursoDatabase {
 	pub retry: Retry,
 }
 
-#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde_as]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct Http {
+	#[serde_as(as = "DurationSecondsWithFrac")]
+	pub idle_timeout: Duration,
+
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub listeners: Vec<HttpListener>,
 }
@@ -1193,6 +1197,15 @@ impl Default for TursoDatabase {
 			path: PathBuf::from("database"),
 			pool: DatabasePool::default(),
 			retry: database_retry_default(),
+		}
+	}
+}
+
+impl Default for Http {
+	fn default() -> Self {
+		Self {
+			idle_timeout: Duration::from_secs(30),
+			listeners: Vec::new(),
 		}
 	}
 }

--- a/packages/server/src/http.rs
+++ b/packages/server/src/http.rs
@@ -189,6 +189,7 @@ impl Server {
 
 		// Create the task tracker.
 		let task_tracker = tokio_util::task::TaskTracker::new();
+		let idle_timeout = self.http_idle_timeout();
 
 		// Create the active connections counter.
 		let active_connections = opentelemetry::global::meter("tangram_http")
@@ -238,14 +239,20 @@ impl Server {
 				async move {
 					match stream {
 						Stream::Stdio(stream) => {
-							Server::serve_connection(stream, service, stopper).await;
+							Server::serve_connection(stream, service, idle_timeout, stopper).await;
 						},
 						Stream::Tcp(stream) => {
 							#[cfg(feature = "tls")]
 							if let Some(tls) = tls {
 								match tls.accept(stream).await {
 									Ok(stream) => {
-										Server::serve_connection(stream, service, stopper).await;
+										Server::serve_connection(
+											stream,
+											service,
+											idle_timeout,
+											stopper,
+										)
+										.await;
 									},
 									Err(error) => {
 										tracing::error!(
@@ -255,17 +262,18 @@ impl Server {
 									},
 								}
 							} else {
-								Server::serve_connection(stream, service, stopper).await;
+								Server::serve_connection(stream, service, idle_timeout, stopper)
+									.await;
 							}
 							#[cfg(not(feature = "tls"))]
-							Server::serve_connection(stream, service, stopper).await;
+							Server::serve_connection(stream, service, idle_timeout, stopper).await;
 						},
 						Stream::Unix(stream) => {
-							Server::serve_connection(stream, service, stopper).await;
+							Server::serve_connection(stream, service, idle_timeout, stopper).await;
 						},
 						#[cfg(feature = "vsock")]
 						Stream::Vsock(stream) => {
-							Server::serve_connection(stream, service, stopper).await;
+							Server::serve_connection(stream, service, idle_timeout, stopper).await;
 						},
 					}
 					drop(guard);
@@ -335,10 +343,18 @@ impl Server {
 		S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 	{
 		let service = self.service(sandbox, stopper.clone());
-		Server::serve_connection(stream, service, stopper).await;
+		let idle_timeout = self.http_idle_timeout();
+		Server::serve_connection(stream, service, idle_timeout, stopper).await;
 	}
 
-	async fn serve_connection<S, T>(stream: S, service: T, stopper: Stopper)
+	fn http_idle_timeout(&self) -> Duration {
+		self.config().http.as_ref().map_or_else(
+			|| crate::config::Http::default().idle_timeout,
+			|config| config.idle_timeout,
+		)
+	}
+
+	async fn serve_connection<S, T>(stream: S, service: T, idle_timeout: Duration, stopper: Stopper)
 	where
 		S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 		T: tower::Service<
@@ -350,7 +366,7 @@ impl Server {
 			+ 'static,
 		T::Future: Send + 'static,
 	{
-		let idle = tangram_http::idle::Idle::new(Duration::from_secs(30));
+		let idle = tangram_http::idle::Idle::new(idle_timeout);
 		let executor = hyper_util::rt::TokioExecutor::new();
 		let mut builder = hyper_util::server::conn::auto::Builder::new(executor);
 		builder


### PR DESCRIPTION
This test reproduces a bug in which, if a session is left idle for longer than the 30-second timeout, it hangs.  On the JS side, the cached session remains expecting the expired connection. On the retry, we succeed but send an empty body.