### PR TITLE
repro(vfs): concurrent opens of the same file fail with fuse passthrough

### DIFF
--- a/packages/cli/tests/vfs/passthrough_concurrent_open.nu
+++ b/packages/cli/tests/vfs/passthrough_concurrent_open.nu
@@ -1,0 +1,33 @@
+use ../../test.nu *
+use ../lib/vfs.nu
+
+# A file served by the VFS must support more than one concurrent open. The provider supplies a new
+# backing descriptor for each open, and the kernel refuses the second one because the inode already
+# has a different backing file, so the second open fails with EIO.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+
+let server_path = mktemp --directory
+let server = spawn --directory $server_path --config {
+	vfs: {
+		kind: 'fuse'
+		passthrough: 'required'
+	}
+}
+vfs assert_mounted $server_path
+
+let id = tg checkin (artifact { file.txt: 'contents' }) | str trim
+let path = vfs root $server_path $id | path join 'file.txt'
+
+# Registering a backing descriptor requires CAP_SYS_ADMIN, which a build made by this harness does
+# not have, so skip unless one open succeeds. Run the test with `--tangram-path` and a binary that
+# holds the capability to exercise passthrough.
+if (^sh -c $'exec 3< "($path)"' | complete).exit_code != 0 {
+	skip_test 'this test requires FUSE passthrough support'
+}
+
+# Hold two descriptors on the file at the same time.
+let output = ^sh -c $'exec 3< "($path)"; exec 4< "($path)"' | complete
+assert ($output.exit_code == 0) $'expected two concurrent opens to succeed, got: ($output.stderr | str trim)'

--- a/packages/vfs/src/fuse.rs
+++ b/packages/vfs/src/fuse.rs
@@ -90,13 +90,24 @@ pub struct Server<P>(Arc<State<P>>);
 pub struct State<P> {
 	active_requests: Mutex<HashMap<u64, CancellationToken>>,
 	no_opendir_support: bool,
-	passthrough_backing_ids: Mutex<HashMap<u64, u32>>,
+	passthrough_backings: Mutex<PassthroughBackings>,
 	passthrough_enabled: bool,
 	passthrough_permission_warning_emitted: AtomicBool,
 	passthrough_required: bool,
 	pending_response_resources: Mutex<HashMap<u64, ResponseResources>>,
 	provider: P,
 	task: Mutex<Option<tangram_futures::task::Shared<()>>>,
+}
+
+#[derive(Default)]
+struct PassthroughBackings {
+	handles: HashMap<u64, u64>,
+	nodes: HashMap<u64, PassthroughBacking>,
+}
+
+struct PassthroughBacking {
+	id: u32,
+	references: u64,
 }
 
 #[derive(Clone, Debug)]

--- a/packages/vfs/src/fuse/request.rs
+++ b/packages/vfs/src/fuse/request.rs
@@ -492,7 +492,12 @@ where
 						};
 						return Ok(Response::Open(out));
 					};
-					match self.register_passthrough_backing(fd, handle, &backing_fd) {
+					match self.register_passthrough_backing(
+						fd,
+						request.header.nodeid,
+						handle,
+						&backing_fd,
+					) {
 						Err(error) => {
 							if error.raw_os_error() == Some(libc::EPERM)
 								&& !self
@@ -676,9 +681,19 @@ where
 	fn register_passthrough_backing(
 		&self,
 		fd: &OwnedFd,
+		node: u64,
 		fh: u64,
 		backing_fd: &OwnedFd,
 	) -> Result<i32> {
+		let mut backings = self.passthrough_backings.lock().unwrap();
+		if let Some(backing) = backings.nodes.get_mut(&node) {
+			backing.references += 1;
+			let id = backing.id.to_i32().unwrap();
+			backings.handles.insert(fh, node);
+
+			return Ok(id);
+		}
+
 		let mut map = sys::fuse_backing_map {
 			fd: backing_fd.as_raw_fd(),
 			flags: 0,
@@ -699,19 +714,30 @@ where
 			.to_u32()
 			.ok_or_else(|| Error::other("invalid backing id"))?;
 
-		// Track the backing ID for release.
-		self.passthrough_backing_ids
-			.lock()
-			.unwrap()
-			.insert(fh, backing_id_u32);
+		// Track the backing ID for reuse and release.
+		backings.handles.insert(fh, node);
+		backings.nodes.insert(
+			node,
+			PassthroughBacking {
+				id: backing_id_u32,
+				references: 1,
+			},
+		);
+
 		Ok(backing_id)
 	}
 
 	pub(super) fn close_passthrough_backing(&self, fd: &OwnedFd, fh: u64) {
-		let backing_id = self.passthrough_backing_ids.lock().unwrap().remove(&fh);
-		let Some(backing_id) = backing_id else {
+		let mut backings = self.passthrough_backings.lock().unwrap();
+		let Some(node) = backings.handles.remove(&fh) else {
 			return;
 		};
+		let backing = backings.nodes.get_mut(&node).unwrap();
+		backing.references -= 1;
+		if backing.references > 0 {
+			return;
+		}
+		let backing_id = backings.nodes.remove(&node).unwrap().id;
 		let mut backing_id = backing_id;
 		// SAFETY: The ioctl receives a valid pointer to the registered backing ID, and the FUSE
 		// descriptor remains open for the duration of the call.

--- a/packages/vfs/src/fuse/startup.rs
+++ b/packages/vfs/src/fuse/startup.rs
@@ -36,7 +36,7 @@ where
 		let server = Self(Arc::new(State {
 			active_requests: Mutex::new(HashMap::new()),
 			no_opendir_support: connection.features.no_opendir_support,
-			passthrough_backing_ids: Mutex::new(HashMap::default()),
+			passthrough_backings: Mutex::new(PassthroughBackings::default()),
 			passthrough_enabled: connection.features.passthrough,
 			passthrough_permission_warning_emitted: AtomicBool::new(false),
 			passthrough_required: config.options.passthrough == Passthrough::Required,

--- a/packages/vfs/src/fuse/tests.rs
+++ b/packages/vfs/src/fuse/tests.rs
@@ -115,7 +115,7 @@ where
 	Server(Arc::new(State {
 		active_requests: Mutex::new(HashMap::new()),
 		no_opendir_support: false,
-		passthrough_backing_ids: Mutex::new(HashMap::new()),
+		passthrough_backings: Mutex::new(PassthroughBackings::default()),
 		passthrough_enabled,
 		passthrough_permission_warning_emitted: AtomicBool::new(false),
 		passthrough_required,


### PR DESCRIPTION
Demonstrate a bug in which attempting to open the same file via the vfs multiple times concurrently will fail:

```
  x expected two concurrent opens to succeed, got: /usr/bin/sh: line 1: /tmp/
  | tangram_test_F0KC8M/tmp.aChfbJuKjp/artifacts/
  | dir_01jekvhcrpjry7gjm2ybagr14pbmr95qyr242yxnf6kbj33cht37pg/file.txt:
  | Input/output error
```

The test is specifically gated on passthrough being enabled, which requires the `CAP_SYS_ADMIN` capability:

```
$ cargo build --all-features
$ sudo setcap cap_sys_admin+ep target/debug/tangram
$ nu packages/cli/test.nu --tangram-path target/debug/tangram passthrough_concurrent_open
```
