### PR TITLE
Fix locked checkins after dependency removal

### DIFF
--- a/packages/cli/tests/checkin/locked_removed_dependency.nu
+++ b/packages/cli/tests/checkin/locked_removed_dependency.nu
@@ -1,0 +1,27 @@
+use ../../test.nu *
+
+# A locked checkin rejects removing the last dependency instead of deleting the lockfile.
+
+let server = spawn
+
+let dependency_path = artifact {
+	tangram.ts: '// a 1.0.0'
+}
+tg tag -p a/1.0.0 $dependency_path
+
+let path = artifact {
+	tangram.ts: 'import a from "a/^1";'
+}
+tg checkin $path | ignore
+
+let lockfile_path = $path | path join tangram.lock
+let original_lock = open $lockfile_path
+
+# Remove the only dependency, making the root no longer solvable.
+'export default "no dependencies";' | save --force ($path | path join tangram.ts)
+
+# --locked must reject the stale lock and leave it untouched.
+let output = tg checkin $path --locked | complete
+failure $output "removing the last dependency should make the lock out of date"
+assert ($lockfile_path | path exists) "the locked checkin should not remove the lockfile"
+assert ((open $lockfile_path) == $original_lock) "the locked checkin should not change the lockfile"

--- a/packages/server/src/checkin/lock.rs
+++ b/packages/server/src/checkin/lock.rs
@@ -86,6 +86,9 @@ impl Session {
 
 		// If the root is not solvable, then remove an existing lock and return.
 		if !root_node.solvable {
+			if arg.options.locked && lock.is_some() {
+				return Err(tg::error!("the lock is out of date"));
+			}
 			match root_node.variant {
 				Variant::Directory(_) => {
 					let lockfile_path = root.join(tg::module::LOCKFILE_FILE_NAME);


### PR DESCRIPTION
## Summary

- reject a locked checkin when removing the last dependency makes an existing lock obsolete
- preserve the existing lockfile when that checkin fails
- add a CLI regression covering the transition from a nonempty lock to no lock

## Root cause

The non-solvable-root branch removed the existing lock and returned before the locked-checkin consistency check ran.

## Impact

`tg checkin --locked` now treats removing the final dependency as an out-of-date lock instead of silently deleting `tangram.lock`.

## Testing

- confirmed the new CLI regression fails before the fix and passes afterward
- `nu packages/cli/test.nu --tangram-path target/debug/tangram locked_removed_dependency locked.nu watch_locked`
- `bun run check`
- `bun run format`
