### PR TITLE
fix incremental checkin indexing synchronization

### DIFF
--- a/packages/cli/tests/checkin/watch_multi_process_mode.nu
+++ b/packages/cli/tests/checkin/watch_multi_process_mode.nu
@@ -1,0 +1,12 @@
+use ../../test.nu *
+
+# A watched checkin fails when the server is not in single-process mode.
+
+let server = spawn --config { advanced: { single_process: false } }
+let path = artifact {
+	tangram.ts: 'export default "hello";'
+}
+let output = tg --url $server.url checkin $path --watch | complete
+
+failure $output
+assert ($output.stderr | str contains "the watch option is not supported in multi-process mode")

--- a/packages/cli/tests/checkin/watch_waits_for_index.nu
+++ b/packages/cli/tests/checkin/watch_waits_for_index.nu
@@ -1,0 +1,55 @@
+use ../../test.nu *
+
+# A checkin reusing a watcher waits for the checkin that published its graph to finish indexing.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+let path = artifact {
+	tangram.ts: 'export default "indexed";'
+}
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --no-cache-pointers --no-lock | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+def update_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --no-cache-pointers --no-lock --update unused | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+# Hold the first checkin after it publishes the watcher but before it indexes the graph.
+let index_watch = (
+	tg checkpoint watch checkin.index --params '{"updates":""}'
+	| from json
+	| get watch
+)
+let first = checkin_background $path
+tg checkpoint wait checkin.index $index_watch 0 | ignore
+
+# A distinct checkin task must wait for the watch's pending index operation.
+let second = update_background $path
+let early = try {
+	job recv --tag $second --timeout 250ms
+} catch {
+	null
+}
+assert ($early == null) "the second checkin should wait for the first checkin to finish indexing"
+
+# Complete indexing and verify that both checkins succeed.
+tg checkpoint continue checkin.index $index_watch 0
+tg checkpoint unwatch checkin.index $index_watch
+let first_output = job recv --tag $first --timeout 10sec
+let second_output = job recv --tag $second --timeout 10sec
+success $first_output
+success $second_output

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -80,6 +80,13 @@ impl Session {
 	) -> tg::Result<
 		impl Stream<Item = tg::Result<tg::progress::Event<tg::checkin::Output>>> + Send + use<>,
 	> {
+		// Validate the arg.
+		if arg.options.watch && !self.server.config.advanced.single_process {
+			return Err(tg::error!(
+				"the watch option is not supported in multi-process mode"
+			));
+		}
+
 		arg.path = self.host_path_for_guest_path(&arg.path)?;
 
 		// Validate and canonicalize the path.
@@ -367,19 +374,43 @@ impl Session {
 		};
 
 		// Attempt to get the graph, lock, and solutions from a watcher.
-		let (mut graph, lock, mut solutions, watch_observation) = if arg.options.watch
-			&& let Some(watch) = self.server.watches.get(&watch_key)
-		{
+		let watch = if arg.options.watch {
+			self.server.watches.get(&watch_key)
+		} else {
+			None
+		};
+		let (mut graph, lock, mut solutions, watch_observation) = if let Some(watch) = watch {
 			if watch.value().options() == &arg.options {
+				let id = watch.value().id();
 				let snapshot = watch.value().get();
-				let graph = snapshot.graph;
-				let lock = snapshot.lock;
-				let solutions = snapshot.solutions;
-				let watch_observation = WatchObservation::Compatible {
-					id: snapshot.id,
-					version: snapshot.version,
-				};
-				(graph, lock, solutions, watch_observation)
+				drop(watch);
+				match snapshot.await {
+					Ok(snapshot) => {
+						let graph = snapshot.graph;
+						let lock = snapshot.lock;
+						let solutions = snapshot.solutions;
+						let watch_observation = WatchObservation::Compatible {
+							id: snapshot.id,
+							version: snapshot.version,
+						};
+						(graph, lock, solutions, watch_observation)
+					},
+					Err(error) => {
+						let removed = self
+							.server
+							.watches
+							.remove_if(&watch_key, |_, watch| watch.id() == id)
+							.is_some();
+						if !removed {
+							return Err(tg::error!(!error, "the watch changed during indexing"));
+						}
+						let graph = Graph::default();
+						let lock = None;
+						let solutions = Solutions::default();
+						let watch_observation = WatchObservation::Vacant;
+						(graph, lock, solutions, watch_observation)
+					},
+				}
 			} else {
 				let graph = Graph::default();
 				let id = watch.value().id();
@@ -559,7 +590,17 @@ impl Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to create the lock"))?;
 
-		// If the watch option is enabled, then create or update the watcher, verify the version, and then spawn a task to clean nodes with no referrers.
+		// Create the index batch.
+		let index_arg = self.checkin_index(
+			&arg,
+			&graph,
+			index_object_args,
+			index_cache_entry_args,
+			root,
+			touched_at,
+		)?;
+
+		// Create or update the watcher and spawn its index task.
 		if self
 			.server
 			.config()
@@ -577,7 +618,7 @@ impl Session {
 					let watch = entry.get();
 
 					// Update the watch.
-					let arg = crate::watch::UpdateArg {
+					let update_arg = crate::watch::UpdateArg {
 						graph: graph.clone(),
 						key: &watch_key,
 						lock,
@@ -586,9 +627,9 @@ impl Session {
 						solutions,
 						version,
 					};
-					let success = watch.update(arg);
-
-					// If the update was not successful, then files were modified during checkin.
+					let success = watch.update(update_arg, || {
+						self.checkin_index_task(index_arg, &arg, root)
+					});
 					if !success {
 						return Err(tg::error!("files were modified during checkin"));
 					}
@@ -597,29 +638,29 @@ impl Session {
 					if entry.get().id() == id =>
 				{
 					// Replace the incompatible watcher.
-					let watch = Watch::new(
-						&self.server,
-						&watch_key,
-						graph.clone(),
+					let new_arg = crate::watch::NewArg {
+						graph: graph.clone(),
 						lock,
-						arg.options.clone(),
-						solutions,
 						next,
-					)
-					.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
+						options: arg.options.clone(),
+						solutions,
+						spawn_index_task: || self.checkin_index_task(index_arg, &arg, root),
+					};
+					let watch = Watch::new(&self.server, &watch_key, new_arg)
+						.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
 					entry.insert(watch);
 				},
 				(dashmap::Entry::Vacant(entry), WatchObservation::Vacant) => {
-					let watch = Watch::new(
-						&self.server,
-						&watch_key,
-						graph.clone(),
+					let new_arg = crate::watch::NewArg {
+						graph: graph.clone(),
 						lock,
-						arg.options.clone(),
-						solutions,
 						next,
-					)
-					.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
+						options: arg.options.clone(),
+						solutions,
+						spawn_index_task: || self.checkin_index_task(index_arg, &arg, root),
+					};
+					let watch = Watch::new(&self.server, &watch_key, new_arg)
+						.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
 					entry.insert(watch);
 				},
 				_ => return Err(tg::error!("the watch changed during checkin")),
@@ -637,18 +678,12 @@ impl Session {
 					}
 				}
 			});
+		} else {
+			self.server
+				.index_batch(index_arg)
+				.await
+				.map_err(|error| tg::error!(!error, "failed to index the checkin"))?;
 		}
-
-		// Index the objects.
-		self.checkin_index(
-			&arg,
-			&graph,
-			index_object_args,
-			index_cache_entry_args,
-			root,
-			touched_at,
-		)
-		.await?;
 
 		let output = TaskOutput {
 			graph,

--- a/packages/server/src/checkin/index.rs
+++ b/packages/server/src/checkin/index.rs
@@ -6,10 +6,11 @@ use {
 	num::ToPrimitive as _,
 	std::path::Path,
 	tangram_client::prelude::*,
+	tangram_index::Index as _,
 };
 
 impl Session {
-	pub(super) async fn checkin_index(
+	pub(super) fn checkin_index(
 		&self,
 		arg: &tg::checkin::Arg,
 		graph: &Graph,
@@ -17,7 +18,7 @@ impl Session {
 		index_cache_entry_args: IndexCacheEntryArgs,
 		root: &Path,
 		touched_at: i64,
-	) -> tg::Result<()> {
+	) -> tg::Result<tangram_index::batch::Arg> {
 		// Create put cache entry args.
 		let mut put_index_cache_entry_args = Vec::new();
 		if arg.options.cache_pointers {
@@ -86,7 +87,7 @@ impl Session {
 			}
 		});
 
-		// Index.
+		// Create the index batch.
 		let arg = tangram_index::batch::Arg {
 			items: put_index_cache_entry_args
 				.into_iter()
@@ -99,11 +100,44 @@ impl Session {
 				.chain(put_grant.map(tangram_index::batch::Item::PutGrant))
 				.collect(),
 		};
-		self.server
-			.index_batch(arg)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to index the checkin"))?;
 
-		Ok(())
+		Ok(arg)
+	}
+
+	pub(super) fn checkin_index_task(
+		&self,
+		arg: tangram_index::batch::Arg,
+		checkin_arg: &tg::checkin::Arg,
+		root: &Path,
+	) -> tangram_futures::task::Shared<tg::Result<()>> {
+		let updates = checkin_arg
+			.updates
+			.iter()
+			.map(ToString::to_string)
+			.collect::<Vec<_>>()
+			.join(",");
+		self.server.index_tasks.spawn({
+			let root = root.to_owned();
+			let server = self.server.clone();
+			|_| async move {
+				crate::checkpoint!(
+					server,
+					"checkin.index",
+					path = %root.display(),
+					updates,
+				)
+				.await;
+				let result = server
+					.index
+					.batch(arg)
+					.await
+					.map_err(|error| tg::error!(!error, "failed to index the checkin"));
+				if let Err(error) = &result {
+					tracing::error!(error = %error.trace(), "failed to index the checkin");
+				}
+
+				result
+			}
+		})
 	}
 }

--- a/packages/server/src/index.rs
+++ b/packages/server/src/index.rs
@@ -586,9 +586,12 @@ impl Server {
 			.spawn({
 				let server = self.clone();
 				|_| async move {
-					if let Err(error) = server.index.batch(arg).await {
+					let result = server.index.batch(arg).await;
+					if let Err(error) = &result {
 						tracing::error!(error = %error.trace(), "failed to index a batch");
 					}
+
+					result
 				}
 			})
 			.detach();

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -112,7 +112,7 @@ pub struct State {
 	diagnostics: Mutex<Vec<tg::Diagnostic>>,
 	grant_tokens: Tokens,
 	index: Index,
-	index_tasks: tangram_futures::task::Set<()>,
+	index_tasks: tangram_futures::task::Set<tg::Result<()>>,
 	#[cfg(target_os = "linux")]
 	ip_pool: tangram_sandbox::network::ip::Pool,
 	library: Mutex<Option<Arc<Temp>>>,

--- a/packages/server/src/module/resolve.rs
+++ b/packages/server/src/module/resolve.rs
@@ -365,7 +365,7 @@ impl Session {
 						&& referrer.item().starts_with(&entry.key().path)
 				})
 				.ok_or_else(|| tg::error!("failed to find a watch for the path"))?;
-			let graph = entry.value().get().graph;
+			let graph = entry.value().get_unindexed().graph;
 			let index = graph
 				.paths
 				.get(referrer.item())

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -7,7 +7,7 @@ use {
 		sync::{Arc, Mutex, atomic::Ordering},
 	},
 	tangram_client::prelude::*,
-	tangram_futures::task::Task,
+	tangram_futures::task::{Shared, Task},
 };
 
 pub mod delete;
@@ -31,8 +31,18 @@ pub struct Watch {
 	task: Task<()>,
 }
 
+pub struct NewArg<F> {
+	pub graph: crate::checkin::Graph,
+	pub lock: Option<Arc<tg::graph::Data>>,
+	pub next: usize,
+	pub options: tg::checkin::Options,
+	pub solutions: crate::checkin::Solutions,
+	pub spawn_index_task: F,
+}
+
 struct State {
 	graph: crate::checkin::Graph,
+	index_task: Shared<tg::Result<()>>,
 	lock: Option<Arc<tg::graph::Data>>,
 	#[cfg(target_os = "macos")]
 	paths: HashSet<PathBuf, fnv::FnvBuildHasher>,
@@ -74,15 +84,19 @@ impl Id {
 }
 
 impl Watch {
-	pub fn new(
-		server: &Server,
-		key: &Key,
-		graph: crate::checkin::Graph,
-		lock: Option<Arc<tg::graph::Data>>,
-		options: tg::checkin::Options,
-		solutions: crate::checkin::Solutions,
-		#[cfg_attr(not(target_os = "linux"), expect(unused_variables))] next: usize,
-	) -> tg::Result<Self> {
+	pub fn new<F>(server: &Server, key: &Key, arg: NewArg<F>) -> tg::Result<Self>
+	where
+		F: FnOnce() -> Shared<tg::Result<()>>,
+	{
+		#[cfg_attr(not(target_os = "linux"), expect(unused_variables))]
+		let NewArg {
+			graph,
+			lock,
+			next,
+			options,
+			solutions,
+			spawn_index_task,
+		} = arg;
 		let id = Id::new(server);
 
 		// Create the watcher.
@@ -108,8 +122,10 @@ impl Watch {
 			.map_err(|error| tg::error!(!error, "failed to create the watcher"))?;
 
 		// Create the state.
+		let index_task = spawn_index_task();
 		let state = State {
 			graph,
+			index_task,
 			lock,
 			#[cfg(target_os = "macos")]
 			paths: HashSet::default(),
@@ -234,7 +250,39 @@ impl Watch {
 		&self.options
 	}
 
-	pub fn get(&self) -> Snapshot {
+	pub fn get(&self) -> impl Future<Output = tg::Result<Snapshot>> + Send + use<> {
+		let id = self.id;
+		let state = self.state.clone();
+		async move {
+			loop {
+				let (index_task, version) = {
+					let state = state.lock().unwrap();
+					(state.index_task.clone(), state.version)
+				};
+				let result = index_task
+					.wait()
+					.await
+					.map_err(|error| tg::error!(!error, "the indexing task panicked"))
+					.and_then(|result| result);
+				let state = state.lock().unwrap();
+				if state.version != version {
+					continue;
+				}
+				result?;
+				let snapshot = Snapshot {
+					graph: state.graph.clone(),
+					id,
+					lock: state.lock.clone(),
+					solutions: state.solutions.clone(),
+					version: state.version,
+				};
+
+				return Ok(snapshot);
+			}
+		}
+	}
+
+	pub fn get_unindexed(&self) -> Snapshot {
 		let state = self.state.lock().unwrap();
 		Snapshot {
 			graph: state.graph.clone(),
@@ -245,7 +293,10 @@ impl Watch {
 		}
 	}
 
-	pub fn update(&self, arg: UpdateArg<'_>) -> bool {
+	pub fn update<F>(&self, arg: UpdateArg<'_>, spawn_index_task: F) -> bool
+	where
+		F: FnOnce() -> Shared<tg::Result<()>>,
+	{
 		let UpdateArg {
 			graph,
 			key,
@@ -262,7 +313,9 @@ impl Watch {
 		}
 
 		// Update the state.
+		let index_task = spawn_index_task();
 		state.graph = graph;
+		state.index_task = index_task;
 		state.lock = lock;
 		state.solutions = solutions;
 		state.version += 1;


### PR DESCRIPTION
## Summary

- Attach the real local background indexing task to each published watch generation.
- Make a compatible incremental checkin wait for pending indexing before taking its snapshot.
- Discard and rebuild a watch when its indexing fails instead of reusing an unindexed graph.
- Reject `checkin --watch` in multi-process mode, where indexing is asynchronous through the outbox.
- Keep module resolution able to read the graph produced by its own completed checkin without changing legacy checkin failure behavior.

## Root cause

A checkin published its updated graph before its asynchronous index batch completed. A second checkin could reuse that graph and return while the first watch generation was still waiting for indexing.

## Validation

- Added the checkpoint-driven `checkin/watch_waits_for_index.nu` regression and confirmed it failed before the fix because the second checkin returned while the first was paused at `checkin.index`.
- Added `checkin/watch_multi_process_mode.nu` and confirmed it failed before the multi-process guard because the watched checkin succeeded.
- All 24 watched-checkin tests pass.
- `index/multi_process_mode.nu` and `run/executable.nu` pass.
- Ran `bun run format` and `bun run check`.

---

Stack 3 of 3. #1009 and #1010 are merged.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>