### PR TITLE
feat(clients/js): tg.Error.Builder

### DIFF
--- a/packages/cli/tests/build/errors.nu
+++ b/packages/cli/tests/build/errors.nu
@@ -11,7 +11,7 @@ let path = artifact {
 		};
 
 		export function x() {
-			throw tg.error("oops");
+			throw tg.error.sync("oops");
 		}
 	'#
 }
@@ -83,11 +83,11 @@ snapshot (tg get $child_error --pretty | redact | normalize_ids) '
 	      "range": {
 	        "start": {
 	          "line": 5,
-	          "character": 10,
+	          "character": 16,
 	        },
 	        "end": {
 	          "line": 5,
-	          "character": 10,
+	          "character": 16,
 	        },
 	      },
 	      "symbol": "x",

--- a/packages/cli/tests/build/rerun_failing_build.nu
+++ b/packages/cli/tests/build/rerun_failing_build.nu
@@ -6,7 +6,7 @@ let server = spawn
 
 let path = artifact {
 	tangram.ts: '
-		export default function () { throw tg.error("whoops"); }
+		export default function () { throw tg.error.sync("whoops"); }
 	'
 }
 
@@ -20,10 +20,10 @@ snapshot $first_output '
 	-> the process failed
 	   id = <process>
 	-> whoops
-	   ╭─[./tangram.ts:1:39]
-	 1 │ export default function () { throw tg.error("whoops"); }
-	   ·                                       ▲
-	   ·                                       ╰── whoops
+	   ╭─[./tangram.ts:1:45]
+	 1 │ export default function () { throw tg.error.sync("whoops"); }
+	   ·                                             ▲
+	   ·                                             ╰── whoops
 	   ╰────
 
 '

--- a/packages/cli/tests/js/error/arg.nu
+++ b/packages/cli/tests/js/error/arg.nu
@@ -1,13 +1,13 @@
 use ../../../test.nu *
 
-# tg.error populates the code and values getters from an argument object.
+# tg.error.sync populates the code and values getters from an argument object.
 
 let server = spawn
 
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			let error = tg.error("boom", { code: "E1", values: { a: "b" } });
+			let error = tg.error.sync("boom", { code: "E1", values: { a: "b" } });
 			return { message: await error.message, code: await error.code, values: await error.values };
 		}
 	'

