### PR TITLE
fix(vfs): stabilize concurrent io_uring mounts

### DIFF
--- a/packages/cli/tests/vfs/io_uring_sandbox_concurrent_spawn.nu
+++ b/packages/cli/tests/vfs/io_uring_sandbox_concurrent_spawn.nu
@@ -2,8 +2,8 @@ use ../../test.nu *
 
 # Every sandboxed process execs its executable through its own per-sandbox FUSE mount, so a build
 # that runs many short-lived sandboxed processes creates and tears down that many FUSE connections.
-# With the io_uring transport, a connection is not always serving by the time its sandbox execs, and
-# the spawn fails with ENOTCONN, or the mount is already gone and the handshake fails with ENODEV.
+# This exercises the readiness handshake and connection teardown ordering that keep one sandbox
+# from observing ENOTCONN or ENODEV while another sandbox is being destroyed.
 
 if $nu.os-info.name != 'linux' {
 	skip_test 'this test requires linux'

--- a/packages/cli/tests/vfs/io_uring_sandbox_concurrent_spawn.nu
+++ b/packages/cli/tests/vfs/io_uring_sandbox_concurrent_spawn.nu
@@ -1,0 +1,38 @@
+use ../../test.nu *
+
+# Every sandboxed process execs its executable through its own per-sandbox FUSE mount, so a build
+# that runs many short-lived sandboxed processes creates and tears down that many FUSE connections.
+# With the io_uring transport, a connection is not always serving by the time its sandbox execs, and
+# the spawn fails with ENOTCONN, or the mount is already gone and the handshake fails with ENODEV.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+if not (fuse_io_uring_available) {
+	skip_test 'this test requires FUSE io_uring support'
+}
+
+let server = spawn --config {
+	vfs: {
+		io: 'io_uring'
+		kind: 'fuse'
+		passthrough: 'disabled'
+	}
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			const script = tg.file("#!/bin/sh\necho \"$1\"", { executable: true });
+			const outputs = await Promise.all(
+				Array.from({ length: 256 }, (_, index) =>
+					tg.run({ args: [String(index)], executable: script }).sandbox(),
+				),
+			);
+			return outputs.length;
+		}
+	'
+}
+
+let output = tg run $path | complete
+success $output 'every concurrent sandboxed process should spawn'

--- a/packages/cli/tests/vfs/io_uring_sandbox_spawn.nu
+++ b/packages/cli/tests/vfs/io_uring_sandbox_spawn.nu
@@ -1,0 +1,43 @@
+use ../../test.nu *
+
+# Every sandboxed process execs its executable through its own per-sandbox FUSE mount. With the
+# io_uring transport each of those mounts creates an SQPOLL ring plus a ring per worker thread, and
+# the rings are charged against the process's locked memory limit, so enough concurrent sandboxes
+# exhaust it and their processes fail to spawn. The runner capacity is set here so the number of
+# concurrent sandboxes does not depend on the host's core count.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+if not (fuse_io_uring_available) {
+	skip_test 'this test requires FUSE io_uring support'
+}
+
+let server = spawn --config {
+	runner: {
+		cpus: 128,
+		memory: (128e9 | into int),
+	}
+	vfs: {
+		io: 'io_uring'
+		kind: 'fuse'
+		passthrough: 'disabled'
+	}
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			const script = tg.file("#!/bin/sh\necho \"$1\"", { executable: true });
+			const outputs = await Promise.all(
+				Array.from({ length: 256 }, (_, index) =>
+					tg.run({ args: [String(index)], executable: script }).sandbox(),
+				),
+			);
+			return outputs.length;
+		}
+	'
+}
+
+let output = tg run $path | complete
+success $output 'every concurrent sandboxed process should spawn'

--- a/packages/cli/tests/vfs/io_uring_sandbox_spawn.nu
+++ b/packages/cli/tests/vfs/io_uring_sandbox_spawn.nu
@@ -1,10 +1,9 @@
 use ../../test.nu *
 
