### PR TITLE
object: fragment outbox batches

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -843,6 +843,9 @@ pub struct ObjectOutbox {
 	pub batch_size: Option<usize>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub fragment_size: Option<usize>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub partition_total: Option<u64>,
 }
 
@@ -2698,6 +2701,9 @@ fn resolve_object_outbox(source: ObjectOutbox) -> server::ObjectOutbox {
 	let mut target = server::ObjectOutbox::default();
 	if let Some(value) = source.batch_size {
 		target.batch_size = value;
+	}
+	if let Some(value) = source.fragment_size {
+		target.fragment_size = value;
 	}
 	if let Some(value) = source.partition_total {
 		target.partition_total = value;

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -554,6 +554,8 @@ pub struct Object {
 pub struct ObjectOutbox {
 	pub batch_size: usize,
 
+	pub fragment_size: usize,
+
 	pub partition_total: u64,
 }
 
@@ -1395,6 +1397,7 @@ impl Default for ObjectOutbox {
 	fn default() -> Self {
 		Self {
 			batch_size: 1024,
+			fragment_size: 1024,
 			partition_total: 256,
 		}
 	}

--- a/packages/server/src/index.rs
+++ b/packages/server/src/index.rs
@@ -727,11 +727,25 @@ impl Server {
 		}
 		if !self.config.advanced.single_process {
 			let config = &self.config.object.outbox;
+			let fragments = arg
+				.items
+				.chunks(config.fragment_size)
+				.map(|items| {
+					let arg = index::batch::Arg {
+						items: items.to_vec(),
+					};
+					arg.serialize().map(Into::into)
+				})
+				.collect::<tg::Result<Vec<_>>>()?;
+			let batch_id = crate::object::outbox::BatchId::new(uuid::Uuid::now_v7().into_bytes());
 			let partition = rand::random_range(0..config.partition_total);
-			let payload = arg.serialize()?.into();
-			let arg = crate::object::outbox::EnqueueArg { partition, payload };
+			let arg = crate::object::outbox::Batch {
+				fragments,
+				id: batch_id,
+				partition,
+			};
 			self.object_store
-				.enqueue_outbox(arg)
+				.enqueue_outbox_batch(arg)
 				.await
 				.map_err(|error| tg::error!(!error, "failed to enqueue the index batch"))?;
 

--- a/packages/server/src/indexer.rs
+++ b/packages/server/src/indexer.rs
@@ -23,7 +23,7 @@ struct Indexer {
 struct State {
 	barriers: Barriers,
 	database_outbox_id: Option<crate::database::outbox::Id>,
-	object_outbox_id: Option<crate::object::outbox::Id>,
+	object_outbox_batch_id: Option<crate::object::outbox::BatchId>,
 	requests: BTreeMap<String, IndexRequest>,
 }
 
@@ -496,40 +496,50 @@ impl Indexer {
 			partition_end: config.partition_end,
 			partition_start: config.partition_start,
 		};
-		let entries = self
+		let fragments = self
 			.server
 			.object_store
-			.dequeue_outbox(arg)
+			.dequeue_outbox_fragments(arg)
 			.await
-			.map_err(|error| tg::error!(!error, "failed to dequeue the object outbox"))?;
-		if entries.is_empty() {
+			.map_err(|error| tg::error!(!error, "failed to dequeue the object outbox fragments"))?;
+		if fragments.is_empty() {
 			return Ok(0);
 		}
 
-		// Deserialize the index batches.
-		let count = entries.len();
-		let mut args = Vec::with_capacity(count);
+		// Combine the fragments into batches.
+		let count = fragments.len();
+		let mut batches = BTreeMap::<_, Vec<_>>::new();
 		let mut keys = Vec::with_capacity(count);
-		for entry in entries {
-			let arg = tangram_index::batch::Arg::deserialize(&entry.payload)?;
-			args.push(arg);
-			let key = crate::object::outbox::Key {
-				id: entry.id,
-				partition: entry.partition,
+		for fragment in fragments {
+			let arg = tangram_index::batch::Arg::deserialize(&fragment.payload)?;
+			batches
+				.entry(fragment.batch)
+				.or_default()
+				.push((fragment.index, arg));
+			let key = crate::object::outbox::FragmentKey {
+				batch: fragment.batch,
+				index: fragment.index,
+				partition: fragment.partition,
 			};
 			keys.push(key);
 		}
 
-		// Submit each outbox entry separately to preserve its transaction boundary.
-		future::try_join_all(args.into_iter().map(|arg| self.server.index.batch(arg)))
-			.await
-			.map_err(|error| tg::error!(!error, "failed to index an object outbox batch"))?;
-		let arg = crate::object::outbox::DeleteArg { keys };
+		// Submit the batches concurrently and each batch's fragments sequentially.
+		future::try_join_all(batches.into_values().map(|mut fragments| async move {
+			fragments.sort_unstable_by_key(|(index, _)| *index);
+			for (_, arg) in fragments {
+				self.server.index.batch(arg).await?;
+			}
+			Ok::<_, tg::Error>(())
+		}))
+		.await
+		.map_err(|error| tg::error!(!error, "failed to index an object outbox batch"))?;
+		let arg = crate::object::outbox::DeleteArg { fragments: keys };
 		self.server
 			.object_store
-			.delete_outbox(arg)
+			.delete_outbox_fragments(arg)
 			.await
-			.map_err(|error| tg::error!(!error, "failed to delete an object outbox batch"))?;
+			.map_err(|error| tg::error!(!error, "failed to delete object outbox fragments"))?;
 
 		Ok(count)
 	}
@@ -849,7 +859,7 @@ impl State {
 		Self {
 			barriers: Barriers::new(),
 			database_outbox_id: None,
-			object_outbox_id: None,
+			object_outbox_batch_id: None,
 			requests: BTreeMap::new(),
 		}
 	}
@@ -879,18 +889,18 @@ impl State {
 		let config = &server.config.object.outbox;
 
 		// Poll the active cohort.
-		if let Some(id) = self.object_outbox_id {
-			let arg = crate::object::outbox::TryGetIdArg {
-				id: Some(id),
+		if let Some(batch) = self.object_outbox_batch_id {
+			let arg = crate::object::outbox::TryGetBatchArg {
+				batch: Some(batch),
 				partition_end: config.partition_total,
 				partition_start: 0,
 			};
-			let id = server
+			let batch = server
 				.object_store
-				.try_get_outbox_id_at_or_before(arg)
+				.try_get_outbox_batch_at_or_before(arg)
 				.await
 				.map_err(|error| tg::error!(!error, "failed to poll the object outbox"))?;
-			if id.is_some() {
+			if batch.is_some() {
 				return Ok(());
 			}
 			for request in self.requests.values_mut() {
@@ -898,7 +908,7 @@ impl State {
 					request.state = IndexRequestState::DatabaseOutbox;
 				}
 			}
-			self.object_outbox_id = None;
+			self.object_outbox_batch_id = None;
 
 			return Ok(());
 		}
@@ -911,27 +921,27 @@ impl State {
 		if !snapshot {
 			return Ok(());
 		}
-		let arg = crate::object::outbox::TryGetIdArg {
-			id: None,
+		let arg = crate::object::outbox::TryGetBatchArg {
+			batch: None,
 			partition_end: config.partition_total,
 			partition_start: 0,
 		};
-		let id = server
+		let batch = server
 			.object_store
-			.try_get_outbox_id_at_or_before(arg)
+			.try_get_outbox_batch_at_or_before(arg)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to snapshot the object outbox"))?;
 		for request in self.requests.values_mut() {
 			if !matches!(request.state, IndexRequestState::ObjectOutbox) {
 				continue;
 			}
-			request.state = if id.is_some() {
+			request.state = if batch.is_some() {
 				IndexRequestState::ObjectOutboxPending
 			} else {
 				IndexRequestState::DatabaseOutbox
 			};
 		}
-		self.object_outbox_id = id;
+		self.object_outbox_batch_id = batch;
 
 		Ok(())
 	}
@@ -1190,7 +1200,7 @@ impl State {
 	fn fail(&mut self, error: &tg::Error, sender: &Sender) {
 		let error = error.to_string();
 		self.database_outbox_id = None;
-		self.object_outbox_id = None;
+		self.object_outbox_batch_id = None;
 		let ids = std::mem::take(&mut self.requests).into_keys();
 		for id in ids {
 			Self::send_response(

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -379,6 +379,11 @@ impl Server {
 				"the object outbox batch size must be greater than zero"
 			));
 		}
+		if outbox.fragment_size == 0 {
+			return Err(tg::error!(
+				"the object outbox fragment size must be greater than zero"
+			));
+		}
 		if outbox.partition_total == 0 {
 			return Err(tg::error!(
 				"the object outbox partition total must be greater than zero"

--- a/packages/server/src/object/store.rs
+++ b/packages/server/src/object/store.rs
@@ -275,48 +275,53 @@ impl object_store::Store for Store {
 		}
 	}
 
-	async fn delete_outbox(&self, arg: outbox::DeleteArg) -> tg::Result<()> {
+	async fn delete_outbox_fragments(&self, arg: outbox::DeleteArg) -> tg::Result<()> {
 		match self {
 			#[cfg(feature = "lmdb")]
-			Self::Lmdb(lmdb) => lmdb.delete_outbox(arg).await,
-			Self::Memory(memory) => object_store::Store::delete_outbox(memory, arg).await,
+			Self::Lmdb(lmdb) => lmdb.delete_outbox_fragments(arg).await,
+			Self::Memory(memory) => object_store::Store::delete_outbox_fragments(memory, arg).await,
 			#[cfg(feature = "scylla")]
-			Self::Scylla(scylla) => scylla.delete_outbox(arg).await,
+			Self::Scylla(scylla) => scylla.delete_outbox_fragments(arg).await,
 		}
 	}
 
-	async fn dequeue_outbox(&self, arg: outbox::DequeueArg) -> tg::Result<Vec<outbox::Item>> {
-		match self {
-			#[cfg(feature = "lmdb")]
-			Self::Lmdb(lmdb) => lmdb.dequeue_outbox(arg).await,
-			Self::Memory(memory) => object_store::Store::dequeue_outbox(memory, arg).await,
-			#[cfg(feature = "scylla")]
-			Self::Scylla(scylla) => scylla.dequeue_outbox(arg).await,
-		}
-	}
-
-	async fn enqueue_outbox(&self, arg: outbox::EnqueueArg) -> tg::Result<()> {
-		match self {
-			#[cfg(feature = "lmdb")]
-			Self::Lmdb(lmdb) => lmdb.enqueue_outbox(arg).await,
-			Self::Memory(memory) => object_store::Store::enqueue_outbox(memory, arg).await,
-			#[cfg(feature = "scylla")]
-			Self::Scylla(scylla) => scylla.enqueue_outbox(arg).await,
-		}
-	}
-
-	async fn try_get_outbox_id_at_or_before(
+	async fn dequeue_outbox_fragments(
 		&self,
-		arg: outbox::TryGetIdArg,
-	) -> tg::Result<Option<outbox::Id>> {
+		arg: outbox::DequeueArg,
+	) -> tg::Result<Vec<outbox::Fragment>> {
 		match self {
 			#[cfg(feature = "lmdb")]
-			Self::Lmdb(lmdb) => lmdb.try_get_outbox_id_at_or_before(arg).await,
+			Self::Lmdb(lmdb) => lmdb.dequeue_outbox_fragments(arg).await,
 			Self::Memory(memory) => {
-				object_store::Store::try_get_outbox_id_at_or_before(memory, arg).await
+				object_store::Store::dequeue_outbox_fragments(memory, arg).await
 			},
 			#[cfg(feature = "scylla")]
-			Self::Scylla(scylla) => scylla.try_get_outbox_id_at_or_before(arg).await,
+			Self::Scylla(scylla) => scylla.dequeue_outbox_fragments(arg).await,
+		}
+	}
+
+	async fn enqueue_outbox_batch(&self, arg: outbox::Batch) -> tg::Result<()> {
+		match self {
+			#[cfg(feature = "lmdb")]
+			Self::Lmdb(lmdb) => lmdb.enqueue_outbox_batch(arg).await,
+			Self::Memory(memory) => object_store::Store::enqueue_outbox_batch(memory, arg).await,
+			#[cfg(feature = "scylla")]
+			Self::Scylla(scylla) => scylla.enqueue_outbox_batch(arg).await,
+		}
+	}
+
+	async fn try_get_outbox_batch_at_or_before(
+		&self,
+		arg: outbox::TryGetBatchArg,
+	) -> tg::Result<Option<outbox::BatchId>> {
+		match self {
+			#[cfg(feature = "lmdb")]
+			Self::Lmdb(lmdb) => lmdb.try_get_outbox_batch_at_or_before(arg).await,
+			Self::Memory(memory) => {
+				object_store::Store::try_get_outbox_batch_at_or_before(memory, arg).await
+			},
+			#[cfg(feature = "scylla")]
+			Self::Scylla(scylla) => scylla.try_get_outbox_batch_at_or_before(arg).await,
 		}
 	}
 

--- a/packages/stores/object/src/lib.rs
+++ b/packages/stores/object/src/lib.rs
@@ -105,25 +105,25 @@ pub trait Store {
 		args: Vec<DeleteArg>,
 	) -> impl std::future::Future<Output = tg::Result<()>> + Send;
 
-	fn delete_outbox(
+	fn delete_outbox_fragments(
 		&self,
 		arg: outbox::DeleteArg,
 	) -> impl std::future::Future<Output = tg::Result<()>> + Send;
 
-	fn dequeue_outbox(
+	fn dequeue_outbox_fragments(
 		&self,
 		arg: outbox::DequeueArg,
-	) -> impl std::future::Future<Output = tg::Result<Vec<outbox::Item>>> + Send;
+	) -> impl std::future::Future<Output = tg::Result<Vec<outbox::Fragment>>> + Send;
 
-	fn enqueue_outbox(
+	fn enqueue_outbox_batch(
 		&self,
-		arg: outbox::EnqueueArg,
+		arg: outbox::Batch,
 	) -> impl std::future::Future<Output = tg::Result<()>> + Send;
 
-	fn try_get_outbox_id_at_or_before(
+	fn try_get_outbox_batch_at_or_before(
 		&self,
-		arg: outbox::TryGetIdArg,
-	) -> impl std::future::Future<Output = tg::Result<Option<outbox::Id>>> + Send;
+		arg: outbox::TryGetBatchArg,
+	) -> impl std::future::Future<Output = tg::Result<Option<outbox::BatchId>>> + Send;
 
 	fn flush(&self) -> impl std::future::Future<Output = tg::Result<()>> + Send;
 }

--- a/packages/stores/object/src/lmdb.rs
+++ b/packages/stores/object/src/lmdb.rs
@@ -42,8 +42,8 @@ type _ResponseReceiver = tokio::sync::oneshot::Receiver<tg::Result<()>>;
 enum Request {
 	Delete(self::delete::Request),
 	DeleteBatch(Vec<self::delete::Request>),
-	DeleteOutbox(crate::outbox::DeleteArg),
-	EnqueueOutbox(self::outbox::EnqueueRequest),
+	DeleteOutboxFragments(crate::outbox::DeleteArg),
+	EnqueueOutboxBatch(crate::outbox::Batch),
 	Put(self::put::Request),
 	PutBatch(Vec<self::put::Request>),
 }
@@ -51,8 +51,11 @@ enum Request {
 #[derive(Debug)]
 enum Key<'a> {
 	Object(&'a tg::object::Id),
-	Outbox { id: u128, partition: u64 },
-	OutboxId,
+	Outbox {
+		batch: [u8; 16],
+		index: u64,
+		partition: u64,
+	},
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, num_derive::FromPrimitive, num_derive::ToPrimitive)]
@@ -60,7 +63,6 @@ enum Key<'a> {
 enum KeyKind {
 	Object = 0,
 	Outbox = 1,
-	OutboxId = 2,
 }
 
 impl Store {
@@ -197,26 +199,26 @@ impl crate::Store for Store {
 		self.delete_batch(args).await
 	}
 
-	async fn delete_outbox(&self, arg: crate::outbox::DeleteArg) -> tg::Result<()> {
-		self.delete_outbox(arg).await
+	async fn delete_outbox_fragments(&self, arg: crate::outbox::DeleteArg) -> tg::Result<()> {
+		self.delete_outbox_fragments(arg).await
 	}
 
-	async fn dequeue_outbox(
+	async fn dequeue_outbox_fragments(
 		&self,
 		arg: crate::outbox::DequeueArg,
-	) -> tg::Result<Vec<crate::outbox::Item>> {
-		self.dequeue_outbox(arg).await
+	) -> tg::Result<Vec<crate::outbox::Fragment>> {
+		self.dequeue_outbox_fragments(arg).await
 	}
 
-	async fn enqueue_outbox(&self, arg: crate::outbox::EnqueueArg) -> tg::Result<()> {
-		self.enqueue_outbox(arg).await
+	async fn enqueue_outbox_batch(&self, arg: crate::outbox::Batch) -> tg::Result<()> {
+		self.enqueue_outbox_batch(arg).await
 	}
 
-	async fn try_get_outbox_id_at_or_before(
+	async fn try_get_outbox_batch_at_or_before(
 		&self,
-		arg: crate::outbox::TryGetIdArg,
-	) -> tg::Result<Option<crate::outbox::Id>> {
-		self.try_get_outbox_id_at_or_before(arg).await
+		arg: crate::outbox::TryGetBatchArg,
+	) -> tg::Result<Option<crate::outbox::BatchId>> {
+		self.try_get_outbox_batch_at_or_before(arg).await
 	}
 
 	async fn flush(&self) -> tg::Result<()> {
@@ -234,13 +236,17 @@ impl fdbt::TuplePack for Key<'_> {
 			Key::Object(id) => {
 				(KeyKind::Object.to_i32().unwrap(), id.to_bytes().as_ref()).pack(w, tuple_depth)
 			},
-			Key::Outbox { id, partition } => (
+			Key::Outbox {
+				batch,
+				index,
+				partition,
+			} => (
 				KeyKind::Outbox.to_i32().unwrap(),
 				partition,
-				id.to_be_bytes().as_slice(),
+				batch.as_slice(),
+				index,
 			)
 				.pack(w, tuple_depth),
-			Key::OutboxId => (KeyKind::OutboxId.to_i32().unwrap(),).pack(w, tuple_depth),
 		}
 	}
 }

--- a/packages/stores/object/src/lmdb/outbox.rs
+++ b/packages/stores/object/src/lmdb/outbox.rs
@@ -1,24 +1,21 @@
 use {
 	super::{Db, Key, KeyKind, Store},
-	crate::outbox::{DeleteArg, DequeueArg, EnqueueArg, Id, Item, TryGetIdArg},
+	crate::outbox::{
+		Batch, BatchId, DeleteArg, DequeueArg, Fragment, FragmentIndex, TryGetBatchArg,
+	},
 	foundationdb_tuple::{self as fdbt, TuplePack as _},
 	heed as lmdb,
 	num::ToPrimitive as _,
 	tangram_client::prelude::*,
 };
 
-pub(super) struct EnqueueRequest {
-	pub partition: u64,
-	pub payload: bytes::Bytes,
-}
-
 impl Store {
-	pub async fn delete_outbox(&self, arg: DeleteArg) -> tg::Result<()> {
-		if arg.keys.is_empty() {
+	pub async fn delete_outbox_fragments(&self, arg: DeleteArg) -> tg::Result<()> {
+		if arg.fragments.is_empty() {
 			return Ok(());
 		}
 		let (sender, receiver) = tokio::sync::oneshot::channel();
-		let request = super::Request::DeleteOutbox(arg);
+		let request = super::Request::DeleteOutboxFragments(arg);
 		self.sender
 			.as_ref()
 			.unwrap()
@@ -30,46 +27,44 @@ impl Store {
 			.map_err(|_| tg::error!("the task panicked"))?
 	}
 
-	pub async fn dequeue_outbox(&self, arg: DequeueArg) -> tg::Result<Vec<Item>> {
+	pub async fn dequeue_outbox_fragments(&self, arg: DequeueArg) -> tg::Result<Vec<Fragment>> {
 		let db = self.db;
 		let env = self.env.clone();
 		tokio::task::spawn_blocking(move || {
 			let transaction = env
 				.read_txn()
 				.map_err(|error| tg::error!(!error, "failed to begin a transaction"))?;
-			let mut items = Vec::new();
+			let mut fragments = Vec::new();
 			for partition in arg.partition_start..arg.partition_end {
 				let prefix = fdbt::pack(&(KeyKind::Outbox.to_i32().unwrap(), partition));
 				let entries = db
 					.prefix_iter(&transaction, &prefix)
 					.map_err(|error| tg::error!(!error, "failed to iterate the outbox"))?;
 				for entry in entries {
-					if items.len() >= arg.batch_size {
-						return Ok(items);
+					if fragments.len() >= arg.batch_size {
+						return Ok(fragments);
 					}
 					let (key, payload) = entry
-						.map_err(|error| tg::error!(!error, "failed to get an outbox item"))?;
-					let (partition, id) = unpack_key(key)?;
-					items.push(Item {
-						id: Id::new(id),
+						.map_err(|error| tg::error!(!error, "failed to get an outbox fragment"))?;
+					let (partition, batch, index) = unpack_key(key)?;
+					fragments.push(Fragment {
+						batch: BatchId::new(batch),
+						index: FragmentIndex::new(index),
 						partition,
 						payload: bytes::Bytes::copy_from_slice(payload),
 					});
 				}
 			}
 
-			Ok(items)
+			Ok(fragments)
 		})
 		.await
 		.map_err(|error| tg::error!(!error, "failed to join the task"))?
 	}
 
-	pub async fn enqueue_outbox(&self, arg: EnqueueArg) -> tg::Result<()> {
+	pub async fn enqueue_outbox_batch(&self, batch: Batch) -> tg::Result<()> {
 		let (sender, receiver) = tokio::sync::oneshot::channel();
-		let request = super::Request::EnqueueOutbox(EnqueueRequest {
-			partition: arg.partition,
-			payload: arg.payload,
-		});
+		let request = super::Request::EnqueueOutboxBatch(batch);
 		self.sender
 			.as_ref()
 			.unwrap()
@@ -81,7 +76,10 @@ impl Store {
 			.map_err(|_| tg::error!("the task panicked"))?
 	}
 
-	pub async fn try_get_outbox_id_at_or_before(&self, arg: TryGetIdArg) -> tg::Result<Option<Id>> {
+	pub async fn try_get_outbox_batch_at_or_before(
+		&self,
+		arg: TryGetBatchArg,
+	) -> tg::Result<Option<BatchId>> {
 		let db = self.db;
 		let env = self.env.clone();
 		tokio::task::spawn_blocking(move || {
@@ -96,80 +94,78 @@ impl Store {
 					.map_err(|error| tg::error!(!error, "failed to iterate the outbox"))?;
 				for entry in entries {
 					let (key, _) = entry
-						.map_err(|error| tg::error!(!error, "failed to get an outbox item"))?;
-					let (_, id) = unpack_key(key)?;
-					if arg.id.is_some_and(|target| id > target.value()) {
+						.map_err(|error| tg::error!(!error, "failed to get an outbox fragment"))?;
+					let (_, batch, _) = unpack_key(key)?;
+					if arg.batch.is_some_and(|target| batch > target.value()) {
 						continue;
 					}
-					output = Some(output.map_or(id, |output: u128| output.max(id)));
+					output = Some(output.map_or(batch, |output: [u8; 16]| output.max(batch)));
 					break;
 				}
 			}
 
-			Ok(output.map(Id::new))
+			Ok(output.map(BatchId::new))
 		})
 		.await
 		.map_err(|error| tg::error!(!error, "failed to join the task"))?
 	}
 
-	pub(super) fn task_delete_outbox(
+	pub(super) fn task_delete_outbox_fragments(
 		db: &Db,
 		transaction: &mut lmdb::RwTxn<'_>,
 		arg: DeleteArg,
 	) -> tg::Result<()> {
-		for key in arg.keys {
+		for fragment in arg.fragments {
 			let key = Key::Outbox {
-				id: key.id.value(),
-				partition: key.partition,
+				batch: fragment.batch.value(),
+				index: fragment.index.value(),
+				partition: fragment.partition,
 			};
 			db.delete(transaction, &key.pack_to_vec())
-				.map_err(|error| tg::error!(!error, "failed to delete the outbox item"))?;
+				.map_err(|error| tg::error!(!error, "failed to delete the outbox fragment"))?;
 		}
 
 		Ok(())
 	}
 
-	pub(super) fn task_enqueue_outbox(
+	pub(super) fn task_enqueue_outbox_batch(
 		db: &Db,
 		transaction: &mut lmdb::RwTxn<'_>,
-		request: EnqueueRequest,
+		batch: Batch,
 	) -> tg::Result<()> {
-		let EnqueueRequest { partition, payload } = request;
-		let counter_key = Key::OutboxId.pack_to_vec();
-		let id = db
-			.get(transaction, &counter_key)
-			.map_err(|error| tg::error!(!error, "failed to get the outbox id"))?
-			.map_or(Ok(0), decode_id)?
-			.checked_add(1)
-			.ok_or_else(|| tg::error!("the outbox id overflowed"))?;
-		db.put(transaction, &counter_key, &id.to_be_bytes())
-			.map_err(|error| tg::error!(!error, "failed to put the outbox id"))?;
-		let key = Key::Outbox { id, partition };
-		db.put(transaction, &key.pack_to_vec(), &payload)
-			.map_err(|error| tg::error!(!error, "failed to put the outbox item"))?;
+		for (index, payload) in batch.fragments.into_iter().enumerate() {
+			let index = u64::try_from(index)
+				.map_err(|_| tg::error!("the outbox fragment index exceeded a u64"))?;
+			let key = Key::Outbox {
+				batch: batch.id.value(),
+				index,
+				partition: batch.partition,
+			};
+			db.put(transaction, &key.pack_to_vec(), &payload)
+				.map_err(|error| tg::error!(!error, "failed to put the outbox fragment"))?;
+		}
 
 		Ok(())
 	}
 }
 
-fn decode_id(bytes: &[u8]) -> tg::Result<u128> {
-	let bytes = bytes
+fn decode_batch(bytes: &[u8]) -> tg::Result<[u8; 16]> {
+	bytes
 		.try_into()
-		.map_err(|_| tg::error!("invalid outbox id length"))?;
-	Ok(u128::from_be_bytes(bytes))
+		.map_err(|_| tg::error!("invalid outbox batch id length"))
 }
 
-fn unpack_key(bytes: &[u8]) -> tg::Result<(u64, u128)> {
-	let (_, partition, id): (i32, u64, Vec<u8>) = fdbt::unpack(bytes)
+fn unpack_key(bytes: &[u8]) -> tg::Result<(u64, [u8; 16], u64)> {
+	let (_, partition, batch, index): (i32, u64, Vec<u8>, u64) = fdbt::unpack(bytes)
 		.map_err(|error| tg::error!(!error, "failed to unpack the outbox key"))?;
-	let id = decode_id(&id)?;
+	let batch = decode_batch(&batch)?;
 
-	Ok((partition, id))
+	Ok((partition, batch, index))
 }
 
 #[cfg(test)]
 mod tests {
-	use {super::*, crate::outbox::Key, std::path::Path};
+	use {super::*, crate::outbox::FragmentKey, std::path::Path};
 
 	fn store(path: &Path) -> Store {
 		let config = super::super::Config {
@@ -184,87 +180,72 @@ mod tests {
 	async fn operations_and_persistence() {
 		let temp = tangram_util::fs::Temp::new().unwrap();
 		std::fs::create_dir(temp.path()).unwrap();
-		let target = {
+		let first = BatchId::new(1_u128.to_be_bytes());
+		let second = BatchId::new(2_u128.to_be_bytes());
+		{
 			let store = store(temp.path());
 			store
-				.enqueue_outbox(EnqueueArg {
+				.enqueue_outbox_batch(Batch {
+					fragments: vec![
+						bytes::Bytes::from_static(b"a"),
+						bytes::Bytes::from_static(b"b"),
+					],
+					id: first,
 					partition: 0,
-					payload: bytes::Bytes::from_static(b"a"),
 				})
 				.await
 				.unwrap();
 			store
-				.enqueue_outbox(EnqueueArg {
+				.enqueue_outbox_batch(Batch {
+					fragments: vec![bytes::Bytes::from_static(b"c")],
+					id: second,
 					partition: 1,
-					payload: bytes::Bytes::from_static(b"b"),
 				})
 				.await
 				.unwrap();
-			store
-				.try_get_outbox_id_at_or_before(TryGetIdArg {
-					id: None,
-					partition_end: 2,
-					partition_start: 0,
-				})
-				.await
-				.unwrap()
-				.unwrap()
-		};
+		}
 
 		let store = store(temp.path());
 		assert_eq!(
 			store
-				.try_get_outbox_id_at_or_before(TryGetIdArg {
-					id: None,
+				.try_get_outbox_batch_at_or_before(TryGetBatchArg {
+					batch: None,
 					partition_end: 2,
 					partition_start: 0,
 				})
 				.await
 				.unwrap(),
-			Some(target)
+			Some(second)
 		);
-		store
-			.enqueue_outbox(EnqueueArg {
-				partition: 0,
-				payload: bytes::Bytes::from_static(b"c"),
-			})
-			.await
-			.unwrap();
-		let newest = store
-			.try_get_outbox_id_at_or_before(TryGetIdArg {
-				id: None,
-				partition_end: 2,
-				partition_start: 0,
-			})
-			.await
-			.unwrap()
-			.unwrap();
-		assert!(newest.value() > target.value());
-		let items = store
-			.dequeue_outbox(DequeueArg {
+		let fragments = store
+			.dequeue_outbox_fragments(DequeueArg {
 				batch_size: usize::MAX,
 				partition_end: 2,
 				partition_start: 0,
 			})
 			.await
 			.unwrap();
-		assert_eq!(items.len(), 3);
-		assert_eq!(items[0].payload, bytes::Bytes::from_static(b"a"));
-		assert_eq!(items[1].payload, bytes::Bytes::from_static(b"c"));
-		assert_eq!(items[2].payload, bytes::Bytes::from_static(b"b"));
-		let keys = items
+		assert_eq!(fragments.len(), 3);
+		assert_eq!(fragments[0].payload, bytes::Bytes::from_static(b"a"));
+		assert_eq!(fragments[1].payload, bytes::Bytes::from_static(b"b"));
+		assert_eq!(fragments[2].payload, bytes::Bytes::from_static(b"c"));
+		let fragments = fragments
 			.into_iter()
-			.filter(|item| item.id.value() <= target.value())
-			.map(|item| Key {
-				id: item.id,
-				partition: item.partition,
+			.filter(|fragment| fragment.batch <= first)
+			.map(|fragment| FragmentKey {
+				batch: fragment.batch,
+				index: fragment.index,
+				partition: fragment.partition,
 			})
 			.collect();
-		store.delete_outbox(DeleteArg { keys }).await.unwrap();
+		store
+			.delete_outbox_fragments(DeleteArg { fragments })
+			.await
+			.unwrap();
 		assert!(
 			store
-				.try_get_outbox_id_at_or_before(TryGetIdArg {
-					id: Some(target),
+				.try_get_outbox_batch_at_or_before(TryGetBatchArg {
+					batch: Some(first),
 					partition_end: 2,
 					partition_start: 0,
 				})
@@ -274,14 +255,14 @@ mod tests {
 		);
 		assert_eq!(
 			store
-				.try_get_outbox_id_at_or_before(TryGetIdArg {
-					id: None,
+				.try_get_outbox_batch_at_or_before(TryGetBatchArg {
+					batch: None,
 					partition_end: 2,
 					partition_start: 0,
 				})
 				.await
 				.unwrap(),
-			Some(newest)
+			Some(second)
 		);
 	}
 }

--- a/packages/stores/object/src/lmdb/task.rs
+++ b/packages/stores/object/src/lmdb/task.rs
@@ -36,11 +36,11 @@ impl Store {
 							Self::task_delete_object(db, &mut transaction, request)
 						})
 					},
-					Request::DeleteOutbox(arg) => {
-						Self::task_delete_outbox(db, &mut transaction, arg)
+					Request::DeleteOutboxFragments(arg) => {
+						Self::task_delete_outbox_fragments(db, &mut transaction, arg)
 					},
-					Request::EnqueueOutbox(request) => {
-						Self::task_enqueue_outbox(db, &mut transaction, request)
+					Request::EnqueueOutboxBatch(batch) => {
+						Self::task_enqueue_outbox_batch(db, &mut transaction, batch)
 					},
 					Request::Put(request) => Self::task_put_object(db, &mut transaction, request),
 					Request::PutBatch(requests) => requests.into_iter().try_for_each(|request| {

--- a/packages/stores/object/src/memory.rs
+++ b/packages/stores/object/src/memory.rs
@@ -23,8 +23,7 @@ pub struct Store {
 #[derive(Default)]
 struct State {
 	objects: Objects,
-	outbox: BTreeMap<(u64, u128), bytes::Bytes>,
-	outbox_id: u128,
+	outbox: BTreeMap<(u64, [u8; 16], u64), bytes::Bytes>,
 }
 
 type Objects = HashMap<tg::object::Id, Object<'static>, tg::id::BuildHasher>;
@@ -78,27 +77,27 @@ impl crate::Store for Store {
 		Ok(())
 	}
 
-	async fn delete_outbox(&self, arg: crate::outbox::DeleteArg) -> tg::Result<()> {
-		self.delete_outbox(arg);
+	async fn delete_outbox_fragments(&self, arg: crate::outbox::DeleteArg) -> tg::Result<()> {
+		self.delete_outbox_fragments(arg);
 		Ok(())
 	}
 
-	async fn dequeue_outbox(
+	async fn dequeue_outbox_fragments(
 		&self,
 		arg: crate::outbox::DequeueArg,
-	) -> tg::Result<Vec<crate::outbox::Item>> {
-		self.dequeue_outbox(arg)
+	) -> tg::Result<Vec<crate::outbox::Fragment>> {
+		self.dequeue_outbox_fragments(arg)
 	}
 
-	async fn enqueue_outbox(&self, arg: crate::outbox::EnqueueArg) -> tg::Result<()> {
-		self.enqueue_outbox(arg)
+	async fn enqueue_outbox_batch(&self, arg: crate::outbox::Batch) -> tg::Result<()> {
+		self.enqueue_outbox_batch(arg)
 	}
 
-	async fn try_get_outbox_id_at_or_before(
+	async fn try_get_outbox_batch_at_or_before(
 		&self,
-		arg: crate::outbox::TryGetIdArg,
-	) -> tg::Result<Option<crate::outbox::Id>> {
-		self.try_get_outbox_id_at_or_before(arg)
+		arg: crate::outbox::TryGetBatchArg,
+	) -> tg::Result<Option<crate::outbox::BatchId>> {
+		self.try_get_outbox_batch_at_or_before(arg)
 	}
 
 	async fn flush(&self) -> tg::Result<()> {

--- a/packages/stores/object/src/memory/outbox.rs
+++ b/packages/stores/object/src/memory/outbox.rs
@@ -1,62 +1,73 @@
 use {
 	super::Store,
-	crate::outbox::{DeleteArg, DequeueArg, EnqueueArg, Id, Item, TryGetIdArg},
+	crate::outbox::{
+		Batch, BatchId, DeleteArg, DequeueArg, Fragment, FragmentIndex, TryGetBatchArg,
+	},
 	tangram_client::prelude::*,
 };
 
 impl Store {
-	pub fn delete_outbox(&self, arg: DeleteArg) {
+	pub fn delete_outbox_fragments(&self, arg: DeleteArg) {
 		let mut state = self.state();
-		for key in arg.keys {
-			state.outbox.remove(&(key.partition, key.id.value()));
+		for fragment in arg.fragments {
+			state.outbox.remove(&(
+				fragment.partition,
+				fragment.batch.value(),
+				fragment.index.value(),
+			));
 		}
 	}
 
-	pub fn dequeue_outbox(&self, arg: DequeueArg) -> tg::Result<Vec<Item>> {
+	pub fn dequeue_outbox_fragments(&self, arg: DequeueArg) -> tg::Result<Vec<Fragment>> {
 		let state = self.state();
-		let items = state
+		let fragments = state
 			.outbox
 			.iter()
-			.filter(|((partition, _), _)| {
+			.filter(|((partition, _, _), _)| {
 				(arg.partition_start..arg.partition_end).contains(partition)
 			})
 			.take(arg.batch_size)
-			.map(|((partition, id), payload)| Item {
-				id: Id::new(*id),
+			.map(|((partition, batch, index), payload)| Fragment {
+				batch: BatchId::new(*batch),
+				index: FragmentIndex::new(*index),
 				partition: *partition,
 				payload: payload.clone(),
 			})
 			.collect();
 
-		Ok(items)
+		Ok(fragments)
 	}
 
-	pub fn enqueue_outbox(&self, arg: EnqueueArg) -> tg::Result<()> {
+	pub fn enqueue_outbox_batch(&self, batch: Batch) -> tg::Result<()> {
 		let mut state = self.state();
-		state.outbox_id = state
-			.outbox_id
-			.checked_add(1)
-			.ok_or_else(|| tg::error!("the outbox id overflowed"))?;
-		let id = state.outbox_id;
-		state.outbox.insert((arg.partition, id), arg.payload);
+		for (index, payload) in batch.fragments.into_iter().enumerate() {
+			let index = u64::try_from(index)
+				.map_err(|_| tg::error!("the outbox fragment index exceeded a u64"))?;
+			state
+				.outbox
+				.insert((batch.partition, batch.id.value(), index), payload);
+		}
 
 		Ok(())
 	}
 
-	pub fn try_get_outbox_id_at_or_before(&self, arg: TryGetIdArg) -> tg::Result<Option<Id>> {
+	pub fn try_get_outbox_batch_at_or_before(
+		&self,
+		arg: TryGetBatchArg,
+	) -> tg::Result<Option<BatchId>> {
 		let state = self.state();
-		let id = state
+		let batch = state
 			.outbox
 			.keys()
-			.filter(|(partition, id)| {
+			.filter(|(partition, batch, _)| {
 				(arg.partition_start..arg.partition_end).contains(partition)
-					&& arg.id.is_none_or(|target| *id <= target.value())
+					&& arg.batch.is_none_or(|target| *batch <= target.value())
 			})
-			.map(|(_, id)| *id)
+			.map(|(_, batch, _)| *batch)
 			.max()
-			.map(Id::new);
+			.map(BatchId::new);
 
-		Ok(id)
+		Ok(batch)
 	}
 }
 
@@ -64,85 +75,71 @@ impl Store {
 mod tests {
 	use {
 		super::*,
-		crate::outbox::{Key, TryGetIdArg},
+		crate::outbox::{FragmentKey, TryGetBatchArg},
 		bytes::Bytes,
 	};
 
 	#[test]
 	fn operations() {
 		let store = Store::new();
+		let first = BatchId::new(1_u128.to_be_bytes());
+		let second = BatchId::new(2_u128.to_be_bytes());
 		store
-			.enqueue_outbox(EnqueueArg {
+			.enqueue_outbox_batch(Batch {
+				fragments: vec![Bytes::from_static(b"a"), Bytes::from_static(b"b")],
+				id: first,
 				partition: 0,
-				payload: Bytes::from_static(b"a"),
 			})
 			.unwrap();
 		store
-			.enqueue_outbox(EnqueueArg {
+			.enqueue_outbox_batch(Batch {
+				fragments: vec![Bytes::from_static(b"c")],
+				id: second,
 				partition: 1,
-				payload: Bytes::from_static(b"b"),
-			})
-			.unwrap();
-		store
-			.enqueue_outbox(EnqueueArg {
-				partition: 0,
-				payload: Bytes::from_static(b"c"),
 			})
 			.unwrap();
 
-		let items = store
-			.dequeue_outbox(DequeueArg {
+		let fragments = store
+			.dequeue_outbox_fragments(DequeueArg {
 				batch_size: 1,
 				partition_end: 1,
 				partition_start: 0,
 			})
 			.unwrap();
-		assert_eq!(items.len(), 1);
-		assert_eq!(items[0].payload, Bytes::from_static(b"a"));
+		assert_eq!(fragments.len(), 1);
+		assert_eq!(fragments[0].index, FragmentIndex::new(0));
+		assert_eq!(fragments[0].payload, Bytes::from_static(b"a"));
 
 		let target = store
-			.try_get_outbox_id_at_or_before(TryGetIdArg {
-				id: None,
+			.try_get_outbox_batch_at_or_before(TryGetBatchArg {
+				batch: None,
 				partition_end: 2,
 				partition_start: 0,
 			})
 			.unwrap()
 			.unwrap();
-		store
-			.enqueue_outbox(EnqueueArg {
-				partition: 1,
-				payload: Bytes::from_static(b"d"),
-			})
-			.unwrap();
-		let newest = store
-			.try_get_outbox_id_at_or_before(TryGetIdArg {
-				id: None,
-				partition_end: 2,
-				partition_start: 0,
-			})
-			.unwrap()
-			.unwrap();
-		assert_ne!(newest, target);
-		let items = store
-			.dequeue_outbox(DequeueArg {
+		assert_eq!(target, second);
+		let fragments = store
+			.dequeue_outbox_fragments(DequeueArg {
 				batch_size: usize::MAX,
 				partition_end: 2,
 				partition_start: 0,
 			})
 			.unwrap();
-		let keys = items
+		let fragments = fragments
 			.into_iter()
-			.filter(|item| item.id.value() <= target.value())
-			.map(|item| Key {
-				id: item.id,
-				partition: item.partition,
+			.filter(|fragment| fragment.batch <= first)
+			.map(|fragment| FragmentKey {
+				batch: fragment.batch,
+				index: fragment.index,
+				partition: fragment.partition,
 			})
 			.collect();
-		store.delete_outbox(DeleteArg { keys });
+		store.delete_outbox_fragments(DeleteArg { fragments });
 		assert!(
 			store
-				.try_get_outbox_id_at_or_before(TryGetIdArg {
-					id: Some(target),
+				.try_get_outbox_batch_at_or_before(TryGetBatchArg {
+					batch: Some(first),
 					partition_end: 2,
 					partition_start: 0,
 				})
@@ -151,13 +148,13 @@ mod tests {
 		);
 		assert_eq!(
 			store
-				.try_get_outbox_id_at_or_before(TryGetIdArg {
-					id: None,
+				.try_get_outbox_batch_at_or_before(TryGetBatchArg {
+					batch: None,
 					partition_end: 2,
 					partition_start: 0,
 				})
 				.unwrap(),
-			Some(newest)
+			Some(second)
 		);
 	}
 }

--- a/packages/stores/object/src/outbox.rs
+++ b/packages/stores/object/src/outbox.rs
@@ -1,24 +1,36 @@
 use bytes::Bytes;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub struct Id(u128);
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct BatchId([u8; 16]);
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct FragmentIndex(u64);
 
 #[derive(Clone, Debug)]
-pub struct Item {
-	pub id: Id,
+pub struct Batch {
+	pub fragments: Vec<Bytes>,
+	pub id: BatchId,
+	pub partition: u64,
+}
+
+#[derive(Clone, Debug)]
+pub struct Fragment {
+	pub batch: BatchId,
+	pub index: FragmentIndex,
 	pub partition: u64,
 	pub payload: Bytes,
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct Key {
-	pub id: Id,
+pub struct FragmentKey {
+	pub batch: BatchId,
+	pub index: FragmentIndex,
 	pub partition: u64,
 }
 
 #[derive(Clone, Debug)]
 pub struct DeleteArg {
-	pub keys: Vec<Key>,
+	pub fragments: Vec<FragmentKey>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -28,27 +40,33 @@ pub struct DequeueArg {
 	pub partition_start: u64,
 }
 
-#[derive(Clone, Debug)]
-pub struct EnqueueArg {
-	pub partition: u64,
-	pub payload: Bytes,
-}
-
 #[derive(Clone, Copy, Debug)]
-pub struct TryGetIdArg {
-	pub id: Option<Id>,
+pub struct TryGetBatchArg {
+	pub batch: Option<BatchId>,
 	pub partition_end: u64,
 	pub partition_start: u64,
 }
 
-impl Id {
+impl BatchId {
 	#[must_use]
-	pub fn new(value: u128) -> Self {
+	pub fn new(value: [u8; 16]) -> Self {
 		Self(value)
 	}
 
 	#[must_use]
-	pub fn value(self) -> u128 {
+	pub fn value(self) -> [u8; 16] {
+		self.0
+	}
+}
+
+impl FragmentIndex {
+	#[must_use]
+	pub fn new(value: u64) -> Self {
+		Self(value)
+	}
+
+	#[must_use]
+	pub fn value(self) -> u64 {
 		self.0
 	}
 }

--- a/packages/stores/object/src/scylla.cql
+++ b/packages/stores/object/src/scylla.cql
@@ -5,8 +5,9 @@ create table if not exists objects (
 );
 
 create table if not exists outbox (
+	batch blob,
+	fragment bigint,
 	partition bigint,
-	id timeuuid,
 	payload blob,
-	primary key ((partition), id)
-) with clustering order by (id asc);
+	primary key ((partition), batch, fragment)
+) with clustering order by (batch asc, fragment asc);

--- a/packages/stores/object/src/scylla.rs
+++ b/packages/stores/object/src/scylla.rs
@@ -40,14 +40,14 @@ pub struct Store {
 
 struct Statements {
 	delete_object: scylla::statement::prepared::PreparedStatement,
-	delete_outbox: scylla::statement::prepared::PreparedStatement,
-	dequeue_outbox: scylla::statement::prepared::PreparedStatement,
-	enqueue_outbox: scylla::statement::prepared::PreparedStatement,
+	delete_outbox_fragment: scylla::statement::prepared::PreparedStatement,
+	dequeue_outbox_fragments: scylla::statement::prepared::PreparedStatement,
+	enqueue_outbox_fragment: scylla::statement::prepared::PreparedStatement,
 	get_object: scylla::statement::prepared::PreparedStatement,
 	get_object_batch: scylla::statement::prepared::PreparedStatement,
 	put_object: scylla::statement::prepared::PreparedStatement,
-	try_get_outbox_id: scylla::statement::prepared::PreparedStatement,
-	try_get_outbox_id_at_or_before: scylla::statement::prepared::PreparedStatement,
+	try_get_outbox_batch: scylla::statement::prepared::PreparedStatement,
+	try_get_outbox_batch_at_or_before: scylla::statement::prepared::PreparedStatement,
 }
 
 impl Store {
@@ -149,79 +149,87 @@ impl Store {
 		let statement = indoc!(
 			"
 				delete from outbox
-				where partition = ? and id = ?;
+				where partition = ? and batch = ? and fragment = ?;
 			"
 		);
-		let mut delete_outbox = session
-			.prepare(statement)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to prepare the delete outbox statement"))?;
-		delete_outbox.set_consistency(scylla::statement::Consistency::LocalQuorum);
+		let mut delete_outbox_fragment = session.prepare(statement).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to prepare the delete outbox fragment statement"
+			)
+		})?;
+		delete_outbox_fragment.set_consistency(scylla::statement::Consistency::LocalQuorum);
 
 		let statement = indoc!(
 			"
-				select id, partition, payload
+				select batch, fragment, partition, payload
 				from outbox
 				where partition in ?
 				limit ?;
 			"
 		);
-		let mut dequeue_outbox = session.prepare(statement).await.map_err(|error| {
-			tg::error!(!error, "failed to prepare the dequeue outbox statement")
+		let mut dequeue_outbox_fragments = session.prepare(statement).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to prepare the dequeue outbox fragments statement"
+			)
 		})?;
-		dequeue_outbox.set_consistency(scylla::statement::Consistency::One);
+		dequeue_outbox_fragments.set_consistency(scylla::statement::Consistency::LocalQuorum);
 
 		let statement = indoc!(
 			"
-				insert into outbox (partition, id, payload)
-				values (?, now(), ?);
+				insert into outbox (batch, fragment, partition, payload)
+				values (?, ?, ?, ?);
 			"
 		);
-		let mut enqueue_outbox = session.prepare(statement).await.map_err(|error| {
-			tg::error!(!error, "failed to prepare the enqueue outbox statement")
+		let mut enqueue_outbox_fragment = session.prepare(statement).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to prepare the enqueue outbox fragment statement"
+			)
 		})?;
-		enqueue_outbox.set_consistency(scylla::statement::Consistency::LocalQuorum);
+		enqueue_outbox_fragment.set_consistency(scylla::statement::Consistency::LocalQuorum);
 
 		let statement = indoc!(
 			"
-				select max(id)
+				select max(batch)
 				from outbox
 				where partition in ?;
 			"
 		);
-		let mut try_get_outbox_id = session
-			.prepare(statement)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to prepare the get outbox id statement"))?;
-		try_get_outbox_id.set_consistency(scylla::statement::Consistency::LocalQuorum);
+		let mut try_get_outbox_batch = session.prepare(statement).await.map_err(|error| {
+			tg::error!(!error, "failed to prepare the get outbox batch statement")
+		})?;
+		try_get_outbox_batch.set_consistency(scylla::statement::Consistency::LocalQuorum);
 
 		let statement = indoc!(
 			"
-				select max(id)
+				select max(batch)
 				from outbox
-				where partition in ? and id <= ?;
+				where partition in ? and batch <= ?;
 			"
 		);
-		let mut try_get_outbox_id_at_or_before =
+		let mut try_get_outbox_batch_at_or_before =
 			session.prepare(statement).await.map_err(|error| {
 				tg::error!(
 					!error,
-					"failed to prepare the bounded get outbox id statement"
+					"failed to prepare the bounded get outbox batch statement"
 				)
 			})?;
-		try_get_outbox_id_at_or_before.set_consistency(scylla::statement::Consistency::LocalQuorum);
+		try_get_outbox_batch_at_or_before
+			.set_consistency(scylla::statement::Consistency::LocalQuorum);
 
 		let scylla = Self {
 			statements: Statements {
 				delete_object,
-				delete_outbox,
-				dequeue_outbox,
-				enqueue_outbox,
+				delete_outbox_fragment,
+				dequeue_outbox_fragments,
+				enqueue_outbox_fragment,
 				get_object,
 				get_object_batch,
 				put_object,
-				try_get_outbox_id,
-				try_get_outbox_id_at_or_before,
+				try_get_outbox_batch,
+				try_get_outbox_batch_at_or_before,
 			},
 			session,
 		};
@@ -255,26 +263,26 @@ impl crate::Store for Store {
 		self.delete_batch(args).await
 	}
 
-	async fn delete_outbox(&self, arg: crate::outbox::DeleteArg) -> tg::Result<()> {
-		self.delete_outbox(arg).await
+	async fn delete_outbox_fragments(&self, arg: crate::outbox::DeleteArg) -> tg::Result<()> {
+		self.delete_outbox_fragments(arg).await
 	}
 
-	async fn dequeue_outbox(
+	async fn dequeue_outbox_fragments(
 		&self,
 		arg: crate::outbox::DequeueArg,
-	) -> tg::Result<Vec<crate::outbox::Item>> {
-		self.dequeue_outbox(arg).await
+	) -> tg::Result<Vec<crate::outbox::Fragment>> {
+		self.dequeue_outbox_fragments(arg).await
 	}
 
-	async fn enqueue_outbox(&self, arg: crate::outbox::EnqueueArg) -> tg::Result<()> {
-		self.enqueue_outbox(arg).await
+	async fn enqueue_outbox_batch(&self, arg: crate::outbox::Batch) -> tg::Result<()> {
+		self.enqueue_outbox_batch(arg).await
 	}
 
-	async fn try_get_outbox_id_at_or_before(
+	async fn try_get_outbox_batch_at_or_before(
 		&self,
-		arg: crate::outbox::TryGetIdArg,
-	) -> tg::Result<Option<crate::outbox::Id>> {
-		self.try_get_outbox_id_at_or_before(arg).await
+		arg: crate::outbox::TryGetBatchArg,
+	) -> tg::Result<Option<crate::outbox::BatchId>> {
+		self.try_get_outbox_batch_at_or_before(arg).await
 	}
 
 	async fn flush(&self) -> tg::Result<()> {

--- a/packages/stores/object/src/scylla/outbox.rs
+++ b/packages/stores/object/src/scylla/outbox.rs
@@ -1,25 +1,31 @@
 use {
 	super::Store,
-	crate::outbox::{DeleteArg, DequeueArg, EnqueueArg, Id, Item, TryGetIdArg},
+	crate::outbox::{
+		Batch, BatchId, DeleteArg, DequeueArg, Fragment, FragmentIndex, TryGetBatchArg,
+	},
 	futures::FutureExt as _,
 	num::ToPrimitive as _,
-	scylla::value::CqlTimeuuid,
 	tangram_client::prelude::*,
 };
 
 impl Store {
-	pub async fn delete_outbox(&self, arg: DeleteArg) -> tg::Result<()> {
-		futures::future::try_join_all(arg.keys.into_iter().map(|key| async move {
-			let partition = key
+	pub async fn delete_outbox_fragments(&self, arg: DeleteArg) -> tg::Result<()> {
+		futures::future::try_join_all(arg.fragments.into_iter().map(|fragment| async move {
+			let partition = fragment
 				.partition
 				.to_i64()
 				.ok_or_else(|| tg::error!("the outbox partition exceeded an i64"))?;
-			let id = CqlTimeuuid::from_u128(key.id.value());
-			let params = (partition, id);
+			let index = fragment
+				.index
+				.value()
+				.to_i64()
+				.ok_or_else(|| tg::error!("the outbox fragment index exceeded an i64"))?;
+			let batch = fragment.batch.value();
+			let params = (partition, batch.as_slice(), index);
 			self.session
-				.execute_unpaged(&self.statements.delete_outbox, params)
+				.execute_unpaged(&self.statements.delete_outbox_fragment, params)
 				.await
-				.map_err(|error| tg::error!(!error, "failed to delete the outbox item"))?;
+				.map_err(|error| tg::error!(!error, "failed to delete the outbox fragment"))?;
 			Ok::<_, tg::Error>(())
 		}))
 		.await?;
@@ -27,7 +33,7 @@ impl Store {
 		Ok(())
 	}
 
-	pub async fn dequeue_outbox(&self, arg: DequeueArg) -> tg::Result<Vec<Item>> {
+	pub async fn dequeue_outbox_fragments(&self, arg: DequeueArg) -> tg::Result<Vec<Fragment>> {
 		let partitions = partitions(arg.partition_start, arg.partition_end)?;
 		if partitions.is_empty() || arg.batch_size == 0 {
 			return Ok(Vec::new());
@@ -36,104 +42,114 @@ impl Store {
 			.batch_size
 			.to_i32()
 			.ok_or_else(|| tg::error!("the outbox batch size exceeded an i32"))?;
-		let items = self
-			.dequeue_outbox_with_statement(&partitions, limit, &self.statements.dequeue_outbox)
-			.await?;
-		if !items.is_empty() {
-			return Ok(items);
-		}
-		let mut statement = self.statements.dequeue_outbox.clone();
-		statement.set_consistency(scylla::statement::Consistency::LocalQuorum);
-		self.dequeue_outbox_with_statement(&partitions, limit, &statement)
+		let params = (&partitions, limit);
+		let result = self
+			.session
+			.execute_unpaged(&self.statements.dequeue_outbox_fragments, params)
+			.boxed()
 			.await
-	}
+			.map_err(|error| tg::error!(!error, "failed to dequeue the outbox fragments"))?
+			.into_rows_result()
+			.map_err(|error| tg::error!(!error, "failed to get the outbox rows"))?;
 
-	pub async fn enqueue_outbox(&self, arg: EnqueueArg) -> tg::Result<()> {
-		let partition = arg
-			.partition
-			.to_i64()
-			.ok_or_else(|| tg::error!("the outbox partition exceeded an i64"))?;
-		let params = (partition, arg.payload);
-		self.session
-			.execute_unpaged(&self.statements.enqueue_outbox, params)
-			.await
-			.map_err(|error| tg::error!(!error, "failed to enqueue the outbox item"))?;
-
-		Ok(())
-	}
-
-	pub async fn try_get_outbox_id_at_or_before(&self, arg: TryGetIdArg) -> tg::Result<Option<Id>> {
-		let partitions = partitions(arg.partition_start, arg.partition_end)?;
-		if partitions.is_empty() {
-			return Ok(None);
-		}
-		let result = if let Some(id) = arg.id {
-			let params = (partitions, CqlTimeuuid::from_u128(id.value()));
-			self.session
-				.execute_unpaged(&self.statements.try_get_outbox_id_at_or_before, params)
-				.boxed()
-				.await
-		} else {
-			let params = (partitions,);
-			self.session
-				.execute_unpaged(&self.statements.try_get_outbox_id, params)
-				.boxed()
-				.await
-		}
-		.map_err(|error| tg::error!(!error, "failed to get the outbox id"))?
-		.into_rows_result()
-		.map_err(|error| tg::error!(!error, "failed to get the outbox rows"))?;
-		let id = result
-			.maybe_first_row::<(Option<CqlTimeuuid>,)>()
-			.map_err(|error| tg::error!(!error, "failed to get the outbox row"))?
-			.and_then(|(id,)| id)
-			.map(|id| Id::new(id.as_u128()));
-
-		Ok(id)
-	}
-
-	async fn dequeue_outbox_with_statement(
-		&self,
-		partitions: &[i64],
-		limit: i32,
-		statement: &scylla::statement::prepared::PreparedStatement,
-	) -> tg::Result<Vec<Item>> {
 		#[derive(scylla::DeserializeRow)]
 		struct Row<'a> {
-			id: CqlTimeuuid,
+			batch: &'a [u8],
+			fragment: i64,
 			partition: i64,
 			payload: &'a [u8],
 		}
 
-		let params = (partitions, limit);
-		let result = self
-			.session
-			.execute_unpaged(statement, params)
-			.boxed()
-			.await
-			.map_err(|error| tg::error!(!error, "failed to dequeue the outbox items"))?
-			.into_rows_result()
-			.map_err(|error| tg::error!(!error, "failed to get the outbox rows"))?;
-		let items = result
+		let fragments = result
 			.rows::<Row>()
 			.map_err(|error| tg::error!(!error, "failed to iterate the outbox rows"))?
 			.map(|result| {
 				let row =
 					result.map_err(|error| tg::error!(!error, "failed to get the outbox row"))?;
+				let batch = row
+					.batch
+					.try_into()
+					.map_err(|_| tg::error!("invalid outbox batch id length"))?;
+				let index = row
+					.fragment
+					.to_u64()
+					.ok_or_else(|| tg::error!("the outbox fragment index was negative"))?;
 				let partition = row
 					.partition
 					.to_u64()
 					.ok_or_else(|| tg::error!("the outbox partition was negative"))?;
-				let item = Item {
-					id: Id::new(row.id.as_u128()),
+				let fragment = Fragment {
+					batch: BatchId::new(batch),
+					index: FragmentIndex::new(index),
 					partition,
 					payload: bytes::Bytes::copy_from_slice(row.payload),
 				};
-				Ok(item)
+				Ok(fragment)
 			})
 			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(items)
+		Ok(fragments)
+	}
+
+	pub async fn enqueue_outbox_batch(&self, batch: Batch) -> tg::Result<()> {
+		let partition = batch
+			.partition
+			.to_i64()
+			.ok_or_else(|| tg::error!("the outbox partition exceeded an i64"))?;
+		let batch_id = batch.id.value();
+		for (index, payload) in batch.fragments.into_iter().enumerate() {
+			let index = index
+				.to_i64()
+				.ok_or_else(|| tg::error!("the outbox fragment index exceeded an i64"))?;
+			let params = (batch_id.as_slice(), index, partition, payload);
+			self.session
+				.execute_unpaged(&self.statements.enqueue_outbox_fragment, params)
+				.await
+				.map_err(|error| tg::error!(!error, "failed to enqueue the outbox fragment"))?;
+		}
+
+		Ok(())
+	}
+
+	pub async fn try_get_outbox_batch_at_or_before(
+		&self,
+		arg: TryGetBatchArg,
+	) -> tg::Result<Option<BatchId>> {
+		let partitions = partitions(arg.partition_start, arg.partition_end)?;
+		if partitions.is_empty() {
+			return Ok(None);
+		}
+		let result = if let Some(batch) = arg.batch {
+			let batch = batch.value();
+			let params = (&partitions, batch.as_slice());
+			self.session
+				.execute_unpaged(&self.statements.try_get_outbox_batch_at_or_before, params)
+				.boxed()
+				.await
+		} else {
+			let params = (&partitions,);
+			self.session
+				.execute_unpaged(&self.statements.try_get_outbox_batch, params)
+				.boxed()
+				.await
+		}
+		.map_err(|error| tg::error!(!error, "failed to get the outbox batch"))?
+		.into_rows_result()
+		.map_err(|error| tg::error!(!error, "failed to get the outbox rows"))?;
+		let batch = result
+			.maybe_first_row::<(Option<Vec<u8>>,)>()
+			.map_err(|error| tg::error!(!error, "failed to get the outbox row"))?
+			.and_then(|(batch,)| batch)
+			.map(|batch| {
+				batch
+					.as_slice()
+					.try_into()
+					.map(BatchId::new)
+					.map_err(|_| tg::error!("invalid outbox batch id length"))
+			})
+			.transpose()?;
+
+		Ok(batch)
 	}
 }
 


### PR DESCRIPTION
## Summary

- split object-store outbox batches into configurable, item-count-based fragments
- model batches with random time-ordered IDs and fragments with increasing indexes
- preserve fragment order within each batch while indexing distinct batches concurrently
- store Scylla fragments under `((partition), batch, fragment)` and use `LOCAL_QUORUM` reads and writes
- publish LMDB fragments together in the existing writer transaction
- rename the object outbox API around batches and fragments

## Motivation

Checkin and sync can produce large index batches, which were serialized and written to the object-store outbox as single large values. Splitting at batch-item boundaries bounds each outbox value while retaining the original batch's ordering requirements.

Scylla writes fragments sequentially within one partition without LWTs, logged batches, or other transactional features. The indexer groups dequeued fragments by batch ID, sorts by fragment index, and awaits each fragment in order before deleting the committed fragments.

## Configuration

`object.outbox.fragment_size` controls the maximum number of index batch items in each fragment. It defaults to 1,024 and must be greater than zero.

## Validation

- `bun run format`
- `bun run check`
- `cargo test -p tangram_object_store --all-features` — 8 passed
- `bun run test` — 1,249 passed and 22 skipped; two unrelated tests timed out under full-suite load
- isolated reruns of `build/process_log_early_eof.nu` and `node/client.nu` both passed
