### PR TITLE
fix incremental solver checkpoint ownership

### DIFF
--- a/packages/cli/tests/checkin/watch_reused_solution_backtrack_key.nu
+++ b/packages/cli/tests/checkin/watch_reused_solution_backtrack_key.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+
+# Incremental backtracking uses candidates for the conflicted dependency rather than candidates saved for another dependency.
+
+let server = spawn
+
+for version in [1.0.0 2.0.0] {
+	let path = artifact { tangram.ts: $'// c ($version)' }
+	tg tag -p $'c/($version)' $path
+}
+for version in [1.0.0 2.0.0] {
+	let path = artifact { tangram.ts: $'// d ($version)' }
+	tg tag -p $'d/($version)' $path
+}
+
+# Establish a watcher whose saved solution selects c/1.0.0.
+let path = artifact {
+	"z.tg.ts": 'import c from "c/^1";'
+}
+tg checkin $path --watch --no-cache-pointers --no-lock | ignore
+
+# Solve d before encountering a new c constraint that conflicts with the saved solution.
+'import d from "d/*";' | save ($path | path join 'a.tg.ts')
+'import c from "c/^2";' | save ($path | path join 'b.tg.ts')
+tg watch touch $path $path
+
+# The c constraints are incompatible, so the checkin must fail rather than resolving c/^2 with a d candidate.
+let output = tg checkin $path --watch --no-cache-pointers --no-lock | complete
+failure $output "the incompatible c constraints should fail"

--- a/packages/server/src/checkin/solve.rs
+++ b/packages/server/src/checkin/solve.rs
@@ -18,9 +18,14 @@ mod prefetch;
 
 struct State<'a> {
 	arg: &'a tg::checkin::Arg,
-	checkpoints: Vec<Checkpoint>,
+	checkpoints: Vec<SavedCheckpoint>,
 	prefetch: Prefetch,
 	root: PathBuf,
+}
+
+struct SavedCheckpoint {
+	checkpoint: Checkpoint,
+	key: tg::specifier::Pattern,
 }
 
 #[derive(Clone)]
@@ -90,9 +95,11 @@ pub struct Solution {
 	pub referrers: Vec<Referrer>,
 }
 
+#[derive(derive_more::IsVariant)]
 enum TagInnerOutput {
-	Solved(tg::Referent<tg::graph::data::Edge<tg::object::Id>>),
 	Conflicted,
+	Reused(tg::Referent<tg::graph::data::Edge<tg::object::Id>>),
+	Selected(tg::Referent<tg::graph::data::Edge<tg::object::Id>>),
 	Unsolved,
 }
 
@@ -381,12 +388,19 @@ impl Session {
 			index: item.referent.item,
 			pattern: Some(tag),
 		};
+		let selected = output.is_selected();
 
 		// Handle the output.
 		match output {
-			TagInnerOutput::Solved(referent) => {
+			TagInnerOutput::Reused(referent) | TagInnerOutput::Selected(referent) => {
 				// Checkpoint.
-				state.checkpoints.push(checkpoint.clone());
+				if selected {
+					let saved_checkpoint = SavedCheckpoint {
+						checkpoint: checkpoint.clone(),
+						key: key.clone(),
+					};
+					state.checkpoints.push(saved_checkpoint);
+				}
 
 				// Add the edge.
 				checkpoint
@@ -483,7 +497,7 @@ impl Session {
 			if !pattern.matches_specifier_for_list(referent.tag().unwrap()) {
 				return Ok(TagInnerOutput::Conflicted);
 			}
-			return Ok(TagInnerOutput::Solved(referent.clone()));
+			return Ok(TagInnerOutput::Reused(referent.clone()));
 		}
 
 		// Get the lock candidate if necessary.
@@ -559,7 +573,7 @@ impl Session {
 		// Add the solution.
 		checkpoint.solutions.insert(key.clone(), solution);
 
-		Ok(TagInnerOutput::Solved(referent))
+		Ok(TagInnerOutput::Selected(referent))
 	}
 
 	fn checkin_solve_get_lock_candidate(
@@ -1265,13 +1279,13 @@ impl Session {
 		let position = state
 			.checkpoints
 			.iter()
-			.position(|checkpoint| checkpoint.solutions.contains_key(key))?;
-		let candidates = state.checkpoints[position].candidates.as_ref()?;
+			.rposition(|checkpoint| &checkpoint.key == key)?;
+		let candidates = state.checkpoints[position].checkpoint.candidates.as_ref()?;
 		if candidates.is_empty() {
 			return None;
 		}
 		state.checkpoints.truncate(position + 1);
-		let mut checkpoint = state.checkpoints.pop()?;
+		let mut checkpoint = state.checkpoints.pop()?.checkpoint;
 		checkpoint.solutions.remove(key);
 		Some(checkpoint)
 	}
@@ -1405,10 +1419,6 @@ impl Solutions {
 
 	pub fn get(&self, key: &tg::specifier::Pattern) -> Option<&Solution> {
 		self.map.get(key)
-	}
-
-	pub fn contains_key(&self, key: &tg::specifier::Pattern) -> bool {
-		self.map.contains_key(key)
 	}
 
 	pub fn insert(&mut self, key: tg::specifier::Pattern, solution: Solution) {


### PR DESCRIPTION
## Summary

- Associate incremental solver checkpoints with the exact dependency key that created them.
- Create checkpoints only for newly selected tag solutions, not reused solutions.
- Backtrack to the most recent checkpoint owned by the failed dependency key.

## Root cause

A reused solution could save a checkpoint offset under the current dependency key even though that solver frame did not own the checkpoint. A later conflict could therefore jump to an unrelated checkpoint and incorrectly accept incompatible constraints.

## Validation

- Added `checkin/watch_reused_solution_backtrack_key.nu`.
- Confirmed the regression failed before the fix because an incompatible checkin incorrectly succeeded.
- Ran the focused solver and watched-checkin tests.
- Ran `bun run check`.

---

Stack 1 of 3.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>