### PR TITLE
Fix watch invalidation for renames and removals

### DIFF
--- a/packages/cli/src/watch/touch.rs
+++ b/packages/cli/src/watch/touch.rs
@@ -12,9 +12,20 @@ pub struct Args {
 	#[arg(index = 2)]
 	items: Vec<PathBuf>,
 
+	/// The file system event kind.
+	#[arg(default_value = "any", long, value_enum)]
+	kind: Kind,
+
 	/// The watch path.
 	#[arg(index = 1)]
 	path: PathBuf,
+}
+
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum Kind {
+	Any,
+	Remove,
+	Rename,
 }
 
 impl Cli {
@@ -31,7 +42,12 @@ impl Cli {
 			.try_collect()
 			.await
 			.map_err(|error| tg::error!(!error, "failed to canonicalize the paths"))?;
-		let arg = tg::watch::touch::Arg { path, items };
+		let kind = match args.kind {
+			Kind::Any => tg::watch::touch::Kind::Any,
+			Kind::Remove => tg::watch::touch::Kind::Remove,
+			Kind::Rename => tg::watch::touch::Kind::Rename,
+		};
+		let arg = tg::watch::touch::Arg { items, kind, path };
 		client
 			.touch_watch(arg)
 			.await

--- a/packages/cli/tests/checkin/watch_remove_and_rename_single_file_during_checkin.nu
+++ b/packages/cli/tests/checkin/watch_remove_and_rename_single_file_during_checkin.nu
@@ -1,0 +1,44 @@
+use ../../test.nu *
+
+# Remove and rename events for a watched single-file root invalidate an incremental checkin that already snapshotted it.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --no-cache-pointers --no-lock | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+def check_event [kind: string] {
+	let path = artifact 'alpha'
+	tg checkin $path --watch --no-cache-pointers --no-lock | ignore
+
+	# Hold an incremental checkin after it snapshots the watched file.
+	let snapshot_watch = (
+		tg checkpoint watch checkin.watch.snapshot --params '{"solve":true,"updates":""}'
+		| from json
+		| get watch
+	)
+	let checkin = checkin_background $path
+	tg checkpoint wait checkin.watch.snapshot $snapshot_watch 0 | ignore
+
+	# Synchronously inject the event for the watched root.
+	tg watch touch $path $path --kind $kind
+
+	# The checkin must reject the stale snapshot.
+	tg checkpoint continue checkin.watch.snapshot $snapshot_watch 0
+	tg checkpoint unwatch checkin.watch.snapshot $snapshot_watch
+	let output = job recv --tag $checkin --timeout 10sec
+	failure $output $"the checkin should reject a concurrent ($kind) event"
+}
+
+for kind in [remove rename] {
+	check_event $kind
+}

--- a/packages/clients/rust/src/watch/touch.rs
+++ b/packages/clients/rust/src/watch/touch.rs
@@ -7,7 +7,17 @@ use {
 #[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct Arg {
 	pub items: Vec<PathBuf>,
+	pub kind: Kind,
 	pub path: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Kind {
+	#[default]
+	Any,
+	Remove,
+	Rename,
 }
 
 impl tg::Session {

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -358,17 +358,11 @@ impl Watch {
 	fn changes(event: &notify::Event) -> HashSet<&Path, fnv::FnvBuildHasher> {
 		let mut changes = HashSet::default();
 		match &event.kind {
-			notify::EventKind::Create(_) => {
-				for path in &event.paths {
-					changes.insert(path.as_path());
-					if let Some(parent) = path.parent() {
-						changes.insert(parent);
-					}
-				}
-			},
-			notify::EventKind::Modify(notify::event::ModifyKind::Name(_))
+			notify::EventKind::Create(_)
+			| notify::EventKind::Modify(notify::event::ModifyKind::Name(_))
 			| notify::EventKind::Remove(_) => {
 				for path in &event.paths {
+					changes.insert(path.as_path());
 					if let Some(parent) = path.parent() {
 						changes.insert(parent);
 					}

--- a/packages/server/src/watch/touch.rs
+++ b/packages/server/src/watch/touch.rs
@@ -27,11 +27,22 @@ impl Session {
 		// Create a notification channel.
 		let (notification_sender, notification_receiver) = tokio::sync::oneshot::channel();
 
+		// Create the event kind.
+		let kind = match arg.kind {
+			tg::watch::touch::Kind::Any => notify::EventKind::Any,
+			tg::watch::touch::Kind::Remove => {
+				notify::EventKind::Remove(notify::event::RemoveKind::Any)
+			},
+			tg::watch::touch::Kind::Rename => notify::EventKind::Modify(
+				notify::event::ModifyKind::Name(notify::event::RenameMode::Any),
+			),
+		};
+
 		// Send a message to touch the watch.
 		sender
 			.send(super::Message {
 				event: notify::Event {
-					kind: notify::EventKind::Any,
+					kind,
 					paths: arg.items.clone(),
 					attrs: notify::event::EventAttributes::new(),
 				},


### PR DESCRIPTION
## Summary

- preserve the exact affected path for rename and remove watch events, in addition to its parent
- extend `tg watch touch` with deterministic remove and rename event kinds
- add a checkpointed CLI regression covering both event kinds during an incremental checkin

## Root cause

Rename and remove events were normalized to only their parent paths. For a watched single-file root, the parent is not in the checkin graph, so the event did not invalidate any node or advance the watch version. An in-flight incremental checkin could therefore publish stale state.

## Impact

Rename and remove events now invalidate both the affected path and its parent. Incremental checkins reject snapshots made stale by either event.

## Testing

- confirmed the new CLI regression fails before the fix and passes afterward
- `nu packages/cli/test.nu --tangram-path target/debug/tangram watch_remove_and_rename_single_file_during_checkin`
- `nu packages/cli/test.nu --tangram-path target/debug/tangram touch_updates_checkin touch_nonexistent`
- `bun run check`
- `bun run format`
