### PR TITLE
sync: do not let a stale index read downgrade an object's stored state

### DIFF
--- a/packages/cli/tests/sync/get_stale_index_stored.nu
+++ b/packages/cli/tests/sync/get_stale_index_stored.nu
@@ -33,6 +33,7 @@ tg --url $remote.url index
 # Get the file. This stores the file's own data but not the blob it points to, and it writes the
 # index entry that the pull later reads.
 tg --url $client.url get $file | ignore
+tg --url $client.url index
 assert equal (tg --url $client.url stored --local $file | from json) {} "the index must report that the file's subtree is not stored"
 
 # Hold the last object to arrive, so that the root cannot finish before the stale value lands.

--- a/packages/cli/tests/sync/get_stale_index_stored.nu
+++ b/packages/cli/tests/sync/get_stale_index_stored.nu
@@ -1,0 +1,71 @@
+use ../../test.nu *
+
+# A pull computes whether each object's subtree is fully stored from the children as they arrive, and
+# the local index reports the same thing, but can be behind: a plain get stores a single object and
+# indexes it with `stored.subtree` false. A stale false must not replace a computed true, because the
+# computed value is recomputed only when a child changes, and every child has already arrived. If it
+# did, the root would never count as stored, and the pull would never finish, even though every
+# object arrived and nothing failed.
+
+let remote = spawn --cloud --name remote
+let client = spawn --name client --config {
+	advanced: { checkpoints: true },
+	remotes: { default: { url: $remote.url } },
+}
+
+# Put a directory with two branches, a file and a deeper directory. The remote sends a level at
+# a time, so the deeper branch's blob is the last object to arrive, and the root is still incomplete
+# when the file's own subtree is complete.
+let directory = (
+	tg --url $remote.url put 'tg.directory({
+		"f": tg.file("fff"),
+		"z": tg.directory({ "v": tg.file("vvv") }),
+	})'
+	| str trim
+)
+
+# Name the file and the deeper branch's blob. Objects are content addressed, so putting the same
+# contents again yields the id of the object that is already in the directory.
+let file = tg --url $remote.url put 'tg.file("fff")' | str trim
+let deep_blob = tg --url $remote.url put 'tg.blob("vvv")' | str trim
+tg --url $remote.url index
+
+# Get the file. This stores the file's own data but not the blob it points to, and it writes the
+# index entry that the pull later reads.
+tg --url $client.url get $file | ignore
+assert equal (tg --url $client.url stored --local $file | from json) {} "the index must report that the file's subtree is not stored"
+
+# Hold the last object to arrive, so that the root cannot finish before the stale value lands.
+let input_watch = (
+	tg --url $client.url checkpoint watch sync.get.input.object --params ({ id: $deep_blob } | to json)
+	| from json
+	| get watch
+)
+
+# Hold the file's visit to the index task until its own blob has arrived.
+let index_watch = (
+	tg --url $client.url checkpoint watch sync.get.index.object --params ({ id: $file } | to json)
+	| from json
+	| get watch
+)
+
+let pull = job spawn {
+	let job_id = job id
+	let output = tg --url $client.url pull $directory | complete
+	$output | job send --tag $job_id 0
+}
+
+# Every object except the held one has arrived, so the pull has computed that the file is stored.
+tg --url $client.url checkpoint wait sync.get.input.object $input_watch 0 | ignore
+
+# Let the index task write the stale value over the computed one.
+tg --url $client.url checkpoint wait sync.get.index.object $index_watch 0 | ignore
+tg --url $client.url checkpoint continue sync.get.index.object $index_watch 0
+tg --url $client.url checkpoint unwatch sync.get.index.object $index_watch
+
+# Release the last object. Nothing is missing and nothing errors.
+tg --url $client.url checkpoint continue sync.get.input.object $input_watch 0
+tg --url $client.url checkpoint unwatch sync.get.input.object $input_watch
+
+let output = job recv --tag $pull --timeout 10sec
+success $output "the pull must end once every object has been transferred"

--- a/packages/server/src/sync/get/index.rs
+++ b/packages/server/src/sync/get/index.rs
@@ -69,6 +69,10 @@ impl Session {
 		state: &State,
 		nodes: Vec<ObjectNode>,
 	) -> tg::Result<()> {
+		for node in &nodes {
+			crate::checkpoint!(self.server, "sync.get.index.object", id = %node.id).await;
+		}
+
 		// Get the ids.
 		let ids = nodes.iter().map(|node| node.id.clone()).collect::<Vec<_>>();
 

--- a/packages/server/src/sync/get/input.rs
+++ b/packages/server/src/sync/get/input.rs
@@ -53,6 +53,9 @@ impl Session {
 				},
 
 				tg::sync::PutMessage::Node(tg::sync::PutNodeMessage::Object(message)) => {
+					crate::checkpoint!(self.server, "sync.get.input.object", id = %message.id)
+						.await;
+
 					// Deserialize the object.
 					let data =
 						tg::object::Data::deserialize(message.id.kind(), message.bytes.as_ref())?;

--- a/packages/server/src/sync/graph.rs
+++ b/packages/server/src/sync/graph.rs
@@ -939,8 +939,10 @@ impl Graph {
 			}
 
 			if let Some(stored) = stored {
-				let merged = Self::merge_process_stored(node.local_stored.as_ref(), stored);
-				node.local_stored = Some(merged);
+				match &mut node.local_stored {
+					Some(local_stored) => local_stored.merge(&stored),
+					None => node.local_stored = Some(stored),
+				}
 			}
 
 			if let Some(permissions) = permissions {

--- a/packages/server/src/sync/graph.rs
+++ b/packages/server/src/sync/graph.rs
@@ -696,7 +696,10 @@ impl Graph {
 		}
 
 		if let Some(stored) = stored {
-			node.local_stored = Some(stored);
+			match &mut node.local_stored {
+				Some(local_stored) => local_stored.merge(&stored),
+				None => node.local_stored = Some(stored),
+			}
 		}
 
 		if let Some(permissions) = permissions {


### PR DESCRIPTION
Fixes a hang where a pull never terminates even though every object transfers and nothing errors.

This hang is caused when the index reports `false` for an object's subtree before a `pull` operation.  The subtree is arriving during the `get`. The `local_stored` field has two sources - the index, and the graph during sync. We don't update the index during the sync, only after, so the index will continue reporting the pre-sync state. This can cause a problem as the subtree arrives. The sync graph stores `subtree: true`, computed from the children.

However, a later index read can downgrade that `true` while processing a shared dependency, in `sync_get_queue_object_batch` when an object is reached again through a second parent, or `sync_get_index_object_batch`. We overwrite the value with the stale index value of `false`, and because no further children remain to receive, it stays `false`.  If an ancestor is still waiting on another branch, it recomputes from the stale `false`. This causes the pull to never terminate, even though all objects are successfully transferred.

The fix is to merge the local_stored value instead of overwriting. During a sync, objects won't become unstored, so we shouldn't downgrade this value once it's computed as `stored`. This is already how `local_visible` behaves.

