### PR TITLE
fix watched lockfile invalidation

### DIFF
--- a/packages/cli/tests/checkin/watch_internal_lockfile_change_during_checkin.nu
+++ b/packages/cli/tests/checkin/watch_internal_lockfile_change_during_checkin.nu
@@ -1,0 +1,74 @@
+use ../../test.nu *
+
+# A watched checkin ignores the lockfile event caused by its own lock write.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+let dependency_path = artifact {
+	tangram.ts: '// a 1.0.0'
+}
+tg tag -p a/1.0.0 $dependency_path
+
+let path = artifact {
+	tangram.ts: 'import a from "a/^1";'
+}
+tg checkin $path --watch | ignore
+
+let dependency_path = artifact {
+	tangram.ts: '// a 1.1.0'
+}
+tg tag -p a/1.1.0 $dependency_path
+
+def update_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --update a | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+# Hold the update after it writes the new lock but before it publishes the watch.
+let publish_watch = (
+	tg checkpoint watch checkin.watch.publish --params '{"solve":true,"updates":"a"}'
+	| from json
+	| get watch
+)
+let update = update_background $path
+tg checkpoint wait checkin.watch.publish $publish_watch 0 | ignore
+
+# Synchronously deliver the event caused by the internal lock write.
+let lockfile_path = $path | path join tangram.lock
+tg watch touch $path $lockfile_path
+
+# The update must still be able to publish the watch.
+tg checkpoint continue checkin.watch.publish $publish_watch 0
+tg checkpoint unwatch checkin.watch.publish $publish_watch
+let output = job recv --tag $update --timeout 10sec
+success $output
+
+let dependency_path = artifact {
+	tangram.ts: '// a 1.2.0'
+}
+tg tag -p a/1.2.0 $dependency_path
+
+# Hold another update with its internal lock write pending.
+let publish_watch = (
+	tg checkpoint watch checkin.watch.publish --params '{"solve":true,"updates":"a"}'
+	| from json
+	| get watch
+)
+let update = update_background $path
+tg checkpoint wait checkin.watch.publish $publish_watch 0 | ignore
+
+# An external write during that window must not be mistaken for the internal write.
+{ nodes: [] } | to json | save --force $lockfile_path
+tg watch touch $path $lockfile_path
+
+tg checkpoint continue checkin.watch.publish $publish_watch 0
+tg checkpoint unwatch checkin.watch.publish $publish_watch
+let output = job recv --tag $update --timeout 10sec
+failure $output "the update should reject an external lockfile write"

--- a/packages/cli/tests/checkin/watch_lockfile_change_during_checkin.nu
+++ b/packages/cli/tests/checkin/watch_lockfile_change_during_checkin.nu
@@ -1,0 +1,77 @@
+use ../../test.nu *
+
+# A watched checkin rejects a lockfile change made after it snapshots the watch.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true
+	}
+}
+
+let a_1_0_path = artifact {
+	tangram.ts: '// a 1.0.0'
+}
+tg tag -p a/1.0.0 $a_1_0_path
+
+let a_1_0_id = tg tag get a/1.0.0 | from json | get item.id
+let lock = {
+	nodes: [
+		{
+			kind: directory
+			entries: {
+				tangram.ts: {
+					index: 1
+					kind: file
+				}
+			}
+		}
+		{
+			kind: file
+			dependencies: {
+				'a/^1': {
+					item: null
+					options: {
+						id: $a_1_0_id
+						tag: a/1.0.0
+					}
+				}
+			}
+			module: ts
+		}
+	]
+}
+let path = artifact {
+	tangram.ts: 'import a from "a/^1";'
+	tangram.lock: ($lock | to json)
+}
+
+# Establish a watch with the original lock.
+tg checkin $path --watch --locked | ignore
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin $path --watch --locked | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+# Hold the next checkin after it snapshots the watch.
+let snapshot_watch = (
+	tg checkpoint watch checkin.watch.snapshot --params '{"solve":true,"updates":""}'
+	| from json
+	| get watch
+)
+let checkin = checkin_background $path
+tg checkpoint wait checkin.watch.snapshot $snapshot_watch 0 | ignore
+
+# Change the lockfile and synchronously deliver its watch event.
+let lockfile_path = $path | path join tangram.lock
+{ nodes: [] } | to json | save --force $lockfile_path
+tg watch touch $path $lockfile_path
+
+# The checkin must reject the stale snapshot.
+tg checkpoint continue checkin.watch.snapshot $snapshot_watch 0
+tg checkpoint unwatch checkin.watch.snapshot $snapshot_watch
+let output = job recv --tag $checkin --timeout 10sec
+failure $output "the checkin should reject a concurrent lockfile change"

