### PR TITLE
fix(vfs/virtiofs): fix a potential use-after-close condition in DAX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "virtiofsd"
 version = "1.14.0"
-source = "git+https://github.com/tangramdotdev/virtiofsd?branch=feat%2Fdax#34280d31d10478c41d11c59afbf8ac042816348f"
+source = "git+https://github.com/tangramdotdev/virtiofsd?rev=d0c78f1b1b01f032b575f581b24d901146606abc#d0c78f1b1b01f032b575f581b24d901146606abc"
 dependencies = [
  "bitflags 1.3.2",
  "btree-range-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,5 +242,5 @@ ignored = [
 ]
 
 [patch.crates-io]
-virtiofsd = { git = "https://github.com/tangramdotdev/virtiofsd", branch = "feat/dax" }
+virtiofsd = { git = "https://github.com/tangramdotdev/virtiofsd", rev = "d0c78f1b1b01f032b575f581b24d901146606abc" }
 heed = { git = "https://github.com/tangramdotdev/heed.git", rev = "c5ea26f535702b0973cf9551e025234d6529cc06" }

--- a/packages/vfs/src/virtiofs.rs
+++ b/packages/vfs/src/virtiofs.rs
@@ -4,7 +4,7 @@ use {
 	std::{
 		ffi::{CStr, CString},
 		io::{self, Write as _},
-		os::fd::{AsRawFd as _, FromRawFd as _, RawFd},
+		os::fd::{FromRawFd as _, OwnedFd},
 		path::{Path, PathBuf},
 		sync::{Arc, Mutex},
 		time::Duration,
@@ -341,15 +341,15 @@ where
 		foffset: u64,
 		_len: u64,
 		flags: virtiofsd::fuse::SetupmappingFlags,
-	) -> Result<(RawFd, u64)> {
+	) -> Result<(OwnedFd, u64)> {
 		if flags.contains(virtiofsd::fuse::SetupmappingFlags::WRITE) {
 			return Err(io::Error::from_raw_os_error(libc::EROFS));
 		}
 		let Some(entry) = self.1.get(&inode) else {
 			return Err(io::Error::from_raw_os_error(libc::EBADF));
 		};
-		let raw = entry.fd.as_raw_fd();
-		Ok((raw, foffset))
+		let fd = entry.fd.try_clone()?;
+		Ok((fd.into(), foffset))
 	}
 }
 


### PR DESCRIPTION
It was possible for a file descriptor to be closed concurrently with virtiofs setupmapping calls, which would result in the wrong file becoming mapped into memory across the virtio boundary.