### PR TITLE
feat(test): assert on server logs

### DIFF
--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -1147,6 +1147,10 @@ export def --env spawn [
 	let server_exit_directory_path = (($env.TMPDIR? | default ($config_path | path dirname)) | path join $server_exit_directory_name)
 	try { mkdir $server_exit_directory_path }
 
+	# Create a path for the server's captured output.
+	let log_path = ($config_path | path dirname | path join 'log')
+	touch $log_path
+
 	# Spawn the server.
 	let server_job = job spawn -d server {
 		let server_job_id = job id
@@ -1163,10 +1167,14 @@ export def --env spawn [
 					\) &
 				exec 3>\"($ready_path)\"
 				exec tangram -c \"($config_path)\" -d \"($directory_path)\" -u \"($url)\" serve --ready-fd 3
-			" e>| lines | each { |line| print -e $"($name | default 'server'): ($line)\r" }
+			" e>| lines | each { |line|
+				$"($line)\n" | save --append $log_path
+				print -e $"($name | default 'server'): ($line)\r"
+			}
 		}
 		'' | save -f $exit_path
 	}
+	let exit_path = ($server_exit_directory_path | path join $'($server_job).exit')
 
 	# Wait for the server to be ready.
 	let ready_timeout = 30sec
@@ -1245,7 +1253,22 @@ export def --env spawn [
 	let cache_directory_name = if $vfs == null or $vfs == false { 'artifacts' } else { 'cache' }
 	let cache_directory = $directory_path | path join $cache_directory_name
 
-	{ cache_directory: $cache_directory, config: $config_path, directory: $directory_path, url: $url }
+	{ cache_directory: $cache_directory, config: $config_path, directory: $directory_path, exit: $exit_path, job: $server_job, log: $log_path, url: $url }
+}
+
+# Stop a server, so that its output is complete, and return the distinct errors
+# it logged as '<target> <message>'. The server must have been spawned with
+# `--config { tracing: { stderr_format: 'json' } }`.
+export def server_errors [server: record] {
+	stop_server_job $server.job
+	wait_for_server_exit $server.exit
+	open --raw $server.log
+		| lines
+		| each { from json }
+		| where level == 'ERROR'
+		| each { |event| $"($event.target) ($event.fields.message)" }
+		| uniq
+		| sort
 }
 
 def clean_databases [id: string] {

--- a/packages/cli/tests/README.md
+++ b/packages/cli/tests/README.md
@@ -31,6 +31,11 @@ tight cluster of snapshots for that one behavior). Reuse the `spawn`,
 `test.nu`. When a file would test several independent behaviors, split it into
 one file per behavior.
 
+To assert on what the server itself logged, spawn it with
+`--config { tracing: { stderr_format: 'json' } }` and snapshot `server_errors`,
+which stops the server so its output is complete and returns the distinct
+errors it logged. An empty snapshot asserts that it logged none.
+
 ### 3. Assert with inline snapshots, not `str contains`
 
 Assert on output with an exact inline `snapshot`, never with `str contains`. A

--- a/packages/cli/tests/build/child_lease_released_once.nu
+++ b/packages/cli/tests/build/child_lease_released_once.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+
+# A parent process finishing releases each child lease exactly once. A lease
+# that the child's handle already released is not released again by the parent,
+# so the server logs no error.
+
+let server = spawn --config { tracing: { stderr_format: 'json' } }
+
+# The two spawns deduplicate to one child holding two leases, so cancelling the
+# first leaves the child running until the parent finishes.
+let path = artifact {
+	tangram.ts: '
+		export const slow = async () => {
+			await tg.sleep(60);
+			return "slow";
+		};
+
+		export default async () => {
+			let first = await tg.build(slow).spawn();
+			await tg.build(slow).spawn();
+			await first.cancel();
+			return "done";
+		};
+	'
+}
+
+tg build $path | ignore
+
+snapshot (server_errors $server) ''

--- a/packages/cli/tests/build/sandbox_destroy_no_server_error.nu
+++ b/packages/cli/tests/build/sandbox_destroy_no_server_error.nu
@@ -1,0 +1,19 @@
+use ../../test.nu *
+
+# A build that succeeds logs no error on the server. Destroying a sandbox kills
+# the sandbox process, which closes the socket under the server's HTTP client
+# and fails its connection with a broken pipe.
+
+let server = spawn --config { tracing: { stderr_format: 'json' } }
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			return "hello";
+		};
+	'
+}
+
+tg build $path | ignore
+
+snapshot (server_errors $server) ''


### PR DESCRIPTION
Allows snapshotting the server output in nushell tests.

Additionally, adds two tests that demonstrate that excessive noise is logged to servers during regular, non-erroneous operation.