--- a/packages/clients/rust/src/graph/data.rs
+++ b/packages/clients/rust/src/graph/data.rs
@@ -13,6 +13,8 @@ use {
 #[derive(
 	Clone,
 	Debug,
+	Eq,
+	PartialEq,
 	serde::Deserialize,
 	serde::Serialize,
 	tangram_serialize::Deserialize,

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -589,9 +589,29 @@ impl Session {
 			.map_err(|error| tg::error!(!error, "failed to write the objects to the store"))?;
 
 		// Write the lock.
-		self.checkin_write_lock(&arg, &graph, next, lock.as_deref(), root, progress)
+		let reserve_lock_write = || match watch_observation {
+			WatchObservation::Compatible { id, version }
+			| WatchObservation::Incompatible { id, version } => {
+				let watch = self
+					.server
+					.watches
+					.get(&watch_key)
+					.filter(|watch| watch.id() == id)
+					.ok_or_else(|| tg::error!("the watch changed during checkin"))?;
+				let lock_write = watch
+					.reserve_lock_write(version)
+					.ok_or_else(|| tg::error!("files were modified during checkin"))?;
+
+				Ok(Some(lock_write))
+			},
+			WatchObservation::Vacant => Ok(None),
+		};
+		progress.spinner("locking", "locking");
+		let (lock, lock_write) = self
+			.checkin_write_lock(&arg, &graph, next, lock, root, reserve_lock_write)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to create the lock"))?;
+		progress.finish("locking");
 
 		// Create the index batch.
 		let index_arg = self.checkin_index(
@@ -627,6 +647,15 @@ impl Session {
 			)
 			.await;
 
+			// Verify that the lock has the expected contents.
+			if lock_write.is_some() {
+				let actual_lock = Self::checkin_try_read_lock(root)
+					.map_err(|error| tg::error!(!error, "failed to read the lock"))?;
+				if !crate::watch::locks_equal(lock.as_deref(), actual_lock.as_ref()) {
+					return Err(tg::error!("the lock was modified during checkin"));
+				}
+			}
+
 			// Create or update the watcher.
 			let entry = self.server.watches.entry(watch_key.clone());
 			match (entry, watch_observation) {
@@ -641,6 +670,7 @@ impl Session {
 						graph: graph.clone(),
 						key: &watch_key,
 						lock,
+						lock_write,
 						next,
 						server: &self.server,
 						solutions,
@@ -666,10 +696,14 @@ impl Session {
 						solutions,
 						spawn_index_task: || self.checkin_index_task(index_arg, &arg, root),
 					};
-					let success = entry.get_mut().replace_if_version(version, || {
-						Watch::new(&self.server, &watch_key, new_arg)
-							.map_err(|error| tg::error!(!error, "failed to create the watch"))
-					})?;
+					let success =
+						entry
+							.get_mut()
+							.replace_if_version(version, lock_write, || {
+								Watch::new(&self.server, &watch_key, new_arg).map_err(|error| {
+									tg::error!(!error, "failed to create the watch")
+								})
+							})?;
 					if !success {
 						return Err(tg::error!("files were modified during checkin"));
 					}

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -599,7 +599,7 @@ impl Session {
 					.filter(|watch| watch.id() == id)
 					.ok_or_else(|| tg::error!("the watch changed during checkin"))?;
 				let lock_write_guard = watch
-					.reserve_lock_write(version)
+					.try_reserve_lock_write(version)
 					.ok_or_else(|| tg::error!("files were modified during checkin"))?;
 
 				Ok(Some(lock_write_guard))
@@ -651,7 +651,7 @@ impl Session {
 			if lock_write_guard.is_some() {
 				let actual_lock = Self::checkin_try_read_lock(root)
 					.map_err(|error| tg::error!(!error, "failed to read the lock"))?;
-				if !crate::watch::locks_equal(lock.as_deref(), actual_lock.as_ref()) {
+				if lock.as_deref() != actual_lock.as_ref() {
 					return Err(tg::error!("the lock was modified during checkin"));
 				}
 			}

--- a/packages/server/src/checkin.rs
+++ b/packages/server/src/checkin.rs
@@ -598,16 +598,16 @@ impl Session {
 					.get(&watch_key)
 					.filter(|watch| watch.id() == id)
 					.ok_or_else(|| tg::error!("the watch changed during checkin"))?;
-				let lock_write = watch
+				let lock_write_guard = watch
 					.reserve_lock_write(version)
 					.ok_or_else(|| tg::error!("files were modified during checkin"))?;
 
-				Ok(Some(lock_write))
+				Ok(Some(lock_write_guard))
 			},
 			WatchObservation::Vacant => Ok(None),
 		};
 		progress.spinner("locking", "locking");
-		let (lock, lock_write) = self
+		let (lock, lock_write_guard) = self
 			.checkin_write_lock(&arg, &graph, next, lock, root, reserve_lock_write)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to create the lock"))?;
@@ -648,7 +648,7 @@ impl Session {
 			.await;
 
 			// Verify that the lock has the expected contents.
-			if lock_write.is_some() {
+			if lock_write_guard.is_some() {
 				let actual_lock = Self::checkin_try_read_lock(root)
 					.map_err(|error| tg::error!(!error, "failed to read the lock"))?;
 				if !crate::watch::locks_equal(lock.as_deref(), actual_lock.as_ref()) {
@@ -670,7 +670,7 @@ impl Session {
 						graph: graph.clone(),
 						key: &watch_key,
 						lock,
-						lock_write,
+						lock_write_guard,
 						next,
 						server: &self.server,
 						solutions,
@@ -699,7 +699,7 @@ impl Session {
 					let success =
 						entry
 							.get_mut()
-							.replace_if_version(version, lock_write, || {
+							.replace_if_version(version, lock_write_guard, || {
 								Watch::new(&self.server, &watch_key, new_arg).map_err(|error| {
 									tg::error!(!error, "failed to create the watch")
 								})

--- a/packages/server/src/checkin/lock.rs
+++ b/packages/server/src/checkin/lock.rs
@@ -60,21 +60,18 @@ impl Session {
 	}
 
 	#[tracing::instrument(level = "trace", skip_all)]
-	pub(super) async fn checkin_write_lock<F>(
+	pub(super) async fn checkin_write_lock(
 		&self,
 		arg: &tg::checkin::Arg,
 		graph: &Graph,
 		next: usize,
 		lock: Option<Arc<tg::graph::Data>>,
 		root: &Path,
-		reserve_lock_write: F,
+		reserve_lock_write: impl FnOnce() -> tg::Result<Option<crate::watch::LockWriteGuard>>,
 	) -> tg::Result<(
 		Option<Arc<tg::graph::Data>>,
 		Option<crate::watch::LockWriteGuard>,
-	)>
-	where
-		F: FnOnce() -> tg::Result<Option<crate::watch::LockWriteGuard>>,
-	{
+	)> {
 		// Get the root node.
 		let root_index = graph.paths.get(root).unwrap();
 		let root_node = graph.nodes.get(root_index).unwrap();

--- a/packages/server/src/checkin/lock.rs
+++ b/packages/server/src/checkin/lock.rs
@@ -70,10 +70,10 @@ impl Session {
 		reserve_lock_write: F,
 	) -> tg::Result<(
 		Option<Arc<tg::graph::Data>>,
-		Option<crate::watch::LockWrite>,
+		Option<crate::watch::LockWriteGuard>,
 	)>
 	where
-		F: FnOnce() -> tg::Result<Option<crate::watch::LockWrite>>,
+		F: FnOnce() -> tg::Result<Option<crate::watch::LockWriteGuard>>,
 	{
 		// Get the root node.
 		let root_index = graph.paths.get(root).unwrap();
@@ -94,7 +94,7 @@ impl Session {
 			if arg.options.locked && lock.is_some() {
 				return Err(tg::error!("the lock is out of date"));
 			}
-			let lock_write = reserve_lock_write()?;
+			let lock_write_guard = reserve_lock_write()?;
 			match root_node.variant {
 				Variant::Directory(_) => {
 					let lockfile_path = root.join(tg::module::LOCKFILE_FILE_NAME);
@@ -107,7 +107,7 @@ impl Session {
 				},
 				Variant::Symlink(_) => (),
 			}
-			return Ok((None, lock_write));
+			return Ok((None, lock_write_guard));
 		}
 
 		// Do not write a lock if the lock was not changed during solving.
@@ -132,7 +132,7 @@ impl Session {
 
 		let lock = Arc::new(new_lock);
 		let expected = (!lock.nodes.is_empty()).then(|| lock.clone());
-		let lock_write = reserve_lock_write()?;
+		let lock_write_guard = reserve_lock_write()?;
 
 		// If the root is a directory, then write a lockfile. Otherwise, write a file lock.
 		match root_node.variant {
@@ -145,7 +145,7 @@ impl Session {
 
 				// Do not write an empty lock.
 				if lock.nodes.is_empty() {
-					return Ok((expected, lock_write));
+					return Ok((expected, lock_write_guard));
 				}
 
 				// Serialize the lock.
@@ -186,7 +186,7 @@ impl Session {
 
 						// Do not write an empty lock.
 						if lock.nodes.is_empty() {
-							return Ok((expected, lock_write));
+							return Ok((expected, lock_write_guard));
 						}
 
 						// Serialize the lock.
@@ -210,7 +210,7 @@ impl Session {
 
 						// Do not write an empty lock.
 						if lock.nodes.is_empty() {
-							return Ok((expected, lock_write));
+							return Ok((expected, lock_write_guard));
 						}
 
 						// Serialize the lock.
@@ -230,7 +230,7 @@ impl Session {
 			Variant::Symlink(_) => {},
 		}
 
-		Ok((expected, lock_write))
+		Ok((expected, lock_write_guard))
 	}
 
 	fn checkin_lock_changed(

--- a/packages/server/src/checkin/lock.rs
+++ b/packages/server/src/checkin/lock.rs
@@ -4,6 +4,7 @@ use {
 	std::{
 		collections::{BTreeMap, HashSet, VecDeque},
 		path::Path,
+		sync::Arc,
 	},
 	tangram_client::prelude::*,
 	tangram_util::iter::Ext as _,
@@ -59,29 +60,33 @@ impl Session {
 	}
 
 	#[tracing::instrument(level = "trace", skip_all)]
-	pub(super) async fn checkin_write_lock(
+	pub(super) async fn checkin_write_lock<F>(
 		&self,
 		arg: &tg::checkin::Arg,
 		graph: &Graph,
 		next: usize,
-		lock: Option<&tg::graph::Data>,
+		lock: Option<Arc<tg::graph::Data>>,
 		root: &Path,
-		progress: &crate::progress::Handle<super::TaskOutput>,
-	) -> tg::Result<()> {
-		progress.spinner("locking", "locking");
-
+		reserve_lock_write: F,
+	) -> tg::Result<(
+		Option<Arc<tg::graph::Data>>,
+		Option<crate::watch::LockWrite>,
+	)>
+	where
+		F: FnOnce() -> tg::Result<Option<crate::watch::LockWrite>>,
+	{
 		// Get the root node.
 		let root_index = graph.paths.get(root).unwrap();
 		let root_node = graph.nodes.get(root_index).unwrap();
 
 		// Do not write a lock if the lock arg is not set.
 		if arg.options.lock.is_none() {
-			return Ok(());
+			return Ok((lock, None));
 		}
 
 		// Do not write a lock if this is a destructive checkin.
 		if arg.options.destructive {
-			return Ok(());
+			return Ok((lock, None));
 		}
 
 		// If the root is not solvable, then remove an existing lock and return.
@@ -89,6 +94,7 @@ impl Session {
 			if arg.options.locked && lock.is_some() {
 				return Err(tg::error!("the lock is out of date"));
 			}
+			let lock_write = reserve_lock_write()?;
 			match root_node.variant {
 				Variant::Directory(_) => {
 					let lockfile_path = root.join(tg::module::LOCKFILE_FILE_NAME);
@@ -101,14 +107,14 @@ impl Session {
 				},
 				Variant::Symlink(_) => (),
 			}
-			return Ok(());
+			return Ok((None, lock_write));
 		}
 
 		// Do not write a lock if the lock was not changed during solving.
-		if let Some(lock) = lock {
+		if let Some(lock) = &lock {
 			let changed = Self::checkin_lock_changed(graph, next, lock);
 			if !changed {
-				return Ok(());
+				return Ok((Some(lock.clone()), None));
 			}
 		}
 
@@ -116,11 +122,17 @@ impl Session {
 		let new_lock = Self::checkin_create_lock(graph, root, arg.options.source_dependencies);
 
 		// If this is a locked checkin, then verify the lock is unchanged.
-		if arg.options.locked && lock.is_some_and(|existing| new_lock.nodes != existing.nodes) {
+		if arg.options.locked
+			&& lock
+				.as_ref()
+				.is_some_and(|existing| new_lock.nodes != existing.nodes)
+		{
 			return Err(tg::error!("the lock is out of date"));
 		}
 
-		let lock = new_lock;
+		let lock = Arc::new(new_lock);
+		let expected = (!lock.nodes.is_empty()).then(|| lock.clone());
+		let lock_write = reserve_lock_write()?;
 
 		// If the root is a directory, then write a lockfile. Otherwise, write a file lock.
 		match root_node.variant {
@@ -133,7 +145,7 @@ impl Session {
 
 				// Do not write an empty lock.
 				if lock.nodes.is_empty() {
-					return Ok(());
+					return Ok((expected, lock_write));
 				}
 
 				// Serialize the lock.
@@ -174,7 +186,7 @@ impl Session {
 
 						// Do not write an empty lock.
 						if lock.nodes.is_empty() {
-							return Ok(());
+							return Ok((expected, lock_write));
 						}
 
 						// Serialize the lock.
@@ -198,7 +210,7 @@ impl Session {
 
 						// Do not write an empty lock.
 						if lock.nodes.is_empty() {
-							return Ok(());
+							return Ok((expected, lock_write));
 						}
 
 						// Serialize the lock.
@@ -218,9 +230,7 @@ impl Session {
 			Variant::Symlink(_) => {},
 		}
 
-		progress.finish("locking");
-
-		Ok(())
+		Ok((expected, lock_write))
 	}
 
 	fn checkin_lock_changed(

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -41,8 +41,7 @@ pub struct NewArg<F> {
 }
 
 pub struct LockWriteGuard {
-	active: bool,
-	state: Arc<Mutex<State>>,
+	state: Option<Arc<Mutex<State>>>,
 	version: u64,
 }
 
@@ -50,7 +49,7 @@ struct State {
 	graph: crate::checkin::Graph,
 	index_task: Shared<tg::Result<()>>,
 	lock: Option<Arc<tg::graph::Data>>,
-	lock_write_version: Option<u64>,
+	pending_lock_write_version: Option<u64>,
 	#[cfg(target_os = "macos")]
 	paths: HashSet<PathBuf, fnv::FnvBuildHasher>,
 	sender: tokio::sync::mpsc::Sender<Message>,
@@ -84,15 +83,6 @@ struct Message {
 	sender: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
-#[must_use]
-pub(crate) fn locks_equal(left: Option<&tg::graph::Data>, right: Option<&tg::graph::Data>) -> bool {
-	match (left, right) {
-		(Some(left), Some(right)) => left.nodes == right.nodes,
-		(None, None) => true,
-		_ => false,
-	}
-}
-
 impl Id {
 	#[must_use]
 	fn new(server: &Server) -> Self {
@@ -102,7 +92,7 @@ impl Id {
 
 impl LockWriteGuard {
 	fn commit(mut self) {
-		self.active = false;
+		self.state = None;
 	}
 }
 
@@ -150,7 +140,7 @@ impl Watch {
 			graph,
 			index_task,
 			lock,
-			lock_write_version: None,
+			pending_lock_write_version: None,
 			#[cfg(target_os = "macos")]
 			paths: HashSet::default(),
 			sender,
@@ -187,7 +177,7 @@ impl Watch {
 					}
 					let lock_changed = uses_lock && lockfile_changed;
 					let read_lock =
-						lock_changed && state.lock().unwrap().lock_write_version.is_none();
+						lock_changed && state.lock().unwrap().pending_lock_write_version.is_none();
 					let lock = read_lock.then(|| crate::Session::checkin_try_read_lock(&root));
 
 					// Lock the state.
@@ -195,13 +185,13 @@ impl Watch {
 
 					// Update the lock unless an internal write is pending.
 					let mut modified = false;
-					if state.lock_write_version.is_none()
+					if state.pending_lock_write_version.is_none()
 						&& let Some(lock) = lock
 					{
 						match lock {
 							Ok(lock) => {
 								let lock = lock.map(Arc::new);
-								if !locks_equal(state.lock.as_deref(), lock.as_deref()) {
+								if state.lock != lock {
 									state.lock = lock;
 									modified = true;
 								}
@@ -327,7 +317,7 @@ impl Watch {
 				return Err(error);
 			},
 		};
-		state.lock_write_version.take();
+		state.pending_lock_write_version.take();
 		*self = watch;
 		if let Some(lock_write_guard) = lock_write_guard {
 			lock_write_guard.commit();
@@ -336,15 +326,14 @@ impl Watch {
 		Ok(true)
 	}
 
-	pub fn reserve_lock_write(&self, version: u64) -> Option<LockWriteGuard> {
+	pub fn try_reserve_lock_write(&self, version: u64) -> Option<LockWriteGuard> {
 		let mut state = self.state.lock().unwrap();
-		if state.version != version || state.lock_write_version.is_some() {
+		if state.version != version || state.pending_lock_write_version.is_some() {
 			return None;
 		}
-		state.lock_write_version = Some(version);
+		state.pending_lock_write_version = Some(version);
 		let lock_write_guard = LockWriteGuard {
-			active: true,
-			state: self.state.clone(),
+			state: Some(self.state.clone()),
 			version,
 		};
 
@@ -420,7 +409,7 @@ impl Watch {
 		state.graph = graph;
 		state.index_task = index_task;
 		state.lock = lock;
-		state.lock_write_version.take();
+		state.pending_lock_write_version.take();
 		state.solutions = solutions;
 		state.version += 1;
 
@@ -505,7 +494,7 @@ impl Watch {
 
 impl State {
 	fn lock_write_guard_matches(&self, lock_write_guard: Option<&LockWriteGuard>) -> bool {
-		match (self.lock_write_version, lock_write_guard) {
+		match (self.pending_lock_write_version, lock_write_guard) {
 			(Some(version), Some(lock_write_guard)) => version == lock_write_guard.version,
 			(None, None) => true,
 			_ => false,
@@ -583,13 +572,13 @@ impl State {
 
 impl Drop for LockWriteGuard {
 	fn drop(&mut self) {
-		if !self.active {
+		let Some(state) = self.state.take() else {
 			return;
-		}
-		let mut state = self.state.lock().unwrap();
-		if state.lock_write_version == Some(self.version) {
+		};
+		let mut state = state.lock().unwrap();
+		if state.pending_lock_write_version == Some(self.version) {
 			state.lock.take();
-			state.lock_write_version.take();
+			state.pending_lock_write_version.take();
 			state.version += 1;
 		}
 	}

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -40,7 +40,7 @@ pub struct NewArg<F> {
 	pub spawn_index_task: F,
 }
 
-pub struct LockWrite {
+pub struct LockWriteGuard {
 	active: bool,
 	state: Arc<Mutex<State>>,
 	version: u64,
@@ -50,7 +50,7 @@ struct State {
 	graph: crate::checkin::Graph,
 	index_task: Shared<tg::Result<()>>,
 	lock: Option<Arc<tg::graph::Data>>,
-	lock_write: Option<u64>,
+	lock_write_version: Option<u64>,
 	#[cfg(target_os = "macos")]
 	paths: HashSet<PathBuf, fnv::FnvBuildHasher>,
 	sender: tokio::sync::mpsc::Sender<Message>,
@@ -72,7 +72,7 @@ pub struct UpdateArg<'a> {
 	pub graph: crate::checkin::Graph,
 	pub key: &'a Key,
 	pub lock: Option<Arc<tg::graph::Data>>,
-	pub lock_write: Option<LockWrite>,
+	pub lock_write_guard: Option<LockWriteGuard>,
 	pub next: usize,
 	pub server: &'a Server,
 	pub solutions: crate::checkin::Solutions,
@@ -100,8 +100,8 @@ impl Id {
 	}
 }
 
-impl LockWrite {
-	fn complete(mut self) {
+impl LockWriteGuard {
+	fn commit(mut self) {
 		self.active = false;
 	}
 }
@@ -150,7 +150,7 @@ impl Watch {
 			graph,
 			index_task,
 			lock,
-			lock_write: None,
+			lock_write_version: None,
 			#[cfg(target_os = "macos")]
 			paths: HashSet::default(),
 			sender,
@@ -186,7 +186,8 @@ impl Watch {
 						paths.remove(root.as_path());
 					}
 					let lock_changed = uses_lock && lockfile_changed;
-					let read_lock = lock_changed && state.lock().unwrap().lock_write.is_none();
+					let read_lock =
+						lock_changed && state.lock().unwrap().lock_write_version.is_none();
 					let lock = read_lock.then(|| crate::Session::checkin_try_read_lock(&root));
 
 					// Lock the state.
@@ -194,7 +195,7 @@ impl Watch {
 
 					// Update the lock unless an internal write is pending.
 					let mut modified = false;
-					if state.lock_write.is_none()
+					if state.lock_write_version.is_none()
 						&& let Some(lock) = lock
 					{
 						match lock {
@@ -307,7 +308,7 @@ impl Watch {
 	pub fn replace_if_version<F>(
 		&mut self,
 		version: u64,
-		lock_write: Option<LockWrite>,
+		lock_write_guard: Option<LockWriteGuard>,
 		replace: F,
 	) -> tg::Result<bool>
 	where
@@ -315,7 +316,7 @@ impl Watch {
 	{
 		let state = self.state.clone();
 		let mut state = state.lock().unwrap();
-		if state.version != version || !state.lock_write_matches(lock_write.as_ref()) {
+		if state.version != version || !state.lock_write_guard_matches(lock_write_guard.as_ref()) {
 			drop(state);
 			return Ok(false);
 		}
@@ -326,28 +327,28 @@ impl Watch {
 				return Err(error);
 			},
 		};
-		state.lock_write.take();
+		state.lock_write_version.take();
 		*self = watch;
-		if let Some(lock_write) = lock_write {
-			lock_write.complete();
+		if let Some(lock_write_guard) = lock_write_guard {
+			lock_write_guard.commit();
 		}
 
 		Ok(true)
 	}
 
-	pub fn reserve_lock_write(&self, version: u64) -> Option<LockWrite> {
+	pub fn reserve_lock_write(&self, version: u64) -> Option<LockWriteGuard> {
 		let mut state = self.state.lock().unwrap();
-		if state.version != version || state.lock_write.is_some() {
+		if state.version != version || state.lock_write_version.is_some() {
 			return None;
 		}
-		state.lock_write = Some(version);
-		let lock_write = LockWrite {
+		state.lock_write_version = Some(version);
+		let lock_write_guard = LockWriteGuard {
 			active: true,
 			state: self.state.clone(),
 			version,
 		};
 
-		Some(lock_write)
+		Some(lock_write_guard)
 	}
 
 	pub fn get(&self) -> impl Future<Output = tg::Result<Snapshot>> + Send + use<> {
@@ -401,7 +402,7 @@ impl Watch {
 			graph,
 			key,
 			lock,
-			lock_write,
+			lock_write_guard,
 			next,
 			server,
 			solutions,
@@ -409,7 +410,7 @@ impl Watch {
 		} = arg;
 		let mut state = self.state.lock().unwrap();
 
-		if state.version != version || !state.lock_write_matches(lock_write.as_ref()) {
+		if state.version != version || !state.lock_write_guard_matches(lock_write_guard.as_ref()) {
 			drop(state);
 			return false;
 		}
@@ -419,7 +420,7 @@ impl Watch {
 		state.graph = graph;
 		state.index_task = index_task;
 		state.lock = lock;
-		state.lock_write.take();
+		state.lock_write_version.take();
 		state.solutions = solutions;
 		state.version += 1;
 
@@ -433,8 +434,8 @@ impl Watch {
 		state.add_paths_linux(next);
 		#[cfg(not(target_os = "linux"))]
 		let _ = next;
-		if let Some(lock_write) = lock_write {
-			lock_write.complete();
+		if let Some(lock_write_guard) = lock_write_guard {
+			lock_write_guard.commit();
 		}
 
 		true
@@ -503,9 +504,9 @@ impl Watch {
 }
 
 impl State {
-	fn lock_write_matches(&self, lock_write: Option<&LockWrite>) -> bool {
-		match (self.lock_write, lock_write) {
-			(Some(version), Some(lock_write)) => version == lock_write.version,
+	fn lock_write_guard_matches(&self, lock_write_guard: Option<&LockWriteGuard>) -> bool {
+		match (self.lock_write_version, lock_write_guard) {
+			(Some(version), Some(lock_write_guard)) => version == lock_write_guard.version,
 			(None, None) => true,
 			_ => false,
 		}
@@ -580,15 +581,15 @@ impl State {
 	}
 }
 
-impl Drop for LockWrite {
+impl Drop for LockWriteGuard {
 	fn drop(&mut self) {
 		if !self.active {
 			return;
 		}
 		let mut state = self.state.lock().unwrap();
-		if state.lock_write == Some(self.version) {
+		if state.lock_write_version == Some(self.version) {
 			state.lock.take();
-			state.lock_write.take();
+			state.lock_write_version.take();
 			state.version += 1;
 		}
 	}

--- a/packages/server/src/watch.rs
+++ b/packages/server/src/watch.rs
@@ -40,10 +40,17 @@ pub struct NewArg<F> {
 	pub spawn_index_task: F,
 }
 
+pub struct LockWrite {
+	active: bool,
+	state: Arc<Mutex<State>>,
+	version: u64,
+}
+
 struct State {
 	graph: crate::checkin::Graph,
 	index_task: Shared<tg::Result<()>>,
 	lock: Option<Arc<tg::graph::Data>>,
+	lock_write: Option<u64>,
 	#[cfg(target_os = "macos")]
 	paths: HashSet<PathBuf, fnv::FnvBuildHasher>,
 	sender: tokio::sync::mpsc::Sender<Message>,
@@ -65,6 +72,7 @@ pub struct UpdateArg<'a> {
 	pub graph: crate::checkin::Graph,
 	pub key: &'a Key,
 	pub lock: Option<Arc<tg::graph::Data>>,
+	pub lock_write: Option<LockWrite>,
 	pub next: usize,
 	pub server: &'a Server,
 	pub solutions: crate::checkin::Solutions,
@@ -76,10 +84,25 @@ struct Message {
 	sender: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
+#[must_use]
+pub(crate) fn locks_equal(left: Option<&tg::graph::Data>, right: Option<&tg::graph::Data>) -> bool {
+	match (left, right) {
+		(Some(left), Some(right)) => left.nodes == right.nodes,
+		(None, None) => true,
+		_ => false,
+	}
+}
+
 impl Id {
 	#[must_use]
 	fn new(server: &Server) -> Self {
 		Self(server.next_watch_id.fetch_add(1, Ordering::Relaxed))
+	}
+}
+
+impl LockWrite {
+	fn complete(mut self) {
+		self.active = false;
 	}
 }
 
@@ -127,6 +150,7 @@ impl Watch {
 			graph,
 			index_task,
 			lock,
+			lock_write: None,
 			#[cfg(target_os = "macos")]
 			paths: HashSet::default(),
 			sender,
@@ -142,29 +166,59 @@ impl Watch {
 		state.lock().unwrap().add_paths_linux(next);
 
 		// Spawn the task.
+		let lockfile_path = key.path.join(tg::module::LOCKFILE_FILE_NAME);
+		let uses_lock = options.lock.is_some();
 		let task = Task::spawn({
+			let lockfile_path = lockfile_path.clone();
 			let state = state.clone();
 			let root = key.path.clone();
 			move |_| async move {
 				while let Some(message) = receiver.recv().await {
 					// Get the paths.
-					let paths = Self::changes(&message.event);
+					let mut paths = Self::changes(&message.event);
+					let lockfile_changed = paths.remove(lockfile_path.as_path());
+					let only_lockfile_changed = message
+						.event
+						.paths
+						.iter()
+						.all(|path| path == &lockfile_path);
+					if lockfile_changed && only_lockfile_changed {
+						paths.remove(root.as_path());
+					}
+					let lock_changed = uses_lock && lockfile_changed;
+					let read_lock = lock_changed && state.lock().unwrap().lock_write.is_none();
+					let lock = read_lock.then(|| crate::Session::checkin_try_read_lock(&root));
 
 					// Lock the state.
 					let mut state = state.lock().unwrap();
 
-					// Update the nodes for the affected paths along with their ancestors.
-					let mut removed = false;
-					for path in paths {
-						// If the affected file is the lockfile, then clear it.
-						if path == root.join("tangram.lock") {
-							state.lock.take();
+					// Update the lock unless an internal write is pending.
+					let mut modified = false;
+					if state.lock_write.is_none()
+						&& let Some(lock) = lock
+					{
+						match lock {
+							Ok(lock) => {
+								let lock = lock.map(Arc::new);
+								if !locks_equal(state.lock.as_deref(), lock.as_deref()) {
+									state.lock = lock;
+									modified = true;
+								}
+							},
+							Err(error) => {
+								tracing::error!(%error, "failed to read the lock");
+								state.lock.take();
+								modified = true;
+							},
 						}
+					}
 
+					// Update the nodes for the affected paths along with their ancestors.
+					for path in paths {
 						let Some(index) = state.graph.paths.get(path).copied() else {
 							continue;
 						};
-						removed = true;
+						modified = true;
 						let mut queue = vec![index];
 						let mut visited = HashSet::<usize, fnv::FnvBuildHasher>::default();
 						while let Some(index) = queue.pop() {
@@ -215,8 +269,8 @@ impl Watch {
 						}
 					}
 
-					// Increment the version if any nodes were removed.
-					if removed {
+					// Increment the version if the lock or any nodes changed.
+					if modified {
 						state.version += 1;
 					}
 
@@ -250,20 +304,50 @@ impl Watch {
 		&self.options
 	}
 
-	pub fn replace_if_version<F>(&mut self, version: u64, replace: F) -> tg::Result<bool>
+	pub fn replace_if_version<F>(
+		&mut self,
+		version: u64,
+		lock_write: Option<LockWrite>,
+		replace: F,
+	) -> tg::Result<bool>
 	where
 		F: FnOnce() -> tg::Result<Self>,
 	{
 		let state = self.state.clone();
-		let state = state.lock().unwrap();
-		if state.version != version {
+		let mut state = state.lock().unwrap();
+		if state.version != version || !state.lock_write_matches(lock_write.as_ref()) {
+			drop(state);
 			return Ok(false);
 		}
-		let watch = replace()?;
+		let watch = match replace() {
+			Ok(watch) => watch,
+			Err(error) => {
+				drop(state);
+				return Err(error);
+			},
+		};
+		state.lock_write.take();
 		*self = watch;
-		drop(state);
+		if let Some(lock_write) = lock_write {
+			lock_write.complete();
+		}
 
 		Ok(true)
+	}
+
+	pub fn reserve_lock_write(&self, version: u64) -> Option<LockWrite> {
+		let mut state = self.state.lock().unwrap();
+		if state.version != version || state.lock_write.is_some() {
+			return None;
+		}
+		state.lock_write = Some(version);
+		let lock_write = LockWrite {
+			active: true,
+			state: self.state.clone(),
+			version,
+		};
+
+		Some(lock_write)
 	}
 
 	pub fn get(&self) -> impl Future<Output = tg::Result<Snapshot>> + Send + use<> {
@@ -317,6 +401,7 @@ impl Watch {
 			graph,
 			key,
 			lock,
+			lock_write,
 			next,
 			server,
 			solutions,
@@ -324,7 +409,8 @@ impl Watch {
 		} = arg;
 		let mut state = self.state.lock().unwrap();
 
-		if state.version != version {
+		if state.version != version || !state.lock_write_matches(lock_write.as_ref()) {
+			drop(state);
 			return false;
 		}
 
@@ -333,6 +419,7 @@ impl Watch {
 		state.graph = graph;
 		state.index_task = index_task;
 		state.lock = lock;
+		state.lock_write.take();
 		state.solutions = solutions;
 		state.version += 1;
 
@@ -346,6 +433,9 @@ impl Watch {
 		state.add_paths_linux(next);
 		#[cfg(not(target_os = "linux"))]
 		let _ = next;
+		if let Some(lock_write) = lock_write {
+			lock_write.complete();
+		}
 
 		true
 	}
@@ -413,6 +503,14 @@ impl Watch {
 }
 
 impl State {
+	fn lock_write_matches(&self, lock_write: Option<&LockWrite>) -> bool {
+		match (self.lock_write, lock_write) {
+			(Some(version), Some(lock_write)) => version == lock_write.version,
+			(None, None) => true,
+			_ => false,
+		}
+	}
+
 	#[cfg(target_os = "macos")]
 	fn update_paths_darwin(&mut self) {
 		// Get the new paths.
@@ -479,5 +577,19 @@ impl State {
 			watcher_paths.remove(path).ok();
 		}
 		watcher_paths.commit().ok();
+	}
+}
+
+impl Drop for LockWrite {
+	fn drop(&mut self) {
+		if !self.active {
+			return;
+		}
+		let mut state = self.state.lock().unwrap();
+		if state.lock_write == Some(self.version) {
+			state.lock.take();
+			state.lock_write.take();
+			state.version += 1;
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- invalidate a watch when the on-disk lock content actually changes
- reserve the observed watch while checkin writes its own lock, then validate the final lock before publication
- publish the newly written lock into the watch cache so duplicate self-events are ignored

## Tests

- checkpointed external lock change after a watch snapshot
- checkpointed internal lock event and external overwrite while a lock write is pending
- bun run check
- focused watched-checkin regression suite