### PR TITLE
feat(builtin): specific error for case insensitve incompatible extraction

### DIFF
--- a/packages/builtin/src/extract.rs
+++ b/packages/builtin/src/extract.rs
@@ -214,12 +214,7 @@ pub(crate) async fn extract_tar(
 			.mode()
 			.ok()
 			.is_some_and(|permissions| permissions & 0o000_111 != 0);
-		let mut file = tokio::fs::OpenOptions::new()
-			.write(true)
-			.create_new(true)
-			.open(&path)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to create the file"))?;
+		let mut file = create_entry_file(&path).await?;
 		tokio::io::copy(&mut entry, &mut file)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to write the file"))?;
@@ -322,12 +317,7 @@ pub(crate) async fn extract_zip(
 			tokio::fs::create_dir_all(parent)
 				.await
 				.map_err(|error| tg::error!(!error, "failed to create the directory"))?;
-			let mut file = tokio::fs::OpenOptions::new()
-				.write(true)
-				.create_new(true)
-				.open(&path)
-				.await
-				.map_err(|error| tg::error!(!error, "failed to create the file"))?;
+			let mut file = create_entry_file(&path).await?;
 			tokio::io::copy(&mut entry_reader.compat(), &mut file)
 				.await
 				.map_err(|error| tg::error!(!error, "failed to write the file"))?;
@@ -436,4 +426,53 @@ pub(crate) async fn extract_zip(
 	}
 
 	Ok(())
+}
+
+// Create the file for an archive entry. The file is created exclusively so that an archive cannot overwrite an entry it has already extracted.
+async fn create_entry_file(path: &Path) -> tg::Result<tokio::fs::File> {
+	let result = tokio::fs::OpenOptions::new()
+		.write(true)
+		.create_new(true)
+		.open(path)
+		.await;
+	let error = match result {
+		Ok(file) => return Ok(file),
+		Err(error) => error,
+	};
+	if error.kind() != std::io::ErrorKind::AlreadyExists {
+		return Err(tg::error!(!error, ?path, "failed to create the file"));
+	}
+
+	// A case insensitive file system reports that an entry exists when a previously extracted entry has a name differing only in case. Report that cause, because it cannot be inferred from the path alone.
+	let Some(existing) = find_case_conflict(path).await else {
+		return Err(tg::error!(!error, ?path, "failed to create the file"));
+	};
+	let source = tg::error!(
+		!error,
+		%existing,
+		"an entry whose name differs only in case already exists, and the file system is case insensitive"
+	);
+
+	Err(tg::error!(
+		!source,
+		?path,
+		"failed to extract the archive entry"
+	))
+}
+
+// Find an entry in the path's parent directory whose name differs from the path's name only in case.
+async fn find_case_conflict(path: &Path) -> Option<String> {
+	let parent = path.parent()?;
+	let name = path.file_name()?.to_str()?;
+	let mut entries = tokio::fs::read_dir(parent).await.ok()?;
+	while let Ok(Some(entry)) = entries.next_entry().await {
+		let existing = entry.file_name();
+		let Some(existing) = existing.to_str() else {
+			continue;
+		};
+		if existing != name && existing.eq_ignore_ascii_case(name) {
+			return Some(existing.to_owned());
+		}
+	}
+	None
 }

--- a/packages/cli/tests/archive/extract_case_insensitive_names.nu
+++ b/packages/cli/tests/archive/extract_case_insensitive_names.nu
@@ -1,0 +1,42 @@
+use ../../test.nu *
+
+# Extracting a tar archive containing two entries whose names differ only in case produces a directory with both entries on a case sensitive file system, and reports the case conflict on a case insensitive one.
+
+let server = spawn
+
+# Create the entries in separate directories, because a case insensitive file system cannot hold both at once.
+let lower = artifact {
+	'chap.html': 'lower'
+}
+let upper = artifact {
+	'Chap.html': 'upper'
+}
+
+# Create a tar archive containing both entries.
+let archive = mktemp -d | path join 'case.tar'
+^tar -cf $archive -C $lower 'chap.html'
+^tar -rf $archive -C $upper 'Chap.html'
+
+# Determine whether the file system the server extracts to is case sensitive.
+let probe = mktemp -d
+'probe' | save -f ($probe | path join 'probe')
+let case_sensitive = not (($probe | path join 'PROBE') | path exists)
+
+# Extract the archive.
+let blob = cat $archive | tg write | str trim
+let output = tg extract $blob | complete
+
+if $case_sensitive {
+	# The extracted directory should contain both entries.
+	success $output "the archive should extract"
+	let extracted = $output.stdout | str trim
+	let entries = tg get $extracted
+	assert ($entries | str contains 'chap.html') "the extracted directory should contain the lowercase entry"
+	assert ($entries | str contains 'Chap.html') "the extracted directory should contain the capitalized entry"
+} else {
+	# The extraction should report the case conflict rather than a bare "file exists" error.
+	failure $output "the archive should not extract"
+	assert ($output.stderr | str contains 'failed to extract the archive entry') "the error should identify the failing archive entry"
+	assert ($output.stderr | str contains 'differs only in case') "the error should explain the case conflict"
+	assert ($output.stderr | str contains 'chap.html') "the error should name the conflicting entry"
+}


### PR DESCRIPTION
This PR adds a specific error for attempting to extract an archive entry that differs only in case on a case-insensitive file system.