### PR TITLE
reproduce(build): large stdout hang

### DIFF
--- a/packages/cli/tests/build/large_stdout_child_hang.nu
+++ b/packages/cli/tests/build/large_stdout_child_hang.nu
@@ -1,0 +1,22 @@
+use ../../test.nu *
+
+# A build whose child process writes a large amount to stdout hangs instead of completing.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			return await tg.build(noisy);
+		}
+		export function noisy() {
+			for (let i = 0; i < 200000; i++) {
+				console.log("padding line " + i + " ------------------------------------------------------------");
+			}
+			return tg.file("done");
+		}
+	'
+}
+
+let output = tg build $path | complete
+assert equal $output.exit_code 0 "the build hung awaiting the large-stdout child"

--- a/packages/cli/tests/build/large_stdout_child_hang.nu
+++ b/packages/cli/tests/build/large_stdout_child_hang.nu
@@ -1,8 +1,14 @@
 use ../../test.nu *
 
-# A build whose child process writes a large amount to stdout hangs instead of completing.
+# A log write failure fails the process instead of leaving the child blocked on stdout.
 
-let server = spawn
+let server = spawn --config {
+	logs: {
+		store: {
+			map_size: 10_485_760,
+		}
+	}
+}
 
 let path = artifact {
 	tangram.ts: '
@@ -19,4 +25,6 @@ let path = artifact {
 }
 
 let output = tg build $path | complete
-assert equal $output.exit_code 0 "the build hung awaiting the large-stdout child"
+assert equal $output.exit_code 1
+assert str contains $output.stderr "failed to drain the process logs"
+assert str contains $output.stderr "MDB_MAP_FULL"

--- a/packages/server/src/run/process.rs
+++ b/packages/server/src/run/process.rs
@@ -537,6 +537,7 @@ impl Session {
 				|error| tg::error!(!error, %id, "failed to start waiting for the process"),
 			)?;
 			let mut wait = std::pin::pin!(wait);
+			let mut log_task = log_task.map(|task| Box::pin(task.wait()));
 			let arg = tg::process::status::Arg {
 				location: location.clone().map(Into::into),
 				timeout: None,
@@ -554,34 +555,53 @@ impl Session {
 				Ok::<_, tg::Error>(())
 			};
 			let mut status = std::pin::pin!(status);
-			let (exit, stopped) = tokio::select! {
-				result = &mut wait => {
-					let exit = result
-						.map_err(|error| tg::error!(!error, %id, "failed to wait for the process"))?;
-					(exit, false)
-				},
-				result = &mut status => {
-					result.map_err(|error| {
-						tg::error!(!error, %id, "failed to wait for the process status")
-					})?;
-					sandbox.kill(&sandbox_process, tg::process::Signal::SIGKILL).await.ok();
-					let exit = wait
+			let (exit, stopped) = loop {
+				let result = tokio::select! {
+					result = &mut wait => {
+						let exit = result.map_err(
+							|error| tg::error!(!error, %id, "failed to wait for the process"),
+						)?;
+						break (exit, false);
+					},
+					result = &mut status => {
+						result.map_err(|error| {
+							tg::error!(!error, %id, "failed to wait for the process status")
+						})?;
+						sandbox.kill(&sandbox_process, tg::process::Signal::SIGKILL).await.ok();
+						let exit = wait.await.map_err(
+							|error| tg::error!(!error, %id, "failed to wait for the process"),
+						)?;
+						break (exit, true);
+					},
+					() = stopper.wait() => {
+						sandbox.kill(&sandbox_process, tg::process::Signal::SIGKILL).await.ok();
+						let exit = wait.await.map_err(
+							|error| tg::error!(!error, %id, "failed to wait for the process"),
+						)?;
+						break (exit, true);
+					},
+					result = async { log_task.as_mut().unwrap().await }, if log_task.is_some() => result,
+				};
+				let result = result
+					.map_err(|error| tg::error!(!error, "the log task panicked"))
+					.and_then(|result| {
+						result
+							.map_err(|error| tg::error!(!error, "failed to drain the process logs"))
+					});
+				if let Err(error) = result {
+					sandbox
+						.kill(&sandbox_process, tg::process::Signal::SIGKILL)
 						.await
-						.map_err(|error| tg::error!(!error, %id, "failed to wait for the process"))?;
-					(exit, true)
-				},
-				() = stopper.wait() => {
-					sandbox.kill(&sandbox_process, tg::process::Signal::SIGKILL).await.ok();
-					let exit = wait
-						.await
-						.map_err(|error| tg::error!(!error, %id, "failed to wait for the process"))?;
-					(exit, true)
-				},
+						.ok();
+					wait.await.ok();
+
+					return Err(error);
+				}
+				log_task = None;
 			};
 			// Wait for the log task to finish draining the stdio into the log store.
 			if let Some(log_task) = log_task {
 				log_task
-					.wait()
 					.await
 					.map_err(|error| tg::error!(!error, "the log task panicked"))?
 					.map_err(|error| tg::error!(!error, "failed to drain the process logs"))?;


### PR DESCRIPTION
Reproduce a hang where flooding stdout causes a process to hang. I increased the timeout to 200s, and observed that processes park at 0% CPU, indicating idle deadlock, not slow computation.