### PR TITLE
fix(cli): create tag parents during spawn

### DIFF
--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -458,7 +458,7 @@ impl Cli {
 			let arg = tg::tag::put::Arg {
 				item: id.into(),
 				location: location.clone(),
-				parents: false,
+				parents: true,
 				public: false,
 				specifier: tag.clone(),
 			};

--- a/packages/cli/tests/build/tag_nested.nu
+++ b/packages/cli/tests/build/tag_nested.nu
@@ -1,0 +1,17 @@
+use ../../test.nu *
+
+# Building with a nested tag creates the tag's parents. Publishing always creates them, but building
+# neither creates them nor exposes a flag to request them, so a nested build tag is otherwise
+# impossible to create.
+
+let server = spawn
+
+let module = artifact {
+	tangram.ts: 'export default function () { return tg.file("test"); }',
+}
+
+let output = tg build --detach --tag test/builds/1.0.0/default $module | complete
+success $output "building with a nested tag should create the tag's parents"
+
+let tag = tg tag get test/builds/1.0.0/default | complete
+success $tag "the nested tag should exist after the build"


### PR DESCRIPTION
Fixes a regression left over from bd60fee31 in which `tg build --tag` now fails to create requested tag parents.