### PR TITLE
fix(builtin): restore builtin process errors

### DIFF
--- a/packages/cli/src/builtin.rs
+++ b/packages/cli/src/builtin.rs
@@ -1,8 +1,4 @@
-use {
-	crate::Cli,
-	std::path::{Path, PathBuf},
-	tangram_client::prelude::*,
-};
+use {crate::Cli, std::path::PathBuf, tangram_client::prelude::*};
 
 mod archive;
 mod checksum;
@@ -29,23 +25,18 @@ pub enum Command {
 	Extract(extract::Args),
 }
 
-impl Command {
-	fn output(&self) -> Option<PathBuf> {
-		let (named, positional) = match self {
-			Self::Archive(args) => (&args.output_named, &args.output_positional),
-			Self::Checksum(args) => (&args.output_named, &args.output_positional),
-			Self::Compress(args) => (&args.output_named, &args.output_positional),
-			Self::Decompress(args) => (&args.output_named, &args.output_positional),
-			Self::Download(args) => (&args.output_named, &args.output_positional),
-			Self::Extract(args) => (&args.output_named, &args.output_positional),
-		};
-		util::resolve_path(named.clone(), positional.clone())
-	}
-}
-
 impl Cli {
 	pub async fn command_builtin(&mut self, args: Args) -> tg::Result<()> {
-		let output = args.command.output();
+		let (named, positional) = match &args.command {
+			Command::Archive(args) => (&args.output_named, &args.output_positional),
+			Command::Checksum(args) => (&args.output_named, &args.output_positional),
+			Command::Compress(args) => (&args.output_named, &args.output_positional),
+			Command::Decompress(args) => (&args.output_named, &args.output_positional),
+			Command::Download(args) => (&args.output_named, &args.output_positional),
+			Command::Extract(args) => (&args.output_named, &args.output_positional),
+		};
+		let output_path = util::resolve_path(named.clone(), positional.clone());
+
 		let result = match args.command {
 			Command::Archive(args) => archive::run(args).await,
 			Command::Checksum(args) => checksum::run(args).await,
@@ -55,44 +46,38 @@ impl Cli {
 			Command::Extract(args) => extract::run(args).await,
 		};
 
-		if let Err(error) = &result {
-			Self::write_builtin_error(output.as_deref(), error).await?;
+		if let Err(error) = &result
+			&& let (Some(tangram_output_path), Some(output_path)) = (
+				std::env::var_os("TANGRAM_OUTPUT").map(PathBuf::from),
+				output_path.as_deref(),
+			) && tangram_output_path == output_path
+		{
+			// Get the error data.
+			let Some(data) = error
+				.state()
+				.object()
+				.map(|object| object.unwrap_error_ref().to_data())
+			else {
+				return result;
+			};
+
+			// Create the output if the builtin did not, because the xattr requires it.
+			if tokio::fs::symlink_metadata(&tangram_output_path)
+				.await
+				.is_err()
+			{
+				tokio::fs::write(&tangram_output_path, b"").await.map_err(
+					|error| tg::error!(!error, path = %tangram_output_path.display(), "failed to write the output"),
+				)?;
+			}
+
+			// Write the error xattr.
+			let json = serde_json::to_vec(&data)
+				.map_err(|error| tg::error!(!error, "failed to serialize the error"))?;
+			xattr::set(&tangram_output_path, "user.tangram.error", &json)
+				.map_err(|error| tg::error!(!error, "failed to write the error xattr"))?;
 		}
 
 		result
-	}
-
-	async fn write_builtin_error(output: Option<&Path>, error: &tg::Error) -> tg::Result<()> {
-		let path = std::env::var_os("TANGRAM_OUTPUT").map(PathBuf::from);
-		let (Some(path), Some(output)) = (path, output) else {
-			return Ok(());
-		};
-		if path != output {
-			return Ok(());
-		}
-
-		// Get the error data.
-		let Some(data) = error
-			.state()
-			.object()
-			.map(|object| object.unwrap_error_ref().to_data())
-		else {
-			return Ok(());
-		};
-
-		// Create the output if the builtin did not, because the xattr requires it.
-		if tokio::fs::symlink_metadata(&path).await.is_err() {
-			tokio::fs::write(&path, b"").await.map_err(
-				|error| tg::error!(!error, path = %path.display(), "failed to write the output"),
-			)?;
-		}
-
-		// Write the error xattr.
-		let json = serde_json::to_vec(&data)
-			.map_err(|error| tg::error!(!error, "failed to serialize the error"))?;
-		xattr::set(&path, "user.tangram.error", &json)
-			.map_err(|error| tg::error!(!error, "failed to write the error xattr"))?;
-
-		Ok(())
 	}
 }

--- a/packages/cli/src/builtin.rs
+++ b/packages/cli/src/builtin.rs
@@ -1,4 +1,8 @@
-use {crate::Cli, std::path::PathBuf, tangram_client::prelude::*};
+use {
+	crate::Cli,
+	std::path::{Path, PathBuf},
+	tangram_client::prelude::*,
+};
 
 mod archive;
 mod checksum;
@@ -25,8 +29,23 @@ pub enum Command {
 	Extract(extract::Args),
 }
 
+impl Command {
+	fn output(&self) -> Option<PathBuf> {
+		let (named, positional) = match self {
+			Self::Archive(args) => (&args.output_named, &args.output_positional),
+			Self::Checksum(args) => (&args.output_named, &args.output_positional),
+			Self::Compress(args) => (&args.output_named, &args.output_positional),
+			Self::Decompress(args) => (&args.output_named, &args.output_positional),
+			Self::Download(args) => (&args.output_named, &args.output_positional),
+			Self::Extract(args) => (&args.output_named, &args.output_positional),
+		};
+		util::resolve_path(named.clone(), positional.clone())
+	}
+}
+
 impl Cli {
 	pub async fn command_builtin(&mut self, args: Args) -> tg::Result<()> {
+		let output = args.command.output();
 		let result = match args.command {
 			Command::Archive(args) => archive::run(args).await,
 			Command::Checksum(args) => checksum::run(args).await,
@@ -37,17 +56,20 @@ impl Cli {
 		};
 
 		if let Err(error) = &result {
-			Self::write_builtin_error(error).await?;
+			Self::write_builtin_error(output.as_deref(), error).await?;
 		}
 
 		result
 	}
 
-	async fn write_builtin_error(error: &tg::Error) -> tg::Result<()> {
-		// Get the output path.
-		let Some(path) = std::env::var_os("TANGRAM_OUTPUT").map(PathBuf::from) else {
+	async fn write_builtin_error(output: Option<&Path>, error: &tg::Error) -> tg::Result<()> {
+		let path = std::env::var_os("TANGRAM_OUTPUT").map(PathBuf::from);
+		let (Some(path), Some(output)) = (path, output) else {
 			return Ok(());
 		};
+		if path != output {
+			return Ok(());
+		}
 
 		// Get the error data.
 		let Some(data) = error

--- a/packages/cli/src/builtin.rs
+++ b/packages/cli/src/builtin.rs
@@ -1,4 +1,4 @@
-use crate::Cli;
+use {crate::Cli, std::path::PathBuf, tangram_client::prelude::*};
 
 mod archive;
 mod checksum;
@@ -26,14 +26,51 @@ pub enum Command {
 }
 
 impl Cli {
-	pub async fn command_builtin(&mut self, args: Args) -> tangram_client::Result<()> {
-		match args.command {
+	pub async fn command_builtin(&mut self, args: Args) -> tg::Result<()> {
+		let result = match args.command {
 			Command::Archive(args) => archive::run(args).await,
 			Command::Checksum(args) => checksum::run(args).await,
 			Command::Compress(args) => compress::run(args).await,
 			Command::Decompress(args) => decompress::run(args).await,
 			Command::Download(args) => download::run(args).await,
 			Command::Extract(args) => extract::run(args).await,
+		};
+
+		if let Err(error) = &result {
+			Self::write_builtin_error(error).await?;
 		}
+
+		result
+	}
+
+	async fn write_builtin_error(error: &tg::Error) -> tg::Result<()> {
+		// Get the output path.
+		let Some(path) = std::env::var_os("TANGRAM_OUTPUT").map(PathBuf::from) else {
+			return Ok(());
+		};
+
+		// Get the error data.
+		let Some(data) = error
+			.state()
+			.object()
+			.map(|object| object.unwrap_error_ref().to_data())
+		else {
+			return Ok(());
+		};
+
+		// Create the output if the builtin did not, because the xattr requires it.
+		if tokio::fs::symlink_metadata(&path).await.is_err() {
+			tokio::fs::write(&path, b"").await.map_err(
+				|error| tg::error!(!error, path = %path.display(), "failed to write the output"),
+			)?;
+		}
+
+		// Write the error xattr.
+		let json = serde_json::to_vec(&data)
+			.map_err(|error| tg::error!(!error, "failed to serialize the error"))?;
+		xattr::set(&path, "user.tangram.error", &json)
+			.map_err(|error| tg::error!(!error, "failed to write the error xattr"))?;
+
+		Ok(())
 	}
 }

--- a/packages/cli/tests/download/error_status.nu
+++ b/packages/cli/tests/download/error_status.nu
@@ -1,0 +1,19 @@
+use ../../test.nu *
+
+# Downloading a URL that responds with an error status fails with the reason on the CLI.
+
+skip_if_offline
+
+let server = spawn
+
+let output = tg download "http://www.example.com/does-not-exist" --checksum sha256:any | complete
+failure $output
+snapshot --normalize $output.stderr '
+	error an error occurred
+	-> the process failed
+	   id = pcs_0000000000000000000000000000
+	-> expected a success status
+	   url = http://www.example.com/does-not-exist
+	-> HTTP status client error (404 Not Found) for url (http://www.example.com/does-not-exist)
+
+'

--- a/packages/cli/tests/download/manual_output.nu
+++ b/packages/cli/tests/download/manual_output.nu
@@ -1,0 +1,35 @@
+use ../../test.nu *
+
+# A manual builtin invocation reports the reason on stderr without writing to a process output path.
+
+skip_if_offline
+
+let directory = mktemp -d
+let output_path = $directory | path join 'output'
+let process_output_path = $directory | path join 'process_output'
+
+# Without a process output path, the failure is reported and nothing is written.
+let output = with-env { TANGRAM_OUTPUT: null } {
+	tg builtin download --output $output_path "http://www.example.com/does-not-exist" | complete
+}
+failure $output
+snapshot --normalize $output.stderr '
+	-> expected a success status
+	   url = http://www.example.com/does-not-exist
+	-> HTTP status client error (404 Not Found) for url (http://www.example.com/does-not-exist)
+
+'
+assert (not ($output_path | path exists)) "the output should not be written"
+
+# With an unrelated process output path, the failure is not written to it.
+let output = with-env { TANGRAM_OUTPUT: $process_output_path } {
+	tg builtin download --output $output_path "http://www.example.com/does-not-exist" | complete
+}
+failure $output
+snapshot --normalize $output.stderr '
+	-> expected a success status
+	   url = http://www.example.com/does-not-exist
+	-> HTTP status client error (404 Not Found) for url (http://www.example.com/does-not-exist)
+
+'
+assert (not ($process_output_path | path exists)) "the process output should not be written"

--- a/packages/cli/tests/js/builtin/download_error_status.nu
+++ b/packages/cli/tests/js/builtin/download_error_status.nu
@@ -1,0 +1,36 @@
+use ../../../test.nu *
+
+# A tg.download that responds with an error status fails with the reason on the CLI.
+
+skip_if_offline
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			return await tg.download("http://www.example.com/does-not-exist");
+		}
+	'
+}
+
+let output = tg build $path | complete
+failure $output
+snapshot --normalize --redact $path $output.stderr '
+	error an error occurred
+	-> the process failed
+	   id = pcs_0000000000000000000000000000
+	-> the child process failed
+	   id = pcs_0011111111111111111111111111
+	   ╭─[<redacted>/tangram.ts:2:9]
+	 1 │ export default async function () {
+	 2 │     return await tg.download("http://www.example.com/does-not-exist");
+	   ·            ▲
+	   ·            ╰── the child process failed
+	 3 │ }
+	   ╰────
+	-> expected a success status
+	   url = http://www.example.com/does-not-exist
+	-> HTTP status client error (404 Not Found) for url (http://www.example.com/does-not-exist)
+
+'


### PR DESCRIPTION
Fixes a regression introduced in fd3cf3e2 in which builtin processes that failed, such as a failed download, no longer pass their error up to the CLI stderr. The process exited with code 1, but stderr was empty.

I confirmed this functionality worked as intended before the refactor.