### PR TITLE
fix(server): set builtin host to None

### DIFF
--- a/packages/cli/tests/scheduler/builtin_host_never_placed.nu
+++ b/packages/cli/tests/scheduler/builtin_host_never_placed.nu
@@ -1,0 +1,30 @@
+use ../../test.nu *
+
+# A builtin's sandbox must not be enqueued with the command's host, "builtin", because a runner
+# advertises `tg::host::current()`, which is only ever a machine host, so no runner could ever
+# satisfy it and the sandbox would stay queued forever. A builtin reaches the scheduler only when the
+# allocation shortcut in `try_spawn_process_task` fails, so the sleeping child occupies the spare cpu
+# until the concurrent builtins are enqueued, then releases enough capacity to place them.
+
+let server = spawn --config { runner: { cpus: 2 } }
+
+let path = artifact {
+	tangram.ts: '
+		export async function hold() {
+			await tg.sleep(2);
+		}
+
+		export default async function () {
+			let artifact = await tg.directory({ "hello.txt": "contents" });
+			let other = await tg.directory({ "goodbye.txt": "contents" });
+			await Promise.all([
+				tg.build(hold),
+				tg.archive(artifact, "tar"),
+				tg.archive(artifact, "zip"),
+				tg.archive(other, "tar"),
+			]);
+		}
+	'
+}
+
+tg build $path

--- a/packages/clients/rust/src/host.rs
+++ b/packages/clients/rust/src/host.rs
@@ -1,3 +1,6 @@
+// The hosts that do not name a machine.
+const VIRTUAL_HOSTS: [&str; 2] = ["builtin", "js"];
+
 /// Get the current host.
 #[must_use]
 pub fn current() -> &'static str {
@@ -17,4 +20,10 @@ pub fn current() -> &'static str {
 	{
 		"x86_64-linux"
 	}
+}
+
+/// Determine whether a host is virtual, meaning that it does not name a machine, so any runner can run its processes.
+#[must_use]
+pub fn is_virtual(host: &str) -> bool {
+	VIRTUAL_HOSTS.contains(&host)
 }

--- a/packages/server/src/process/spawn/local.rs
+++ b/packages/server/src/process/spawn/local.rs
@@ -296,7 +296,7 @@ impl Session {
 		let (sandbox, sandbox_arg, sandbox_token) = match &arg.sandbox {
 			Some(tg::Either::Left(sandbox_arg)) => {
 				let mut sandbox_arg = Self::normalize_sandbox_create_arg(sandbox_arg.clone())?;
-				sandbox_arg.host = Some(host.to_owned());
+				sandbox_arg.host = (!tg::host::is_virtual(host)).then(|| host.to_owned());
 				sandbox_arg.location.clone_from(&arg.location);
 				sandbox_arg.owner.clone_from(&owner);
 				let isolation = self.server.resolve_sandbox_isolation()?;


### PR DESCRIPTION
Builtin processes run in a sandbox that is agnostic to the runner's OS/arch, but the sandbox was labeled with the command's host, "builtin".  A sandbox's host means "place me on a runner advertising this", while runners only ever advertise their native OS/arch. Builtins usually avoid the scheduler entirely via an allocation shortcut that grabs local capacity and spawns directly on the server's own runner, which works as intended. 

However, when that shortcut fails due to a concurrent fan-out exhausting capacity, the sandbox is enqueued, and the scheduler's host filter can never match it. It then waits forever even as capacity frees up.

This change leaves the sandbox host unset for virtual hosts (builtin, js), meaning "any runner may take it", while machine hosts still propagate as real constraints.

Additionally, remove the unused `tgar` variant from `ArchiveFormat` in the JS client, which typechecks but then fails at runtime because there is no corresponding implementation in Rust.