### PR TITLE
fix(vfs): report nonzero inode numbers from readdir

### DIFF
--- a/packages/cli/tests/vfs/readdir_inodes.nu
+++ b/packages/cli/tests/vfs/readdir_inodes.nu
@@ -1,0 +1,36 @@
+use ../../test.nu *
+use ../lib/vfs.nu
+
+vfs skip_unless_supported
+
+# Every entry returned by readdir must report a nonzero inode number. GNU make ignores
+# directory entries whose inode number is zero, so such entries are invisible to it even
+# though they exist.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+if (which make | is-empty) {
+	skip_test 'this test requires make'
+}
+
+# Create more entries than fit in the first readdirplus response, so that the tail of the
+# listing is served by readdir.
+const count = 1000
+let source = mktemp --directory
+for index in 0..<$count {
+	'data' | save ($source | path join $'file_($index | fill --alignment right --character 0 --width 4).txt')
+}
+
+let server_path = mktemp --directory
+let server = spawn --directory $server_path --config { vfs: true }
+vfs assert_mounted $server_path
+
+let id = tg checkin $source | str trim
+let path = vfs root $server_path $id
+
+let build_path = mktemp --directory
+"all:\n\t@echo $(words $(wildcard " + $path + "/*))\n" | save ($build_path | path join 'Makefile')
+let visible = ^make --no-print-directory -C $build_path | str trim | into int
+
+assert ($visible == $count) $'expected make to see all ($count) entries, but it saw ($visible)'

--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -1194,11 +1194,6 @@ impl Provider {
 		Ok(entries)
 	}
 
-	/// Get the node ID to report for a readdir entry. Entries created from an artifact carry
-	/// a node ID of zero until they are looked up, but readdir must report a nonzero inode
-	/// number, because GNU make and other tools ignore directory entries whose inode number
-	/// is zero. The node is inserted without a lookup reference, because readdir, unlike
-	/// readdirplus, does not cause the kernel to hold one.
 	fn readdir_entry_node(
 		&self,
 		snapshot: &DirectorySnapshot,

--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -1162,7 +1162,8 @@ impl Provider {
 				break;
 			}
 			size = size.saturating_add(entry_size);
-			entries.push((entry.name, entry.node, entry.kind));
+			let node = self.readdir_entry_node(snapshot, &entry)?;
+			entries.push((entry.name, node, entry.kind));
 		}
 
 		Ok(entries)
@@ -1186,10 +1187,35 @@ impl Provider {
 				break;
 			}
 			size = size.saturating_add(entry_size);
-			entries.push((entry.name, entry.node, entry.kind));
+			let node = self.readdir_entry_node(snapshot, &entry)?;
+			entries.push((entry.name, node, entry.kind));
 		}
 
 		Ok(entries)
+	}
+
+	/// Get the node ID to report for a readdir entry. Entries created from an artifact carry
+	/// a node ID of zero until they are looked up, but readdir must report a nonzero inode
+	/// number, because GNU make and other tools ignore directory entries whose inode number
+	/// is zero. The node is inserted without a lookup reference, because readdir, unlike
+	/// readdirplus, does not cause the kernel to hold one.
+	fn readdir_entry_node(
+		&self,
+		snapshot: &DirectorySnapshot,
+		entry: &DirectorySnapshotEntry,
+	) -> std::io::Result<u64> {
+		let Some(artifact) = &entry.artifact else {
+			return Ok(entry.node);
+		};
+		let attrs = Self::attrs_from_artifact(Some(artifact));
+		self.nodes.get_or_insert_child(
+			snapshot.node,
+			&entry.name,
+			artifact.clone(),
+			snapshot.depth + 1,
+			attrs,
+			false,
+		)
 	}
 
 	async fn directory_snapshot_entries_inner(


### PR DESCRIPTION
I observed that GNU make failed to read files that `stat()` could find. It turns out that `make` skips directory entries with inode 0. The kernel serves the beginning of an entry with READDIRPLUS, which always uses `get_or_insert_child`, so there is always an entry.  `create_directory_snapshot` stored `node: 0` for artifact-backed entries, which was passed directly to `FuseDirentHeader.ino`, which means `make` will filter it out.

The fix is to always use `get_or_insert_child` in both READDIR and READDIRPLUS.

I added a test that checks in a large directory and asks make to count the entries. This fails without the fix, reporting 193 entries, and passes with it. I also observed this fixing my production failure, in which a configure script failed to find a `.in` file that was plainly present in a large directory.