### PR TITLE
repro(cli): demonstrate server stop issues

### DIFF
--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -146,7 +146,6 @@ impl Cli {
 	}
 
 	pub(crate) async fn print_error(&mut self, error: tg::Referent<tg::Error>) {
-		let client = self.client().await.ok();
 		let internal = self
 			.config
 			.as_ref()
@@ -166,9 +165,9 @@ impl Cli {
 				.map(|object| object.unwrap_error())
 			{
 				error
-			} else if let Some(error) = match &client {
-				Some(client) => error_referent.item().load_with_handle(client).await.ok(),
-				None => None,
+			} else if let Some(error) = match self.client().await {
+				Ok(client) => error_referent.item().load_with_handle(&client).await.ok(),
+				Err(_) => None,
 			} {
 				error
 			} else {

--- a/packages/cli/src/print.rs
+++ b/packages/cli/src/print.rs
@@ -60,7 +60,6 @@ impl Cli {
 		T: serde::Serialize + Send + 'static,
 		S: Stream<Item = tg::Result<T>> + Send + 'static,
 	{
-		let client = self.client().await?;
 		let mut stdout = tokio::io::BufWriter::new(tokio::io::stdout());
 		let tty = tangram_util::tty::is_foreground_controlling_tty(libc::STDOUT_FILENO);
 		let pretty = options.pretty || tty;
@@ -91,15 +90,10 @@ impl Cli {
 			let value = serde_json::to_value(&value)
 				.map_err(|error| tg::error!(!error, "failed to serialize the value"))?;
 			let indent = if pretty { 1 } else { 0 };
-			Self::print_value_inner(
-				&client,
-				&mut stdout,
-				&value.into(),
-				options.clone(),
-				tg::object::get::Arg::default(),
-				indent,
-			)
-			.await?;
+			let value = value.into();
+			self.load_value(&value, options.clone(), tg::object::get::Arg::default())
+				.await?;
+			Self::print_value_inner(&mut stdout, &value, options.clone(), indent).await?;
 			if tty {
 				stdout
 					.flush()
@@ -134,9 +128,9 @@ impl Cli {
 		options: Options,
 		arg: tg::object::get::Arg,
 	) -> tg::Result<()> {
-		let client = self.client().await?;
 		let mut stdout = tokio::io::BufWriter::new(tokio::io::stdout());
-		Self::print_value_inner(&client, &mut stdout, value, options, arg, 0).await?;
+		self.load_value(value, options.clone(), arg).await?;
+		Self::print_value_inner(&mut stdout, value, options, 0).await?;
 		stdout
 			.write_all(b"\n")
 			.await
@@ -148,12 +142,30 @@ impl Cli {
 		Ok(())
 	}
 
-	pub(crate) async fn print_value_inner(
-		client: &impl tg::Handle,
-		stdout: &mut tokio::io::BufWriter<tokio::io::Stdout>,
+	async fn load_value(
+		&mut self,
 		value: &tg::Value,
 		options: Options,
 		arg: tg::object::get::Arg,
+	) -> tg::Result<()> {
+		let depth = match options.depth.unwrap_or(Depth::Finite(0)) {
+			Depth::Finite(depth) => Some(depth),
+			Depth::Infinite => None,
+		};
+		if depth == Some(0) || value.objects().is_empty() {
+			return Ok(());
+		}
+		let client = self.client().await?;
+		value
+			.load_with_handle(&client, arg, depth, options.blobs)
+			.await?;
+		Ok(())
+	}
+
+	pub(crate) async fn print_value_inner(
+		stdout: &mut tokio::io::BufWriter<tokio::io::Stdout>,
+		value: &tg::Value,
+		options: Options,
 		indent: usize,
 	) -> tg::Result<()> {
 		let depth = match options.depth.unwrap_or(Depth::Finite(0)) {
@@ -161,7 +173,6 @@ impl Cli {
 			Depth::Infinite => None,
 		};
 		let blobs = options.blobs;
-		value.load_with_handle(client, arg, depth, blobs).await?;
 		let tty = tangram_util::tty::is_foreground_controlling_tty(libc::STDOUT_FILENO);
 		let indentation = (options.pretty || tty).then_some(INDENTATION);
 		let options = tg::value::print::Options {

--- a/packages/cli/src/server.rs
+++ b/packages/cli/src/server.rs
@@ -227,9 +227,22 @@ impl Cli {
 	pub(crate) async fn stop_server(&self) -> tg::Result<()> {
 		// Read the PID from the lock file.
 		let lock_path = self.directory_path().join("lock");
-		let pid = tokio::fs::read_to_string(&lock_path)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to read the pid from the lock file"))?
+		let lock = match tokio::fs::read_to_string(&lock_path).await {
+			Ok(lock) => lock,
+			Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+				return Ok(());
+			},
+			Err(error) => {
+				return Err(tg::error!(
+					!error,
+					"failed to read the pid from the lock file"
+				));
+			},
+		};
+		if lock.is_empty() {
+			return Ok(());
+		}
+		let pid = lock
 			.parse::<i32>()
 			.map_err(|error| tg::error!(!error, "invalid lock file"))?;
 

--- a/packages/cli/tests/server/status_does_not_spawn.nu
+++ b/packages/cli/tests/server/status_does_not_spawn.nu
@@ -1,0 +1,9 @@
+use ../../test.nu *
+
+# Checking the status of a stopped server does not spawn it.
+
+let directory = mktemp -d
+let output = with-env { TANGRAM_MODE: auto } { tg -d $directory server status | complete }
+success $output
+assert equal ($output.stdout | from json) 'stopped'
+assert not (($directory | path join 'socket') | path exists)

--- a/packages/cli/tests/server/stop_error_does_not_spawn.nu
+++ b/packages/cli/tests/server/stop_error_does_not_spawn.nu
@@ -1,0 +1,18 @@
+use ../../test.nu *
+
+# A failing `server stop` does not spawn a server. Printing an error acquires a client, and a client in auto mode spawns a server when it cannot connect.
+
+let directory = mktemp -d
+'not a pid' | save -f ($directory | path join 'lock')
+
+# The harness sets client mode, which never spawns. Auto mode is the default a user gets.
+let output = with-env { TANGRAM_MODE: auto } { tg -d $directory server stop | complete }
+failure $output
+
+# Record whether a server appeared, then stop it before asserting, so that a failure of this test does not leak a server the harness cannot reap.
+let spawned = ($directory | path join 'socket') | path exists
+if $spawned {
+	tg -d $directory server stop | complete | ignore
+}
+
+assert not $spawned 'printing the error should not have spawned a server'

--- a/packages/cli/tests/server/stop_error_does_not_spawn.nu
+++ b/packages/cli/tests/server/stop_error_does_not_spawn.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# A failing `server stop` does not spawn a server. Printing an error acquires a client, and a client in auto mode spawns a server when it cannot connect.
+# Printing an error from a failing `server stop` does not spawn a server.
 
 let directory = mktemp -d
 'not a pid' | save -f ($directory | path join 'lock')

--- a/packages/cli/tests/server/stop_when_stopped.nu
+++ b/packages/cli/tests/server/stop_when_stopped.nu
@@ -2,6 +2,10 @@ use ../../test.nu *
 
 # Stopping a server that has already stopped succeeds. A clean shutdown truncates the lock file rather than removing it, so the second stop reads an empty lock file.
 
+let directory = mktemp -d
+let output = tg -d $directory server stop | complete
+success $output 'stopping a server that has never started should succeed'
+
 let server = spawn
 
 let output = tg -d $server.directory server stop | complete

--- a/packages/cli/tests/server/stop_when_stopped.nu
+++ b/packages/cli/tests/server/stop_when_stopped.nu
@@ -1,0 +1,11 @@
+use ../../test.nu *
+
+# Stopping a server that has already stopped succeeds. A clean shutdown truncates the lock file rather than removing it, so the second stop reads an empty lock file.
+
+let server = spawn
+
+let output = tg -d $server.directory server stop | complete
+success $output
+
+let output = tg -d $server.directory server stop | complete
+success $output 'stopping an already stopped server should succeed'


### PR DESCRIPTION
Adds two tests demonstrating odd server lifecyle issues:

- `stop_when_stopped` - running `tg server stop` anfter already running `tg server stop` currently fails with an error `cannot parse integer from empty string`. This should likely be an idempotent operation, and succeed doing nothing.

- `stop_error_does_not_spawn` - when running `tg server stop` in `auto` mode when there is no server running, a server gets spawned. That's probably not correct.