### PR TITLE
test(cli): cover a process using an object pulled from a remote

### DIFF
--- a/packages/cli/tests/grants/pulled_object_in_command.nu
+++ b/packages/cli/tests/grants/pulled_object_in_command.nu
@@ -1,0 +1,42 @@
+use ../../test.nu *
+
+# A process can use an object that its own child build pulled from a remote.
+#
+# The tool build is a remote cache hit, so the file the command reads arrives by pull. Caching it
+# requires Object(Subtree) on it, and a pulled object carries no grant, was produced by no process
+# here, and is named by no tag. Granting object_subtree on it publicly makes this build succeed, so
+# the missing grant is the only thing in the way.
+
+let remote = spawn --busybox --name remote
+
+let path = artifact {
+	tangram.ts: '
+		import busybox from "busybox";
+
+		export function tool() {
+			return tg.file("hello");
+		}
+
+		export default async function () {
+			let file = await tg.build(tool).then(tg.File.expect);
+			return tg.run`cat ${file} > $TANGRAM_OUTPUT`.env(tg.build(busybox));
+		}
+	',
+}
+
+let tool = tg --url $remote.url build --detach $"($path)#tool" | str trim
+tg --url $remote.url wait $tool
+let output = tg --url $remote.url output $tool | from json | get value | split row '?' | get 0
+
+let cold = spawn --busybox --name cold --config {
+	remotes: { default: { url: $remote.url } }
+}
+tg --url $cold.url pull $output
+tg --url $cold.url index
+
+# With the object stored, the only way to fail below is the authorization check.
+assert equal (tg --url $cold.url stored --local $output | from json) { subtree: true } "the pulled object should be stored on the cold client."
+
+let result = tg --url $cold.url build $path | complete
+success $result "a process should be able to use an object its own child build pulled."
+assert equal (tg --url $cold.url cat ($result.stdout | str trim) | str trim) "hello" "the process should read the pulled file."

--- a/packages/cli/tests/pull/remote_cache_hit_process.nu
+++ b/packages/cli/tests/pull/remote_cache_hit_process.nu
@@ -1,0 +1,36 @@
+use ../../test.nu *
+
+# Pulling a remote cache-hit process replaces its local index-only record with complete process data.
+
+let remote = spawn --name remote
+
+let path = artifact {
+	tangram.ts: '
+		export function dependency() { return tg.file("dependency"); }
+		export default async function () { return tg.build(dependency); }
+	',
+}
+
+# Populate the remote cache for the dependency.
+let remote_dependency = tg --url $remote.url build --detach $"($path)#dependency" | str trim
+tg --url $remote.url wait $remote_dependency | ignore
+
+# Reuse the dependency on a clean client, creating an index-only process record locally.
+let local = spawn --name local --config {
+	remotes: { default: { url: $remote.url } },
+}
+let parent = tg --url $local.url build --detach $path | str trim
+tg --url $local.url wait $parent | ignore
+let child = tg --url $local.url process children $parent | from json | first
+assert $child.cached "the dependency should be a remote cache hit"
+let child_id = $child.process | split row '?' | first
+let remote_dependency_id = $remote_dependency | split row '?' | first
+assert equal $child_id $remote_dependency_id "the child should reuse the remote process"
+
+tg --url $local.url index
+
+tg --url $local.url pull $child.process
+
+let local_process = tg --url $local.url process get --local $child_id | complete
+success $local_process "the pulled cache-hit process should have complete data locally"
+assert equal ($local_process.stdout | from json | get status) finished "the local process data should be finished"

--- a/packages/server/src/process/spawn/child.rs
+++ b/packages/server/src/process/spawn/child.rs
@@ -1,4 +1,4 @@
-use {crate::Session, tangram_client::prelude::*};
+use {crate::Session, std::collections::BTreeSet, tangram_client::prelude::*};
 
 pub(super) struct AddProcessChildArg<'a> {
 	pub cached: bool,
@@ -10,6 +10,7 @@ pub(super) struct AddProcessChildArg<'a> {
 	pub parent: &'a tg::process::Id,
 	pub sandbox: Option<&'a tg::sandbox::Id>,
 	pub tokens: &'a tg::authorization::Tokens,
