### PR TITLE
feat(builtin): add overwrite mode to archive extract

### DIFF
--- a/packages/cli/src/builtin/download.rs
+++ b/packages/cli/src/builtin/download.rs
@@ -33,6 +33,10 @@ pub struct Args {
 	#[arg(index = 2, conflicts_with = "output_named")]
 	pub output_positional: Option<PathBuf>,
 
+	/// When extracting, allow an entry to replace one that was already extracted, as tar does.
+	#[arg(long)]
+	pub overwrite: bool,
+
 	#[arg(index = 1)]
 	pub url: Uri,
 }
@@ -134,10 +138,11 @@ pub async fn run(args: Args) -> tg::Result<()> {
 			)?;
 			match format {
 				tg::ArchiveFormat::Tar => {
-					super::extract::extract_tar(output, &mut reader, compression).await?;
+					super::extract::extract_tar(output, &mut reader, compression, args.overwrite)
+						.await?;
 				},
 				tg::ArchiveFormat::Zip => {
-					super::extract::extract_zip(output, &mut reader).await?;
+					super::extract::extract_zip(output, &mut reader, args.overwrite).await?;
 				},
 			}
 		},

--- a/packages/cli/src/builtin/extract.rs
+++ b/packages/cli/src/builtin/extract.rs
@@ -25,6 +25,10 @@ pub struct Args {
 
 	#[arg(index = 2, conflicts_with = "output_named")]
 	pub output_positional: Option<PathBuf>,
+
+	/// Allow an entry to replace one that was already extracted, as tar does.
+	#[arg(long)]
+	pub overwrite: bool,
 }
 
 pub async fn run(args: Args) -> tg::Result<()> {
@@ -52,8 +56,10 @@ pub async fn run(args: Args) -> tg::Result<()> {
 		|error| tg::error!(!error, path = %output.display(), "failed to create the output"),
 	)?;
 	match format {
-		tg::ArchiveFormat::Tar => extract_tar(&output, &mut input, compression).await?,
-		tg::ArchiveFormat::Zip => extract_zip(&output, &mut input).await?,
+		tg::ArchiveFormat::Tar => {
+			extract_tar(&output, &mut input, compression, args.overwrite).await?;
+		},
+		tg::ArchiveFormat::Zip => extract_zip(&output, &mut input, args.overwrite).await?,
 	}
 	progress.finish("finished extracting")?;
 
@@ -64,6 +70,7 @@ pub(crate) async fn extract_tar(
 	output: &Path,
 	reader: &mut (impl tokio::io::AsyncBufRead + Send + Unpin + 'static),
 	compression: Option<tg::CompressionFormat>,
+	overwrite: bool,
 ) -> tg::Result<()> {
 	let reader = match compression {
 		Some(tg::CompressionFormat::Bz2) => {
@@ -105,6 +112,9 @@ pub(crate) async fn extract_tar(
 		tokio::fs::create_dir_all(parent)
 			.await
 			.map_err(|error| tg::error!(!error, "failed to create the directory"))?;
+		if overwrite {
+			remove_entry(&path).await?;
+		}
 		if kind.is_symlink() {
 			let target = entry
 				.link_name()
@@ -143,6 +153,7 @@ pub(crate) async fn extract_tar(
 pub(crate) async fn extract_zip(
 	output: &Path,
 	reader: &mut (impl tokio::io::AsyncBufRead + Send + Unpin + 'static),
+	overwrite: bool,
 ) -> tg::Result<()> {
 	let mut entries = Vec::new();
 	let mut central_directory = Vec::new();
@@ -179,6 +190,9 @@ pub(crate) async fn extract_zip(
 			tokio::fs::create_dir_all(parent)
 				.await
 				.map_err(|error| tg::error!(!error, "failed to create the directory"))?;
+			if overwrite {
+				remove_entry(&path).await?;
+			}
 			let mut file = create_entry_file(&path).await?;
 			tokio::io::copy(&mut entry_reader.compat(), &mut file)
 				.await
@@ -267,6 +281,27 @@ pub(crate) async fn extract_zip(
 	}
 
 	Ok(())
+}
+
+// Remove an already extracted entry so that a later entry with the same path can replace it, as tar does.
+async fn remove_entry(path: &Path) -> tg::Result<()> {
+	let metadata = match tokio::fs::symlink_metadata(path).await {
+		Ok(metadata) => metadata,
+		Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+		Err(error) => {
+			return Err(tg::error!(
+				!error,
+				?path,
+				"failed to read the entry metadata"
+			));
+		},
+	};
+	if metadata.is_dir() {
+		return Err(tg::error!(?path, "an entry cannot replace a directory"));
+	}
+	tokio::fs::remove_file(path)
+		.await
+		.map_err(|error| tg::error!(!error, ?path, "failed to remove the entry"))
 }
 
 // Create the file for an archive entry. The file is created exclusively so that an archive cannot overwrite an entry it has already extracted.

--- a/packages/cli/src/download.rs
+++ b/packages/cli/src/download.rs
@@ -13,6 +13,10 @@ pub struct Args {
 	#[arg(long)]
 	pub mode: Option<tg::DownloadMode>,
 
+	/// When extracting, allow an entry to replace one that was already extracted, as tar does.
+	#[arg(long)]
+	pub overwrite: bool,
+
 	#[arg(index = 1)]
 	pub url: Uri,
 }
@@ -34,6 +38,7 @@ impl Cli {
 		let download_options = tg::DownloadOptions {
 			checksum,
 			mode: Some(mode),
+			overwrite: args.overwrite.then_some(true),
 		};
 		let command = tg::builtin::download_command(&args.url, Some(download_options));
 		let command = command

--- a/packages/cli/src/extract.rs
+++ b/packages/cli/src/extract.rs
@@ -7,6 +7,10 @@ pub struct Args {
 	#[command(flatten)]
 	pub build: crate::process::build::Options,
 
+	/// Allow an entry to replace one that was already extracted, as tar does.
+	#[arg(long)]
+	pub overwrite: bool,
+
 	#[arg(index = 1)]
 	pub reference: tg::Reference,
 }
@@ -18,7 +22,10 @@ impl Cli {
 		let blob = tg::Object::with_referent(blob)
 			.try_unwrap_blob()
 			.map_err(|_| tg::error!("expected a blob"))?;
-		let command = tg::builtin::extract_command(&blob);
+		let options = tg::ExtractOptions {
+			overwrite: args.overwrite.then_some(true),
+		};
+		let command = tg::builtin::extract_command(&blob, Some(options));
 		let command = command
 			.store_with_handle(&client)
 			.await

--- a/packages/cli/tests/archive/extract_case_insensitive_names.nu
+++ b/packages/cli/tests/archive/extract_case_insensitive_names.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# Extracting a tar archive containing two entries whose names differ only in case produces a directory with both entries on a case sensitive file system, and reports the case conflict on a case insensitive one.
+# Extracting a tar archive containing two entries whose names differ only in case produces a directory with both entries on a case sensitive file system, and reports the case conflict on a case insensitive one. With `--overwrite` the conflict is not an error, and the last entry wins.
 
 # Create the entries in separate directories, because a case insensitive file system cannot hold both at once.
 let lower = artifact {
@@ -35,4 +35,19 @@ if $case_sensitive {
 	assert ($output.stderr | str contains 'failed to extract the archive entry') "the error should identify the failing archive entry"
 	assert ($output.stderr | str contains 'differs only in case') "the error should explain the case conflict"
 	assert ($output.stderr | str contains 'chap.html') "the error should name the conflicting entry"
+}
+
+# Extract the archive with `--overwrite`.
+let overwritten = mktemp -d | path join 'overwritten'
+let output = tg builtin extract --input $archive --overwrite --output $overwritten | complete
+success $output "the archive should extract"
+
+if $case_sensitive {
+	# The extracted directory should still contain both entries.
+	assert (($overwritten | path join 'chap.html') | path exists) "the extracted directory should contain the lowercase entry"
+	assert (($overwritten | path join 'Chap.html') | path exists) "the extracted directory should contain the capitalized entry"
+} else {
+	# The capitalized entry should have replaced the lowercase one.
+	assert ((ls $overwritten | length) == 1) "the extracted directory should contain one entry"
+	assert ((open --raw ($overwritten | path join 'Chap.html')) == 'upper') "the capitalized entry should replace the lowercase entry"
 }

--- a/packages/cli/tests/archive/extract_case_insensitive_names.nu
+++ b/packages/cli/tests/archive/extract_case_insensitive_names.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# Extracting a tar archive containing two entries whose names differ only in case produces a directory with both entries on a case sensitive file system, and reports the case conflict on a case insensitive one. With `--overwrite` the conflict is not an error, and the last entry wins.
+# Extracting a tar archive containing two entries whose names differ only in case produces a directory with both entries on a case sensitive file system, and reports the case conflict on a case insensitive one. With `--overwrite` the conflict is not an error, and the last entry wins on either file system.
 
 # Create the entries in separate directories, because a case insensitive file system cannot hold both at once.
 let lower = artifact {
@@ -37,17 +37,8 @@ if $case_sensitive {
 	assert ($output.stderr | str contains 'chap.html') "the error should name the conflicting entry"
 }
 
-# Extract the archive with `--overwrite`.
+# Extract the archive with `--overwrite`. The capitalized entry comes last, so it wins on a case sensitive file system by name and on a case insensitive one by replacing the lowercase entry.
 let overwritten = mktemp -d | path join 'overwritten'
 let output = tg builtin extract --input $archive --overwrite --output $overwritten | complete
 success $output "the archive should extract"
-
-if $case_sensitive {
-	# The extracted directory should still contain both entries.
-	assert (($overwritten | path join 'chap.html') | path exists) "the extracted directory should contain the lowercase entry"
-	assert (($overwritten | path join 'Chap.html') | path exists) "the extracted directory should contain the capitalized entry"
-} else {
-	# The capitalized entry should have replaced the lowercase one.
-	assert ((ls $overwritten | length) == 1) "the extracted directory should contain one entry"
-	assert ((open --raw ($overwritten | path join 'Chap.html')) == 'upper') "the capitalized entry should replace the lowercase entry"
-}
+snapshot (open --raw ($overwritten | path join 'Chap.html')) 'upper'

--- a/packages/cli/tests/archive/extract_duplicate_names.nu
+++ b/packages/cli/tests/archive/extract_duplicate_names.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# Extracting a tar archive that contains the same entry twice is rejected, unless `--overwrite` is set, in which case the last entry wins, as tar does.
+# Extracting a tar archive that contains the same entry twice reports the repeated entry, and with `--overwrite` it succeeds and the last entry replaces the first, as tar does.
 
 # Create the entries in separate directories, because a directory cannot hold both at once.
 let first = artifact {
@@ -15,14 +15,22 @@ let archive = mktemp -d | path join 'duplicate.tar'
 ^tar -cf $archive -C $first 'greeting'
 ^tar -rf $archive -C $second 'greeting'
 
-# Without `--overwrite`, the repeated entry should be rejected.
-let rejected = mktemp -d | path join 'rejected'
-let output = tg builtin extract --input $archive --output $rejected | complete
+# Extract the archive.
+let extracted = mktemp -d | path join 'output'
+let output = tg builtin extract --input $archive --output $extracted | complete
 failure $output "the archive should not extract"
-assert ($output.stderr | str contains 'failed to create the file') "the error should identify the failing archive entry"
 
-# With `--overwrite`, the archive should extract and the last entry should win.
-let extracted = mktemp -d | path join 'extracted'
-let output = tg builtin extract --input $archive --overwrite --output $extracted | complete
+# Drop the progress frames, whose count and byte counts vary from run to run.
+let error = $output.stderr | lines | where { |line| not ($line | str starts-with 'extracting') }
+snapshot --redact $extracted $error '
+	-> failed to create the file
+	   path = "<redacted>/greeting"
+	-> File exists (os error 17)
+
+'
+
+# Extract the archive with `--overwrite`.
+let overwritten = mktemp -d | path join 'overwritten'
+let output = tg builtin extract --input $archive --overwrite --output $overwritten | complete
 success $output "the archive should extract"
-assert ((open --raw ($extracted | path join 'greeting')) == 'second') "the last entry should replace the first"
+snapshot (open --raw ($overwritten | path join 'greeting')) 'second'

--- a/packages/cli/tests/archive/extract_duplicate_names.nu
+++ b/packages/cli/tests/archive/extract_duplicate_names.nu
@@ -1,0 +1,28 @@
+use ../../test.nu *
+
+# Extracting a tar archive that contains the same entry twice is rejected, unless `--overwrite` is set, in which case the last entry wins, as tar does.
+
+# Create the entries in separate directories, because a directory cannot hold both at once.
+let first = artifact {
+	'greeting': 'first'
+}
+let second = artifact {
+	'greeting': 'second'
+}
+
+# Create a tar archive containing the entry twice.
+let archive = mktemp -d | path join 'duplicate.tar'
+^tar -cf $archive -C $first 'greeting'
+^tar -rf $archive -C $second 'greeting'
+
+# Without `--overwrite`, the repeated entry should be rejected.
+let rejected = mktemp -d | path join 'rejected'
+let output = tg builtin extract --input $archive --output $rejected | complete
+failure $output "the archive should not extract"
+assert ($output.stderr | str contains 'failed to create the file') "the error should identify the failing archive entry"
+
+# With `--overwrite`, the archive should extract and the last entry should win.
+let extracted = mktemp -d | path join 'extracted'
+let output = tg builtin extract --input $archive --overwrite --output $extracted | complete
+success $output "the archive should extract"
+assert ((open --raw ($extracted | path join 'greeting')) == 'second') "the last entry should replace the first"

--- a/packages/clients/js/src/builtin.ts
+++ b/packages/clients/js/src/builtin.ts
@@ -7,6 +7,11 @@ export type CompressionFormat = "bz2" | "gz" | "xz" | "zst";
 export type DownloadOptions = {
 	checksum?: tg.Checksum.Algorithm | null;
 	mode?: "raw" | "decompress" | "extract" | null;
+	overwrite?: boolean | null;
+};
+
+export type ExtractOptions = {
+	overwrite?: boolean | null;
 };
 
 /** Archive an artifact. */
@@ -146,6 +151,7 @@ export let download = async (
 			: []),
 		"--mode",
 		mode,
+		...(options.overwrite === true ? ["--overwrite"] : []),
 		"--output",
 		tg.output,
 		url,
@@ -167,9 +173,20 @@ export let download = async (
 };
 
 /** Extract an artifact from an archive. */
-export let extract = async (blob: tg.Blob): Promise<tg.Artifact> => {
+export let extract = async (
+	blob: tg.Blob,
+	options?: ExtractOptions | null,
+): Promise<tg.Artifact> => {
 	let input = await tg.file(blob);
-	let args = ["builtin", "extract", "--input", input, "--output", tg.output];
+	let args = [
+		"builtin",
+		"extract",
+		"--input",
+		input,
+		...(options?.overwrite === true ? ["--overwrite"] : []),
+		"--output",
+		tg.output,
+	];
 	let value = await tg
 		.build()
 		.host(tg.host.current)

--- a/packages/clients/rust/src/builtin.rs
+++ b/packages/clients/rust/src/builtin.rs
@@ -48,6 +48,9 @@ pub struct DownloadOptions {
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub mode: Option<DownloadMode>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub overwrite: Option<bool>,
 }
 
 #[derive(
@@ -67,6 +70,12 @@ pub enum DownloadMode {
 	Raw,
 	Decompress,
 	Extract,
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+pub struct ExtractOptions {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub overwrite: Option<bool>,
 }
 
 pub async fn archive(
@@ -465,9 +474,11 @@ where
 	if let Some(algorithm) = options.checksum {
 		args.extend(["--checksum".into(), algorithm.to_string().into()]);
 	}
+	args.extend(["--mode".into(), mode.to_string().into()]);
+	if options.overwrite == Some(true) {
+		args.push("--overwrite".into());
+	}
 	args.extend([
-		"--mode".into(),
-		mode.to_string().into(),
 		"--output".into(),
 		tg::Placeholder::new("output").into(),
 		url.to_string().into(),
@@ -508,6 +519,11 @@ pub fn download_command(url: &Uri, options: Option<DownloadOptions>) -> tg::Comm
 	args.extend([
 		"--mode".into(),
 		options.mode.unwrap_or_default().to_string().into(),
+	]);
+	if options.overwrite == Some(true) {
+		args.push("--overwrite".into());
+	}
+	args.extend([
 		"--output".into(),
 		tg::Placeholder::new("output").into(),
 		url.to_string().into(),
@@ -525,24 +541,34 @@ pub fn download_command(url: &Uri, options: Option<DownloadOptions>) -> tg::Comm
 		.expect("the command builder should be complete")
 }
 
-pub async fn extract(input: &tg::Blob) -> tg::Result<tg::Artifact> {
+pub async fn extract(
+	input: &tg::Blob,
+	options: Option<ExtractOptions>,
+) -> tg::Result<tg::Artifact> {
 	let handle = tg::handle()?;
-	extract_with_handle(handle, input).await
+	extract_with_handle(handle, input, options).await
 }
 
-pub async fn extract_with_handle<H>(handle: &H, input: &tg::Blob) -> tg::Result<tg::Artifact>
+pub async fn extract_with_handle<H>(
+	handle: &H,
+	input: &tg::Blob,
+	options: Option<ExtractOptions>,
+) -> tg::Result<tg::Artifact>
 where
 	H: tg::Handle,
 {
+	let options = options.unwrap_or_default();
 	let input = tg::File::with_contents(input.clone());
-	let args = vec![
+	let mut args = vec![
 		tg::Value::from("builtin"),
 		"extract".into(),
 		"--input".into(),
 		input.into(),
-		"--output".into(),
-		tg::Placeholder::new("output").into(),
 	];
+	if options.overwrite == Some(true) {
+		args.push("--overwrite".into());
+	}
+	args.extend(["--output".into(), tg::Placeholder::new("output").into()]);
 	let arg = tg::process::Arg {
 		args,
 		executable: Some(tg::command::Executable {
@@ -559,16 +585,19 @@ where
 }
 
 #[must_use]
-pub fn extract_command(input: &tg::Blob) -> tg::Command {
+pub fn extract_command(input: &tg::Blob, options: Option<ExtractOptions>) -> tg::Command {
+	let options = options.unwrap_or_default();
 	let input = tg::File::with_contents(input.clone());
-	let args: Vec<tg::command::Value> = vec![
+	let mut args: Vec<tg::command::Value> = vec![
 		"builtin".into(),
 		"extract".into(),
 		"--input".into(),
 		input.into(),
-		"--output".into(),
-		tg::Placeholder::new("output").into(),
 	];
+	if options.overwrite == Some(true) {
+		args.push("--overwrite".into());
+	}
+	args.extend(["--output".into(), tg::Placeholder::new("output").into()]);
 	let executable = tg::command::Executable {
 		artifact: None,
 		path: Some("tg".into()),

--- a/packages/clients/rust/src/lib.rs
+++ b/packages/clients/rust/src/lib.rs
@@ -16,7 +16,9 @@ pub use {
 	self::{
 		artifact::Handle as Artifact,
 		blob::Handle as Blob,
-		builtin::{ArchiveFormat, CompressionFormat, DownloadMode, DownloadOptions},
+		builtin::{
+			ArchiveFormat, CompressionFormat, DownloadMode, DownloadOptions, ExtractOptions,
+		},
 		checkin::checkin,
 		checkout::checkout,
 		checksum::Checksum,


### PR DESCRIPTION
Our archive extraction is stricter than GNU tar because it errors explicitly when it encounters duplicate entries or case-sensitivity collisions. This strictness is generally a good thing, but some real-world tarballs are poorly constructed. GNU tar can extract them without issue, while we fail.

This PR implements an opt-in `overwrite` mode that relaxes this strictness and instead matches GNU tar, where the last entry wins. You must explicitly opt in to this behavior, but it allows Tangram to handle these tarballs instead of requiring upstream fixes.