### PR TITLE
repro(build): a build may enable network if a checksum is provided

### DIFF
--- a/packages/cli/tests/build/nested_build_network_checksum.nu
+++ b/packages/cli/tests/build/nested_build_network_checksum.nu
@@ -1,0 +1,17 @@
+use ../../test.nu *
+
+# A child build that provides a checksum may enable the network even though its parent build's sandbox does not have the network enabled.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			return await tg.build`true`
+				.network(true)
+				.checksum("sha256:any");
+		}
+	',
+}
+
+success (tg build $path | complete)

--- a/packages/cli/tests/build/nested_sandbox_escalation.nu
+++ b/packages/cli/tests/build/nested_sandbox_escalation.nu
@@ -69,14 +69,17 @@ let network_path = artifact {
 }
 success (tg run --sandbox --network=true $network_path | complete)
 
-assert_denied '
-	export default async function () {
-		return await tg.run`true`
-			.sandbox()
-			.network()
-			.checksum("sha256:any");
-	}
-' 'the child sandbox network is more permissive than the parent sandbox network'
+let checksum_path = artifact {
+	tangram.ts: '
+		export default async function () {
+			return await tg.run`true`
+				.sandbox()
+				.network()
+				.checksum("sha256:any");
+		}
+	',
+}
+success (tg build $checksum_path | complete)
 
 let mount = mktemp --directory | str trim
 let readonly_mount_path = artifact {

--- a/packages/server/src/process/spawn.rs
+++ b/packages/server/src/process/spawn.rs
@@ -74,12 +74,13 @@ impl Session {
 			arg.retry = process.retry;
 		}
 
-		// Validate a child sandbox against its parent.
-		if let Some(parent) = request_origin_sandbox.as_ref().or_else(|| {
-			authenticated_process
-				.as_ref()
-				.map(|process| &process.sandbox)
-		}) && let Some(tg::Either::Left(sandbox)) = &arg.sandbox
+		// Validate an unchecksummed child sandbox against its parent.
+		if arg.checksum.is_none()
+			&& let Some(parent) = request_origin_sandbox.as_ref().or_else(|| {
+				authenticated_process
+					.as_ref()
+					.map(|process| &process.sandbox)
+			}) && let Some(tg::Either::Left(sandbox)) = &arg.sandbox
 		{
 			self.validate_sandbox_create_arg_with_parent(sandbox, parent)
 				.await?;


### PR DESCRIPTION
Illustrate a regression in which a build is no longer able to enable the network despite providing a checksum.

I believe this was introduced in 4ff476d916d8ad5080e410cfa561e2248a717a83.