-# Every sandboxed process execs its executable through its own per-sandbox FUSE mount. With the
-# io_uring transport each of those mounts creates an SQPOLL ring plus a ring per worker thread, and
-# the rings are charged against the process's locked memory limit, so enough concurrent sandboxes
-# exhaust it and their processes fail to spawn. The runner capacity is set here so the number of
-# concurrent sandboxes does not depend on the host's core count.
+# Every sandboxed process execs its executable through its own per-sandbox FUSE mount. This ensures
+# that the lightweight per-sandbox io_uring configuration stays within the process's locked memory
+# limit under high concurrency. The runner capacity is set here so the number of concurrent
+# sandboxes does not depend on the host's core count.
 
 if $nu.os-info.name != 'linux' {
 	skip_test 'this test requires linux'

--- a/packages/server/src/runner/sandbox.rs
+++ b/packages/server/src/runner/sandbox.rs
@@ -701,7 +701,7 @@ impl Session {
 			serve_task,
 			temp,
 			#[cfg(target_os = "linux")]
-			vfs,
+			mut vfs,
 			#[cfg(target_os = "linux")]
 			vfs_principal,
 		} = create_output;
@@ -746,9 +746,12 @@ impl Session {
 			state,
 			stopper,
 		};
+		#[cfg(target_os = "linux")]
+		let result = self.run_sandbox_task(arg, &mut vfs).boxed().await;
+		#[cfg(not(target_os = "linux"))]
 		let result = self.run_sandbox_task(arg).boxed().await;
 
-		// Stop the VFS.
+		// Stop the VFS after an early sandbox task failure.
 		#[cfg(target_os = "linux")]
 		if let Some(vfs) = vfs {
 			vfs.stop();
@@ -761,7 +764,11 @@ impl Session {
 		self.retain_sandbox_task(arg).await
 	}
 
-	async fn run_sandbox_task(&self, arg: RunSandboxTaskArg) -> tg::Result<RetainSandboxTaskArg> {
+	async fn run_sandbox_task(
+		&self,
+		arg: RunSandboxTaskArg,
+		#[cfg(target_os = "linux")] vfs: &mut Option<crate::vfs::Server>,
+	) -> tg::Result<RetainSandboxTaskArg> {
 		let RunSandboxTaskArg {
 			mut control,
 			event_sender,
@@ -996,6 +1003,13 @@ impl Session {
 			.wait()
 			.await
 			.map_err(|error| tg::error!(!error, "the serve task panicked"))?;
+
+		// Stop the VFS while the sandbox still owns its mount namespace.
+		#[cfg(target_os = "linux")]
+		if let Some(vfs) = vfs.take() {
+			vfs.stop();
+			vfs.wait().await;
+		}
 
 		// Destroy the sandbox while retaining its process and control state.
 		sandbox

--- a/packages/server/src/runner/sandbox/pool.rs
+++ b/packages/server/src/runner/sandbox/pool.rs
@@ -114,18 +114,18 @@ async fn destroy(output: CreateSandboxOutput) -> tg::Result<()> {
 		.await
 		.map_err(|error| tg::error!(!error, "the pooled sandbox serve task panicked"));
 
-	// Destroy the sandbox process.
-	let sandbox_result = sandbox
-		.destroy()
-		.await
-		.map_err(|error| tg::error!(!error, "failed to destroy the pooled sandbox process"));
-
-	// Stop the VFS.
+	// Stop the VFS while the sandbox still owns its mount namespace.
 	#[cfg(target_os = "linux")]
 	if let Some(vfs) = vfs {
 		vfs.stop();
 		vfs.wait().await;
 	}
+
+	// Destroy the sandbox process.
+	let sandbox_result = sandbox
+		.destroy()
+		.await
+		.map_err(|error| tg::error!(!error, "failed to destroy the pooled sandbox process"));
 
 	// Remove the temp directory.
 	let temp_result = temp

--- a/packages/vfs/src/fuse.rs
+++ b/packages/vfs/src/fuse.rs
@@ -24,7 +24,7 @@ use {
 		io::Error,
 		mem::{MaybeUninit, size_of},
 		ops::Deref,
-		os::fd::{AsFd as _, AsRawFd as _, OwnedFd, RawFd},
+		os::fd::{AsFd as _, AsRawFd as _, OwnedFd},
 		os::unix::ffi::OsStringExt as _,
 		os::unix::process::CommandExt as _,
 		path::Path,
@@ -59,6 +59,7 @@ const FUSE_DEV_IOC_BACKING_OPEN: rustix::ioctl::Opcode =
 	rustix::ioctl::opcode::write::<sys::fuse_backing_map>(FUSE_DEV_IOC_MAGIC, 1);
 const FUSE_DEV_IOC_BACKING_CLOSE: rustix::ioctl::Opcode =
 	rustix::ioctl::opcode::write::<u32>(FUSE_DEV_IOC_MAGIC, 2);
+const FUSE_MOUNT_READY_TIMEOUT: Duration = Duration::from_secs(5);
 const S_IFDIR: u32 = 0o040_000;
 const S_IFREG: u32 = 0o100_000;
 const S_IFLNK: u32 = 0o120_000;
@@ -300,8 +301,35 @@ pub fn mount_dev_fuse(sendfd: &OwnedFd, path: &Path) -> std::io::Result<()> {
 	let mut cmsg_space = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(1))];
 	let mut cmsg_buffer = SendAncillaryBuffer::new(&mut cmsg_space);
 	cmsg_buffer.push(SendAncillaryMessage::ScmRights(&fds));
-	rustix::net::sendmsg(sendfd, &iovecs, &mut cmsg_buffer, SendFlags::empty())
+	rustix::net::sendmsg(sendfd, &iovecs, &mut cmsg_buffer, SendFlags::NOSIGNAL)
 		.map_err(Error::from)?;
+
+	// Wait for the server to start the transport workers.
+	let mut ready = [0u8; 1];
+	let size = loop {
+		match rustix::io::read(sendfd, &mut ready) {
+			Err(Errno::INTR) => {},
+			Err(error) => return Err(Error::from(error)),
+			Ok(size) => break size,
+		}
+	};
+	if size != 1 {
+		return Err(Error::other(
+			"the FUSE server stopped before starting the transport",
+		));
+	}
+
+	// Confirm that the server can service a request through the mounted filesystem.
+	let mut entries = std::fs::read_dir(path)?;
+	entries.next().transpose()?;
+
+	// Signal that the mount is ready.
+	let size = rustix::net::send(sendfd, &[0], SendFlags::NOSIGNAL).map_err(Error::from)?;
+	if size != 1 {
+		return Err(Error::other(
+			"failed to signal that the FUSE mount is ready",
+		));
+	}
 
 	Ok(())
 }

--- a/packages/vfs/src/fuse/connection.rs
+++ b/packages/vfs/src/fuse/connection.rs
@@ -3,9 +3,10 @@ use super::*;
 const READ_WRITE_MAX_READER_COUNT: usize = 8;
 
 pub(super) struct Connection {
+	pub(super) abort: OwnedFd,
 	pub(super) fd: Arc<OwnedFd>,
 	pub(super) features: Features,
-	pub(super) id: u64,
+	pub(super) ready: Option<Arc<OwnedFd>>,
 }
 
 impl<P> Server<P>
@@ -19,13 +20,27 @@ where
 		supports_no_opendir: bool,
 		fd: Arc<OwnedFd>,
 		connection_id: Option<u64>,
+		ready: Option<Arc<OwnedFd>>,
 	) -> Result<Connection> {
-		let features = Self::init_handshake(fd.as_ref(), options, limits, supports_no_opendir)?;
 		let id = match connection_id {
 			None => self::connection_id(path)?,
 			Some(connection_id) => connection_id,
 		};
-		Ok(Connection { fd, features, id })
+		let abort = Self::open_connection_abort(id)?;
+		let features = match Self::init_handshake(fd.as_ref(), options, limits, supports_no_opendir)
+		{
+			Err(error) => {
+				Self::abort_connection(&abort).ok();
+				return Err(error);
+			},
+			Ok(features) => features,
+		};
+		Ok(Connection {
+			abort,
+			fd,
+			features,
+			ready,
+		})
 	}
 
 	pub(super) fn mount(recvfd: &OwnedFd) -> Result<(Arc<OwnedFd>, Option<u64>)> {
@@ -217,8 +232,8 @@ where
 		Ok(())
 	}
 
-	pub(super) async fn disconnect_transport(&self, path: &Path, connection_id: u64) -> bool {
-		let aborted = Self::abort_connection(connection_id)
+	pub(super) async fn disconnect_transport(&self, abort: &OwnedFd, path: &Path) -> bool {
+		let aborted = Self::abort_connection(abort)
 			.inspect_err(|error| tracing::error!(%error, "failed to abort the FUSE connection"))
 			.is_ok();
 		if self.auto_unmount {
@@ -231,13 +246,63 @@ where
 		aborted
 	}
 
-	pub(super) fn abort_connection(connection_id: u64) -> Result<()> {
+	pub(super) fn open_connection_abort(connection_id: u64) -> Result<OwnedFd> {
 		let abort = Path::new("/sys/fs/fuse/connections")
 			.join(connection_id.to_string())
 			.join("abort");
-		std::fs::write(abort, b"1")?;
+		let abort = std::fs::File::options()
+			.write(true)
+			.open(abort)
+			.map_err(|error| {
+				Error::other(format!(
+					"failed to open the abort descriptor for FUSE connection {connection_id}: {error}",
+				))
+			})?
+			.into();
+
+		Ok(abort)
+	}
+
+	pub(super) fn abort_connection(abort: &OwnedFd) -> Result<()> {
+		let size = rustix::io::write(abort, b"1")?;
+		if size != 1 {
+			return Err(Error::other("failed to abort the FUSE connection"));
+		}
 
 		Ok(())
+	}
+
+	pub(super) async fn wait_for_mount_ready(ready: Arc<OwnedFd>) -> Result<()> {
+		let size = rustix::net::send(ready.as_ref(), &[0], SendFlags::NOSIGNAL)?;
+		if size != 1 {
+			return Err(Error::other(
+				"failed to signal that the FUSE transport is ready",
+			));
+		}
+		let wait = tokio::task::spawn_blocking(move || {
+			let mut buffer = [0u8; 1];
+			let size = loop {
+				match rustix::io::read(ready.as_ref(), &mut buffer) {
+					Err(Errno::INTR) => {},
+					Err(error) => return Err(Error::from(error)),
+					Ok(size) => break size,
+				}
+			};
+			if size != 1 {
+				return Err(Error::other("the FUSE mount readiness channel closed"));
+			}
+
+			Ok(())
+		});
+		let result = tokio::time::timeout(FUSE_MOUNT_READY_TIMEOUT, wait)
+			.await
+			.map_err(|_| Error::other("timed out waiting for the FUSE mount readiness probe"))?
+			.map_err(|error| {
+				Error::other(format!("the FUSE mount readiness task failed: {error}"))
+			})?;
+		result.map_err(|error| {
+			Error::other(format!("the FUSE mount readiness probe failed: {error}"))
+		})
 	}
 
 	pub(super) fn join_transport_threads(
@@ -358,7 +423,7 @@ pub(super) fn parse_connection_id(mountinfo: &str, path: &Path) -> Result<u64> {
 		let Some((major, minor)) = fields.get(2).and_then(|device| device.split_once(':')) else {
 			continue;
 		};
-		let major = major.parse::<u32>().map_err(|error| {
+		major.parse::<u32>().map_err(|error| {
 			Error::other(format!(
 				"failed to parse the FUSE device major number: {error}"
 			))
@@ -368,7 +433,7 @@ pub(super) fn parse_connection_id(mountinfo: &str, path: &Path) -> Result<u64> {
 				"failed to parse the FUSE device minor number: {error}"
 			))
 		})?;
-		let connection_id = libc::makedev(major, minor);
+		let connection_id = u64::from(minor);
 
 		return Ok(connection_id);
 	}

--- a/packages/vfs/src/fuse/read_write.rs
+++ b/packages/vfs/src/fuse/read_write.rs
@@ -15,6 +15,7 @@ pub(super) struct ReadWriteStartupContext<'a> {
 	pub(super) event_sender: tokio::sync::mpsc::UnboundedSender<WorkerEvent>,
 	pub(super) limits: RequestLimits,
 	pub(super) path: &'a Path,
+	pub(super) ready: Option<Arc<OwnedFd>>,
 }
 
 impl<P> Server<P>
@@ -34,12 +35,13 @@ where
 			event_sender,
 			limits,
 			path,
+			ready,
 		} = context;
 
 		// Prepare the readers and dispatcher.
 		let reader_fds = match Self::clone_read_write_fds(&connection.fd) {
 			Err(error) => {
-				self.disconnect_transport(path, connection.id).await;
+				self.disconnect_transport(&connection.abort, path).await;
 				return Err(error);
 			},
 			Ok(reader_fds) => reader_fds,
@@ -115,11 +117,17 @@ where
 				}
 			}
 		}
+		if startup_error.is_none()
+			&& let Some(ready) = ready
+			&& let Err(error) = Self::wait_for_mount_ready(ready).await
+		{
+			startup_error = Some(error);
+		}
 
 		// Clean up a partial startup.
 		if let Some(error) = startup_error {
 			self.cancel_async_requests();
-			let disconnected = self.disconnect_transport(path, connection.id).await;
+			let disconnected = self.disconnect_transport(&connection.abort, path).await;
 			Self::join_transport_threads(&mut thread_handles, disconnected);
 			if !disconnected {
 				dispatcher.abort();

--- a/packages/vfs/src/fuse/ring.rs
+++ b/packages/vfs/src/fuse/ring.rs
@@ -17,14 +17,14 @@ pub(super) struct RingConfig {
 }
 
 pub(super) struct RingStartupContext<'a> {
-	pub(super) connection_id: u64,
+	pub(super) abort: &'a OwnedFd,
 	pub(super) event_receiver: &'a mut tokio::sync::mpsc::UnboundedReceiver<WorkerEvent>,
 	pub(super) event_sender: tokio::sync::mpsc::UnboundedSender<WorkerEvent>,
 	pub(super) fd: Arc<OwnedFd>,
 	pub(super) path: &'a Path,
+	pub(super) ready: Option<Arc<OwnedFd>>,
 	pub(super) ring_config: RingConfig,
 	pub(super) runtime: tokio::runtime::Handle,
-	pub(super) sqpoll_wq_fd: RawFd,
 }
 
 pub(super) struct RingStartupFailure {
@@ -37,7 +37,6 @@ struct RingWorkerConfig {
 	payload_size: usize,
 	queue_ids: Vec<u16>,
 	slots_per_queue: usize,
-	sqpoll_wq_fd: RawFd,
 	worker_id: usize,
 }
 
@@ -45,7 +44,7 @@ impl<P> Server<P>
 where
 	P: Provider + Send + Sync + 'static,
 {
-	pub(super) fn ring_config(page_size: usize) -> Result<RingConfig> {
+	pub(super) fn ring_config(page_size: usize, external_mount: bool) -> Result<RingConfig> {
 		// Derive the per-queue payload budget.
 		if page_size == 0 {
 			return Err(Error::other("the system page size is zero"));
@@ -64,17 +63,25 @@ where
 		let payload_memory_per_slot = queue_count
 			.checked_mul(limits.payload_size)
 			.ok_or_else(|| Error::other("the io_uring payload memory size overflowed"))?;
-		let slots_per_queue = IO_URING_PAYLOAD_MEMORY_BUDGET
-			.checked_div(payload_memory_per_slot)
-			.unwrap_or(0)
-			.clamp(1, IO_URING_MAX_SLOTS_PER_QUEUE);
+		let slots_per_queue = if external_mount {
+			1
+		} else {
+			IO_URING_PAYLOAD_MEMORY_BUDGET
+				.checked_div(payload_memory_per_slot)
+				.unwrap_or(0)
+				.clamp(1, IO_URING_MAX_SLOTS_PER_QUEUE)
+		};
 
 		// Derive the worker count.
 		let available_parallelism =
 			std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
-		let worker_count = available_parallelism
-			.min(queue_count)
-			.clamp(1, IO_URING_MAX_READER_COUNT);
+		let worker_count = if external_mount {
+			1
+		} else {
+			available_parallelism
+				.min(queue_count)
+				.clamp(1, IO_URING_MAX_READER_COUNT)
+		};
 
 		Ok(RingConfig {
 			limits,
@@ -171,14 +178,14 @@ where
 		context: RingStartupContext<'_>,
 	) -> std::result::Result<Vec<std::thread::JoinHandle<()>>, RingStartupFailure> {
 		let RingStartupContext {
-			connection_id,
+			abort,
 			event_receiver,
 			event_sender,
 			fd,
 			path,
+			ready,
 			ring_config,
 			runtime,
-			sqpoll_wq_fd,
 		} = context;
 		let mut thread_handles = Vec::new();
 		let startup = async {
@@ -214,7 +221,6 @@ where
 					payload_size: ring_config.limits.payload_size,
 					queue_ids,
 					slots_per_queue: ring_config.slots_per_queue,
-					sqpoll_wq_fd,
 					worker_id,
 				};
 				let thread = std::thread::Builder::new()
@@ -258,7 +264,10 @@ where
 			}
 
 			// Confirm that the kernel can dispatch through io_uring.
-			Self::probe_io_uring(path).await?;
+			match ready {
+				None => Self::probe_io_uring(path).await?,
+				Some(ready) => Self::wait_for_mount_ready(ready).await?,
+			}
 			while let Ok(event) = event_receiver.try_recv() {
 				if let WorkerEvent::Failed { error, worker } = event {
 					return Err(Error::other(format!(
@@ -306,7 +315,7 @@ where
 		// Clean up a partial startup.
 		if let Err(error) = startup {
 			self.cancel_async_requests();
-			let disconnected = self.disconnect_transport(path, connection_id).await;
+			let disconnected = self.disconnect_transport(abort, path).await;
 			Self::join_transport_threads(&mut thread_handles, disconnected);
 			if disconnected {
 				self.rollback_all_response_resources(fd.as_ref());

--- a/packages/vfs/src/fuse/ring/worker.rs
+++ b/packages/vfs/src/fuse/ring/worker.rs
@@ -384,7 +384,6 @@ where
 			payload_size,
 			queue_ids,
 			slots_per_queue,
-			sqpoll_wq_fd,
 			worker_id,
 		} = config;
 		let eventfd = rustix::event::eventfd(0, EventfdFlags::CLOEXEC)
@@ -418,7 +417,7 @@ where
 
 		// Create and register the worker ring.
 		let mut builder = IoUring::<io_uring::squeue::Entry128>::builder();
-		builder.setup_attach_wq(sqpoll_wq_fd).setup_no_sqarray();
+		builder.setup_no_sqarray();
 		let io_uring = builder
 			.build(ring_entries)
 			.map_err(|error| Error::other(format!("failed to build the thread ring: {error}")))?;

--- a/packages/vfs/src/fuse/startup.rs
+++ b/packages/vfs/src/fuse/startup.rs
@@ -1,18 +1,17 @@
 use super::{
+	Arc, AtomicBool, DEFAULT_MAX_WRITE, Error, Features, HashMap, Io, Mutex, Options, OwnedFd,
+	Passthrough, PassthroughBackings, Path, Provider, RequestLimits, Result, Server, State,
+	WorkerEvent,
 	connection::Connection,
+	fusermount3,
 	read_write::ReadWriteStartupContext,
 	ring::{RingConfig, RingStartupContext},
-	*,
 };
-
-const IO_URING_ENTRIES: u32 = 256;
-const SQPOLL_IDLE_MS: u32 = 2_000;
-
-type SqpollRing = IoUring<io_uring::squeue::Entry128>;
 
 struct Mount {
 	connection_id: Option<u64>,
 	fd: Arc<OwnedFd>,
+	ready: Option<Arc<OwnedFd>>,
 }
 
 struct StartupConfig {
@@ -51,11 +50,17 @@ where
 	}
 
 	async fn receive_mount(recvfd: OwnedFd) -> Result<Mount> {
-		let (fd, connection_id) = tokio::task::spawn_blocking(move || Self::mount(&recvfd))
+		let (result, recvfd) = tokio::task::spawn_blocking(move || (Self::mount(&recvfd), recvfd))
 			.await
-			.map_err(Error::other)?
-			.inspect_err(|error| tracing::error!(%error, "failed to mount"))?;
-		let mount = Mount { connection_id, fd };
+			.map_err(Error::other)?;
+		let (fd, connection_id) =
+			result.inspect_err(|error| tracing::error!(%error, "failed to mount"))?;
+		let ready = connection_id.is_some().then(|| Arc::new(recvfd));
+		let mount = Mount {
+			connection_id,
+			fd,
+			ready,
+		};
 		Ok(mount)
 	}
 
@@ -66,16 +71,17 @@ where
 		mount: Mount,
 	) -> Result<Self> {
 		// Select ReadWrite before initializing an external connection because it cannot be remounted for a fallback.
-		let auto_unmount = mount.connection_id.is_none();
-		if !auto_unmount && options.io == Io::Auto {
+		let external_mount = mount.connection_id.is_some();
+		let auto_unmount = !external_mount;
+		if external_mount && options.io == Io::Auto {
 			options.io = Io::ReadWrite;
 		}
 
 		// Prepare the FUSE connection.
 		let supports_no_opendir = provider.supports_no_opendir();
-		let mut config = Self::startup_config(options)?;
-		let (mut connection, mut sqpoll_ring) =
-			Self::prepare_connection(path, supports_no_opendir, &mut config, mount).await?;
+		let mut config = Self::startup_config(options, external_mount)?;
+		let mut connection =
+			Self::prepare_connection(path, supports_no_opendir, &config, mount).await?;
 
 		// Create the server state.
 		let server = Self(Arc::new(State {
@@ -99,14 +105,14 @@ where
 				.ring_config
 				.ok_or_else(|| Error::other("missing the io_uring transport configuration"))?;
 			let context = RingStartupContext {
-				connection_id: connection.id,
+				abort: &connection.abort,
 				event_receiver: &mut event_receiver,
 				event_sender: event_sender.clone(),
 				fd: connection.fd.clone(),
 				path,
+				ready: connection.ready.clone(),
 				ring_config,
 				runtime: runtime.clone(),
-				sqpoll_wq_fd: sqpoll_ring.as_ref().unwrap().as_raw_fd(),
 			};
 			match server.start_ring_transport(context).await {
 				Err(failure) if config.options.io == Io::Auto => {
@@ -121,7 +127,7 @@ where
 						error = %failure.error,
 						"failed to start the FUSE io_uring transport; falling back to ReadWrite",
 					);
-					drop(sqpoll_ring.take());
+					drop(connection);
 					config.options.io = Io::ReadWrite;
 					config.limits =
 						Self::request_limits(rustix::param::page_size(), DEFAULT_MAX_WRITE)?;
@@ -133,6 +139,7 @@ where
 						supports_no_opendir,
 						mount.fd,
 						mount.connection_id,
+						mount.ready,
 					)
 					.await?;
 					server.validate_fallback_features(connection.features)?;
@@ -142,6 +149,7 @@ where
 						event_sender: event_sender.clone(),
 						limits: config.limits,
 						path,
+						ready: connection.ready.clone(),
 					};
 					let (threads, dispatcher) = server.start_read_write_transport(context).await?;
 					Transport {
@@ -162,6 +170,7 @@ where
 				event_sender: event_sender.clone(),
 				limits: config.limits,
 				path,
+				ready: connection.ready.clone(),
 			};
 			let (threads, dispatcher) = server.start_read_write_transport(context).await?;
 			Transport {
@@ -181,7 +190,7 @@ where
 			} = transport;
 			shutdown_server.cancel_async_requests();
 			let disconnected = shutdown_server
-				.disconnect_transport(&path, connection.id)
+				.disconnect_transport(&connection.abort, &path)
 				.await;
 			Self::join_transport_threads(&mut threads, disconnected);
 			if let Some(dispatcher) = dispatcher {
@@ -194,7 +203,6 @@ where
 				shutdown_server.rollback_all_response_resources(connection.fd.as_ref());
 			}
 			drop(connection);
-			drop(sqpoll_ring);
 		};
 
 		// Start the transport supervisor.
@@ -214,13 +222,13 @@ where
 		Ok(server)
 	}
 
-	fn startup_config(mut options: Options) -> Result<StartupConfig> {
+	fn startup_config(mut options: Options, external_mount: bool) -> Result<StartupConfig> {
 		// Configure the requested transport.
 		let page_size = rustix::param::page_size();
 		let ring_config = if options.io == Io::ReadWrite {
 			None
 		} else {
-			match Self::ring_config(page_size) {
+			match Self::ring_config(page_size, external_mount) {
 				Err(error) if options.io == Io::Auto => {
 					tracing::warn!(
 						%error,
@@ -250,52 +258,19 @@ where
 	async fn prepare_connection(
 		path: &Path,
 		supports_no_opendir: bool,
-		config: &mut StartupConfig,
-		mut mount: Mount,
-	) -> Result<(Connection, Option<SqpollRing>)> {
-		// Attempt to connect.
-		loop {
-			// Create the connection.
-			let connection = Self::connect(
-				path,
-				config.options,
-				config.limits,
-				supports_no_opendir,
-				mount.fd.clone(),
-				mount.connection_id,
-			)
-			.await?;
-
-			// If io_uring is unsupported fall back to normal i/o.
-			if !connection.features.over_io_uring {
-				return Ok((connection, None));
-			}
-
-			match Self::build_sqpoll_ring() {
-				Err(error) if config.options.io == Io::Auto => {
-					tracing::warn!(
-						%error,
-						"failed to build the FUSE io_uring SQPOLL ring; falling back to the ReadWrite transport",
-					);
-					drop(connection);
-					config.options.io = Io::ReadWrite;
-					config.ring_config = None;
-					config.limits =
-						Self::request_limits(rustix::param::page_size(), DEFAULT_MAX_WRITE)?;
-					mount = Self::remount(path).await?;
-				},
-				Err(error) => return Err(error),
-				Ok(ring) => return Ok((connection, Some(ring))),
-			}
-		}
-	}
-
-	fn build_sqpoll_ring() -> Result<SqpollRing> {
-		let mut builder = IoUring::<io_uring::squeue::Entry128>::builder();
-		builder.setup_sqpoll(SQPOLL_IDLE_MS).setup_no_sqarray();
-		builder
-			.build(IO_URING_ENTRIES)
-			.map_err(|error| Error::other(format!("failed to build an SQPOLL ring: {error}")))
+		config: &StartupConfig,
+		mount: Mount,
+	) -> Result<Connection> {
+		Self::connect(
+			path,
+			config.options,
+			config.limits,
+			supports_no_opendir,
+			mount.fd,
+			mount.connection_id,
+			mount.ready,
+		)
+		.await
 	}
 
 	async fn remount(path: &Path) -> Result<Mount> {

--- a/packages/vfs/src/fuse/tests.rs
+++ b/packages/vfs/src/fuse/tests.rs
@@ -195,6 +195,38 @@ fn parses_possible_cpu_sets() {
 }
 
 #[test]
+fn external_mounts_use_lightweight_ring_configs() {
+	let config = Server::<TestProvider>::ring_config(4096, true).unwrap();
+
+	assert_eq!(config.slots_per_queue, 1);
+	assert_eq!(config.worker_count, 1);
+}
+
+#[tokio::test]
+async fn waits_for_external_mount_readiness_signals() {
+	let (receiver, sender) = rustix::net::socketpair(
+		AddressFamily::UNIX,
+		SocketType::STREAM,
+		SocketFlags::CLOEXEC,
+		None,
+	)
+	.unwrap();
+	let client = tokio::task::spawn_blocking(move || {
+		let mut ready = [0u8; 1];
+		assert_eq!(rustix::io::read(&sender, &mut ready).unwrap(), 1);
+		assert_eq!(
+			rustix::net::send(&sender, &[0], SendFlags::NOSIGNAL).unwrap(),
+			1,
+		);
+	});
+
+	Server::<TestProvider>::wait_for_mount_ready(Arc::new(receiver))
+		.await
+		.unwrap();
+	client.await.unwrap();
+}
+
+#[test]
 fn readlink_responses_validate_targets_without_copying() {
 	let target = Bytes::from_static(b"target");
 	let pointer = target.as_ptr();
@@ -231,12 +263,12 @@ fn stale_uring_slots_are_replaced_with_distinct_buffers() {
 fn parses_fuse_connection_ids_without_accessing_the_mount() {
 	let mountinfo = concat!(
 		"20 1 8:1 / / rw - ext4 /dev/root rw\n",
-		"21 20 0:42 / /tmp/mount\\040point rw - fuse tangram rw\n",
+		"21 20 0:260 / /tmp/mount\\040point rw - fuse tangram rw\n",
 	);
 	let connection_id =
 		connection::parse_connection_id(mountinfo, Path::new("/tmp/mount point")).unwrap();
 
-	assert_eq!(connection_id, libc::makedev(0, 42));
+	assert_eq!(connection_id, 260);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add regression coverage for concurrent and high-volume per-sandbox FUSE mounts using io_uring
- add a two-way readiness handshake for externally created mounts so they are not used before transport workers can serve requests
- use a lightweight io_uring configuration for external mounts and remove the per-connection SQPOLL ring
- retain the fusectl abort descriptor and stop VFS servers before destroying their mount namespaces
- use the plain FUSE device minor as the fusectl connection ID, including IDs above 255

## Root causes

Each external mount created an SQPOLL ring plus multiple worker rings, exhausting locked memory under high concurrency. Separately, the mount creator could continue before the transport was ready, and teardown could destroy the mount namespace before the VFS had stopped. Stress testing also exposed that encoding the mountinfo major/minor pair with `makedev` produced the wrong fusectl directory for connection minors above 255.

## Impact

Concurrent sandboxed processes can reliably start and tear down with the FUSE io_uring transport enabled, without intermittent `ENOTCONN`, `ENODEV`, fusectl lookup failures, or locked-memory exhaustion.

## Validation

The repository does not currently define an automated test CI workflow. These checks were run locally on Linux with `/sys/module/fuse/parameters/enable_uring=Y`:

- `nu packages/cli/test.nu --jobs 1 --timeout 180sec io_uring_sandbox` — 2 passed
- `nu packages/cli/test.nu --jobs 1 --timeout 180sec 'vfs/'` — 15 passed, 1 passthrough test skipped because `CAP_SYS_ADMIN` was unavailable
- `cargo test -p tangram_vfs` — 21 passed
- `bun run check`
- `bun run format`