+	pub wait: Option<&'a tg::process::wait::Output>,
 }
 
 impl Session {
@@ -26,7 +27,7 @@ impl Session {
 		};
 		let Some(parent_sandbox) = self.server.runner.state().try_get_process_sandbox(&parent)
 		else {
-			self.index_process_child(&parent, &data, &command, sandbox.as_ref(), None)
+			self.index_process_child(&parent, &data, &command, sandbox.as_ref(), None, arg.wait)
 				.await?;
 			return Ok(());
 		};
@@ -84,6 +85,7 @@ impl Session {
 			&command,
 			sandbox.as_ref(),
 			Some(parent_data),
+			arg.wait,
 		)
 		.await?;
 
@@ -97,7 +99,19 @@ impl Session {
 		command: &tg::command::Id,
 		sandbox: Option<&tg::sandbox::Id>,
 		parent_data: Option<tg::process::Data>,
+		wait: Option<&tg::process::wait::Output>,
 	) -> tg::Result<()> {
+		let (error, output) = if child.cached {
+			match wait {
+				Some(wait) => (
+					Some(Self::index_process_child_error(wait.error.as_ref())),
+					Some(Self::index_process_child_output(wait.output.as_ref())),
+				),
+				None => (None, None),
+			}
+		} else {
+			(None, None)
+		};
 		let now = self.server.clock.unix_timestamp()?;
 		let child_id = &child.process.node;
 		let parent_arg = parent_data.map(|parent_data| {
@@ -125,12 +139,12 @@ impl Session {
 			children: None,
 			command: command.clone().into(),
 			data: None,
-			error: None,
+			error,
 			id: child_id.clone(),
 			log: None,
 			metadata: tg::process::Metadata::default(),
 			options: child.process.options.clone(),
-			output: None,
+			output,
 			parent: Some(parent.clone()),
 			sandbox: sandbox.cloned(),
 			stored: tangram_index::process::Stored::default(),
@@ -159,5 +173,27 @@ impl Session {
 			.map_err(|error| tg::error!(!error, "failed to index the process child"))?;
 
 		Ok(())
+	}
+
+	fn index_process_child_error(
+		error: Option<&tg::Either<tg::error::Data, tg::Referent<tg::error::Id>>>,
+	) -> Option<Vec<tg::object::Id>> {
+		error.map(|error| match error {
+			tg::Either::Left(data) => {
+				let mut objects = BTreeSet::new();
+				data.children(&mut objects);
+				objects.into_iter().collect()
+			},
+			tg::Either::Right(error) => vec![error.node.clone().into()],
+		})
+	}
+
+	fn index_process_child_output(output: Option<&tg::value::Data>) -> Option<Vec<tg::object::Id>> {
+		let output = output?;
+		let mut objects = BTreeSet::new();
+		output.children(&mut objects);
+		let output = objects.into_iter().collect();
+
+		Some(output)
 	}
 }

--- a/packages/server/src/process/spawn/local.rs
+++ b/packages/server/src/process/spawn/local.rs
@@ -444,6 +444,7 @@ impl Session {
 			parent,
 			sandbox: sandbox.as_ref(),
 			tokens: &output.tokens,
+			wait: output.wait.as_ref(),
 		})
 		.await
 		.map_err(

--- a/packages/server/src/pull.rs
+++ b/packages/server/src/pull.rs
@@ -89,6 +89,9 @@ impl Session {
 			let Some(process) = process else {
 				return false;
 			};
+			if process.data.is_none() {
+				return false;
+			}
 			let stored = process.stored;
 			if arg.process_children {
 				stored.subtree

--- a/packages/server/src/sync/get.rs
+++ b/packages/server/src/sync/get.rs
@@ -321,6 +321,8 @@ impl Session {
 			.map_err(|error| tg::error!(!error, "failed to touch the processes"))?;
 		let mut outputs = vec![None; ids.len()];
 		for (index, output) in std::iter::zip(touch_indices, touched) {
+			// Treat a process without data as absent.
+			let output = output.filter(|process| process.data.is_some());
 			if output.is_none() {
 				permissions[index] = None;
 			}


### PR DESCRIPTION
Demonstrate a failure in which a process has a child that pulls an object from a remote to use in its own output. This currently fails to authorize.