### PR TITLE
fix concurrent checkin watch updates

### DIFF
--- a/packages/cli/tests/checkin/watch_concurrent_options.nu
+++ b/packages/cli/tests/checkin/watch_concurrent_options.nu
@@ -1,0 +1,47 @@
+use ../../test.nu *
+
+# A checkin cannot update a watcher that was replaced by a concurrent checkin with different options.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+let dependency_path = artifact { tangram.ts: '// a 1.0.0' }
+tg tag -p a/1.0.0 $dependency_path
+
+let path = artifact {
+	tangram.ts: 'import a from "a/*";'
+}
+tg checkin $path --watch --no-cache-pointers --no-lock | ignore
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --no-cache-pointers --no-lock | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+# Hold a solved checkin after it snapshots the solved watcher.
+let snapshot_watch = (
+	tg checkpoint watch checkin.watch.snapshot --params '{"solve":true,"updates":""}'
+	| from json
+	| get watch
+)
+let solved_checkin = checkin_background $path
+tg checkpoint wait checkin.watch.snapshot $snapshot_watch 0 | ignore
+
+# Replace the watcher with no-solve state, then allow the stale solved checkin to finish.
+let unsolved = tg checkin $path --watch --no-cache-pointers --no-lock --no-solve
+tg checkpoint continue checkin.watch.snapshot $snapshot_watch 0
+tg checkpoint unwatch checkin.watch.snapshot $snapshot_watch
+let solved_output = job recv --tag $solved_checkin --timeout 10sec
+failure $solved_output "the stale solved checkin should not update the replacement watcher"
+
+# The replacement watcher must retain no-solve state.
+let watched = tg checkin $path --watch --no-cache-pointers --no-lock --no-solve
+let cold = tg checkin $path --no-cache-pointers --no-lock --no-solve
+assert ($unsolved == $cold) "the concurrent no-solve checkin should match a cold checkin"
+assert ($watched == $cold) "the no-solve watcher should not contain stale solved state"

--- a/packages/cli/tests/checkin/watch_concurrent_updates.nu
+++ b/packages/cli/tests/checkin/watch_concurrent_updates.nu
@@ -1,0 +1,46 @@
+use ../../test.nu *
+
+# Concurrent selective updates compare against the watcher revision they originally observed.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+for name in [a b] {
+	let dependency_path = artifact { tangram.ts: $'// ($name) 1.0.0' }
+	tg tag -p $'($name)/1.0.0' $dependency_path
+}
+
+let path = artifact {
+	tangram.ts: '
+		import a from "a/*";
+		import b from "b/*";
+	'
+}
+tg checkin $path --watch --no-cache-pointers --no-lock | ignore
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --no-cache-pointers --no-lock --update a | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+# Hold update a after it snapshots the watcher, then let update b commit first.
+let snapshot_watch = (
+	tg checkpoint watch checkin.watch.snapshot --params '{"updates":"a"}'
+	| from json
+	| get watch
+)
+let update_a = checkin_background $path
+tg checkpoint wait checkin.watch.snapshot $snapshot_watch 0 | ignore
+tg checkin $path --watch --no-cache-pointers --no-lock --update b | ignore
+
+# The stale update must fail rather than overwrite the newer watcher revision.
+tg checkpoint continue checkin.watch.snapshot $snapshot_watch 0
+tg checkpoint unwatch checkin.watch.snapshot $snapshot_watch
+let output = job recv --tag $update_a --timeout 10sec
+failure $output "the stale selective update should not overwrite the watcher"

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -60,6 +60,13 @@ type StoreArgs = IndexMap<tg::object::Id, crate::object::store::PutArg, tg::id::
 
 type GraphData = IndexMap<tg::graph::Id, tg::graph::Data, tg::id::BuildHasher>;
 
