### PR TITLE
fix(server): read process state from runner

### DIFF
--- a/packages/server/src/process/wait.rs
+++ b/packages/server/src/process/wait.rs
@@ -121,7 +121,7 @@ impl Session {
 		let permission =
 			tg::grant::Permission::Process(tg::grant::permission::process::Permission::Node);
 		let authorize_future = self.authorize(resource, permissions).boxed();
-		let get_future = self.try_get_process_from_index(id).boxed();
+		let get_future = self.try_get_process_local_inner(id, false).boxed();
 		let check_future = async {
 			let (permissions, process) = future::try_join(authorize_future, get_future).await?;
 			Ok::<_, tg::Error>(process.is_some().then_some(permissions).flatten())


### PR DESCRIPTION
Use `try_get_process_local_inner` instead of `try_get_process_from_index` in `try_wait_process_local`. This matches `try_get_process_status_stream` and guards against a freshly spawned, not-yet-indexed process immediately causing our subscription to drop, so the eventual finish status message publishes to no subscribers.