### PR TITLE
feat(clients/js): improve resolve diagnostic

### DIFF
--- a/packages/cli/tests/build/resolve_undefined_error_path.nu
+++ b/packages/cli/tests/build/resolve_undefined_error_path.nu
@@ -1,0 +1,26 @@
+use ../../test.nu *
+
+# Resolving a value whose optional field is unset reports the path to the offending key.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		type Arg = { bar?: string };
+
+		export default async function () {
+			const arg: Arg = {};
+			return await tg.resolve({ foo: [{ bar: arg.bar }] });
+		}
+	'
+}
+
+let output = tg build $path | complete
+failure $output
+snapshot ($output.stderr | redact $path | normalize_ids) '
+	error an error occurred
+	-> the process failed
+	   id = <process>
+	-> invalid value to resolve at .foo[0].bar: undefined is not a value, use null instead
+
+'

--- a/packages/clients/js/src/resolve.ts
+++ b/packages/clients/js/src/resolve.ts
@@ -106,9 +106,10 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 		path: string,
 	): Promise<Resolved<T>> => {
 		value = await value;
+		let location = path === "" ? "" : ` at ${path}`;
 		if (typeof value === "object" && value !== null) {
 			if (visited.has(value)) {
-				throw new Error(`cycle detected${at(path)}`);
+				throw new Error(`cycle detected${location}`);
 			}
 			visited = visited.add(value);
 		}
@@ -139,16 +140,19 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 		} else if (typeof value === "object") {
 			output = Object.fromEntries(
 				await Promise.all(
-					Object.entries(value).map(async ([key, value]) => {
-						value = await inner(value, visited, `${path}.${key}`);
-						return [key, value];
-					}),
+					Object.entries(value).map(async ([key, value]) => [
+						key,
+						await inner(value, visited, `${path}.${key}`),
+					]),
 				),
 			) as tg.Resolved<T>;
 		} else {
-			throw new Error(
-				`invalid value to resolve${at(path)}: ${typeof value === "undefined" ? "undefined is not a value, use null instead" : typeof value}`,
-			);
+			let type = typeof value;
+			let description =
+				type === "undefined"
+					? "undefined is not a value, use null instead"
+					: type;
+			throw new Error(`invalid value to resolve${location}: ${description}`);
 		}
 		if (typeof value === "object" && value !== null) {
 			visited = visited.delete(value);
@@ -157,6 +161,3 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 	};
 	return await inner(value, im.Set(), "");
 };
-
-/** Render a path within the value being resolved, for use in an error message. */
-let at = (path: string) => (path === "" ? "" : ` at ${path}`);

--- a/packages/clients/js/src/resolve.ts
+++ b/packages/clients/js/src/resolve.ts
@@ -103,11 +103,12 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 	let inner = async <T extends tg.Unresolved<tg.Value>>(
 		value: tg.Unresolved<tg.Value>,
 		visited: im.Set<object>,
+		path: string,
 	): Promise<Resolved<T>> => {
 		value = await value;
 		if (typeof value === "object" && value !== null) {
 			if (visited.has(value)) {
-				throw new Error("cycle detected");
+				throw new Error(`cycle detected${at(path)}`);
 			}
 			visited = visited.add(value);
 		}
@@ -133,24 +134,29 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 			output = (await tg.command(value)) as tg.Resolved<T>;
 		} else if (value instanceof Array) {
 			output = (await Promise.all(
-				value.map((item) => inner(item, visited)),
+				value.map((item, index) => inner(item, visited, `${path}[${index}]`)),
 			)) as tg.Resolved<T>;
 		} else if (typeof value === "object") {
 			output = Object.fromEntries(
 				await Promise.all(
 					Object.entries(value).map(async ([key, value]) => {
-						value = await inner(value, visited);
+						value = await inner(value, visited, `${path}.${key}`);
 						return [key, value];
 					}),
 				),
 			) as tg.Resolved<T>;
 		} else {
-			throw new Error("invalid value to resolve");
+			throw new Error(
+				`invalid value to resolve${at(path)}: ${typeof value === "undefined" ? "undefined is not a value, use null instead" : typeof value}`,
+			);
 		}
 		if (typeof value === "object" && value !== null) {
 			visited = visited.delete(value);
 		}
 		return output;
 	};
-	return await inner(value, im.Set());
+	return await inner(value, im.Set(), "");
 };
+
+/** Render a path within the value being resolved, for use in an error message. */
+let at = (path: string) => (path === "" ? "" : ` at ${path}`);


### PR DESCRIPTION
Improve the error message in `tg.resolve` to report the location of the offending value.