### PR TITLE
fix(server): dont resubscribe every retry loop in send_control_request

### DIFF
--- a/packages/cli/tests/run/stdio_drain_response_loss.nu
+++ b/packages/cli/tests/run/stdio_drain_response_loss.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+
+# Reading a sandboxed child's piped stdout captures all of it even when the child
+# emits output in bursts slower than the stdio_drain_timeout. That is the corner case
+# where each drain read blocks past the timeout, so its reply must survive the retry
+# loop's subscription gap rather than being lost.
+
+let server = spawn --config { runner: { stdio_drain_timeout: 0.01 } }
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			let process = await tg.spawn(child).stdio("pipe").sandbox();
+			let stdout = await process.stdout.readAllToString();
+			console.log(stdout);
+		}
+
+		export async function child() {
+			for (let i = 0; i < 8; i++) {
+				console.log("line " + i);
+				await tg.sleep(0.05);
+			}
+		}
+	',
+}
+
+let output = tg run $path | complete
+success $output
+assert ($output.stdout | str contains "line 7")

--- a/packages/server/src/control.rs
+++ b/packages/server/src/control.rs
@@ -2,7 +2,7 @@ use {
 	crate::Session,
 	dashmap::DashMap,
 	futures::{StreamExt as _, TryStreamExt as _, stream::BoxStream},
-	std::{marker::PhantomData, ops::ControlFlow, sync::Arc, time::Duration},
+	std::{marker::PhantomData, sync::Arc, time::Duration},
 	tangram_client::prelude::*,
 	tangram_messenger::{Messenger as _, Payload},
 };
@@ -218,69 +218,57 @@ impl Session {
 			marker: _,
 		} = arg;
 		let server = self.server.clone();
-		let result = tangram_futures::retry::retry(&options.retry, || {
-			let ack = ack.clone();
-			let client_subject = client_subject.clone();
-			let request = request.clone();
-			let response = response.clone();
-			let server = server.clone();
-			let server_subject = server_subject.clone();
-			let timeout = options.timeout;
-			async move {
-				let responses = server
-					.messenger
-					.subscribe::<I>(client_subject)
-					.await
-					.map_err(|source| {
-						Some(tg::error!(!source, "failed to subscribe to the response"))
-					})?;
-				let mut responses = std::pin::pin!(responses);
+		let Options { retry, timeout } = options;
 
-				server
-					.messenger
-					.publish(server_subject.clone(), request)
-					.await
-					.map_err(|source| Some(tg::error!(!source, "failed to publish the request")))?;
+		// Keep the subscription alive across retries so a response published between attempts is not dropped for lack of a subscriber.
+		let responses = server
+			.messenger
+			.subscribe::<I>(client_subject)
+			.await
+			.map_err(|source| tg::error!(!source, "failed to subscribe to the response"))?;
+		let mut responses = std::pin::pin!(responses);
 
-				let result = tokio::time::timeout(timeout, async {
-					loop {
-						let message = responses
-							.next()
-							.await
-							.ok_or_else(|| tg::error!("the response stream ended"))?
-							.map_err(|source| {
-								tg::error!(!source, "failed to receive the response")
-							})?;
-						let Some((id, response)) = response(message.payload)? else {
-							continue;
-						};
-						let ack = ack(id);
-						server
-							.messenger
-							.publish(server_subject.clone(), ack)
-							.await
-							.inspect_err(|error| {
-								tracing::error!(%error, "failed to ack the response");
-							})
-							.ok();
-						return Ok::<_, tg::Error>(response);
-					}
-				})
-				.await;
-
-				match result {
-					Ok(Ok(response)) => Ok(ControlFlow::Break(response)),
-					Ok(Err(error)) => Err(Some(error)),
-					Err(_) => Ok(ControlFlow::Continue(None)),
-				}
+		let mut retries = std::pin::pin!(tangram_futures::retry::stream(retry));
+		loop {
+			if retries.next().await.is_none() {
+				return Err(tg::error!("timed out waiting for the response"));
 			}
-		})
-		.await;
 
-		match result {
-			Ok(response) => Ok(response),
-			Err(None) => Err(tg::error!("timed out waiting for the response")),
-			Err(Some(error)) => Err(error),
+			server
+				.messenger
+				.publish(server_subject.clone(), request.clone())
+				.await
+				.map_err(|source| tg::error!(!source, "failed to publish the request"))?;
+
+			let result = tokio::time::timeout(timeout, async {
+				loop {
+					let message = responses
+						.next()
+						.await
+						.ok_or_else(|| tg::error!("the response stream ended"))?
+						.map_err(|source| tg::error!(!source, "failed to receive the response"))?;
+					let Some((id, response)) = response(message.payload)? else {
+						continue;
+					};
+					let ack = ack(id);
+					server
+						.messenger
+						.publish(server_subject.clone(), ack)
+						.await
+						.inspect_err(|error| {
+							tracing::error!(%error, "failed to ack the response");
+						})
+						.ok();
+					return Ok::<_, tg::Error>(response);
+				}
+			})
+			.await;
+
+			match result {
+				Ok(Ok(response)) => return Ok(response),
+				Ok(Err(error)) => return Err(error),
+				Err(_) => (),
+			}
 		}
 	}
 }

--- a/packages/server/src/control.rs
+++ b/packages/server/src/control.rs
@@ -220,7 +220,6 @@ impl Session {
 		let server = self.server.clone();
 		let Options { retry, timeout } = options;
 
-		// Keep the subscription alive across retries so a response published between attempts is not dropped for lack of a subscriber.
 		let responses = server
 			.messenger
 			.subscribe::<I>(client_subject)


### PR DESCRIPTION
This PR reproduces a bug in which a process outputs stdio in slow bursts, and some of the pipe reads block longer than the 1-second drain timeout. Each time it timed out, the retry loop tore down and recreated its subscription. If the reply arrives during this gap, it is dropped, as the messenger only delivers to subscribers present at the instant the message is published. The requester kept re-sending the request, but the runner deduplicates repeats by id. It already answered that id once into the gap between subscription teardown and setup, so it never answers again. The lost reply is never regenerated and the drain deadlocks.

The included test sets a small drain timeout and prints to stdout repeatedly at a longer interval, replicating the case where the reply shows up in this subscription gap. Without the fix, this test hangs.

The fix subscribes to the reply subject once outside the loop and keeps this subscription alive across all retries, so there is never a gap where there's no subscriber. Late replies are buffered and delivered, ensuring we don't lose any reads.