+#[derive(Clone, Copy)]
+enum WatchObservation {
+	Compatible { id: crate::watch::Id, version: u64 },
+	Incompatible { id: crate::watch::Id },
+	Vacant,
+}
+
 impl Session {
 	#[tracing::instrument(
 		fields(path = ?arg.path, root = arg.options.root),
@@ -360,23 +367,50 @@ impl Session {
 		};
 
 		// Attempt to get the graph, lock, and solutions from a watcher.
-		let (mut graph, lock, mut solutions, version) = if arg.options.watch
+		let (mut graph, lock, mut solutions, watch_observation) = if arg.options.watch
 			&& let Some(watch) = self.server.watches.get(&watch_key)
-			&& watch.value().options() == &arg.options
 		{
-			let snapshot = watch.value().get();
-			let graph = snapshot.graph;
-			let lock = snapshot.lock;
-			let solutions = snapshot.solutions;
-			let version = Some(snapshot.version);
-			(graph, lock, solutions, version)
+			if watch.value().options() == &arg.options {
+				let snapshot = watch.value().get();
+				let graph = snapshot.graph;
+				let lock = snapshot.lock;
+				let solutions = snapshot.solutions;
+				let watch_observation = WatchObservation::Compatible {
+					id: snapshot.id,
+					version: snapshot.version,
+				};
+				(graph, lock, solutions, watch_observation)
+			} else {
+				let graph = Graph::default();
+				let id = watch.value().id();
+				let lock = None;
+				let solutions = Solutions::default();
+				let watch_observation = WatchObservation::Incompatible { id };
+				(graph, lock, solutions, watch_observation)
+			}
 		} else {
 			let graph = Graph::default();
 			let lock = None;
 			let solutions = Solutions::default();
-			let version = None;
-			(graph, lock, solutions, version)
+			let watch_observation = WatchObservation::Vacant;
+			(graph, lock, solutions, watch_observation)
 		};
+		if arg.options.watch {
+			let updates = arg
+				.updates
+				.iter()
+				.map(ToString::to_string)
+				.collect::<Vec<_>>()
+				.join(",");
+			crate::checkpoint!(
+				self.server,
+				"checkin.watch.snapshot",
+				path = %root.display(),
+				solve = arg.options.solve,
+				updates,
+			)
+			.await;
+		}
 
 		// Read the lock if it was not retrieved from the watcher and the lock option is set.
 		let lock = if let Some(lock) = lock {
@@ -535,8 +569,10 @@ impl Session {
 		{
 			// Create or update the watcher.
 			let entry = self.server.watches.entry(watch_key.clone());
-			match entry {
-				dashmap::Entry::Occupied(entry) if version.is_some() => {
+			match (entry, watch_observation) {
+				(dashmap::Entry::Occupied(entry), WatchObservation::Compatible { id, version })
+					if entry.get().id() == id && entry.get().options() == &arg.options =>
+				{
 					// Verify the version.
 					let watch = entry.get();
 
@@ -557,7 +593,9 @@ impl Session {
 						return Err(tg::error!("files were modified during checkin"));
 					}
 				},
-				dashmap::Entry::Occupied(mut entry) => {
+				(dashmap::Entry::Occupied(mut entry), WatchObservation::Incompatible { id })
+					if entry.get().id() == id =>
+				{
 					// Replace the incompatible watcher.
 					let watch = Watch::new(
 						&self.server,
@@ -571,7 +609,7 @@ impl Session {
 					.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
 					entry.insert(watch);
 				},
-				dashmap::Entry::Vacant(entry) => {
+				(dashmap::Entry::Vacant(entry), WatchObservation::Vacant) => {
 					let watch = Watch::new(
 						&self.server,
 						&watch_key,
@@ -584,6 +622,7 @@ impl Session {
 					.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
 					entry.insert(watch);
 				},
+				_ => return Err(tg::error!("the watch changed during checkin")),
 			}
 
 			// Spawn a task to clean nodes with no referrers.

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -16,7 +16,7 @@ use {
 		ops::{ControlFlow, Deref},
 		os::fd::AsRawFd as _,
 		path::PathBuf,
-		sync::{Arc, Mutex},
+		sync::{Arc, Mutex, atomic::AtomicU64},
 	},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
@@ -119,6 +119,7 @@ pub struct State {
 	lock: Mutex<Option<tokio::fs::File>>,
 	log_store: self::log::Store,
 	messenger: Messenger,
+	next_watch_id: AtomicU64,
 	object_get_tasks: self::object::get::Tasks,
 	object_store: self::object::Store,
 	path: PathBuf,
@@ -755,6 +756,7 @@ impl Server {
 		let vfs = Mutex::new(None);
 
 		// Create the watches.
+		let next_watch_id = AtomicU64::new(0);
 		let watches = DashMap::default();
 
 		// Create the token keys.
@@ -789,6 +791,7 @@ impl Server {
 			lock,
 			log_store,
 			messenger,
+			next_watch_id,
 			object_get_tasks,
 			object_store,
 			path,

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -4,7 +4,7 @@ use {
 	std::{
 		collections::HashSet,
 		path::{Path, PathBuf},
-		sync::{Arc, Mutex},
+		sync::{Arc, Mutex, atomic::Ordering},
 	},
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
@@ -14,6 +14,9 @@ pub mod delete;
 pub mod list;
 pub mod touch;
 
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Id(u64);
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Key {
 	pub path: PathBuf,
@@ -21,6 +24,7 @@ pub struct Key {
 }
 
 pub struct Watch {
+	id: Id,
 	options: tg::checkin::Options,
 	state: Arc<Mutex<State>>,
 	#[expect(dead_code)]
@@ -41,6 +45,7 @@ struct State {
 
 pub struct Snapshot {
 	pub graph: crate::checkin::Graph,
+	pub id: Id,
 	pub lock: Option<Arc<tg::graph::Data>>,
 	pub solutions: crate::checkin::Solutions,
 	pub version: u64,
@@ -53,12 +58,19 @@ pub struct UpdateArg<'a> {
 	pub next: usize,
 	pub server: &'a Server,
 	pub solutions: crate::checkin::Solutions,
-	pub version: Option<u64>,
+	pub version: u64,
 }
 
 struct Message {
 	event: notify::Event,
 	sender: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl Id {
+	#[must_use]
+	fn new(server: &Server) -> Self {
+		Self(server.next_watch_id.fetch_add(1, Ordering::Relaxed))
+	}
 }
 
 impl Watch {
@@ -71,6 +83,8 @@ impl Watch {
 		solutions: crate::checkin::Solutions,
 		#[cfg_attr(not(target_os = "linux"), expect(unused_variables))] next: usize,
 	) -> tg::Result<Self> {
+		let id = Id::new(server);
+
 		// Create the watcher.
 		let config = notify::Config::default();
 		let (sender, mut receiver) = tokio::sync::mpsc::channel::<Message>(1024);
@@ -199,16 +213,21 @@ impl Watch {
 		});
 
 		// Spawn the timeout task.
-		let timeout = Self::spawn_timeout_task(server, key);
+		let timeout = Self::spawn_timeout_task(server, key, id);
 		state.lock().unwrap().timeout_task.replace(timeout);
 
 		let watch = Self {
+			id,
 			options,
 			state,
 			task,
 		};
 
 		Ok(watch)
+	}
+
+	pub fn id(&self) -> Id {
+		self.id
 	}
 
 	pub fn options(&self) -> &tg::checkin::Options {
@@ -219,6 +238,7 @@ impl Watch {
 		let state = self.state.lock().unwrap();
 		Snapshot {
 			graph: state.graph.clone(),
+			id: self.id,
 			lock: state.lock.clone(),
 			solutions: state.solutions.clone(),
 			version: state.version,
@@ -237,9 +257,7 @@ impl Watch {
 		} = arg;
 		let mut state = self.state.lock().unwrap();
 
-		if let Some(version) = version
-			&& state.version != version
-		{
+		if state.version != version {
 			return false;
 		}
 
@@ -247,11 +265,12 @@ impl Watch {
 		state.graph = graph;
 		state.lock = lock;
 		state.solutions = solutions;
+		state.version += 1;
 
 		// Reset the timeout task.
 		state
 			.timeout_task
-			.replace(Self::spawn_timeout_task(server, key));
+			.replace(Self::spawn_timeout_task(server, key, self.id));
 
 		// On Linux, add the new paths.
 		#[cfg(target_os = "linux")]
@@ -314,7 +333,7 @@ impl Watch {
 		changes
 	}
 
-	fn spawn_timeout_task(server: &Server, key: &Key) -> Task<()> {
+	fn spawn_timeout_task(server: &Server, key: &Key, id: Id) -> Task<()> {
 		Task::spawn({
 			let ttl = server.config.watch.clone().unwrap_or_default().ttl;
 			let key = key.clone();
@@ -324,7 +343,7 @@ impl Watch {
 				tokio::time::sleep(ttl).await;
 
 				// Delete the watch.
-				server.watches.remove(&key);
+				server.watches.remove_if(&key, |_, watch| watch.id == id);
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Make watched checkin commits compare-and-swap against the observed watch identity, version, and options.
- Use `tangram_server::watch::Id` backed by a server-local incrementing `AtomicU64`.
- Increment the watch version on every successful update and make timeout removal identity-safe.

## Root cause

Concurrent checkins could snapshot the same watch and both commit their results. The later stale commit could overwrite a newer graph or incompatible options because the map entry itself was not validated atomically at commit time.

## Validation

- Added `checkin/watch_concurrent_updates.nu` and `checkin/watch_concurrent_options.nu`.
- Confirmed both regressions failed before the fix because stale checkins incorrectly succeeded.
- Ran the full watched-checkin test group.
- Ran `bun run check`.

---

Stack 2 of 3. Depends on #1009.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>