### PR TITLE
Fix incompatible watch replacement synchronization

### DIFF
--- a/packages/cli/tests/checkin/watch_incompatible_change_during_checkin.nu
+++ b/packages/cli/tests/checkin/watch_incompatible_change_during_checkin.nu
@@ -1,0 +1,41 @@
+use ../../test.nu *
+
+# A checkin replacing a watch with incompatible options rejects a concurrent filesystem change.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+let path = artifact {
+	tangram.ts: 'export default "before";'
+}
+tg checkin $path --watch --no-cache-pointers --no-lock | ignore
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --no-cache-pointers --no-lock --no-solve | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+# Hold an incompatible checkin after it has read the filesystem but before it replaces the watch.
+let publish_watch = (
+	tg checkpoint watch checkin.watch.publish --params '{"solve":false,"updates":""}'
+	| from json
+	| get watch
+)
+let checkin = checkin_background $path
+tg checkpoint wait checkin.watch.publish $publish_watch 0 | ignore
+
+# Modify the input and synchronously deliver the event to the existing watch.
+'export default "after";' | save --force ($path | path join tangram.ts)
+tg watch touch $path ($path | path join tangram.ts)
+
+# The incompatible checkin must not replace the changed watch with its stale graph.
+tg checkpoint continue checkin.watch.publish $publish_watch 0
+tg checkpoint unwatch checkin.watch.publish $publish_watch
+let output = job recv --tag $checkin --timeout 10sec
+failure $output "the incompatible checkin should reject a concurrent filesystem change"

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -63,7 +63,7 @@ type GraphData = IndexMap<tg::graph::Id, tg::graph::Data, tg::id::BuildHasher>;
 #[derive(Clone, Copy)]
 enum WatchObservation {
 	Compatible { id: crate::watch::Id, version: u64 },
-	Incompatible { id: crate::watch::Id },
+	Incompatible { id: crate::watch::Id, version: u64 },
 	Vacant,
 }
 
