### PR TITLE
repro(server): queued process should wait for capacity

### DIFF
--- a/packages/cli/tests/scheduler/queued_process_connection_timeout.nu
+++ b/packages/cli/tests/scheduler/queued_process_connection_timeout.nu
@@ -1,0 +1,21 @@
+use ../../test.nu *
+
+let server = spawn --config {
+	runner: { cpus: 1 },
+}
+
+let path = artifact {
+	tangram.ts: '
+		export async function blocker() {
+			await tg.sleep(12);
+		}
+
+		export function child() {
+			return "child";
+		}
+	',
+}
+
+tg build --detach $"($path)#blocker" | ignore
+let output = tg build $"($path)#child" | complete
+success $output "a queued process should wait for runner capacity"


### PR DESCRIPTION
This test demonstrates a regression introduced in [bfa170be90107764899e6fb3180d0fcbae02bfbc](https://github.com/tangramdotdev/tangram/commit/bfa170be90107764899e6fb3180d0fcbae02bfbc) - the queued process should wait the full 12 seconds for available capacity. On main, this fails after the 10 second timeout.