### PR TITLE
feat(cli): add the tag ancestors options to spawn, run, and build

### DIFF
--- a/packages/cli/src/node.rs
+++ b/packages/cli/src/node.rs
@@ -78,6 +78,82 @@ impl Ancestors {
 }
 
 #[derive(Clone, Debug, Default, clap::Args)]
+pub struct TagAncestors {
+	/// Create the tag's missing ancestors after pulling.
+	#[arg(
+		default_missing_value = "true",
+		id = "tag_ancestors.create_tag_ancestors",
+		long = "create-tag-ancestors",
+		num_args = 0..=1,
+		overrides_with = "tag_ancestors.no_create_tag_ancestors",
+		require_equals = true,
+		value_name = "BOOL",
+		visible_alias = "create-tag-parents",
+	)]
+	create: Option<bool>,
+
+	/// Do not create the tag's missing ancestors.
+	#[arg(
+		default_missing_value = "true",
+		id = "tag_ancestors.no_create_tag_ancestors",
+		long = "no-create-tag-ancestors",
+		num_args = 0..=1,
+		overrides_with = "tag_ancestors.create_tag_ancestors",
+		require_equals = true,
+		value_name = "BOOL",
+		visible_alias = "no-create-tag-parents",
+	)]
+	no_create: Option<bool>,
+
+	/// Do not pull the tag's ancestors.
+	#[arg(
+		default_missing_value = "true",
+		id = "tag_ancestors.no_pull_tag_ancestors",
+		long = "no-pull-tag-ancestors",
+		num_args = 0..=1,
+		overrides_with = "tag_ancestors.pull_tag_ancestors",
+		require_equals = true,
+		value_name = "BOOL",
+		visible_alias = "no-pull-tag-parents",
+	)]
+	no_pull: Option<bool>,
+
+	/// Pull the tag's ancestors using the specified policy: always, missing, or never.
+	#[arg(
+		default_missing_value = "always",
+		id = "tag_ancestors.pull_tag_ancestors",
+		long = "pull-tag-ancestors",
+		num_args = 0..=1,
+		overrides_with = "tag_ancestors.no_pull_tag_ancestors",
+		require_equals = true,
+		value_name = "POLICY",
+		visible_alias = "pull-tag-parents",
+	)]
+	pull: Option<tg::node::AncestorsPull>,
+}
+
+impl TagAncestors {
+	#[must_use]
+	pub fn get(&self) -> tg::node::Ancestors {
+		let create = self
+			.create
+			.or(self.no_create.map(|value| !value))
+			.unwrap_or(false);
+		let pull = self
+			.pull
+			.or(self.no_pull.map(|value| {
+				if value {
+					tg::node::AncestorsPull::Never
+				} else {
+					tg::node::AncestorsPull::Missing
+				}
+			}))
+			.unwrap_or_default();
+		tg::node::Ancestors { create, pull }
+	}
+}
+
+#[derive(Clone, Debug, Default, clap::Args)]
 pub struct Options {
 	/// Transfer ancestors using the specified policy: always, missing, or never.
 	#[arg(

--- a/packages/cli/src/process/spawn.rs
+++ b/packages/cli/src/process/spawn.rs
@@ -139,6 +139,9 @@ pub struct Options {
 	pub tag: Option<tg::Specifier>,
 
 	#[command(flatten)]
+	pub tag_ancestors: crate::node::TagAncestors,
+
+	#[command(flatten)]
 	pub tty: Tty,
 }
 
@@ -352,6 +355,7 @@ pub(crate) struct InnerOutput {
 	pub referent: tg::Referent<tg::graph::Edge<tg::Object>>,
 	pub sandboxed: bool,
 	pub tag: Option<tg::Specifier>,
+	pub tag_ancestors: tg::node::Ancestors,
 }
 
 impl Cli {
@@ -432,6 +436,7 @@ impl Cli {
 			referent,
 			sandboxed,
 			tag,
+			tag_ancestors,
 		} = self.spawn_inner(options, reference, trailing).await?;
 
 		let process = tg::Process::spawn_with_progress_with_handle(&client, arg, |stream| {
@@ -456,7 +461,7 @@ impl Cli {
 				.cloned()
 				.ok_or_else(|| tg::error!("a tag requires a sandboxed process"))?;
 			let arg = tg::tag::put::Arg {
-				ancestors: tg::node::Ancestors::default(),
+				ancestors: tag_ancestors,
 				target: id.into(),
 				location: location.clone(),
 				public: false,
@@ -950,6 +955,7 @@ impl Cli {
 			referent,
 			sandboxed,
 			tag: options.tag,
+			tag_ancestors: options.tag_ancestors.get(),
 		})
 	}
 }

--- a/packages/cli/tests/build/tag_create_ancestors.nu
+++ b/packages/cli/tests/build/tag_create_ancestors.nu
@@ -1,0 +1,53 @@
+use ../../test.nu *
+
+# Building with a nested tag should be able to create the tag's missing ancestor groups, the way
+# tagging and creating a group do, and should keep refusing by default. Every spelling of the flag is
+# covered: the aliases, the explicit boolean values, and the last flag winning when both are given.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: 'export default function () { return "hello"; }'
+}
+
+# Every spelling that leaves creating disabled should refuse.
+let refusals = [
+	[]
+	[--no-create-tag-ancestors]
+	[--no-create-tag-parents]
+	['--create-tag-ancestors=false']
+	['--no-create-tag-ancestors=true']
+	[--create-tag-ancestors --no-create-tag-ancestors]
+]
+for flags in $refusals {
+	let refused = tg build ...$flags --tag refused/builds/1.0.0/default $path | complete
+	failure $refused $"building with ($flags | str join ' ') should fail when the ancestors do not exist"
+	assert ($refused.stderr | str contains "the parent does not exist")
+}
+failure (tg group get refused | complete) "a refused build should not create any ancestors"
+
+# Every spelling that enables creating should create the whole chain.
+let creations = [
+	{ root: ancestors, flags: [--create-tag-ancestors] }
+	{ root: parents, flags: [--create-tag-parents] }
+	{ root: explicit, flags: ['--create-tag-ancestors=true'] }
+	{ root: negated, flags: ['--no-create-tag-ancestors=false'] }
+	{ root: override, flags: [--no-create-tag-ancestors --create-tag-ancestors] }
+]
+for creation in $creations {
+	let specifier = $"($creation.root)/builds/1.0.0/default"
+	let output = tg build ...$creation.flags --tag $specifier $path | complete
+	success $output $"building with ($creation.flags | str join ' ') should create the tag's ancestors"
+
+	let tag = tg tag get $specifier | from json
+	assert equal $tag.specifier $specifier "the tag should keep its specifier"
+	assert equal $tag.target.kind "process" "the tag should point to the process"
+
+	let root = tg group get $creation.root | from json
+	let builds = tg group get $"($creation.root)/builds" | from json
+	let version = tg group get $"($creation.root)/builds/1.0.0" | from json
+	assert equal $root.specifier $creation.root "the root ancestor should exist"
+	assert equal $builds.parent $root.id "each ancestor should hold the one above it"
+	assert equal $version.parent $builds.id "the whole chain should exist"
+	assert equal $tag.parent $version.id "the tag should hold the last ancestor"
+}

--- a/packages/cli/tests/build/tag_pull_ancestors.nu
+++ b/packages/cli/tests/build/tag_pull_ancestors.nu
@@ -1,0 +1,80 @@
+use ../../test.nu *
+
+# Building with a nested tag should pull the tag's missing ancestors from a remote, the way tagging
+# does. Every spelling of the flag is covered: the aliases, the explicit policies, and the last flag
+# winning when both are given.
+
+let remote = spawn --name remote
+let local = spawn --name local --config {
+	remotes: { default: { url: $remote.url } }
+}
+
+let path = artifact {
+	tangram.ts: 'export default function () { return "hello"; }'
+}
+
+# Create a chain of ancestors on the remote only.
+def create_remote_ancestors [remote: record, root: string] {
+	tg --url $remote.url group create $root | ignore
+	tg --url $remote.url group create $"($root)/builds" | ignore
+	tg --url $remote.url group create $"($root)/builds/1.0.0" | from json
+}
+
+# Every spelling that never pulls should refuse, since the ancestors stay on the remote.
+create_remote_ancestors $remote refused
+let refusals = [
+	[--no-pull-tag-ancestors]
+	[--no-pull-tag-parents]
+	['--pull-tag-ancestors=never']
+	['--no-pull-tag-ancestors=true']
+	[--pull-tag-ancestors --no-pull-tag-ancestors]
+]
+for flags in $refusals {
+	let refused = tg --url $local.url build ...$flags --tag refused/builds/1.0.0/default $path | complete
+	failure $refused $"building with ($flags | str join ' ') should fail without pulling the ancestors"
+	assert ($refused.stderr | str contains "the parent does not exist")
+}
+failure (tg --url $local.url group get --local refused | complete) "a refused build should not pull any ancestors"
+
+# Every spelling that pulls should take the ancestors from the remote.
+let pulls = [
+	{ root: default, flags: [] }
+	{ root: bare, flags: [--pull-tag-ancestors] }
+	{ root: always, flags: ['--pull-tag-ancestors=always'] }
+	{ root: missing, flags: ['--pull-tag-ancestors=missing'] }
+	{ root: alias, flags: ['--pull-tag-parents=missing'] }
+	{ root: negated, flags: ['--no-pull-tag-ancestors=false'] }
+	{ root: override, flags: [--no-pull-tag-ancestors --pull-tag-ancestors] }
+]
+for pull in $pulls {
+	let version = create_remote_ancestors $remote $pull.root
+	let specifier = $"($pull.root)/builds/1.0.0/default"
+	let output = tg --url $local.url build ...$pull.flags --tag $specifier $path | complete
+	success $output $"building with ($pull.flags | str join ' ') should pull the tag's ancestors"
+
+	let tag = tg --url $local.url tag get $specifier | from json
+	assert equal $tag.specifier $specifier "the tag should keep its specifier"
+	assert equal $tag.parent $version.id "the tag should hold the ancestor from the remote"
+	let pulled = tg --url $local.url group get --local $"($pull.root)/builds/1.0.0" | from json
+	assert equal $pulled.id $version.id "the ancestors should come from the remote"
+}
+
+# Missing should keep a conflicting local root, leaving the tag's parent missing.
+let local_root = tg --url $local.url group create conflict | from json
+let version = create_remote_ancestors $remote conflict
+assert not equal $local_root.id (tg --url $remote.url group get conflict | from json | get id)
+let refused = tg --url $local.url build --tag conflict/builds/1.0.0/default $path | complete
+failure $refused "building should fail while a conflicting local root shadows the remote ancestors"
+assert equal (tg --url $local.url group get --local conflict | from json | get id) $local_root.id
+
+# Always should replace the conflicting local root with the remote's.
+let output = tg --url $local.url build '--pull-tag-ancestors=always' --tag conflict/builds/1.0.0/default $path | complete
+success $output "building should replace a conflicting local root when always pulling"
+assert equal (tg --url $local.url group get --local conflict/builds/1.0.0 | from json | get id) $version.id
+
+# Creating should not consult the remote when pulling is disabled.
+let version = create_remote_ancestors $remote created
+let output = tg --url $local.url build --create-tag-ancestors --no-pull-tag-ancestors --tag created/builds/1.0.0/default $path | complete
+success $output "building should create the tag's ancestors locally without pulling"
+let created = tg --url $local.url group get --local created/builds/1.0.0 | from json
+assert not equal $created.id $version.id "the created ancestors should not come from the remote"


### PR DESCRIPTION
Adds a `TagAncestors` clap group (--create-tag-ancestors / --pull-tag-ancestors, plus their no- and -parents forms, no short) and threads it into the tag put from spawn.