@@ -380,12 +380,13 @@ impl Session {
 			None
 		};
 		let (mut graph, lock, mut solutions, watch_observation) = if let Some(watch) = watch {
-			if watch.value().options() == &arg.options {
-				let id = watch.value().id();
-				let snapshot = watch.value().get();
-				drop(watch);
-				match snapshot.await {
-					Ok(snapshot) => {
+			let compatible = watch.value().options() == &arg.options;
+			let id = watch.value().id();
+			let snapshot = watch.value().get();
+			drop(watch);
+			match snapshot.await {
+				Ok(snapshot) => {
+					if compatible {
 						let graph = snapshot.graph;
 						let lock = snapshot.lock;
 						let solutions = snapshot.solutions;
@@ -394,30 +395,32 @@ impl Session {
 							version: snapshot.version,
 						};
 						(graph, lock, solutions, watch_observation)
-					},
-					Err(error) => {
-						let removed = self
-							.server
-							.watches
-							.remove_if(&watch_key, |_, watch| watch.id() == id)
-							.is_some();
-						if !removed {
-							return Err(tg::error!(!error, "the watch changed during indexing"));
-						}
+					} else {
 						let graph = Graph::default();
 						let lock = None;
 						let solutions = Solutions::default();
-						let watch_observation = WatchObservation::Vacant;
+						let watch_observation = WatchObservation::Incompatible {
+							id: snapshot.id,
+							version: snapshot.version,
+						};
 						(graph, lock, solutions, watch_observation)
-					},
-				}
-			} else {
-				let graph = Graph::default();
-				let id = watch.value().id();
-				let lock = None;
-				let solutions = Solutions::default();
-				let watch_observation = WatchObservation::Incompatible { id };
-				(graph, lock, solutions, watch_observation)
+					}
+				},
+				Err(error) => {
+					let removed = self
+						.server
+						.watches
+						.remove_if(&watch_key, |_, watch| watch.id() == id)
+						.is_some();
+					if !removed {
+						return Err(tg::error!(!error, "the watch changed during indexing"));
+					}
+					let graph = Graph::default();
+					let lock = None;
+					let solutions = Solutions::default();
+					let watch_observation = WatchObservation::Vacant;
+					(graph, lock, solutions, watch_observation)
+				},
 			}
 		} else {
 			let graph = Graph::default();
@@ -608,6 +611,22 @@ impl Session {
 			.as_ref()
 			.is_some_and(|_| arg.options.watch)
 		{
+			let updates = arg
+				.updates
+				.iter()
+				.map(ToString::to_string)
+				.collect::<Vec<_>>()
+				.join(",");
+			crate::checkpoint!(
+				self.server,
+				"checkin.watch.publish",
+				nodes = graph.nodes.len(),
+				path = %root.display(),
+				solve = arg.options.solve,
+				updates,
+			)
+			.await;
+
 			// Create or update the watcher.
 			let entry = self.server.watches.entry(watch_key.clone());
 			match (entry, watch_observation) {
@@ -634,9 +653,10 @@ impl Session {
 						return Err(tg::error!("files were modified during checkin"));
 					}
 				},
-				(dashmap::Entry::Occupied(mut entry), WatchObservation::Incompatible { id })
-					if entry.get().id() == id =>
-				{
+				(
+					dashmap::Entry::Occupied(mut entry),
+					WatchObservation::Incompatible { id, version },
+				) if entry.get().id() == id => {
 					// Replace the incompatible watcher.
 					let new_arg = crate::watch::NewArg {
 						graph: graph.clone(),
@@ -646,9 +666,13 @@ impl Session {
 						solutions,
 						spawn_index_task: || self.checkin_index_task(index_arg, &arg, root),
 					};
-					let watch = Watch::new(&self.server, &watch_key, new_arg)
-						.map_err(|error| tg::error!(!error, "failed to create the watch"))?;
-					entry.insert(watch);
+					let success = entry.get_mut().replace_if_version(version, || {
+						Watch::new(&self.server, &watch_key, new_arg)
+							.map_err(|error| tg::error!(!error, "failed to create the watch"))
+					})?;
+					if !success {
+						return Err(tg::error!("files were modified during checkin"));
+					}
 				},
 				(dashmap::Entry::Vacant(entry), WatchObservation::Vacant) => {
 					let new_arg = crate::watch::NewArg {

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -250,6 +250,22 @@ impl Watch {
 		&self.options
 	}
 
+	pub fn replace_if_version<F>(&mut self, version: u64, replace: F) -> tg::Result<bool>
+	where
+		F: FnOnce() -> tg::Result<Self>,
+	{
+		let state = self.state.clone();
+		let state = state.lock().unwrap();
+		if state.version != version {
+			return Ok(false);
+		}
+		let watch = replace()?;
+		*self = watch;
+		drop(state);
+
+		Ok(true)
+	}
+
 	pub fn get(&self) -> impl Future<Output = tg::Result<Snapshot>> + Send + use<> {
 		let id = self.id;
 		let state = self.state.clone();


### PR DESCRIPTION
## Summary

- await an existing watch's index task even when the new checkin options are incompatible
- retain the observed watch version while rebuilding incompatible state
- replace an incompatible watch only if its version is still current
- add a checkpointed CLI regression for a filesystem change during replacement

## Root cause

Incompatible checkins recorded only the watch ID. A filesystem event advanced the watch version without changing its ID, so a stale checkin could still replace the newer watch state.

## Impact

Changing checkin options no longer bypasses watch concurrency control. A checkin now rejects an incompatible replacement if the watched filesystem changes after observation.

## Testing

- confirmed the new CLI regression fails before the fix and passes afterward
- `nu packages/cli/test.nu --tangram-path target/debug/tangram watch_incompatible_change_during_checkin watch_concurrent_options watch_concurrent_updates watch_waits_for_index watch_no_solve`
- `bun run check`
- `bun run format`
