### PR TITLE
fix(server): do not cleanup expired sandboxes via sandbox control in single process mode

### DIFF
--- a/packages/cli/tests/server/restart_after_kill.nu
+++ b/packages/cli/tests/server/restart_after_kill.nu
@@ -2,6 +2,7 @@ use ../../test.nu *
 
 # A server that is killed while a process is running must be able to start again. It currently hangs before it signals readiness, so the server directory is unusable until the index is deleted.
 
+print -e 'spawning the server'
 let server = spawn
 
 let path = artifact {
@@ -14,18 +15,26 @@ let path = artifact {
 	'
 }
 
+print -e 'building'
 let build = tg build --detach --verbose $path | from json
 let process = $build.process
+print -e $'built ($process)'
 
 # Wait until the process is running, so that the server is killed with work in flight.
 wait_until { (tg log $process | complete).stdout | str contains 'started' } "the process must start"
+print -e 'the process is running'
 
 # Kill the server.
 let pid = open ($server.directory | path join 'lock') | into int
+print -e $'killing the server ($pid)'
 kill --signal 9 $pid
 wait_until { ps | where pid == $pid | is-empty } "the server must stop"
+print -e 'the server stopped'
 
 # The server must start again and be usable.
+print -e 'spawning the server again'
 spawn --directory $server.directory --url $server.url
+print -e 'the server started again'
 let output = tg health | complete
 success $output "the server must be usable after being killed"
+print -e 'the server is healthy'

--- a/packages/cli/tests/server/restart_after_kill.nu
+++ b/packages/cli/tests/server/restart_after_kill.nu
@@ -1,0 +1,31 @@
+use ../../test.nu *
+
+# A server that is killed while a process is running must be able to start again. It currently hangs before it signals readiness, so the server directory is unusable until the index is deleted.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			console.log("started");
+			await tg.sleep(60);
+			return tg.file("hello");
+		};
+	'
+}
+
+let build = tg build --detach --verbose $path | from json
+let process = $build.process
+
+# Wait until the process is running, so that the server is killed with work in flight.
+wait_until { (tg log $process | complete).stdout | str contains 'started' } "the process must start"
+
+# Kill the server.
+let pid = open ($server.directory | path join 'lock') | into int
+kill --signal 9 $pid
+wait_until { ps | where pid == $pid | is-empty } "the server must stop"
+
+# The server must start again and be usable.
+spawn --directory $server.directory --url $server.url
+let output = tg health | complete
+success $output "the server must be usable after being killed"

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -1360,22 +1360,13 @@ impl Server {
 			.map_err(|error| tg::error!(!error, "failed to list sandboxes"))?;
 		outputs
 			.into_iter()
-			.map(|output| {
-				let session = session.clone();
-				async move {
-					let error = tg::error::Data {
-						code: Some(tg::error::Code::HeartbeatExpiration),
-						message: Some("heartbeat expired".into()),
-						..Default::default()
-					};
-					let error = Some(tg::Either::Left(error));
-					if let Err(error) = session
-						.try_destroy_sandbox_local(&output.id, error)
-						.boxed()
-						.await
-					{
-						tracing::error!(sandbox = %output.id, error = %error.trace(), "failed to destroy the sandbox");
-					}
+			.map(|output| async move {
+				let result = self
+					.destroy_expired_runner_sandbox(&output.id)
+					.boxed()
+					.await;
+				if let Err(error) = result {
+					tracing::error!(sandbox = %output.id, error = %error.trace(), "failed to destroy the sandbox");
 				}
 			})
 			.collect::<FuturesUnordered<_>>()

--- a/packages/server/src/scheduler/runner.rs
+++ b/packages/server/src/scheduler/runner.rs
@@ -221,7 +221,10 @@ impl Server {
 		Ok(())
 	}
 
-	async fn destroy_expired_runner_sandbox(&self, id: &tg::sandbox::Id) -> tg::Result<()> {
+	pub(crate) async fn destroy_expired_runner_sandbox(
+		&self,
+		id: &tg::sandbox::Id,
+	) -> tg::Result<()> {
 		let now = time::OffsetDateTime::now_utc().unix_timestamp();
 		let error = tg::error::Data {
 			code: Some(tg::error::Code::HeartbeatExpiration),


### PR DESCRIPTION
Demonstrate a server startup bug. After issuing a SIGKILL to a server that is currently running a process, we must be able to restart the server.