### PR TITLE
Repro/process input reauthorize

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -168,6 +168,9 @@ pub enum Role {
 #[serde(deny_unknown_fields)]
 pub struct Advanced {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub authorize_always_unsafe: Option<bool>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub checkpoints: Option<bool>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1909,6 +1912,9 @@ fn resolve_role(source: Role) -> server::Role {
 
 fn resolve_advanced(source: Advanced) -> server::Advanced {
 	let mut target = server::Advanced::default();
+	if let Some(value) = source.authorize_always_unsafe {
+		target.authorize_always_unsafe = value;
+	}
 	if let Some(value) = source.checkpoints {
 		target.checkpoints = value;
 	}

--- a/packages/cli/tests/grants/process_input_reauthorization_cost.nu
+++ b/packages/cli/tests/grants/process_input_reauthorization_cost.nu
@@ -1,0 +1,47 @@
+use ../../test.nu *
+
+# What re-authorizing an input costs. A process loads one directory from its own input repeatedly, first against a server that authorizes normally and then against one configured to grant everything. The walk reaches the input by going up to the command, which holds the process's only grant, so the price tracks how many parents the input has, and a shared library directory has many.
+
+let source = '
+	const PARENTS = 256;
+	const N = 100;
+
+	export const measure = async (wrapper: tg.Directory) => {
+		const dir = await wrapper.get("p0/lib").then(tg.Directory.expect);
+		const id = dir.id;
+		const start = Date.now();
+		for (let i = 0; i < N; i++) {
+			await tg.Directory.withId(id).load();
+		}
+		return tg.file(`${N} ${Date.now() - start}`);
+	};
+
+	export default async () => {
+		const lib = await tg.directory({ "libfoo.so": tg.file("foo") });
+		const entries: Record<string, tg.Unresolved<tg.Directory>> = {};
+		for (let i = 0; i < PARENTS; i++) {
+			entries[`p${i}`] = tg.directory({ [`u${i}.o`]: tg.file(`unit ${i}`), lib });
+		}
+		return tg.build(measure, await tg.directory(entries));
+	};
+'
+
+# Every parent holds a distinct file, because parents with identical contents would collapse to one object and the input would have a single parent.
+let path = artifact { tangram.ts: $source }
+
+def elapsed_ms []: nothing -> float {
+	let fields = tg build $path | str trim | tg cat $in | str trim | split row ' '
+	($fields | last | into float) / ($fields | first | into float)
+}
+
+let authorizing = spawn --name authorizing
+let authorizing_ms = elapsed_ms
+
+let granting = spawn --name granting --config {
+	advanced: { authorize_always_unsafe: true },
+}
+let granting_ms = elapsed_ms
+
+print $"($authorizing_ms)ms per load authorizing, ($granting_ms)ms per load granting everything"
+
+assert ($authorizing_ms < $granting_ms * 3) $"authorizing an input the process already holds cost ($authorizing_ms)ms per load against ($granting_ms)ms when authorization is skipped"

--- a/packages/cli/tests/grants/process_input_reauthorization_cost.nu
+++ b/packages/cli/tests/grants/process_input_reauthorization_cost.nu
@@ -1,13 +1,16 @@
 use ../../test.nu *
 
-# What re-authorizing an input costs. A process loads one directory from its own input repeatedly, first against a server that authorizes normally and then against one configured to grant everything. The walk reaches the input by going up to the command, which holds the process's only grant, so the price tracks how many parents the input has, and a shared library directory has many.
+# What re-authorizing an input costs. A process loads one directory from its own input repeatedly, first against a server that authorizes normally and then against one configured to grant everything. Authorization reaches the input by walking up to the command, which holds the process's only grant, so the price is set by how many objects lie between the two.
 
 let source = '
-	const PARENTS = 256;
+	const DISTANCE = 256;
 	const N = 100;
 
 	export const measure = async (wrapper: tg.Directory) => {
-		const dir = await wrapper.get("p0/lib").then(tg.Directory.expect);
+		let dir = wrapper;
+		for (let i = 0; i < DISTANCE; i++) {
+			dir = await dir.get(`d${i}`).then(tg.Directory.expect);
+		}
 		const id = dir.id;
 		const start = Date.now();
 		for (let i = 0; i < N; i++) {
@@ -17,16 +20,14 @@ let source = '
 	};
 
 	export default async () => {
-		const lib = await tg.directory({ "libfoo.so": tg.file("foo") });
-		const entries: Record<string, tg.Unresolved<tg.Directory>> = {};
-		for (let i = 0; i < PARENTS; i++) {
-			entries[`p${i}`] = tg.directory({ [`u${i}.o`]: tg.file(`unit ${i}`), lib });
+		let dir = await tg.directory({ "libfoo.so": tg.file("foo") });
+		for (let i = DISTANCE - 1; i >= 0; i--) {
+			dir = await tg.directory({ [`d${i}`]: dir });
 		}
-		return tg.build(measure, await tg.directory(entries));
+		return tg.build(measure, dir);
 	};
 '
 
-# Every parent holds a distinct file, because parents with identical contents would collapse to one object and the input would have a single parent.
 let path = artifact { tangram.ts: $source }
 
 def elapsed_ms []: nothing -> float {

--- a/packages/cli/tests/grants/process_input_reauthorized_by_index.nu
+++ b/packages/cli/tests/grants/process_input_reauthorized_by_index.nu
@@ -1,0 +1,32 @@
+use ../../test.nu *
+
+# A process is entitled to its own input by construction, but a handle built from an id alone carries no token, so the server authorizes that input through the index on every load rather than once.
+
+let server = spawn --config {
+	tracing: {
+		filter: 'tangram=info,tangram_server=info,tangram_server::authorization=debug',
+		stderr_format: 'json',
+	},
+}
+
+let source = '
+	export const measure = async (dir: tg.Directory) => {
+		const id = dir.id;
+		for (let i = 0; i < 10; i++) {
+			await tg.Directory.withId(id).load();
+		}
+		return tg.file(id);
+	};
+
+	export default () => tg.build(measure, tg.directory({ "libfoo.so": tg.file("foo") }));
+'
+
+let id = tg build (artifact { tangram.ts: $source }) | str trim | tg cat $in | str trim
+
+let walks = open --raw $server.log
+	| lines
+	| each { from json }
+	| where { |event| $event.fields.message? == 'authorizing through the index' and $event.fields.resource? == $id }
+	| length
+
+assert ($walks <= 1) $"a process must not re-authorize its own input, but the index authorized ($id) ($walks) times"

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -41,6 +41,13 @@ impl Session {
 		R: IntoAuthorizationResource,
 		I: IntoIterator<Item = (R, tg::grant::permission::Set)>,
 	{
+		if self.server.config.advanced.authorize_always_unsafe {
+			return Ok(args
+				.into_iter()
+				.map(|(_, permissions)| Some(permissions))
+				.collect());
+		}
+
 		let mut outputs = Vec::new();
 		let mut index_args = Vec::new();
 		let mut index_positions = Vec::new();

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -80,6 +80,8 @@ impl Session {
 				continue;
 			}
 
+			tracing::debug!(%resource, principal = %self.context.principal, "authorizing through the index");
+
 			outputs.push(None);
 			index_positions.push(position);
 			index_args.push(tangram_index::authorize::Arg {

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -85,6 +85,8 @@ pub enum Role {
 
 #[derive(Clone, Debug)]
 pub struct Advanced {
+	pub authorize_always_unsafe: bool,
+
 	pub checkpoints: bool,
 
 	pub disable_version_check: bool,
@@ -1046,6 +1048,7 @@ impl Default for Config {
 impl Default for Advanced {
 	fn default() -> Self {
 		Self {
+			authorize_always_unsafe: false,
 			checkpoints: false,
 			disable_version_check: false,
 			internal_error_locations: false,


### PR DESCRIPTION
Adds tests demonstrating the extra cost when a process needs to re-authorize its own input.  This mirrors a pattern found in `std` in which we end up re-authorizing paths during linker proxying because they are passed to the linker directly, then unrendered, which produces handles using `withId`. We then spend a lot of extra time re-authorizing the same handful of toolchain paths multiple times.

The benchmark that demonstrated this in tgld consisted of re-linking a small file many times repeatedly in the same process, and observing the link time with TGLD enabled was dominated by re-authorizing the toolchain library directories on every repetition.

The code change is a flag to skip authorization entirely.

- `process_input_reauthorized_by_index` simply shows that we do re-walk on each call.
- `process_input_reauthorization_cost` creates a deeply nested directory and measures calling `await tg.Directory.withId(id).load();` repeatedly, which is similar work to what happens in the unrender case in tgld.