--- a/packages/cli/tests/js/error/children_reachable.nu
+++ b/packages/cli/tests/js/error/children_reachable.nu
@@ -18,7 +18,7 @@ let path = artifact {
 			let diagnosticFile = await tg.file("diagnostic");
 			let stackFile = await tg.file("stack");
 
-			let error = tg.error("boom", {
+			let error = tg.error.sync("boom", {
 				location: {
 					file: { kind: "module", value: makeModule(locationFile) },
 					range,

--- a/packages/cli/tests/js/error/expect.nu
+++ b/packages/cli/tests/js/error/expect.nu
@@ -5,7 +5,7 @@ use ../../../test.nu *
 let server = spawn
 
 let path = artifact {
-	tangram.ts: 'export default async function () { return await tg.Error.expect(tg.error("boom")).message; }'
+	tangram.ts: 'export default async function () { return await tg.Error.expect(tg.error.sync("boom")).message; }'
 }
 
 let output = tg build $path

--- a/packages/cli/tests/js/error/stack_clear.nu
+++ b/packages/cli/tests/js/error/stack_clear.nu
@@ -7,8 +7,8 @@ let server = spawn
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			let cleared = tg.error({ stack: null });
-			let captured = tg.error();
+			let cleared = tg.error.sync({ stack: null });
+			let captured = tg.error.sync();
 			return [
 				(await cleared.stack) === null,
 				(await captured.stack) !== null,

--- a/packages/cli/tests/js/error/stack_clear_null.nu
+++ b/packages/cli/tests/js/error/stack_clear_null.nu
@@ -7,8 +7,8 @@ let server = spawn
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			let cleared = tg.error("message", { stack: null });
-			let captured = tg.error("message");
+			let cleared = tg.error.sync("message", { stack: null });
+			let captured = tg.error.sync("message");
 			return (await cleared.stack) === null && (await captured.stack) !== null;
 		}
 	'

--- a/packages/cli/tests/js/null/optional_apis.nu
+++ b/packages/cli/tests/js/null/optional_apis.nu
@@ -11,7 +11,7 @@ let path = artifact {
 			let archive = await tg.archive(directory, "tar", null);
 			let prefix = await tg.Mutation.prefix("prefix", null);
 			let suffix = await tg.Mutation.suffix("suffix", null);
-			let error = tg.error({ values: null });
+			let error = tg.error.sync({ values: null });
 			let printed = tg.Value.print(null, { color: null });
 			return [
 				archive instanceof tg.Blob,

--- a/packages/cli/tests/js/value/print_error_diagnostics.nu
+++ b/packages/cli/tests/js/value/print_error_diagnostics.nu
@@ -7,7 +7,7 @@ let server = spawn
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			let error = tg.error("boom", {
+			let error = tg.error.sync("boom", {
 				diagnostics: [{ message: "diagmsg", severity: "error" }],
 			});
 			let output = tg.Value.print(error);

--- a/packages/cli/tests/js/value/print_error_source.nu
+++ b/packages/cli/tests/js/value/print_error_source.nu
@@ -7,8 +7,8 @@ let server = spawn
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			let error = tg.error("outer", {
-				source: { item: tg.error("inner"), options: {} },
+			let error = tg.error.sync("outer", {
+				source: { item: tg.error.sync("inner"), options: {} },
 			});
 			let output = tg.Value.print(error);
 			return output.includes(`"source":`) && output.includes("inner");

--- a/packages/cli/tests/js/value/print_omits_null_fields.nu
+++ b/packages/cli/tests/js/value/print_omits_null_fields.nu
@@ -7,7 +7,7 @@ let server = spawn
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			let errorPrint = tg.Value.print(tg.error("boom"));
+			let errorPrint = tg.Value.print(tg.error.sync("boom"));
 			let errorOmitsNull =
 				!errorPrint.includes(`"code":`) &&
 				!errorPrint.includes(`"diagnostics":`) &&

--- a/packages/cli/tests/push/process_with_error.nu
+++ b/packages/cli/tests/push/process_with_error.nu
@@ -7,7 +7,7 @@ use ./process.nu test
 let path = artifact {
 	tangram.ts: r#'
 		export default function () {
-			throw tg.error("whoops");
+			throw tg.error.sync("whoops");
 		}
 	'#
 }

--- a/packages/cli/tests/run/child_process_error.nu
+++ b/packages/cli/tests/run/child_process_error.nu
@@ -11,7 +11,7 @@ let path = artifact {
 		}
 
 		export function foo() {
-			throw tg.error("error");
+			throw tg.error.sync("error");
 		}
 	',
 }

--- a/packages/cli/tests/run/child_process_error.snapshot
+++ b/packages/cli/tests/run/child_process_error.snapshot
@@ -11,10 +11,10 @@ error an error occurred
  3 │ }
    ╰────
 -> error
-   ╭─[./tangram.ts:6:11]
+   ╭─[./tangram.ts:6:17]
  5 │ export function foo() {
- 6 │     throw tg.error("error");
-   ·              ▲
-   ·              ╰── error
+ 6 │     throw tg.error.sync("error");
+   ·                    ▲
+   ·                    ╰── error
  7 │ }
    ╰────

--- a/packages/clients/js/src/error.ts
+++ b/packages/clients/js/src/error.ts
@@ -1,78 +1,79 @@
 import * as tg from "./index.ts";
 
 /** Create an error. */
-export function error(): tg.Error;
-export function error(message: string, arg?: tg.Error.Arg | null): tg.Error;
-export function error(arg: tg.Error.Arg): tg.Error;
 export function error(
-	firstArg?: string | tg.Error.Arg,
-	secondArg?: tg.Error.Arg | null,
-): tg.Error {
-	let object: tg.Error.Object = {
-		code: null,
-		diagnostics: null,
-		location: null,
-		message: null,
-		source: null,
-		stack: null,
-		values: {},
-	};
-	let stackWasSet = false;
-	if (firstArg !== null && typeof firstArg === "string") {
-		object.message = firstArg;
-		if (secondArg !== undefined && secondArg !== null) {
-			if (secondArg.code !== undefined) {
-				object.code = secondArg.code;
-			}
-			if (secondArg.diagnostics !== undefined) {
-				object.diagnostics = secondArg.diagnostics;
-			}
-			if (secondArg.location !== undefined) {
-				object.location = secondArg.location;
-			}
-			if (secondArg.message !== undefined) {
-				object.message = secondArg.message;
-			}
-			if (secondArg.source !== undefined) {
-				object.source = secondArg.source;
-			}
-			if (secondArg.stack !== undefined) {
-				object.stack = secondArg.stack;
-				stackWasSet = true;
-			}
-			if (secondArg.values !== undefined) {
-				object.values = secondArg.values ?? {};
-			}
-		}
-	} else if (firstArg !== null && typeof firstArg === "object") {
-		if (firstArg.code !== undefined) {
-			object.code = firstArg.code;
-		}
-		if (firstArg.diagnostics !== undefined) {
-			object.diagnostics = firstArg.diagnostics;
-		}
-		if (firstArg.location !== undefined) {
-			object.location = firstArg.location;
-		}
-		if (firstArg.message !== undefined) {
-			object.message = firstArg.message;
-		}
-		if (firstArg.source !== undefined) {
-			object.source = firstArg.source;
-		}
-		if (firstArg.stack !== undefined) {
-			object.stack = firstArg.stack;
-			stackWasSet = true;
-		}
-		if (firstArg.values !== undefined) {
-			object.values = firstArg.values ?? {};
-		}
-	}
-	if (!stackWasSet) {
+	strings: TemplateStringsArray,
+	...placeholders: tg.Args<string>
+): tg.Error.Builder;
+export function error(...args: tg.Args<tg.Error.Arg>): tg.Error.Builder;
+export function error(
+	firstArg?:
+		| TemplateStringsArray
+		| tg.Unresolved<tg.ValueOrMaybeMutationMap<tg.Error.Arg>>,
+	...args: tg.Args<tg.Error.Arg>
+): tg.Error.Builder {
+	return firstArg === undefined
+		? new tg.Error.Builder(...args)
+		: new tg.Error.Builder(firstArg, ...args);
+}
+
+export namespace error {
+	export function sync(): tg.Error;
+	export function sync(
+		message: string,
+		arg?: tg.Error.Arg.Object | null,
+	): tg.Error;
+	export function sync(arg: tg.Error.Arg.Object): tg.Error;
+	export function sync(
+		firstArg?: string | tg.Error.Arg.Object,
+		secondArg?: tg.Error.Arg.Object | null,
+	): tg.Error {
+		let stackObject: { stack: Array<tg.Error.Location> | null } = {
+			stack: null,
+		};
 		// @ts-expect-error
-		globalThis.Error.captureStackTrace(object, tg.error);
+		globalThis.Error.captureStackTrace(stackObject, tg.error.sync);
+		let object: tg.Error.Object = {
+			code: null,
+			diagnostics: null,
+			location: null,
+			message: null,
+			source: null,
+			stack: stackObject.stack,
+			values: {},
+		};
+		let args: Array<tg.Error.Arg.Object | null | undefined> =
+			typeof firstArg === "string"
+				? [{ message: firstArg }, secondArg]
+				: [firstArg];
+		for (let arg of args) {
+			if (arg === undefined || arg === null) {
+				continue;
+			}
+			if (arg.code !== undefined) {
+				object.code = arg.code;
+			}
+			if (arg.diagnostics !== undefined) {
+				object.diagnostics = arg.diagnostics;
+			}
+			if (arg.location !== undefined) {
+				object.location = arg.location;
+			}
+			if (arg.message !== undefined) {
+				object.message = arg.message;
+			}
+			if (arg.source !== undefined) {
+				object.source = arg.source;
+			}
+			if (arg.stack !== undefined) {
+				object.stack = arg.stack;
+			}
+			if (arg.values !== undefined) {
+				object.values = arg.values ?? {};
+			}
+		}
+		return tg.Error.withObject(object);
 	}
-	return tg.Error.withObject(object);
 }
 
 /** An error. */
@@ -112,6 +113,61 @@ export class Error {
 	/** Create an error from data. */
 	static fromData(data: tg.Error.Data): tg.Error {
 		return tg.Error.withObject(tg.Error.Object.fromData(data));
+	}
+
+	/** Create an error. */
+	static async new(...args: tg.Args<tg.Error.Arg>): Promise<tg.Error> {
+		let stackObject: { stack: Array<tg.Error.Location> | null } = {
+			stack: null,
+		};
+		// @ts-expect-error
+		globalThis.Error.captureStackTrace(stackObject, tg.Error.new);
+		let stack = stackObject.stack;
+		let arg = await tg.Error.arg({ stack }, ...args);
+		let object: tg.Error.Object = {
+			code: arg.code ?? null,
+			diagnostics: arg.diagnostics ?? null,
+			location: arg.location ?? null,
+			message: arg.message ?? null,
+			source: arg.source ?? null,
+			stack: arg.stack ?? null,
+			values: arg.values ?? {},
+		};
+		return tg.Error.withObject(object);
+	}
+
+	static async arg(
+		...args: tg.Args<tg.Error.Arg>
+	): Promise<tg.Error.Arg.Object> {
+		return await tg.Error.argResolved(
+			...(await Promise.all(args.map(tg.resolve))),
+		);
+	}
+
+	static async argResolved(
+		...args: Array<tg.ValueOrMaybeMutationMap<tg.Error.Arg>>
+	): Promise<tg.Error.Arg.Object> {
+		return await tg.Args.applyResolved<tg.Error.Arg, tg.Error.Arg.Object>({
+			args,
+			map: async (arg) => {
+				if (typeof arg === "string") {
+					return { message: arg };
+				} else if (arg instanceof tg.Error) {
+					return await arg.object();
+				} else {
+					return arg;
+				}
+			},
+			reduce: {
+				code: "set",
+				diagnostics: "set",
+				location: "set",
+				message: "set",
+				source: "set",
+				stack: "set",
+				values: "merge",
+			},
+		});
 	}
 
 	/** Convert an error to data. */
@@ -250,15 +306,121 @@ export class Error {
 export namespace Error {
 	export type Id = string;
 
-	export type Arg = {
-		code?: string | null;
-		diagnostics?: Array<tg.Diagnostic> | null;
-		location?: tg.Error.Location | null;
-		message?: string | null;
-		source?: tg.Referent<tg.Error.Object | tg.Error> | null;
-		stack?: Array<tg.Error.Location> | null;
-		values?: { [key: string]: string } | null;
-	};
+	export class Builder {
+		#args: tg.Args<tg.Error.Arg>;
+
+		constructor(
+			strings: TemplateStringsArray,
+			...placeholders: tg.Args<string>
+		);
+		constructor(
+			firstArg?:
+				| TemplateStringsArray
+				| tg.Unresolved<tg.ValueOrMaybeMutationMap<tg.Error.Arg>>,
+			...args: tg.Args<tg.Error.Arg>
+		);
+		constructor(...args: tg.Args<tg.Error.Arg>);
+		constructor(...args: any[]) {
+			let firstArg = args[0];
+			if (Array.isArray(firstArg) && "raw" in firstArg) {
+				let strings = firstArg as TemplateStringsArray;
+				let placeholders = args.slice(1) as tg.Args<string>;
+				let components = [];
+				for (let i = 0; i < strings.length - 1; i++) {
+					let string = strings[i]!;
+					components.push(string);
+					let placeholder = placeholders[i]!;
+					components.push(placeholder);
+				}
+				components.push(strings[strings.length - 1]!);
+				let string = components.join("");
+				this.#args = [string];
+			} else {
+				this.#args = args;
+			}
+			let stackObject: { stack: Array<tg.Error.Location> | null } = {
+				stack: null,
+			};
+			// @ts-expect-error
+			globalThis.Error.captureStackTrace(stackObject, tg.Error.Builder);
+			let stack = stackObject.stack;
+			this.#args.unshift({ stack });
+		}
+
+		code(code: tg.Unresolved<tg.MaybeMutation<string> | null>): this {
+			this.#args.push({ code });
+			return this;
+		}
+
+		diagnostics(
+			diagnostics: tg.Unresolved<tg.MaybeMutation<Array<tg.Diagnostic>> | null>,
+		): this {
+			this.#args.push({ diagnostics });
+			return this;
+		}
+
+		location(
+			location: tg.Unresolved<tg.MaybeMutation<tg.Error.Location> | null>,
+		): this {
+			this.#args.push({ location });
+			return this;
+		}
+
+		message(message: tg.Unresolved<tg.MaybeMutation<string> | null>): this {
+			this.#args.push({ message });
+			return this;
+		}
+
+		source(
+			source: tg.Unresolved<tg.MaybeMutation<
+				tg.Referent<tg.Error.Object | tg.Error>
+			> | null>,
+		): this {
+			this.#args.push({ source });
+			return this;
+		}
+
+		stack(
+			stack: tg.Unresolved<tg.MaybeMutation<Array<tg.Error.Location>> | null>,
+		): this {
+			this.#args.push({ stack });
+			return this;
+		}
+
+		values(
+			values: tg.Unresolved<tg.MaybeMutation<{ [key: string]: string }> | null>,
+		): this {
+			this.#args.push({ values });
+			return this;
+		}
+
+		then<TResult1 = tg.Error, TResult2 = never>(
+			onfulfilled?:
+				| ((value: tg.Error) => TResult1 | PromiseLike<TResult1>)
+				| undefined
+				| null,
+			onrejected?:
+				| ((reason: any) => TResult2 | PromiseLike<TResult2>)
+				| undefined
+				| null,
+		): PromiseLike<TResult1 | TResult2> {
+			return tg.Error.new(...this.#args).then(onfulfilled, onrejected);
+		}
+	}
+
+	export type Arg = string | tg.Error | tg.Error.Arg.Object;
+
+	export namespace Arg {
+		export type Object = {
+			code?: string | null;
+			diagnostics?: Array<tg.Diagnostic> | null;
+			location?: tg.Error.Location | null;
+			message?: string | null;
+			source?: tg.Referent<tg.Error.Object | tg.Error> | null;
+			stack?: Array<tg.Error.Location> | null;
+			values?: { [key: string]: string } | null;
+		};
+	}
 
 	export type Object = {
 		code: string | null;

--- a/packages/clients/js/src/process.ts
+++ b/packages/clients/js/src/process.ts
@@ -520,13 +520,13 @@ export class Process<O extends tg.Value = tg.Value> {
 			if (this.#options.name !== undefined && this.#options.name !== null) {
 				values.name = this.#options.name;
 			}
-			throw tg.error("the child process failed", {
+			throw tg.error.sync("the child process failed", {
 				source,
 				values,
 			});
 		}
 		if (wait.exit >= 1 && wait.exit < 128) {
-			const error = tg.error(`the process exited with code ${wait.exit}`);
+			const error = tg.error.sync(`the process exited with code ${wait.exit}`);
 			const source = {
 				item: error,
 				options: this.#options,
@@ -537,13 +537,13 @@ export class Process<O extends tg.Value = tg.Value> {
 			if (this.#options.name !== undefined && this.#options.name !== null) {
 				values.name = this.#options.name;
 			}
-			throw tg.error("the child process failed", {
+			throw tg.error.sync("the child process failed", {
 				source,
 				values,
 			});
 		}
 		if (wait.exit >= 128) {
-			const error = tg.error(`the process exited with code ${wait.exit}`);
+			const error = tg.error.sync(`the process exited with code ${wait.exit}`);
 			const source = {
 				item: error,
 				options: this.#options,
@@ -554,7 +554,7 @@ export class Process<O extends tg.Value = tg.Value> {
 			if (this.#options.name !== undefined && this.#options.name !== null) {
 				values.name = this.#options.name;
 			}
-			throw tg.error(
+			throw tg.error.sync(
 				`the child process exited with signal ${wait.exit - 128}`,
 				{
 					source,

--- a/packages/clients/js/src/process/build.ts
+++ b/packages/clients/js/src/process/build.ts
@@ -23,7 +23,7 @@ export let builder = (...args: any): any => {
 			(arg.tty === undefined || arg.tty === false);
 		cacheable = cacheable || arg.checksum !== undefined;
 		if (!cacheable) {
-			throw tg.error("a build must be cacheable");
+			throw tg.error.sync("a build must be cacheable");
 		}
 	};
 	let firstArg: tg.Process.ArgObject = {

--- a/packages/clients/js/src/resolve.ts
+++ b/packages/clients/js/src/resolve.ts
@@ -125,6 +125,7 @@ export let resolve = async <T extends tg.Unresolved<tg.Value>>(
 			value instanceof tg.Symlink ||
 			value instanceof tg.Graph ||
 			value instanceof tg.Command ||
+			value instanceof tg.Error ||
 			value instanceof Uint8Array ||
 			value instanceof tg.Mutation ||
 			value instanceof tg.Template ||


### PR DESCRIPTION
Implement `tg.Error.Builder`, use it to attach the ID of a missing object get to the error as a value.