### PR TITLE
server/process: avoid canceling finished children

### DIFF
--- a/packages/cli/tests/build/remote_fanout.nu
+++ b/packages/cli/tests/build/remote_fanout.nu
@@ -1,7 +1,7 @@
 use ../../test.nu *
 
-# A build fanning out eight children across four concurrent remote
-# runners completes and returns every child's result.
+# A build fanning out eight children across four concurrent remote runners
+# completes without releasing leases for children it already waited for.
 #
 # Regression test for 802b850c (#765).
 
@@ -19,6 +19,9 @@ let runners = ["runner1", "runner2", "runner3", "runner4"] | each { |name|
 
 	# Start the runner server.
 	let config = {
+		advanced: {
+			checkpoints: true,
+		},
 		remotes: {
 			default: {
 				token: $created.token.token
@@ -34,6 +37,13 @@ let runners = ["runner1", "runner2", "runner3", "runner4"] | each { |name|
 		}
 	}
 	spawn --name $name --config $config
+}
+
+# Block any attempt by a parent to release an awaited child's lease.
+let release_watches = $runners | each { |runner|
+	tg --url $runner.url checkpoint watch runner.process.child_lease.release
+	| from json
+	| get watch
 }
 
 # Start the local server.
@@ -66,5 +76,10 @@ let path = artifact {
 
 # Run a remote build
 let id = tg build --remote --detach $path
-let output = tg wait $id
-snapshot $output '{"exit":0,"output":[0,1,2,3,4,5,6,7]}'
+let output = timeout 10s tg wait $id | complete
+for entry in ($runners | enumerate) {
+	let watch = $release_watches | get $entry.index
+	tg --url $entry.item.url checkpoint unwatch runner.process.child_lease.release $watch
+}
+success $output "the parent should not release leases for children it waited for"
+snapshot ($output.stdout | str trim) '{"exit":0,"output":[0,1,2,3,4,5,6,7]}'

--- a/packages/server/src/process.rs
+++ b/packages/server/src/process.rs
@@ -27,7 +27,7 @@ pub(crate) type ConnectionFuture = BoxFuture<'static, tg::Result<control::Connec
 pub type Map = DashMap<tg::process::Id, tg::sandbox::Id, tg::id::BuildHasher>;
 
 pub struct State {
-	pub children: Vec<Child>,
+	pub child_leases: Vec<ChildLease>,
 	pub control: tokio::sync::mpsc::Sender<tg::process::control::ClientMessage>,
 	pub data: tg::process::Data,
 	pub finish: Option<tg::process::control::FinishServerRequestArg>,
@@ -37,7 +37,7 @@ pub struct State {
 	pub stopper: tangram_futures::task::Stopper,
 }
 
-pub struct Child {
+pub struct ChildLease {
 	pub lease: String,
 	pub location: Option<tg::location::Arg>,
 	pub process: tg::process::Id,

--- a/packages/server/src/process/spawn/child.rs
+++ b/packages/server/src/process/spawn/child.rs
@@ -49,11 +49,13 @@ impl Session {
 				process: tg::Referent::new(child.clone(), options),
 			});
 		if let Some(lease) = arg.lease {
-			parent_process.children.push(crate::process::Child {
-				lease: lease.to_owned(),
-				location: arg.location.cloned().map(Into::into),
-				process: child.clone(),
-			});
+			parent_process
+				.child_leases
+				.push(crate::process::ChildLease {
+					lease: lease.to_owned(),
+					location: arg.location.cloned().map(Into::into),
+					process: child.clone(),
+				});
 		}
 		let parent_data = parent_process.data.clone();
 		let control = parent_process.control.clone();

--- a/packages/server/src/process/spawn/wait.rs
+++ b/packages/server/src/process/spawn/wait.rs
@@ -323,15 +323,18 @@ impl Session {
 		output: Output,
 		wait: Option<tg::process::wait::Output>,
 	) -> tg::Result<tg::process::spawn::Output> {
-		let data_wait = output.wait()?;
-		Ok(tg::process::spawn::Output {
+		let wait = wait.or(output.wait()?);
+		let lease = if wait.is_some() { None } else { output.lease };
+		let output = tg::process::spawn::Output {
 			cached: output.cached,
-			lease: output.lease,
+			lease,
 			location: Some(tg::Location::Local(tg::location::Local::default())),
 			process: tg::Either::Right(output.id),
 			token: output.token,
-			wait: wait.or(data_wait),
-		})
+			wait,
+		};
+
+		Ok(output)
 	}
 
 	async fn spawn_process_get_cached_process_region_or_remote(

--- a/packages/server/src/process/wait.rs
+++ b/packages/server/src/process/wait.rs
@@ -64,7 +64,7 @@ impl Session {
 					.map_err(|error| tg::error!(!error, %id, "failed to wait for the process"))?
 			{
 				let future =
-					self.attach_wait_process_cancel_guard(id, &arg, None, stopper.clone(), future);
+					self.attach_wait_process_guard(id, &arg, None, stopper.clone(), future);
 				return Ok(Some(future));
 			}
 
@@ -77,7 +77,7 @@ impl Session {
 				let location = Some(tg::Location::Local(tg::location::Local {
 					region: Some(region),
 				}));
-				let future = self.attach_wait_process_cancel_guard(
+				let future = self.attach_wait_process_guard(
 					id,
 					&arg,
 					location.map(Into::into),
@@ -104,7 +104,7 @@ impl Session {
 			})
 			.into(),
 		);
-		let future = self.attach_wait_process_cancel_guard(id, &arg, location, stopper, future);
+		let future = self.attach_wait_process_guard(id, &arg, location, stopper, future);
 
 		Ok(Some(future))
 	}
@@ -328,7 +328,7 @@ impl Session {
 		Ok(Some((future.boxed(), remote.clone())))
 	}
 
-	fn attach_wait_process_cancel_guard(
+	fn attach_wait_process_guard(
 		&self,
 		id: &tg::process::Id,
 		arg: &tg::process::wait::Arg,
@@ -336,6 +336,30 @@ impl Session {
 		stopper: Option<Stopper>,
 		future: BoxFuture<'static, tg::Result<Option<tg::process::wait::Output>>>,
 	) -> BoxFuture<'static, tg::Result<Option<tg::process::wait::Output>>> {
+		// Remove the parent's child leases when the child finishes.
+		let future = if let tg::Principal::Process(parent) = &self.context.principal {
+			let child = id.clone();
+			let parent = parent.clone();
+			let server = self.server.clone();
+			async move {
+				let output = future.await;
+				if matches!(&output, Ok(Some(_))) {
+					server
+						.runner
+						.state()
+						.try_update_process(&parent, |process| {
+							process
+								.child_leases
+								.retain(|child_lease| child_lease.process != child);
+						});
+				}
+				output
+			}
+			.boxed()
+		} else {
+			future
+		};
+
 		// If a lease is provided, attach a cancellation guard.
 		if let Some(lease) = arg.lease.clone() {
 			let cancel = Arc::new(AtomicBool::new(true));

--- a/packages/server/src/runner/process.rs
+++ b/packages/server/src/runner/process.rs
@@ -504,7 +504,7 @@ impl Session {
 		sandbox_state.processes.insert(
 			id.clone(),
 			crate::process::State {
-				children: Vec::new(),
+				child_leases: Vec::new(),
 				control: control_sender.clone(),
 				data: state.to_data(),
 				finish: None,
@@ -946,19 +946,27 @@ impl Session {
 		process_state.data.finished_at = Some(time::OffsetDateTime::now_utc().unix_timestamp());
 		process_state.data.output = value;
 		process_state.data.status = tg::process::Status::Finished;
-		let children = std::mem::take(&mut process_state.children);
+		let child_leases = std::mem::take(&mut process_state.child_leases);
 		let data = process_state.data.clone();
 		drop(sandbox);
 
-		children
+		child_leases
 			.into_iter()
-			.map(|child| {
+			.map(|child_lease| {
+				let parent = id.clone();
 				let session = session.clone();
 				async move {
-					let id = child.process;
+					let id = child_lease.process;
+					crate::checkpoint!(
+						session.server,
+						"runner.process.child_lease.release",
+						child = %id,
+						parent = %parent,
+					)
+					.await;
 					let arg = tg::process::cancel::Arg {
-						lease: child.lease,
-						location: child.location,
+						lease: child_lease.lease,
+						location: child_lease.location,
 					};
 					if let Err(error) = session.cancel_process(&id, arg).await {
 						tracing::error!(error = %error.trace(), process = %id, "failed to release a child process lease");


### PR DESCRIPTION
## Summary

- remove parent child leases after successful waits
- omit leases from completed spawn responses
- cover multi-runner cleanup with a checkpoint regression test

## Root cause

Parents retained every child lease until completion, so cleanup sent release requests even for children already known to be finished, including children on other runners.

## Testing

- bun run format
- bun run check
- nu packages/cli/test.nu remote_fanout
- nu packages/cli/test.nu "cancel_propagates_to_children|child_lease_released_once"

Closes #1005