### PR TITLE
index/fdb: use tg::Error retry loops

### DIFF
--- a/packages/index/src/fdb.rs
+++ b/packages/index/src/fdb.rs
@@ -39,7 +39,6 @@ pub(crate) use error::{propagate, retry};
 pub(crate) use transaction::run;
 pub(super) use {
 	key::{Key, Kind},
-	transaction::Transaction,
 	writer::Metrics,
 };
 

--- a/packages/index/src/fdb.rs
+++ b/packages/index/src/fdb.rs
@@ -36,7 +36,7 @@ mod visible;
 mod writer;
 
 pub(crate) use error::{propagate, retry};
-pub(crate) use transaction::{run, run_read};
+pub(crate) use transaction::run;
 pub(super) use {
 	key::{Key, Kind},
 	transaction::Transaction,

--- a/packages/index/src/fdb.rs
+++ b/packages/index/src/fdb.rs
@@ -28,15 +28,18 @@ mod response;
 mod runner;
 mod sandbox;
 mod tag;
+mod transaction;
 mod update;
 mod usage;
 mod user;
 mod visible;
 mod writer;
 
-pub(crate) use error::{Result, custom_error, error};
+pub(crate) use error::{propagate, retry};
+pub(crate) use transaction::run;
 pub(super) use {
 	key::{Key, Kind},
+	transaction::Transaction,
 	writer::Metrics,
 };
 
@@ -220,10 +223,10 @@ impl Index {
 	fn unpack<'a, T: fdbt::TupleUnpack<'a>>(
 		subspace: &fdbt::Subspace,
 		bytes: &'a [u8],
-	) -> crate::fdb::Result<T> {
+	) -> tg::Result<T> {
 		subspace
 			.unpack(bytes)
-			.map_err(|error| crate::fdb::error!(!error, "failed to unpack key"))
+			.map_err(|error| tg::error!(!error, "failed to unpack key"))
 	}
 
 	pub async fn get_transaction_id(&self) -> tg::Result<u64> {

--- a/packages/index/src/fdb.rs
+++ b/packages/index/src/fdb.rs
@@ -36,7 +36,7 @@ mod visible;
 mod writer;
 
 pub(crate) use error::{propagate, retry};
-pub(crate) use transaction::run;
+pub(crate) use transaction::{run, run_read};
 pub(super) use {
 	key::{Key, Kind},
 	transaction::Transaction,

--- a/packages/index/src/fdb/ancestor.rs
+++ b/packages/index/src/fdb/ancestor.rs
@@ -1,6 +1,9 @@
 use {
-	crate::fdb::Index, foundationdb as fdb, foundationdb_tuple::Subspace,
-	std::collections::HashSet, tangram_client::prelude::*,
+	crate::fdb::Index,
+	foundationdb as fdb,
+	foundationdb_tuple::Subspace,
+	std::{collections::HashSet, ops::ControlFlow},
+	tangram_client::prelude::*,
 };
 
 impl Index {
@@ -18,65 +21,71 @@ impl Index {
 		transaction: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::Id,
-	) -> crate::fdb::Result<Option<Vec<tg::Id>>> {
+	) -> tg::Result<ControlFlow<Option<Vec<tg::Id>>, fdb::FdbError>> {
 		let mut ancestors = Vec::new();
 		let mut current = Some(id.clone());
 		let mut visited = HashSet::<_, tg::id::BuildHasher>::default();
 		while let Some(id) = current {
 			if !visited.insert(id.clone()) {
-				return Err(crate::fdb::error!(%id, "the owner hierarchy contains a cycle"));
+				return Err(tg::error!(%id, "the owner hierarchy contains a cycle"));
 			}
 			current = match id.kind() {
 				tg::id::Kind::Group => {
-					let group = Self::try_get_group_with_transaction(
-						transaction,
-						subspace,
-						&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-					)
-					.await?;
+					let group = crate::fdb::propagate!(
+						Self::try_get_group_with_transaction(
+							transaction,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					);
 					let Some(group) = group else {
 						if ancestors.is_empty() {
-							return Ok(None);
+							return Ok(ControlFlow::Break(None));
 						}
-						return Err(crate::fdb::error!(%id, "failed to find an ancestor"));
+						return Err(tg::error!(%id, "failed to find an ancestor"));
 					};
 					group.parent
 				},
 				tg::id::Kind::Organization => {
-					let organization = Self::try_get_organization_with_transaction(
-						transaction,
-						subspace,
-						&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-					)
-					.await?;
+					let organization = crate::fdb::propagate!(
+						Self::try_get_organization_with_transaction(
+							transaction,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					);
 					if organization.is_none() {
 						if ancestors.is_empty() {
-							return Ok(None);
+							return Ok(ControlFlow::Break(None));
 						}
-						return Err(crate::fdb::error!(%id, "failed to find an ancestor"));
+						return Err(tg::error!(%id, "failed to find an ancestor"));
 					}
 					None
 				},
 				tg::id::Kind::User => {
-					let user = Self::try_get_user_with_transaction(
-						transaction,
-						subspace,
-						&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-					)
-					.await?;
+					let user = crate::fdb::propagate!(
+						Self::try_get_user_with_transaction(
+							transaction,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					);
 					if user.is_none() {
 						if ancestors.is_empty() {
-							return Ok(None);
+							return Ok(ControlFlow::Break(None));
 						}
-						return Err(crate::fdb::error!(%id, "failed to find an ancestor"));
+						return Err(tg::error!(%id, "failed to find an ancestor"));
 					}
 					None
 				},
-				_ => return Err(crate::fdb::error!(%id, "invalid owner")),
+				_ => return Err(tg::error!(%id, "invalid owner")),
 			};
 			ancestors.push(id);
 		}
 
-		Ok(Some(ancestors))
+		Ok(ControlFlow::Break(Some(ancestors)))
 	}
 }

--- a/packages/index/src/fdb/authorize.rs
+++ b/packages/index/src/fdb/authorize.rs
@@ -4,7 +4,10 @@ use {
 	foundationdb_tuple::Subspace,
 	futures::{StreamExt as _, TryStreamExt as _, stream},
 	num_traits::ToPrimitive as _,
-	std::collections::{HashMap, HashSet, VecDeque},
+	std::{
+		collections::{HashMap, HashSet, VecDeque},
+		ops::ControlFlow,
+	},
 	tangram_client::prelude::*,
 };
 
@@ -248,9 +251,9 @@ impl Index {
 		subspace: &Subspace,
 		args: &[crate::authorize::Arg],
 		principal: &tg::Principal,
-	) -> crate::fdb::Result<Vec<Option<crate::authorize::Output>>> {
+	) -> tg::Result<ControlFlow<Vec<Option<crate::authorize::Output>>, fdb::FdbError>> {
 		if args.is_empty() {
-			return Ok(Vec::new());
+			return Ok(ControlFlow::Break(Vec::new()));
 		}
 		if matches!(principal, tg::Principal::Root) {
 			let outputs = args
@@ -261,29 +264,43 @@ impl Index {
 					})
 				})
 				.collect();
-			return Ok(outputs);
+			return Ok(ControlFlow::Break(outputs));
 		}
 		let mut requester = Requester::new(principal);
 		if PRECOMPUTE_REQUESTER_PRINCIPALS {
-			Self::load_requester_subjects_with_transaction(
-				txn,
-				subspace,
-				config.concurrency,
-				&mut requester,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::load_requester_subjects_with_transaction(
+					txn,
+					subspace,
+					config.concurrency,
+					&mut requester,
+				)
+				.await
+			);
 		}
 		let resource_requests = args
 			.iter()
 			.map(|arg| arg.resource.clone())
 			.collect::<Vec<_>>();
-		let resources = stream::iter(resource_requests)
-			.map(|resource| async move {
-				Self::try_resolve_resource_with_transaction(txn, subspace, &resource).await
-			})
-			.buffered(config.concurrency)
-			.try_collect::<Vec<_>>()
-			.await?;
+		let resources = {
+			let result = stream::iter(resource_requests)
+				.map(|resource| async move {
+					Self::try_resolve_resource_with_transaction(txn, subspace, &resource).await
+				})
+				.buffered(config.concurrency)
+				.try_collect::<Vec<_>>()
+				.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
 		let permissions = std::iter::zip(args, &resources)
 			.map(|(arg, resource)| {
 				let Some((resource, exact)) = resource else {
@@ -293,9 +310,8 @@ impl Index {
 					return Ok(Some(arg.permissions));
 				}
 				crate::authorize::permissions_for_specifier_prefix(resource, arg.permissions)
-					.map_err(crate::fdb::custom_error)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let token_resources = args
 			.iter()
 			.map(|arg| arg.token.as_ref().map(|body| body.resource.clone()))
@@ -337,14 +353,16 @@ impl Index {
 				token,
 				txn,
 			};
-			let authorized = Self::authorize_with_transaction(
-				context,
-				&id,
-				permissions,
-				authorization,
-				&mut cache,
-			)
-			.await?;
+			let authorized = crate::fdb::propagate!(
+				Self::authorize_with_transaction(
+					context,
+					&id,
+					permissions,
+					authorization,
+					&mut cache,
+				)
+				.await
+			);
 			let permissions = if permissions == arg.permissions {
 				authorized
 			} else if authorized.contains(permissions) {
@@ -355,7 +373,7 @@ impl Index {
 			outputs.push(Some(crate::authorize::Output { permissions }));
 		}
 
-		Ok(outputs)
+		Ok(ControlFlow::Break(outputs))
 	}
 
 	async fn load_requester_subjects_with_transaction(
@@ -363,12 +381,12 @@ impl Index {
 		subspace: &Subspace,
 		concurrency: usize,
 		requester: &mut Requester<'_>,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let Some(id) = requester.id.clone() else {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		};
 		if !matches!(id.kind(), tg::id::Kind::Group | tg::id::Kind::User) {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 		let mut visited = HashSet::new();
 		let mut frontier = vec![id];
@@ -379,14 +397,46 @@ impl Index {
 				.collect::<Vec<_>>();
 			let relations = stream::iter(members)
 				.map(|member| async move {
-					futures::try_join!(
+					let (groups, organizations) = futures::try_join!(
 						Self::get_member_groups_with_transaction(txn, subspace, &member),
 						Self::get_member_organizations_with_transaction(txn, subspace, &member),
-					)
+					)?;
+					let groups = {
+						let result = groups;
+						match result {
+							ControlFlow::Break(value) => value,
+							ControlFlow::Continue(error) => {
+								return Ok(ControlFlow::Continue(error));
+							},
+						}
+					};
+					let organizations = {
+						let result = organizations;
+						match result {
+							ControlFlow::Break(value) => value,
+							ControlFlow::Continue(error) => {
+								return Ok(ControlFlow::Continue(error));
+							},
+						}
+					};
+
+					Ok::<_, tg::Error>(ControlFlow::Break((groups, organizations)))
 				})
 				.buffer_unordered(concurrency)
 				.try_collect::<Vec<_>>()
 				.await?;
+			let relations = {
+				let results = relations;
+				let mut values = Vec::new();
+				for result in results {
+					let value = match result {
+						ControlFlow::Break(value) => value,
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					};
+					values.push(value);
+				}
+				values
+			};
 			let mut next = Vec::new();
 			for (groups, organizations) in relations {
 				for group in groups {
@@ -403,7 +453,7 @@ impl Index {
 			}
 			frontier = next;
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn authorize_with_transaction(
@@ -412,18 +462,20 @@ impl Index {
 		permissions: tg::authorization::permission::Set,
 		authorization: &mut HashMap<(tg::Id, tg::authorization::Permission), bool>,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<tg::authorization::permission::Set> {
+	) -> tg::Result<ControlFlow<tg::authorization::permission::Set, fdb::FdbError>> {
 		let roots = permissions
 			.iter()
 			.map(|permission| (resource.clone(), permission))
 			.collect::<Vec<_>>();
-		Self::authorize_permissions_ordinary_with_transaction(
-			context,
-			&roots,
-			authorization,
-			cache,
-		)
-		.await?;
+		crate::fdb::propagate!(
+			Self::authorize_permissions_ordinary_with_transaction(
+				context,
+				&roots,
+				authorization,
+				cache,
+			)
+			.await
+		);
 		let mut authorized = permissions.empty_like();
 		for permission in permissions.iter() {
 			let key = (resource.clone(), permission);
@@ -436,13 +488,13 @@ impl Index {
 			let permission_authorized = match permission {
 				tg::authorization::Permission::Object(
 					tg::authorization::permission::object::Permission::Subtree,
-				) => Self::authorize_with_object_subtree_search_with_transaction(
+				) => crate::fdb::propagate!(Self::authorize_with_object_subtree_search_with_transaction(
 					context,
 					resource,
 					authorization,
 					cache,
 				)
-				.await?
+				.await)
 				.unwrap_or(false),
 				tg::authorization::Permission::Process(
 					permission @ (tg::authorization::permission::process::Permission::NodeCommand
@@ -450,14 +502,14 @@ impl Index {
 					| tg::authorization::permission::process::Permission::NodeLog
 					| tg::authorization::permission::process::Permission::NodeOutput),
 				) => {
-					Self::authorize_process_node_with_transaction(
+					crate::fdb::propagate!(Self::authorize_process_node_with_transaction(
 						context,
 						resource,
 						permission,
 						authorization,
 						cache,
 					)
-					.await?
+					.await)
 				},
 				tg::authorization::Permission::Process(
 					permission @ (tg::authorization::permission::process::Permission::Subtree
@@ -465,14 +517,14 @@ impl Index {
 					| tg::authorization::permission::process::Permission::SubtreeError
 					| tg::authorization::permission::process::Permission::SubtreeLog
 					| tg::authorization::permission::process::Permission::SubtreeOutput),
-				) => Self::authorize_with_process_subtree_search_with_transaction(
+				) => crate::fdb::propagate!(Self::authorize_with_process_subtree_search_with_transaction(
 					context,
 					resource,
 					permission,
 					authorization,
 					cache,
 				)
-				.await?
+				.await)
 				.unwrap_or(false),
 				_ => false,
 			};
@@ -482,7 +534,7 @@ impl Index {
 				));
 			}
 		}
-		Ok(authorized)
+		Ok(ControlFlow::Break(authorized))
 	}
 
 	async fn authorize_permissions_ordinary_with_transaction(
@@ -490,7 +542,7 @@ impl Index {
 		roots: &[(tg::Id, tg::authorization::Permission)],
 		authorization: &mut HashMap<(tg::Id, tg::authorization::Permission), bool>,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let mut nodes = Vec::new();
 		let mut node_ids = HashMap::new();
 		let mut queue = VecDeque::new();
@@ -532,7 +584,7 @@ impl Index {
 				.iter()
 				.all(|root| authorization.get(root).copied().unwrap_or(false))
 			{
-				return Ok(());
+				return Ok(ControlFlow::Break(()));
 			}
 			let dependency_concurrency = context.config.concurrency.div_ceil(requests.len().max(1));
 
@@ -555,18 +607,48 @@ impl Index {
 						);
 						let (directly_authorized, dependencies) =
 							futures::try_join!(directly_authorized, dependencies)?;
+						let directly_authorized = {
+							let result = directly_authorized;
+							match result {
+								ControlFlow::Break(value) => value,
+								ControlFlow::Continue(error) => {
+									return Ok(ControlFlow::Continue(error));
+								},
+							}
+						};
+						let dependencies = {
+							let result = dependencies;
+							match result {
+								ControlFlow::Break(value) => value,
+								ControlFlow::Continue(error) => {
+									return Ok(ControlFlow::Continue(error));
+								},
+							}
+						};
 						direct_cache.merge(dependency_cache);
-						Ok::<_, fdb::FdbBindingError>(AuthorizationNodeEvaluation {
+						Ok::<_, tg::Error>(ControlFlow::Break(AuthorizationNodeEvaluation {
 							node_id,
 							directly_authorized,
 							dependencies,
 							cache: direct_cache,
-						})
+						}))
 					},
 				)
 				.buffer_unordered(context.config.concurrency)
 				.try_collect::<Vec<_>>()
 				.await?;
+			let evaluations = {
+				let results = evaluations;
+				let mut values = Vec::new();
+				for result in results {
+					let value = match result {
+						ControlFlow::Break(value) => value,
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					};
+					values.push(value);
+				}
+				values
+			};
 
 			for evaluation in evaluations {
 				cache.merge(evaluation.cache);
@@ -613,14 +695,14 @@ impl Index {
 				.iter()
 				.all(|root| authorization.get(root).copied().unwrap_or(false))
 			{
-				return Ok(());
+				return Ok(ControlFlow::Break(()));
 			}
 		}
 
 		for node in nodes {
 			authorization.entry(node.key).or_insert(false);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	fn propagate_authorization(
@@ -645,18 +727,18 @@ impl Index {
 		resource: &tg::Id,
 		permission: tg::authorization::Permission,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		if let (tg::Principal::Process(process), tg::authorization::Permission::Process(_)) =
 			(context.requester.principal, permission)
 			&& tg::Id::from(process.clone()) == *resource
 		{
-			return Ok(true);
+			return Ok(ControlFlow::Break(true));
 		}
 		if let (tg::Principal::User(user), tg::authorization::Permission::User(_)) =
 			(context.requester.principal, permission)
 			&& tg::Id::from(user.clone()) == *resource
 		{
-			return Ok(true);
+			return Ok(ControlFlow::Break(true));
 		}
 		if let (
 			tg::Principal::Sandbox(sandbox),
@@ -667,7 +749,7 @@ impl Index {
 		) = (context.requester.principal, permission)
 			&& tg::Id::from(sandbox.clone()) == *resource
 		{
-			return Ok(true);
+			return Ok(ControlFlow::Break(true));
 		}
 		if matches!(
 			permission,
@@ -677,51 +759,55 @@ impl Index {
 			)
 		) && resource.kind() == tg::id::Kind::Sandbox
 		{
-			let sandbox =
-				tg::sandbox::Id::try_from(resource.clone()).map_err(crate::fdb::custom_error)?;
-			if let Some(owner) = Self::get_cached_sandbox_owner_with_transaction(
-				context.txn,
-				context.subspace,
-				&sandbox,
-				cache,
-			)
-			.await?
-			{
-				let owner = owner.try_to_subject().map_err(crate::fdb::custom_error)?;
-				if Self::subject_contains_requester_with_transaction(
+			let sandbox = tg::sandbox::Id::try_from(resource.clone())?;
+			if let Some(owner) = crate::fdb::propagate!(
+				Self::get_cached_sandbox_owner_with_transaction(
 					context.txn,
 					context.subspace,
-					&owner,
-					context.requester,
+					&sandbox,
+					cache,
 				)
-				.await?
-				{
-					return Ok(true);
+				.await
+			) {
+				let owner = owner.try_to_subject()?;
+				if crate::fdb::propagate!(
+					Self::subject_contains_requester_with_transaction(
+						context.txn,
+						context.subspace,
+						&owner,
+						context.requester,
+					)
+					.await
+				) {
+					return Ok(ControlFlow::Break(true));
 				}
 			}
 		}
 
-		let grants = Self::get_cached_resource_grants_with_transaction(
-			context.txn,
-			context.subspace,
-			resource,
-			cache,
-		)
-		.await?;
+		let grants = crate::fdb::propagate!(
+			Self::get_cached_resource_grants_with_transaction(
+				context.txn,
+				context.subspace,
+				resource,
+				cache,
+			)
+			.await
+		);
 		for (granted_subject, granted_permission) in grants {
 			if granted_permission.implies(permission)
-				&& Self::subject_contains_requester_with_transaction(
-					context.txn,
-					context.subspace,
-					&granted_subject,
-					context.requester,
-				)
-				.await?
-			{
-				return Ok(true);
+				&& crate::fdb::propagate!(
+					Self::subject_contains_requester_with_transaction(
+						context.txn,
+						context.subspace,
+						&granted_subject,
+						context.requester,
+					)
+					.await
+				) {
+				return Ok(ControlFlow::Break(true));
 			}
 		}
-		Ok(false)
+		Ok(ControlFlow::Break(false))
 	}
 
 	fn is_authorized_by_token(
@@ -739,7 +825,7 @@ impl Index {
 		resource: &tg::Id,
 		authorization: &mut HashMap<(tg::Id, tg::authorization::Permission), bool>,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Option<bool>> {
+	) -> tg::Result<ControlFlow<Option<bool>, fdb::FdbError>> {
 		let subtree = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Subtree,
 		);
@@ -750,26 +836,28 @@ impl Index {
 			max_depth: context.config.object_subtree.max_depth,
 			remaining: context.config.object_subtree.max_objects,
 		};
-		let root = tg::object::Id::try_from(resource.clone()).map_err(crate::fdb::custom_error)?;
+		let root = tg::object::Id::try_from(resource.clone())?;
 		let mut visited = HashSet::from([root.clone()]);
 		let mut frontier = vec![root];
 		let mut depth = 0;
 		while !frontier.is_empty() {
 			if frontier.len() > budget.remaining {
-				return Ok(None);
+				return Ok(ControlFlow::Break(None));
 			}
 			budget.remaining -= frontier.len();
 			let subtree_roots = frontier
 				.iter()
 				.map(|object| (tg::Id::from(object.clone()), subtree))
 				.collect::<Vec<_>>();
-			Self::authorize_permissions_ordinary_with_transaction(
-				context,
-				&subtree_roots,
-				authorization,
-				cache,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::authorize_permissions_ordinary_with_transaction(
+					context,
+					&subtree_roots,
+					authorization,
+					cache,
+				)
+				.await
+			);
 			let uncovered = frontier
 				.into_iter()
 				.filter(|object| {
@@ -785,18 +873,20 @@ impl Index {
 				.iter()
 				.map(|object| (tg::Id::from(object.clone()), node))
 				.collect::<Vec<_>>();
-			Self::authorize_permissions_ordinary_with_transaction(
-				context,
-				&node_roots,
-				authorization,
-				cache,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::authorize_permissions_ordinary_with_transaction(
+					context,
+					&node_roots,
+					authorization,
+					cache,
+				)
+				.await
+			);
 			if node_roots
 				.iter()
 				.any(|key| !authorization.get(key).copied().unwrap_or(false))
 			{
-				return Ok(Some(false));
+				return Ok(ControlFlow::Break(Some(false)));
 			}
 
 			let limit = if depth == budget.max_depth {
@@ -811,41 +901,55 @@ impl Index {
 				.into_iter()
 				.map(|object| (object.clone(), cache.clone_for_object_children(&object)))
 				.collect::<Vec<_>>();
-			let children = stream::iter(requests)
-				.map(|(object, mut cache)| async move {
-					let children = Self::get_cached_object_children_limited_with_transaction(
-						context.txn,
-						context.subspace,
-						&object,
-						limit,
-						&mut cache,
-					)
-					.await?;
-					Ok::<_, fdb::FdbBindingError>((children, cache))
-				})
-				.buffer_unordered(context.config.concurrency)
-				.try_collect::<Vec<_>>()
-				.await?;
+			let children = {
+				let result = stream::iter(requests)
+					.map(|(object, mut cache)| async move {
+						let children = crate::fdb::propagate!(
+							Self::get_cached_object_children_limited_with_transaction(
+								context.txn,
+								context.subspace,
+								&object,
+								limit,
+								&mut cache,
+							)
+							.await
+						);
+						Ok::<_, tg::Error>(ControlFlow::Break((children, cache)))
+					})
+					.buffer_unordered(context.config.concurrency)
+					.try_collect::<Vec<_>>()
+					.await;
+				let results = result?;
+				let mut values = Vec::new();
+				for result in results {
+					let value = match result {
+						ControlFlow::Break(value) => value,
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					};
+					values.push(value);
+				}
+				values
+			};
 			let mut next = Vec::new();
 			for (children, child_cache) in children {
 				cache.merge(child_cache);
 				for child in children {
 					if visited.insert(child.clone()) {
 						if depth == budget.max_depth {
-							return Ok(None);
+							return Ok(ControlFlow::Break(None));
 						}
 						next.push(child);
 					}
 				}
 			}
 			if next.len() > budget.remaining {
-				return Ok(None);
+				return Ok(ControlFlow::Break(None));
 			}
 			frontier = next;
 			depth += 1;
 		}
 
-		Ok(Some(true))
+		Ok(ControlFlow::Break(Some(true)))
 	}
 
 	async fn authorize_with_process_subtree_search_with_transaction(
@@ -854,7 +958,7 @@ impl Index {
 		permission: tg::authorization::permission::process::Permission,
 		authorization: &mut HashMap<(tg::Id, tg::authorization::Permission), bool>,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Option<bool>> {
+	) -> tg::Result<ControlFlow<Option<bool>, fdb::FdbError>> {
 		let node_permission = match permission {
 			tg::authorization::permission::process::Permission::Subtree => {
 				tg::authorization::permission::process::Permission::Node
@@ -878,26 +982,28 @@ impl Index {
 			max_depth: context.config.process_subtree.max_depth,
 			remaining: context.config.process_subtree.max_processes,
 		};
-		let root = tg::process::Id::try_from(resource.clone()).map_err(crate::fdb::custom_error)?;
+		let root = tg::process::Id::try_from(resource.clone())?;
 		let mut visited = HashSet::from([root.clone()]);
 		let mut frontier = vec![root];
 		let mut depth = 0;
 		while !frontier.is_empty() {
 			if frontier.len() > budget.remaining {
-				return Ok(None);
+				return Ok(ControlFlow::Break(None));
 			}
 			budget.remaining -= frontier.len();
 			let subtree_roots = frontier
 				.iter()
 				.map(|process| (tg::Id::from(process.clone()), subtree))
 				.collect::<Vec<_>>();
-			Self::authorize_permissions_ordinary_with_transaction(
-				context,
-				&subtree_roots,
-				authorization,
-				cache,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::authorize_permissions_ordinary_with_transaction(
+					context,
+					&subtree_roots,
+					authorization,
+					cache,
+				)
+				.await
+			);
 			let uncovered = frontier
 				.into_iter()
 				.filter(|process| {
@@ -914,29 +1020,32 @@ impl Index {
 				.iter()
 				.map(|process| (tg::Id::from(process.clone()), node))
 				.collect::<Vec<_>>();
-			Self::authorize_permissions_ordinary_with_transaction(
-				context,
-				&node_roots,
-				authorization,
-				cache,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::authorize_permissions_ordinary_with_transaction(
+					context,
+					&node_roots,
+					authorization,
+					cache,
+				)
+				.await
+			);
 			for process in &uncovered {
 				let resource = tg::Id::from(process.clone());
 				let key = (resource.clone(), node);
 				if authorization.get(&key).copied().unwrap_or(false) {
 					continue;
 				}
-				if !Self::authorize_process_node_with_transaction(
-					context,
-					&resource,
-					node_permission,
-					authorization,
-					cache,
-				)
-				.await?
-				{
-					return Ok(Some(false));
+				if !crate::fdb::propagate!(
+					Self::authorize_process_node_with_transaction(
+						context,
+						&resource,
+						node_permission,
+						authorization,
+						cache,
+					)
+					.await
+				) {
+					return Ok(ControlFlow::Break(Some(false)));
 				}
 			}
 
@@ -952,41 +1061,55 @@ impl Index {
 				.into_iter()
 				.map(|process| (process.clone(), cache.clone_for_process_children(&process)))
 				.collect::<Vec<_>>();
-			let children = stream::iter(requests)
-				.map(|(process, mut cache)| async move {
-					let children = Self::get_cached_process_children_limited_with_transaction(
-						context.txn,
-						context.subspace,
-						&process,
-						limit,
-						&mut cache,
-					)
-					.await?;
-					Ok::<_, fdb::FdbBindingError>((children, cache))
-				})
-				.buffer_unordered(context.config.concurrency)
-				.try_collect::<Vec<_>>()
-				.await?;
+			let children = {
+				let result = stream::iter(requests)
+					.map(|(process, mut cache)| async move {
+						let children = crate::fdb::propagate!(
+							Self::get_cached_process_children_limited_with_transaction(
+								context.txn,
+								context.subspace,
+								&process,
+								limit,
+								&mut cache,
+							)
+							.await
+						);
+						Ok::<_, tg::Error>(ControlFlow::Break((children, cache)))
+					})
+					.buffer_unordered(context.config.concurrency)
+					.try_collect::<Vec<_>>()
+					.await;
+				let results = result?;
+				let mut values = Vec::new();
+				for result in results {
+					let value = match result {
+						ControlFlow::Break(value) => value,
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					};
+					values.push(value);
+				}
+				values
+			};
 			let mut next = Vec::new();
 			for (children, child_cache) in children {
 				cache.merge(child_cache);
 				for child in children {
 					if visited.insert(child.clone()) {
 						if depth == budget.max_depth {
-							return Ok(None);
+							return Ok(ControlFlow::Break(None));
 						}
 						next.push(child);
 					}
 				}
 			}
 			if next.len() > budget.remaining {
-				return Ok(None);
+				return Ok(ControlFlow::Break(None));
 			}
 			frontier = next;
 			depth += 1;
 		}
 
-		Ok(Some(true))
+		Ok(ControlFlow::Break(Some(true)))
 	}
 
 	async fn authorize_process_node_with_transaction(
@@ -995,18 +1118,20 @@ impl Index {
 		permission: tg::authorization::permission::process::Permission,
 		authorization: &mut HashMap<(tg::Id, tg::authorization::Permission), bool>,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let process_permission = tg::authorization::Permission::Process(permission);
 		let root = (resource.clone(), process_permission);
-		Self::authorize_permissions_ordinary_with_transaction(
-			context,
-			std::slice::from_ref(&root),
-			authorization,
-			cache,
-		)
-		.await?;
+		crate::fdb::propagate!(
+			Self::authorize_permissions_ordinary_with_transaction(
+				context,
+				std::slice::from_ref(&root),
+				authorization,
+				cache,
+			)
+			.await
+		);
 		if authorization.get(&root).copied().unwrap_or(false) {
-			return Ok(true);
+			return Ok(ControlFlow::Break(true));
 		}
 		let kind = match permission {
 			tg::authorization::permission::process::Permission::NodeCommand => {
@@ -1021,17 +1146,18 @@ impl Index {
 			tg::authorization::permission::process::Permission::NodeOutput => {
 				crate::process::object::Kind::Output
 			},
-			_ => return Ok(false),
+			_ => return Ok(ControlFlow::Break(false)),
 		};
-		let process =
-			tg::process::Id::try_from(resource.clone()).map_err(crate::fdb::custom_error)?;
-		let objects = Self::get_cached_process_objects_with_transaction(
-			context.txn,
-			context.subspace,
-			&process,
-			cache,
-		)
-		.await?;
+		let process = tg::process::Id::try_from(resource.clone())?;
+		let objects = crate::fdb::propagate!(
+			Self::get_cached_process_objects_with_transaction(
+				context.txn,
+				context.subspace,
+				&process,
+				cache,
+			)
+			.await
+		);
 		let objects = objects
 			.into_iter()
 			.filter_map(|(object, object_kind)| {
@@ -1045,7 +1171,7 @@ impl Index {
 			})
 			.collect::<Vec<_>>();
 		if objects.is_empty() {
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		}
 		let subtree = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Subtree,
@@ -1054,32 +1180,36 @@ impl Index {
 			.iter()
 			.map(|object| (tg::Id::from(object.clone()), subtree))
 			.collect::<Vec<_>>();
-		Self::authorize_permissions_ordinary_with_transaction(
-			context,
-			&roots,
-			authorization,
-			cache,
-		)
-		.await?;
+		crate::fdb::propagate!(
+			Self::authorize_permissions_ordinary_with_transaction(
+				context,
+				&roots,
+				authorization,
+				cache,
+			)
+			.await
+		);
 		for (object, root) in std::iter::zip(objects, roots) {
 			if authorization.get(&root).copied().unwrap_or(false) {
 				continue;
 			}
 			let resource = object.into();
-			if !Self::authorize_with_object_subtree_search_with_transaction(
-				context,
-				&resource,
-				authorization,
-				cache,
+			if !crate::fdb::propagate!(
+				Self::authorize_with_object_subtree_search_with_transaction(
+					context,
+					&resource,
+					authorization,
+					cache,
+				)
+				.await
 			)
-			.await?
 			.unwrap_or(false)
 			{
-				return Ok(false);
+				return Ok(ControlFlow::Break(false));
 			}
 		}
 
-		Ok(true)
+		Ok(ControlFlow::Break(true))
 	}
 
 	async fn get_authorization_dependencies_with_transaction(
@@ -1089,13 +1219,13 @@ impl Index {
 		resource: &tg::Id,
 		permission: tg::authorization::Permission,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Vec<(tg::Id, tg::authorization::Permission)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::Id, tg::authorization::Permission)>, fdb::FdbError>> {
 		let mut dependencies = Vec::new();
 
 		// Add the process subject grant relationships.
-		let grants =
-			Self::get_cached_resource_grants_with_transaction(txn, subspace, resource, cache)
-				.await?;
+		let grants = crate::fdb::propagate!(
+			Self::get_cached_resource_grants_with_transaction(txn, subspace, resource, cache).await
+		);
 		for (subject, granted_permission) in grants {
 			if !granted_permission.implies(permission) {
 				continue;
@@ -1114,31 +1244,30 @@ impl Index {
 
 		match permission {
 			tg::authorization::Permission::Object(_) => {
-				let object =
-					tg::object::Id::try_from(resource.clone()).map_err(crate::fdb::custom_error)?;
+				let object = tg::object::Id::try_from(resource.clone())?;
 				let cached_parents = cache.object_parents.get(&object).cloned();
 				let cached_processes = cache.object_processes.get(&object).cloned();
 				let tag_key = (resource.clone(), permission);
 				let cached_tags = cache.target_tags.get(&tag_key).cloned();
-				let object_parents = async {
-					if let Some(parents) = cached_parents {
-						Ok(parents)
-					} else {
+				let object_parents = if let Some(parents) = cached_parents {
+					parents
+				} else {
+					crate::fdb::propagate!(
 						Self::get_object_parents_with_transaction(txn, subspace, &object).await
-					}
+					)
 				};
-				let processes = async {
-					if let Some(processes) = cached_processes {
-						Ok(processes)
-					} else {
+				let processes = if let Some(processes) = cached_processes {
+					processes
+				} else {
+					crate::fdb::propagate!(
 						Self::get_object_processes_with_transaction(txn, subspace, &object).await
-					}
+					)
 				};
-				let tags = async {
-					if let Some(tags) = cached_tags {
-						Ok(tags)
-					} else {
-						let mut tag_cache = Cache::default();
+				let tags = if let Some(tags) = cached_tags {
+					tags
+				} else {
+					let mut tag_cache = Cache::default();
+					crate::fdb::propagate!(
 						Self::get_cached_target_tags_with_transaction(
 							txn,
 							subspace,
@@ -1148,10 +1277,8 @@ impl Index {
 							&mut tag_cache,
 						)
 						.await
-					}
+					)
 				};
-				let (object_parents, processes, tags) =
-					futures::try_join!(object_parents, processes, tags)?;
 				cache
 					.object_parents
 					.insert(object.clone(), object_parents.clone());
@@ -1186,35 +1313,31 @@ impl Index {
 				dependencies.extend(tags);
 			},
 			tg::authorization::Permission::Process(process_permission) => {
-				let process = tg::process::Id::try_from(resource.clone())
-					.map_err(crate::fdb::custom_error)?;
+				let process = tg::process::Id::try_from(resource.clone())?;
 				let cached_sandbox = cache.process_sandboxes.get(&process).cloned();
 				let cached_parents = cache.process_parents.get(&process).cloned();
 				let tag_key = (resource.clone(), permission);
 				let cached_tags = cache.target_tags.get(&tag_key).cloned();
-				let sandbox = async {
-					if let Some(sandbox) = cached_sandbox {
-						Ok(sandbox)
-					} else {
-						Ok::<_, fdb::FdbBindingError>(
-							Self::try_get_process_with_transaction(txn, subspace, &process)
-								.await?
-								.and_then(|process| process.sandbox),
-						)
-					}
+				let sandbox = if let Some(sandbox) = cached_sandbox {
+					sandbox
+				} else {
+					crate::fdb::propagate!(
+						Self::try_get_process_with_transaction(txn, subspace, &process).await
+					)
+					.and_then(|process| process.sandbox)
 				};
-				let process_parents = async {
-					if let Some(parents) = cached_parents {
-						Ok(parents)
-					} else {
+				let process_parents = if let Some(parents) = cached_parents {
+					parents
+				} else {
+					crate::fdb::propagate!(
 						Self::get_process_parents_with_transaction(txn, subspace, &process).await
-					}
+					)
 				};
-				let tags = async {
-					if let Some(tags) = cached_tags {
-						Ok(tags)
-					} else {
-						let mut tag_cache = Cache::default();
+				let tags = if let Some(tags) = cached_tags {
+					tags
+				} else {
+					let mut tag_cache = Cache::default();
+					crate::fdb::propagate!(
 						Self::get_cached_target_tags_with_transaction(
 							txn,
 							subspace,
@@ -1224,10 +1347,8 @@ impl Index {
 							&mut tag_cache,
 						)
 						.await
-					}
+					)
 				};
-				let (sandbox, process_parents, tags) =
-					futures::try_join!(sandbox, process_parents, tags)?;
 				cache
 					.process_sandboxes
 					.insert(process.clone(), sandbox.clone());
@@ -1267,13 +1388,13 @@ impl Index {
 					)
 				) && resource.kind() == tg::id::Kind::Sandbox
 				{
-					let sandbox = tg::sandbox::Id::try_from(resource.clone())
-						.map_err(crate::fdb::custom_error)?;
-					if let Some(owner) = Self::get_cached_sandbox_owner_with_transaction(
-						txn, subspace, &sandbox, cache,
-					)
-					.await?
-					{
+					let sandbox = tg::sandbox::Id::try_from(resource.clone())?;
+					if let Some(owner) = crate::fdb::propagate!(
+						Self::get_cached_sandbox_owner_with_transaction(
+							txn, subspace, &sandbox, cache,
+						)
+						.await
+					) {
 						let owner = match owner {
 							tg::Principal::Group(id) => Some(tg::Id::from(id)),
 							tg::Principal::Organization(id) => Some(tg::Id::from(id)),
@@ -1287,22 +1408,22 @@ impl Index {
 						if let Some(owner) = owner {
 							dependencies.push((
 								owner.clone(),
-								crate::authorize::write_permission_for_resource(&owner)
-									.map_err(crate::fdb::custom_error)?,
+								crate::authorize::write_permission_for_resource(&owner)?,
 							));
 						}
 					}
 				}
-				if let Some(parent) = Self::get_cached_resource_parent_with_transaction(
-					txn, subspace, resource, cache,
-				)
-				.await?
-				{
+				if let Some(parent) = crate::fdb::propagate!(
+					Self::get_cached_resource_parent_with_transaction(
+						txn, subspace, resource, cache,
+					)
+					.await
+				) {
 					dependencies.push((parent, permission));
 				}
 			},
 		}
-		Ok(dependencies)
+		Ok(ControlFlow::Break(dependencies))
 	}
 
 	async fn subject_contains_requester_with_transaction(
@@ -1310,39 +1431,45 @@ impl Index {
 		subspace: &Subspace,
 		subject: &tg::authorization::Subject,
 		requester: &Requester<'_>,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		if PRECOMPUTE_REQUESTER_PRINCIPALS {
-			return Ok(requester.subjects.contains(subject));
+			return Ok(ControlFlow::Break(requester.subjects.contains(subject)));
 		}
 		if subject == &tg::authorization::Subject::Public {
-			return Ok(true);
+			return Ok(ControlFlow::Break(true));
 		}
 		if requester.subject == *subject {
-			return Ok(true);
+			return Ok(ControlFlow::Break(true));
 		}
 		if requester.id.is_none() {
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		}
 		let contains = {
 			let cache = requester.membership_cache();
 			cache.subject_contains_requester.get(subject).copied()
 		};
 		if let Some(contains) = contains {
-			return Ok(contains);
+			return Ok(ControlFlow::Break(contains));
 		}
 		let contains = match subject {
 			tg::authorization::Subject::Group(group) => {
-				Self::group_contains_requester_with_transaction(txn, subspace, group, requester)
-					.await?
+				crate::fdb::propagate!(
+					Self::group_contains_requester_with_transaction(
+						txn, subspace, group, requester,
+					)
+					.await
+				)
 			},
 			tg::authorization::Subject::Organization(organization) => {
-				Self::organization_contains_requester_with_transaction(
-					txn,
-					subspace,
-					organization,
-					requester,
+				crate::fdb::propagate!(
+					Self::organization_contains_requester_with_transaction(
+						txn,
+						subspace,
+						organization,
+						requester,
+					)
+					.await
 				)
-				.await?
 			},
 			_ => false,
 		};
@@ -1350,7 +1477,7 @@ impl Index {
 			.membership_cache()
 			.subject_contains_requester
 			.insert(subject.clone(), contains);
-		Ok(contains)
+		Ok(ControlFlow::Break(contains))
 	}
 
 	async fn group_contains_requester_with_transaction(
@@ -1358,14 +1485,14 @@ impl Index {
 		subspace: &Subspace,
 		group: &tg::group::Id,
 		requester: &Requester<'_>,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let subject = tg::authorization::Subject::Group(group.clone());
 		let contains = {
 			let cache = requester.membership_cache();
 			cache.subject_contains_requester.get(&subject).copied()
 		};
 		if let Some(contains) = contains {
-			return Ok(contains);
+			return Ok(ControlFlow::Break(contains));
 		}
 		let root = group.clone();
 		let mut visited = HashSet::new();
@@ -1385,7 +1512,7 @@ impl Index {
 						.membership_cache()
 						.subject_contains_requester
 						.insert(tg::authorization::Subject::Group(root), true);
-					return Ok(true);
+					return Ok(ControlFlow::Break(true));
 				}
 				continue;
 			}
@@ -1396,13 +1523,13 @@ impl Index {
 			let members = if let Some(members) = members {
 				members
 			} else {
-				let members: std::sync::Arc<[tg::Id]> =
-					Self::get_group_members_with_transaction(txn, subspace, &group)
-						.await?
-						.into_iter()
-						.map(tg::Id::from)
-						.collect::<Vec<_>>()
-						.into();
+				let members: std::sync::Arc<[tg::Id]> = crate::fdb::propagate!(
+					Self::get_group_members_with_transaction(txn, subspace, &group).await
+				)
+				.into_iter()
+				.map(tg::Id::from)
+				.collect::<Vec<_>>()
+				.into();
 				requester
 					.membership_cache()
 					.group_members
@@ -1415,12 +1542,10 @@ impl Index {
 						.membership_cache()
 						.subject_contains_requester
 						.insert(tg::authorization::Subject::Group(root), true);
-					return Ok(true);
+					return Ok(ControlFlow::Break(true));
 				}
 				if member.kind() == tg::id::Kind::Group {
-					queue.push_back(
-						tg::group::Id::try_from(member).map_err(crate::fdb::custom_error)?,
-					);
+					queue.push_back(tg::group::Id::try_from(member)?);
 				}
 			}
 		}
@@ -1430,7 +1555,7 @@ impl Index {
 				.subject_contains_requester
 				.insert(tg::authorization::Subject::Group(group), false);
 		}
-		Ok(false)
+		Ok(ControlFlow::Break(false))
 	}
 
 	async fn organization_contains_requester_with_transaction(
@@ -1438,14 +1563,14 @@ impl Index {
 		subspace: &Subspace,
 		organization: &tg::organization::Id,
 		requester: &Requester<'_>,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let subject = tg::authorization::Subject::Organization(organization.clone());
 		let contains = {
 			let cache = requester.membership_cache();
 			cache.subject_contains_requester.get(&subject).copied()
 		};
 		if let Some(contains) = contains {
-			return Ok(contains);
+			return Ok(ControlFlow::Break(contains));
 		}
 		let members = {
 			let cache = requester.membership_cache();
@@ -1454,13 +1579,13 @@ impl Index {
 		let members = if let Some(members) = members {
 			members
 		} else {
-			let members: std::sync::Arc<[tg::Id]> =
-				Self::get_organization_members_with_transaction(txn, subspace, organization)
-					.await?
-					.into_iter()
-					.map(tg::Id::from)
-					.collect::<Vec<_>>()
-					.into();
+			let members: std::sync::Arc<[tg::Id]> = crate::fdb::propagate!(
+				Self::get_organization_members_with_transaction(txn, subspace, organization).await
+			)
+			.into_iter()
+			.map(tg::Id::from)
+			.collect::<Vec<_>>()
+			.into();
 			requester
 				.membership_cache()
 				.organization_members
@@ -1476,13 +1601,16 @@ impl Index {
 						tg::authorization::Subject::Organization(organization.clone()),
 						true,
 					);
-				return Ok(true);
+				return Ok(ControlFlow::Break(true));
 			}
 			if member.kind() == tg::id::Kind::Group {
-				let group = tg::group::Id::try_from(member).map_err(crate::fdb::custom_error)?;
-				if Self::group_contains_requester_with_transaction(txn, subspace, &group, requester)
-					.await?
-				{
+				let group = tg::group::Id::try_from(member)?;
+				if crate::fdb::propagate!(
+					Self::group_contains_requester_with_transaction(
+						txn, subspace, &group, requester,
+					)
+					.await
+				) {
 					requester
 						.membership_cache()
 						.subject_contains_requester
@@ -1490,7 +1618,7 @@ impl Index {
 							tg::authorization::Subject::Organization(organization.clone()),
 							true,
 						);
-					return Ok(true);
+					return Ok(ControlFlow::Break(true));
 				}
 			}
 		}
@@ -1501,7 +1629,7 @@ impl Index {
 				tg::authorization::Subject::Organization(organization.clone()),
 				false,
 			);
-		Ok(false)
+		Ok(ControlFlow::Break(false))
 	}
 
 	async fn get_cached_resource_grants_with_transaction(
@@ -1509,15 +1637,22 @@ impl Index {
 		subspace: &Subspace,
 		resource: &tg::Id,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Vec<(tg::authorization::Subject, tg::authorization::Permission)>> {
+	) -> tg::Result<
+		ControlFlow<
+			Vec<(tg::authorization::Subject, tg::authorization::Permission)>,
+			fdb::FdbError,
+		>,
+	> {
 		if let Some(grants) = cache.resource_grants.get(resource) {
-			return Ok(grants.clone());
+			return Ok(ControlFlow::Break(grants.clone()));
 		}
-		let grants = Self::get_resource_grants_with_transaction(txn, subspace, resource).await?;
+		let grants = crate::fdb::propagate!(
+			Self::get_resource_grants_with_transaction(txn, subspace, resource).await
+		);
 		cache
 			.resource_grants
 			.insert(resource.clone(), grants.clone());
-		Ok(grants)
+		Ok(ControlFlow::Break(grants))
 	}
 
 	async fn get_cached_resource_parent_with_transaction(
@@ -1525,37 +1660,27 @@ impl Index {
 		subspace: &Subspace,
 		resource: &tg::Id,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Option<tg::Id>> {
+	) -> tg::Result<ControlFlow<Option<tg::Id>, fdb::FdbError>> {
 		if let Some(parent) = cache.resource_parents.get(resource) {
-			return Ok(parent.clone());
+			return Ok(ControlFlow::Break(parent.clone()));
 		}
 		let parent = match resource.kind() {
-			tg::id::Kind::Tag => Self::try_get_tag_with_transaction(
-				txn,
-				subspace,
-				&resource
-					.clone()
-					.try_into()
-					.map_err(crate::fdb::custom_error)?,
+			tg::id::Kind::Tag => crate::fdb::propagate!(
+				Self::try_get_tag_with_transaction(txn, subspace, &resource.clone().try_into()?,)
+					.await
 			)
-			.await?
 			.and_then(|tag| tag.parent),
-			tg::id::Kind::Group => Self::try_get_group_with_transaction(
-				txn,
-				subspace,
-				&resource
-					.clone()
-					.try_into()
-					.map_err(crate::fdb::custom_error)?,
+			tg::id::Kind::Group => crate::fdb::propagate!(
+				Self::try_get_group_with_transaction(txn, subspace, &resource.clone().try_into()?,)
+					.await
 			)
-			.await?
 			.and_then(|group| group.parent),
 			_ => None,
 		};
 		cache
 			.resource_parents
 			.insert(resource.clone(), parent.clone());
-		Ok(parent)
+		Ok(ControlFlow::Break(parent))
 	}
 
 	async fn get_cached_target_tags_with_transaction(
@@ -1565,22 +1690,37 @@ impl Index {
 		node: &tg::Id,
 		permission: tg::authorization::Permission,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Vec<(tg::Id, tg::authorization::Permission)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::Id, tg::authorization::Permission)>, fdb::FdbError>> {
 		let key = (node.clone(), permission);
 		if let Some(tags) = cache.target_tags.get(&key) {
-			return Ok(tags.clone());
+			return Ok(ControlFlow::Break(tags.clone()));
 		}
 		let target_bytes = node.to_bytes();
-		let tags =
-			Self::get_target_tags_with_transaction(txn, subspace, target_bytes.as_ref()).await?;
-		let tags = stream::iter(tags)
-			.map(|tag| async move {
-				let value = Self::try_get_tag_with_transaction(txn, subspace, &tag).await?;
-				Ok::<_, fdb::FdbBindingError>((tag, value))
-			})
-			.buffered(concurrency)
-			.try_collect::<Vec<_>>()
-			.await?;
+		let tags = crate::fdb::propagate!(
+			Self::get_target_tags_with_transaction(txn, subspace, target_bytes.as_ref()).await
+		);
+		let tags = {
+			let result = stream::iter(tags)
+				.map(|tag| async move {
+					let value = crate::fdb::propagate!(
+						Self::try_get_tag_with_transaction(txn, subspace, &tag).await
+					);
+					Ok::<_, tg::Error>(ControlFlow::Break((tag, value)))
+				})
+				.buffered(concurrency)
+				.try_collect::<Vec<_>>()
+				.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
 		let mut parents = Vec::new();
 		for (tag, value) in tags {
 			let Some(value) = value else {
@@ -1600,7 +1740,7 @@ impl Index {
 			}
 		}
 		cache.target_tags.insert(key, parents.clone());
-		Ok(parents)
+		Ok(ControlFlow::Break(parents))
 	}
 
 	async fn get_cached_object_children_limited_with_transaction(
@@ -1609,9 +1749,11 @@ impl Index {
 		object: &tg::object::Id,
 		limit: usize,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Vec<tg::object::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::object::Id>, fdb::FdbError>> {
 		if let Some(children) = cache.object_children.get(object) {
-			return Ok(children.iter().take(limit).cloned().collect());
+			return Ok(ControlFlow::Break(
+				children.iter().take(limit).cloned().collect(),
+			));
 		}
 		let bytes = object.to_bytes();
 		let key = (Kind::ObjectChild.to_i32().unwrap(), bytes.as_ref());
@@ -1622,23 +1764,23 @@ impl Index {
 			limit: Some(limit),
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let children = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Object(crate::fdb::object::Key::ObjectChild { child, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		if children.len() < limit {
 			cache
 				.object_children
 				.insert(object.clone(), children.clone());
 		}
-		Ok(children)
+		Ok(ControlFlow::Break(children))
 	}
 
 	async fn get_cached_process_children_limited_with_transaction(
@@ -1647,9 +1789,11 @@ impl Index {
 		process: &tg::process::Id,
 		limit: usize,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Vec<tg::process::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::process::Id>, fdb::FdbError>> {
 		if let Some(children) = cache.process_children.get(process) {
-			return Ok(children.iter().take(limit).cloned().collect());
+			return Ok(ControlFlow::Break(
+				children.iter().take(limit).cloned().collect(),
+			));
 		}
 		let bytes = process.to_bytes();
 		let key = (Kind::ProcessChild.to_i32().unwrap(), bytes.as_ref());
@@ -1660,24 +1804,24 @@ impl Index {
 			limit: Some(limit),
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let children = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Process(crate::fdb::process::Key::ProcessChild { child, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		if children.len() < limit {
 			cache
 				.process_children
 				.insert(process.clone(), children.clone());
 		}
 
-		Ok(children)
+		Ok(ControlFlow::Break(children))
 	}
 
 	async fn get_cached_process_objects_with_transaction(
@@ -1685,9 +1829,10 @@ impl Index {
 		subspace: &Subspace,
 		process: &tg::process::Id,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Vec<(tg::object::Id, crate::process::object::Kind)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::object::Id, crate::process::object::Kind)>, fdb::FdbError>>
+	{
 		if let Some(objects) = cache.process_objects.get(process) {
-			return Ok(objects.clone());
+			return Ok(ControlFlow::Break(objects.clone()));
 		}
 		let bytes = process.to_bytes();
 		let key = (Kind::ProcessObject.to_i32().unwrap(), bytes.as_ref());
@@ -1697,7 +1842,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let objects = entries
 			.iter()
 			.map(|entry| {
@@ -1705,16 +1850,16 @@ impl Index {
 				let Key::Process(crate::fdb::process::Key::ProcessObject { kind, object, .. }) =
 					key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok((object, kind))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		cache
 			.process_objects
 			.insert(process.clone(), objects.clone());
 
-		Ok(objects)
+		Ok(ControlFlow::Break(objects))
 	}
 
 	async fn get_cached_sandbox_owner_with_transaction(
@@ -1722,21 +1867,18 @@ impl Index {
 		subspace: &Subspace,
 		sandbox: &tg::sandbox::Id,
 		cache: &mut Cache,
-	) -> crate::fdb::Result<Option<tg::Principal>> {
+	) -> tg::Result<ControlFlow<Option<tg::Principal>, fdb::FdbError>> {
 		if let Some(owner) = cache.sandbox_owners.get(sandbox) {
-			return Ok(owner.clone());
+			return Ok(ControlFlow::Break(owner.clone()));
 		}
 		let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(sandbox.clone()));
 		let key = Self::pack(subspace, &key);
-		let owner = txn
-			.get(&key, false)
-			.await?
+		let owner = crate::fdb::retry!(txn.get(&key, false).await)
 			.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?
+			.transpose()?
 			.and_then(|sandbox| sandbox.data)
 			.and_then(|data| data.owner);
 		cache.sandbox_owners.insert(sandbox.clone(), owner.clone());
-		Ok(owner)
+		Ok(ControlFlow::Break(owner))
 	}
 }

--- a/packages/index/src/fdb/authorize.rs
+++ b/packages/index/src/fdb/authorize.rs
@@ -1249,25 +1249,25 @@ impl Index {
 				let cached_processes = cache.object_processes.get(&object).cloned();
 				let tag_key = (resource.clone(), permission);
 				let cached_tags = cache.target_tags.get(&tag_key).cloned();
-				let object_parents = if let Some(parents) = cached_parents {
-					parents
-				} else {
-					crate::fdb::propagate!(
+				let object_parents = async {
+					if let Some(parents) = cached_parents {
+						Ok(ControlFlow::Break(parents))
+					} else {
 						Self::get_object_parents_with_transaction(txn, subspace, &object).await
-					)
+					}
 				};
-				let processes = if let Some(processes) = cached_processes {
-					processes
-				} else {
-					crate::fdb::propagate!(
+				let processes = async {
+					if let Some(processes) = cached_processes {
+						Ok(ControlFlow::Break(processes))
+					} else {
 						Self::get_object_processes_with_transaction(txn, subspace, &object).await
-					)
+					}
 				};
-				let tags = if let Some(tags) = cached_tags {
-					tags
-				} else {
-					let mut tag_cache = Cache::default();
-					crate::fdb::propagate!(
+				let tags = async {
+					if let Some(tags) = cached_tags {
+						Ok(ControlFlow::Break(tags))
+					} else {
+						let mut tag_cache = Cache::default();
 						Self::get_cached_target_tags_with_transaction(
 							txn,
 							subspace,
@@ -1277,7 +1277,21 @@ impl Index {
 							&mut tag_cache,
 						)
 						.await
-					)
+					}
+				};
+				let (object_parents, processes, tags) =
+					futures::try_join!(object_parents, processes, tags)?;
+				let object_parents = match object_parents {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				let processes = match processes {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				let tags = match tags {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
 				};
 				cache
 					.object_parents
@@ -1318,26 +1332,31 @@ impl Index {
 				let cached_parents = cache.process_parents.get(&process).cloned();
 				let tag_key = (resource.clone(), permission);
 				let cached_tags = cache.target_tags.get(&tag_key).cloned();
-				let sandbox = if let Some(sandbox) = cached_sandbox {
-					sandbox
-				} else {
-					crate::fdb::propagate!(
-						Self::try_get_process_with_transaction(txn, subspace, &process).await
-					)
-					.and_then(|process| process.sandbox)
+				let sandbox = async {
+					if let Some(sandbox) = cached_sandbox {
+						Ok(ControlFlow::Break(sandbox))
+					} else {
+						let result =
+							Self::try_get_process_with_transaction(txn, subspace, &process).await;
+						let process = crate::fdb::propagate!(result);
+
+						Ok(ControlFlow::Break(
+							process.and_then(|process| process.sandbox),
+						))
+					}
 				};
-				let process_parents = if let Some(parents) = cached_parents {
-					parents
-				} else {
-					crate::fdb::propagate!(
+				let process_parents = async {
+					if let Some(parents) = cached_parents {
+						Ok(ControlFlow::Break(parents))
+					} else {
 						Self::get_process_parents_with_transaction(txn, subspace, &process).await
-					)
+					}
 				};
-				let tags = if let Some(tags) = cached_tags {
-					tags
-				} else {
-					let mut tag_cache = Cache::default();
-					crate::fdb::propagate!(
+				let tags = async {
+					if let Some(tags) = cached_tags {
+						Ok(ControlFlow::Break(tags))
+					} else {
+						let mut tag_cache = Cache::default();
 						Self::get_cached_target_tags_with_transaction(
 							txn,
 							subspace,
@@ -1347,7 +1366,21 @@ impl Index {
 							&mut tag_cache,
 						)
 						.await
-					)
+					}
+				};
+				let (sandbox, process_parents, tags) =
+					futures::try_join!(sandbox, process_parents, tags)?;
+				let sandbox = match sandbox {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				let process_parents = match process_parents {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				let tags = match tags {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
 				};
 				cache
 					.process_sandboxes

--- a/packages/index/src/fdb/authorize.rs
+++ b/packages/index/src/fdb/authorize.rs
@@ -291,7 +291,7 @@ impl Index {
 				.try_collect::<Vec<_>>()
 				.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -427,7 +427,7 @@ impl Index {
 				.await?;
 			let relations = {
 				let results = relations;
-				let mut values = Vec::new();
+				let mut values = Vec::with_capacity(results.len());
 				for result in results {
 					let value = match result {
 						ControlFlow::Break(value) => value,
@@ -639,7 +639,7 @@ impl Index {
 				.await?;
 			let evaluations = {
 				let results = evaluations;
-				let mut values = Vec::new();
+				let mut values = Vec::with_capacity(results.len());
 				for result in results {
 					let value = match result {
 						ControlFlow::Break(value) => value,
@@ -920,7 +920,7 @@ impl Index {
 					.try_collect::<Vec<_>>()
 					.await;
 				let results = result?;
-				let mut values = Vec::new();
+				let mut values = Vec::with_capacity(results.len());
 				for result in results {
 					let value = match result {
 						ControlFlow::Break(value) => value,
@@ -1080,7 +1080,7 @@ impl Index {
 					.try_collect::<Vec<_>>()
 					.await;
 				let results = result?;
-				let mut values = Vec::new();
+				let mut values = Vec::with_capacity(results.len());
 				for result in results {
 					let value = match result {
 						ControlFlow::Break(value) => value,
@@ -1711,7 +1711,7 @@ impl Index {
 				.try_collect::<Vec<_>>()
 				.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -1764,7 +1764,8 @@ impl Index {
 			limit: Some(limit),
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let children = entries
 			.iter()
 			.map(|entry| {
@@ -1804,7 +1805,8 @@ impl Index {
 			limit: Some(limit),
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let children = entries
 			.iter()
 			.map(|entry| {
@@ -1842,7 +1844,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let objects = entries
 			.iter()
 			.map(|entry| {
@@ -1873,7 +1876,8 @@ impl Index {
 		}
 		let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(sandbox.clone()));
 		let key = Self::pack(subspace, &key);
-		let owner = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let owner = crate::fdb::retry!(result)
 			.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
 			.transpose()?
 			.and_then(|sandbox| sandbox.data)

--- a/packages/index/src/fdb/batch.rs
+++ b/packages/index/src/fdb/batch.rs
@@ -1,6 +1,7 @@
 use {
 	super::{Index, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -24,183 +25,225 @@ impl Index {
 		arg: &crate::batch::Arg,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for item in &arg.items {
 			match item {
 				crate::batch::Item::DeleteGrant(arg) => {
-					Self::delete_grants_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::delete_grants_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::DeleteGroup(id) => {
-					Self::delete_groups_with_transaction(txn, subspace, std::slice::from_ref(id))
-						.await?;
+					crate::fdb::propagate!(
+						Self::delete_groups_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(id),
+						)
+						.await
+					);
 				},
 				crate::batch::Item::DeleteGroupMember(arg) => {
-					Self::delete_group_members_with_transaction(
+					crate::fdb::propagate!(Self::delete_group_members_with_transaction(
 						txn,
 						subspace,
 						std::slice::from_ref(arg),
-					)?;
+					));
 				},
 				crate::batch::Item::DeleteOrganization(id) => {
-					Self::delete_organizations_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(id),
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::delete_organizations_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(id),
+						)
+						.await
+					);
 				},
 				crate::batch::Item::DeleteOrganizationMember(arg) => {
-					Self::delete_organization_members_with_transaction(
+					crate::fdb::propagate!(Self::delete_organization_members_with_transaction(
 						txn,
 						subspace,
 						std::slice::from_ref(arg),
-					)?;
+					));
 				},
 				crate::batch::Item::DeleteSandbox(id) => {
-					Self::delete_sandboxes_with_transaction(
+					crate::fdb::propagate!(Self::delete_sandboxes_with_transaction(
 						txn,
 						subspace,
 						std::slice::from_ref(id),
-					)?;
+					));
 				},
 				crate::batch::Item::DeleteTag(id) => {
-					Self::delete_tags_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(id),
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::delete_tags_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(id),
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::DeleteUser(id) => {
-					Self::delete_users_with_transaction(txn, subspace, std::slice::from_ref(id))
-						.await?;
+					crate::fdb::propagate!(
+						Self::delete_users_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(id),
+						)
+						.await
+					);
 				},
 				crate::batch::Item::EnqueueLogCompaction(process) => {
-					Self::enqueue_log_compaction_with_transaction(
-						txn,
-						subspace,
-						process,
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::enqueue_log_compaction_with_transaction(
+							txn,
+							subspace,
+							process,
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutCacheEntry(arg) => {
-					Self::put_cache_entries_with_transaction(
+					crate::fdb::propagate!(Self::put_cache_entries_with_transaction(
 						txn,
 						subspace,
 						std::slice::from_ref(arg),
 						partition_total,
-					)?;
+					));
 				},
 				crate::batch::Item::PutGrant(arg) => {
-					Self::put_grants_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_grants_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutGroup(arg) => {
-					Self::put_groups_with_transaction(txn, subspace, std::slice::from_ref(arg))?;
+					crate::fdb::propagate!(Self::put_groups_with_transaction(
+						txn,
+						subspace,
+						std::slice::from_ref(arg),
+					));
 				},
 				crate::batch::Item::PutGroupMember(arg) => {
-					Self::put_group_members_with_transaction(
+					crate::fdb::propagate!(Self::put_group_members_with_transaction(
 						txn,
 						subspace,
 						std::slice::from_ref(arg),
-					)?;
+					));
 				},
 				crate::batch::Item::PutObject(arg) => {
-					Self::put_objects_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_objects_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutAccountObject(arg) => {
-					Self::put_account_object(
-						txn,
-						subspace,
-						arg,
-						partition_total,
-						usage_partition_total,
-						true,
-						None,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_account_object(
+							txn,
+							subspace,
+							arg,
+							partition_total,
+							usage_partition_total,
+							true,
+							None,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutAccountProcess(arg) => {
-					Self::put_account_process(
-						txn,
-						subspace,
-						arg,
-						partition_total,
-						usage_partition_total,
-						true,
-						None,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_account_process(
+							txn,
+							subspace,
+							arg,
+							partition_total,
+							usage_partition_total,
+							true,
+							None,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutOrganization(arg) => {
-					Self::put_organizations_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_organizations_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutOrganizationMember(arg) => {
-					Self::put_organization_members_with_transaction(
+					crate::fdb::propagate!(Self::put_organization_members_with_transaction(
 						txn,
 						subspace,
 						std::slice::from_ref(arg),
-					)?;
+					));
 				},
 				crate::batch::Item::PutProcess(arg) => {
-					Self::put_processes_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_processes_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutSandbox(arg) => {
-					Self::put_sandboxes_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-						partition_total,
-						usage_partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_sandboxes_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+							partition_total,
+							usage_partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutTag(arg) => {
-					Self::put_tags_with_transaction(
-						txn,
-						subspace,
-						std::slice::from_ref(arg),
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::put_tags_with_transaction(
+							txn,
+							subspace,
+							std::slice::from_ref(arg),
+							partition_total,
+						)
+						.await
+					);
 				},
 				crate::batch::Item::PutUser(arg) => {
-					Self::put_users_with_transaction(txn, subspace, std::slice::from_ref(arg))
-						.await?;
+					crate::fdb::propagate!(
+						Self::put_users_with_transaction(txn, subspace, std::slice::from_ref(arg),)
+							.await
+					);
 				},
 			}
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/cache/get.rs
+++ b/packages/index/src/fdb/cache/get.rs
@@ -37,7 +37,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -58,7 +58,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::cache::Entry>, fdb::FdbError>> {
 		let key = Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};

--- a/packages/index/src/fdb/cache/get.rs
+++ b/packages/index/src/fdb/cache/get.rs
@@ -2,6 +2,7 @@ use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -28,27 +29,41 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::artifact::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::cache::Entry>>> {
-		futures::future::try_join_all(
-			ids.iter()
-				.map(|id| Self::try_get_cache_entry_with_transaction(txn, subspace, id)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::cache::Entry>>, fdb::FdbError>> {
+		let entries = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_cache_entry_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(entries))
 	}
 
 	pub(crate) async fn try_get_cache_entry_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::artifact::Id,
-	) -> crate::fdb::Result<Option<crate::cache::Entry>> {
+	) -> tg::Result<ControlFlow<Option<crate::cache::Entry>, fdb::FdbError>> {
 		let key = Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::cache::Entry::deserialize(&bytes).map_err(crate::fdb::custom_error)?,
-		))
+		let entry = Some(crate::cache::Entry::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(entry))
 	}
 }

--- a/packages/index/src/fdb/cache/put.rs
+++ b/packages/index/src/fdb/cache/put.rs
@@ -1,6 +1,8 @@
 use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
+	tangram_client::prelude::*,
 };
 
 impl Index {
@@ -9,7 +11,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		arg: &crate::cache::put::Arg,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let id = &arg.id;
 
 		let key = Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
@@ -18,8 +20,7 @@ impl Index {
 			reference_count: 0,
 			touched_at: arg.touched_at,
 		}
-		.serialize()
-		.map_err(crate::fdb::custom_error)?;
+		.serialize()?;
 		txn.set_option(fdb::options::TransactionOption::NextWriteNoWriteConflictRange)
 			.unwrap();
 		txn.set(&key, &value);
@@ -56,7 +57,7 @@ impl Index {
 			.unwrap();
 		txn.set(&key, &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) fn put_cache_entries_with_transaction(
@@ -64,10 +65,15 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		args: &[crate::cache::put::Arg],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for cache_entry in args {
-			Self::put_cache_entry(txn, subspace, cache_entry, partition_total)?;
+			crate::fdb::propagate!(Self::put_cache_entry(
+				txn,
+				subspace,
+				cache_entry,
+				partition_total,
+			));
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/cache/touch.rs
+++ b/packages/index/src/fdb/cache/touch.rs
@@ -54,7 +54,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -78,7 +78,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::cache::Entry>, fdb::FdbError>> {
 		let key = Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let existing = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let existing = crate::fdb::retry!(result);
 		let existing = existing
 			.as_ref()
 			.map(|bytes| crate::cache::Entry::deserialize(bytes))
@@ -93,11 +94,8 @@ impl Index {
 
 		let mut key_end = key.clone();
 		key_end.push(0x00);
-		crate::fdb::retry!(txn.add_conflict_range(
-			&key,
-			&key_end,
-			fdb::options::ConflictRangeType::Read,
-		));
+		let result = txn.add_conflict_range(&key, &key_end, fdb::options::ConflictRangeType::Read);
+		crate::fdb::retry!(result);
 
 		cache_entry.touched_at = cache_entry.touched_at.max(touched_at);
 		let value = cache_entry

--- a/packages/index/src/fdb/cache/touch.rs
+++ b/packages/index/src/fdb/cache/touch.rs
@@ -3,7 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	futures::future,
-	std::time::Duration,
+	std::{ops::ControlFlow, time::Duration},
 	tangram_client::prelude::*,
 };
 
@@ -36,22 +36,36 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Vec<Option<crate::cache::Entry>>> {
-		future::try_join_all(ids.iter().map(|id| {
-			let subspace = subspace.clone();
-			async move {
-				Self::touch_cache_entry_with_transaction(
-					txn,
-					&subspace,
-					id,
-					touched_at,
-					time_to_touch,
-					partition_total,
-				)
-				.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::cache::Entry>>, fdb::FdbError>> {
+		let entries = {
+			let result = future::try_join_all(ids.iter().map(|id| {
+				let subspace = subspace.clone();
+				async move {
+					Self::touch_cache_entry_with_transaction(
+						txn,
+						&subspace,
+						id,
+						touched_at,
+						time_to_touch,
+						partition_total,
+					)
+					.await
+				}
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
 			}
-		}))
-		.await
+			values
+		};
+
+		Ok(ControlFlow::Break(entries))
 	}
 
 	async fn touch_cache_entry_with_transaction(
@@ -61,31 +75,34 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<crate::cache::Entry>> {
+	) -> tg::Result<ControlFlow<Option<crate::cache::Entry>, fdb::FdbError>> {
 		let key = Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let existing = txn.get(&key, false).await?;
+		let existing = crate::fdb::retry!(txn.get(&key, false).await);
 		let existing = existing
 			.as_ref()
 			.map(|bytes| crate::cache::Entry::deserialize(bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 		let Some(mut cache_entry) = existing else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
 		let time_to_touch = i64::try_from(time_to_touch.as_secs()).unwrap();
 		if touched_at - cache_entry.touched_at < time_to_touch {
-			return Ok(Some(cache_entry));
+			return Ok(ControlFlow::Break(Some(cache_entry)));
 		}
 
 		let mut key_end = key.clone();
 		key_end.push(0x00);
-		txn.add_conflict_range(&key, &key_end, fdb::options::ConflictRangeType::Read)?;
+		crate::fdb::retry!(txn.add_conflict_range(
+			&key,
+			&key_end,
+			fdb::options::ConflictRangeType::Read,
+		));
 
 		cache_entry.touched_at = cache_entry.touched_at.max(touched_at);
 		let value = cache_entry
 			.serialize()
-			.map_err(|error| crate::fdb::error!(!error, "failed to serialize the cache entry"))?;
+			.map_err(|error| tg::error!(!error, "failed to serialize the cache entry"))?;
 		txn.set(&key, &value);
 		if cache_entry.reference_count == 0 {
 			let id_bytes = id.to_bytes();
@@ -101,6 +118,6 @@ impl Index {
 			txn.set(&key, &[]);
 		}
 
-		Ok(Some(cache_entry))
+		Ok(ControlFlow::Break(Some(cache_entry)))
 	}
 }

--- a/packages/index/src/fdb/clean.rs
+++ b/packages/index/src/fdb/clean.rs
@@ -7,6 +7,7 @@ use {
 	foundationdb_tuple::Subspace,
 	futures::StreamExt as _,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -75,7 +76,7 @@ impl Index {
 
 	pub(super) async fn clean_with_transaction(
 		arg: TransactionArg<'_>,
-	) -> crate::fdb::Result<crate::clean::Output> {
+	) -> tg::Result<ControlFlow<crate::clean::Output, fdb::FdbError>> {
 		let TransactionArg {
 			batch_size,
 			max_object_touched_at,
@@ -89,16 +90,18 @@ impl Index {
 			usage_partition_total,
 			txn,
 		} = arg;
-		let grants = Self::delete_expired_grants(
-			txn,
-			subspace,
-			now,
-			batch_size,
-			partition_start,
-			partition_end,
-			partition_total,
-		)
-		.await?;
+		let grants = crate::fdb::propagate!(
+			Self::delete_expired_grants(
+				txn,
+				subspace,
+				now,
+				batch_size,
+				partition_start,
+				partition_end,
+				partition_total,
+			)
+			.await
+		);
 		let mut output = crate::clean::Output {
 			grants,
 			..Default::default()
@@ -127,12 +130,12 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while candidates.len() < remaining_batch_size {
-				let Some(entry) = entries.next().await.transpose()? else {
+				let Some(entry) = crate::fdb::retry!(entries.next().await.transpose()) else {
 					break;
 				};
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::Clean(key) = key else {
-					return Err(crate::fdb::error!("expected clean key"));
+					return Err(tg::error!("expected clean key"));
 				};
 				let (item, partition, touched_at, max_touched_at) = match key {
 					crate::fdb::clean::Key::AccountObject {
@@ -212,38 +215,43 @@ impl Index {
 		for candidate in &candidates {
 			match &candidate.item {
 				Item::AccountObject { account, object } => {
-					Self::clean_account_object_entry(
-						txn,
-						subspace,
-						account,
-						object,
-						now,
-						candidate.partition,
-						candidate.touched_at,
-						partition_total,
-						usage_partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::clean_account_object_entry(
+							txn,
+							subspace,
+							account,
+							object,
+							now,
+							candidate.partition,
+							candidate.touched_at,
+							partition_total,
+							usage_partition_total,
+						)
+						.await
+					);
 					continue;
 				},
 				Item::AccountProcess { account, process } => {
-					Self::clean_account_process_entry(
-						txn,
-						subspace,
-						account,
-						process,
-						now,
-						candidate.partition,
-						candidate.touched_at,
-						partition_total,
-						usage_partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::clean_account_process_entry(
+							txn,
+							subspace,
+							account,
+							process,
+							now,
+							candidate.partition,
+							candidate.touched_at,
+							partition_total,
+							usage_partition_total,
+						)
+						.await
+					);
 					continue;
 				},
 				Item::CacheEntry(_) | Item::Object(_) | Item::Process(_) | Item::Sandbox(_) => {},
 			}
-			let touched_at = Self::get_touched_at(txn, subspace, &candidate.item).await?;
+			let touched_at =
+				crate::fdb::propagate!(Self::get_touched_at(txn, subspace, &candidate.item).await);
 			if touched_at != candidate.touched_at {
 				Self::delete_clean_key(txn, subspace, candidate);
 				continue;
@@ -252,22 +260,35 @@ impl Index {
 			let reference_count = match &candidate.item {
 				Item::AccountObject { .. } | Item::AccountProcess { .. } => unreachable!(),
 				Item::CacheEntry(id) => {
-					Self::compute_cache_entry_reference_count(txn, subspace, id).await?
+					crate::fdb::propagate!(
+						Self::compute_cache_entry_reference_count(txn, subspace, id).await
+					)
 				},
-				Item::Object(id) => Self::compute_object_reference_count(txn, subspace, id).await?,
+				Item::Object(id) => crate::fdb::propagate!(
+					Self::compute_object_reference_count(txn, subspace, id).await
+				),
 				Item::Process(id) => {
-					Self::compute_process_reference_count(txn, subspace, id).await?
+					crate::fdb::propagate!(
+						Self::compute_process_reference_count(txn, subspace, id).await
+					)
 				},
 				Item::Sandbox(id) => {
-					Self::compute_sandbox_reference_count(txn, subspace, id).await?
+					crate::fdb::propagate!(
+						Self::compute_sandbox_reference_count(txn, subspace, id).await
+					)
 				},
 			};
 
 			let item = if reference_count > 0 {
-				Self::set_reference_count(txn, subspace, &candidate.item, reference_count).await?;
+				crate::fdb::propagate!(
+					Self::set_reference_count(txn, subspace, &candidate.item, reference_count)
+						.await
+				);
 				None
 			} else {
-				Self::delete_item(txn, subspace, &candidate.item, partition_total).await?;
+				crate::fdb::propagate!(
+					Self::delete_item(txn, subspace, &candidate.item, partition_total).await
+				);
 				Some(candidate.item.clone())
 			};
 
@@ -286,7 +307,7 @@ impl Index {
 
 		output.done = grants == 0 && candidates.is_empty();
 
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	async fn delete_expired_grants(
@@ -297,7 +318,7 @@ impl Index {
 		partition_start: u64,
 		partition_end: u64,
 		partition_total: u64,
-	) -> crate::fdb::Result<usize> {
+	) -> tg::Result<ControlFlow<usize, fdb::FdbError>> {
 		let key_kind = Kind::GrantExpiresAt.to_i32().unwrap();
 		let mut args = Vec::new();
 		for partition in partition_start..partition_end {
@@ -314,7 +335,7 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while args.len() < batch_size {
-				let Some(entry) = entries.next().await.transpose()? else {
+				let Some(entry) = crate::fdb::retry!(entries.next().await.transpose()) else {
 					break;
 				};
 				let key = Self::unpack(subspace, entry.key())?;
@@ -328,7 +349,7 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("expected a grant expiration key"));
+					return Err(tg::error!("expected a grant expiration key"));
 				};
 				args.push((
 					crate::grant::delete::Arg {
@@ -345,20 +366,22 @@ impl Index {
 		let count = args.len();
 		for (arg, source) in args {
 			for permission in arg.permissions.iter() {
-				Self::delete_grant_index_entry(
-					txn,
-					subspace,
-					&crate::fdb::grant::GrantIndexEntry {
-						creator: arg.creator.as_ref(),
-						expires_at: arg.expires_at,
-						permission,
-						subject: &arg.subject,
-						resource: &arg.resource,
-					},
-					source,
-					partition_total,
-				)
-				.await?;
+				crate::fdb::propagate!(
+					Self::delete_grant_index_entry(
+						txn,
+						subspace,
+						&crate::fdb::grant::GrantIndexEntry {
+							creator: arg.creator.as_ref(),
+							expires_at: arg.expires_at,
+							permission,
+							subject: &arg.subject,
+							resource: &arg.resource,
+						},
+						source,
+						partition_total,
+					)
+					.await
+				);
 				Self::enqueue_grant_update(
 					txn,
 					subspace,
@@ -369,49 +392,47 @@ impl Index {
 				);
 			}
 		}
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn get_touched_at(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		item: &Item,
-	) -> crate::fdb::Result<i64> {
-		match item {
+	) -> tg::Result<ControlFlow<i64, fdb::FdbError>> {
+		let touched_at = match item {
 			Item::AccountObject { .. } | Item::AccountProcess { .. } => unreachable!(),
 			Item::CacheEntry(id) => {
-				let entry = Self::try_get_cache_entry_with_transaction(txn, subspace, id)
-					.await?
-					.ok_or_else(
-						|| crate::fdb::error!(%id, "the clean key referenced a missing cache entry"),
-					)?;
-				Ok(entry.touched_at)
+				let entry = crate::fdb::propagate!(
+					Self::try_get_cache_entry_with_transaction(txn, subspace, id).await
+				)
+				.ok_or_else(|| tg::error!(%id, "the clean key referenced a missing cache entry"))?;
+				entry.touched_at
 			},
 			Item::Object(id) => {
-				let object = Self::try_get_object_with_transaction(txn, subspace, id)
-					.await?
-					.ok_or_else(
-						|| crate::fdb::error!(%id, "the clean key referenced a missing object"),
-					)?;
-				Ok(object.touched_at)
+				let object = crate::fdb::propagate!(
+					Self::try_get_object_with_transaction(txn, subspace, id).await
+				)
+				.ok_or_else(|| tg::error!(%id, "the clean key referenced a missing object"))?;
+				object.touched_at
 			},
 			Item::Process(id) => {
-				let process = Self::try_get_process_with_transaction(txn, subspace, id)
-					.await?
-					.ok_or_else(
-						|| crate::fdb::error!(%id, "the clean key referenced a missing process"),
-					)?;
-				Ok(process.touched_at)
+				let process = crate::fdb::propagate!(
+					Self::try_get_process_with_transaction(txn, subspace, id).await
+				)
+				.ok_or_else(|| tg::error!(%id, "the clean key referenced a missing process"))?;
+				process.touched_at
 			},
 			Item::Sandbox(id) => {
-				let sandbox = Self::try_get_sandbox_with_transaction(txn, subspace, id)
-					.await?
-					.ok_or_else(
-						|| crate::fdb::error!(%id, "the clean key referenced a missing sandbox"),
-					)?;
-				Ok(sandbox.touched_at)
+				let sandbox = crate::fdb::propagate!(
+					Self::try_get_sandbox_with_transaction(txn, subspace, id).await
+				)
+				.ok_or_else(|| tg::error!(%id, "the clean key referenced a missing sandbox"))?;
+				sandbox.touched_at
 			},
-		}
+		};
+
+		Ok(ControlFlow::Break(touched_at))
 	}
 
 	fn delete_clean_key(txn: &fdb::Transaction, subspace: &Subspace, candidate: &Candidate) {
@@ -461,7 +482,7 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::artifact::Id,
-	) -> crate::fdb::Result<u64> {
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
 		let id_bytes = id.to_bytes();
 
 		let cache_entry_object_future = async {
@@ -478,7 +499,7 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 
 		let dependency_cache_entry_future = async {
@@ -498,21 +519,23 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 
-		let (cache_entry_object_count, dependency_cache_entry_count) =
-			futures::future::try_join(cache_entry_object_future, dependency_cache_entry_future)
-				.await?;
+		let (cache_entry_object_count, dependency_cache_entry_count) = crate::fdb::retry!(
+			futures::future::try_join(cache_entry_object_future, dependency_cache_entry_future,)
+				.await
+		);
 		let count = cache_entry_object_count + dependency_cache_entry_count;
-		Ok(count)
+
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn compute_object_reference_count(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::object::Id,
-	) -> crate::fdb::Result<u64> {
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
 		let child_object_future = async {
 			let id = id.to_bytes();
 			let prefix = (Kind::ChildObject.to_i32().unwrap(), id.as_ref());
@@ -528,7 +551,7 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 		let object_process_future = async {
 			let id = id.to_bytes();
@@ -545,7 +568,7 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 		let target_tag_future = async {
 			let id = id.to_bytes();
@@ -562,15 +585,16 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
-		let (child_object_count, object_process_count, target_tag_count) =
+		let (child_object_count, object_process_count, target_tag_count) = crate::fdb::retry!(
 			futures::future::try_join3(
 				child_object_future,
 				object_process_future,
 				target_tag_future,
 			)
-			.await?;
+			.await
+		);
 		let object_account_future = async {
 			let id = id.to_bytes();
 			let prefix = (Kind::ObjectAccount.to_i32().unwrap(), id.as_ref());
@@ -585,7 +609,7 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 		let update_future = async {
 			let id = id.to_bytes();
@@ -604,23 +628,24 @@ impl Index {
 					.to_u64()
 					.unwrap();
 			}
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
-		let (object_account_count, update_count) =
-			futures::future::try_join(object_account_future, update_future).await?;
+		let (object_account_count, update_count) = crate::fdb::retry!(
+			futures::future::try_join(object_account_future, update_future).await
+		);
 		let count = child_object_count
 			+ object_account_count
 			+ object_process_count
 			+ target_tag_count
 			+ update_count;
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn compute_process_reference_count(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::process::Id,
-	) -> crate::fdb::Result<u64> {
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
 		let child_process_future = async {
 			let id = id.to_bytes();
 			let prefix = (Kind::ChildProcess.to_i32().unwrap(), id.as_ref());
@@ -636,7 +661,7 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 		let target_tag_future = async {
 			let id = id.to_bytes();
@@ -653,10 +678,11 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
-		let (child_process_count, target_tag_count) =
-			futures::future::try_join(child_process_future, target_tag_future).await?;
+		let (child_process_count, target_tag_count) = crate::fdb::retry!(
+			futures::future::try_join(child_process_future, target_tag_future).await
+		);
 		let process_account_future = async {
 			let id = id.to_bytes();
 			let prefix = (Kind::ProcessAccount.to_i32().unwrap(), id.as_ref());
@@ -671,7 +697,7 @@ impl Index {
 				.len()
 				.to_u64()
 				.unwrap();
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
 		let update_future = async {
 			let id = id.to_bytes();
@@ -690,19 +716,21 @@ impl Index {
 					.to_u64()
 					.unwrap();
 			}
-			Ok::<_, fdb::FdbBindingError>(count)
+			Ok::<_, fdb::FdbError>(count)
 		};
-		let (process_account_count, update_count) =
-			futures::future::try_join(process_account_future, update_future).await?;
+		let (process_account_count, update_count) = crate::fdb::retry!(
+			futures::future::try_join(process_account_future, update_future).await
+		);
 		let count = child_process_count + process_account_count + target_tag_count + update_count;
-		Ok(count)
+
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn compute_sandbox_reference_count(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::sandbox::Id,
-	) -> crate::fdb::Result<u64> {
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
 		let id = id.to_bytes();
 		let prefix = (Kind::SandboxProcess.to_i32().unwrap(), id.as_ref());
 		let prefix = Self::pack(subspace, &prefix);
@@ -711,14 +739,12 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let count = txn
-			.get_range(&range, 1, false)
-			.await?
+		let count = crate::fdb::retry!(txn.get_range(&range, 1, false).await)
 			.len()
 			.to_u64()
 			.unwrap();
 
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn set_reference_count(
@@ -726,55 +752,51 @@ impl Index {
 		subspace: &Subspace,
 		item: &Item,
 		reference_count: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		match item {
 			Item::AccountObject { .. } | Item::AccountProcess { .. } => unreachable!(),
 			Item::CacheEntry(id) => {
 				let key = crate::fdb::Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = txn.get(&key, false).await? {
-					let mut entry = crate::cache::Entry::deserialize(&bytes)
-						.map_err(crate::fdb::custom_error)?;
+				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+					let mut entry = crate::cache::Entry::deserialize(&bytes)?;
 					entry.reference_count = reference_count;
-					let bytes = entry.serialize().map_err(crate::fdb::custom_error)?;
+					let bytes = entry.serialize()?;
 					txn.set(&key, &bytes);
 				}
 			},
 			Item::Object(id) => {
 				let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = txn.get(&key, false).await? {
-					let mut object = crate::object::Object::deserialize(&bytes)
-						.map_err(crate::fdb::custom_error)?;
+				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+					let mut object = crate::object::Object::deserialize(&bytes)?;
 					object.reference_count = reference_count;
-					let bytes = object.serialize().map_err(crate::fdb::custom_error)?;
+					let bytes = object.serialize()?;
 					txn.set(&key, &bytes);
 				}
 			},
 			Item::Process(id) => {
 				let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = txn.get(&key, false).await? {
-					let mut process = crate::process::Process::deserialize(&bytes)
-						.map_err(crate::fdb::custom_error)?;
+				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+					let mut process = crate::process::Process::deserialize(&bytes)?;
 					process.reference_count = reference_count;
-					let bytes = process.serialize().map_err(crate::fdb::custom_error)?;
+					let bytes = process.serialize()?;
 					txn.set(&key, &bytes);
 				}
 			},
 			Item::Sandbox(id) => {
 				let key = crate::fdb::Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = txn.get(&key, false).await? {
-					let mut sandbox = crate::sandbox::Sandbox::deserialize(&bytes)
-						.map_err(crate::fdb::custom_error)?;
+				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+					let mut sandbox = crate::sandbox::Sandbox::deserialize(&bytes)?;
 					sandbox.reference_count = reference_count;
-					let bytes = sandbox.serialize().map_err(crate::fdb::custom_error)?;
+					let bytes = sandbox.serialize()?;
 					txn.set(&key, &bytes);
 				}
 			},
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn delete_item(
@@ -782,7 +804,7 @@ impl Index {
 		subspace: &Subspace,
 		item: &Item,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		match item {
 			Item::AccountObject { .. } | Item::AccountProcess { .. } => unreachable!(),
 			Item::CacheEntry(id) => {
@@ -799,7 +821,7 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::artifact::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
 		txn.clear(&key);
@@ -815,7 +837,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let dependencies = entries
 			.iter()
 			.map(|entry| {
@@ -825,11 +847,11 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("expected cache entry dependency key"));
+					return Err(tg::error!("expected cache entry dependency key"));
 				};
 				Ok(dependency)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
 		let (begin, end) = range_subspace.range();
 		txn.clear_range(&begin, &end);
@@ -842,16 +864,18 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 
-			Self::decrement_cache_entry_reference_count(
-				txn,
-				subspace,
-				&dependency,
-				partition_total,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::decrement_cache_entry_reference_count(
+					txn,
+					subspace,
+					&dependency,
+					partition_total,
+				)
+				.await
+			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn delete_object(
@@ -859,16 +883,21 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::object::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let resource = id.clone().into();
-		Self::delete_materialized_grants_for_resource(txn, subspace, &resource, partition_total)
-			.await?;
+		crate::fdb::propagate!(
+			Self::delete_materialized_grants_for_resource(
+				txn,
+				subspace,
+				&resource,
+				partition_total,
+			)
+			.await
+		);
 
 		let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let cache_entry = txn
-			.get(&key, false)
-			.await?
+		let cache_entry = crate::fdb::retry!(txn.get(&key, false).await)
 			.and_then(|bytes| crate::object::Object::deserialize(&bytes).ok())
 			.and_then(|obj| obj.cache_entry);
 
@@ -883,7 +912,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let children = entries
 			.iter()
 			.map(|entry| {
@@ -891,11 +920,11 @@ impl Index {
 				let crate::fdb::Key::Object(crate::fdb::object::Key::ObjectChild { child, .. }) =
 					key
 				else {
-					return Err(crate::fdb::error!("expected object child key"));
+					return Err(tg::error!("expected object child key"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let (begin, end) = range_subspace.range();
 		txn.clear_range(&begin, &end);
 		for child in &children {
@@ -907,7 +936,10 @@ impl Index {
 			txn.clear(&key);
 		}
 		for child in children {
-			Self::decrement_object_reference_count(txn, subspace, &child, partition_total).await?;
+			crate::fdb::propagate!(
+				Self::decrement_object_reference_count(txn, subspace, &child, partition_total)
+					.await
+			);
 		}
 
 		if let Some(cache_entry) = &cache_entry {
@@ -925,16 +957,18 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 
-			Self::decrement_cache_entry_reference_count(
-				txn,
-				subspace,
-				cache_entry,
-				partition_total,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::decrement_cache_entry_reference_count(
+					txn,
+					subspace,
+					cache_entry,
+					partition_total,
+				)
+				.await
+			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn delete_process(
@@ -942,19 +976,23 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::process::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let resource = id.clone().into();
-		Self::delete_materialized_grants_for_resource(txn, subspace, &resource, partition_total)
-			.await?;
+		crate::fdb::propagate!(
+			Self::delete_materialized_grants_for_resource(
+				txn,
+				subspace,
+				&resource,
+				partition_total,
+			)
+			.await
+		);
 
 		let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let sandbox = txn
-			.get(&key, false)
-			.await?
+		let sandbox = crate::fdb::retry!(txn.get(&key, false).await)
 			.map(|bytes| crate::process::Process::deserialize(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?
+			.transpose()?
 			.and_then(|process| process.sandbox);
 		txn.clear(&key);
 		let id_bytes = id.to_bytes();
@@ -966,7 +1004,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let children = entries
 			.iter()
 			.map(|entry| {
@@ -975,11 +1013,11 @@ impl Index {
 					child, ..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("expected process child key"));
+					return Err(tg::error!("expected process child key"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let (begin, end) = range_subspace.range();
 		txn.clear_range(&begin, &end);
 		for child in &children {
@@ -991,7 +1029,10 @@ impl Index {
 			txn.clear(&key);
 		}
 		for child in children {
-			Self::decrement_process_reference_count(txn, subspace, &child, partition_total).await?;
+			crate::fdb::propagate!(
+				Self::decrement_process_reference_count(txn, subspace, &child, partition_total)
+					.await
+			);
 		}
 
 		let prefix = (Kind::ProcessObject.to_i32().unwrap(), id_bytes.as_ref());
@@ -1001,7 +1042,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let object_processes = entries
 			.iter()
 			.map(|entry| {
@@ -1012,11 +1053,11 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("expected process object key"));
+					return Err(tg::error!("expected process object key"));
 				};
 				Ok((object, kind))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let (begin, end) = range_subspace.range();
 		txn.clear_range(&begin, &end);
 		for (object, kind) in &object_processes {
@@ -1038,7 +1079,10 @@ impl Index {
 			}
 		}
 		for (object, _) in object_processes {
-			Self::decrement_object_reference_count(txn, subspace, &object, partition_total).await?;
+			crate::fdb::propagate!(
+				Self::decrement_object_reference_count(txn, subspace, &object, partition_total)
+					.await
+			);
 		}
 
 		if let Some(sandbox) = sandbox {
@@ -1056,18 +1100,20 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 
-			Self::decrement_sandbox_reference_count(txn, subspace, &sandbox, partition_total)
-				.await?;
+			crate::fdb::propagate!(
+				Self::decrement_sandbox_reference_count(txn, subspace, &sandbox, partition_total,)
+					.await
+			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	fn delete_sandbox(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::sandbox::Id,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		Self::delete_sandboxes_with_transaction(txn, subspace, std::slice::from_ref(id))
 	}
 
@@ -1076,7 +1122,7 @@ impl Index {
 		subspace: &Subspace,
 		resource: &tg::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		// Collect the materialized grants.
 		let resource_bytes = resource.to_bytes();
 		let prefix = (
@@ -1089,7 +1135,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let values = txn.get_range(&range, 1, false).await?;
+		let values = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let entries = values
 			.iter()
 			.map(|entry| {
@@ -1101,39 +1147,40 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("expected a resource grant key"));
+					return Err(tg::error!("expected a resource grant key"));
 				};
-				let value = crate::fdb::grant::GrantValue::deserialize(entry.value())
-					.map_err(crate::fdb::custom_error)?;
+				let value = crate::fdb::grant::GrantValue::deserialize(entry.value())?;
 				let entry = value
 					.source_expires_at(crate::fdb::grant::GrantSource::Materialized)
 					.map(|expires_at| (creator, expires_at, permission, subject));
 				Ok(entry)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?
+			.collect::<tg::Result<Vec<_>>>()?
 			.into_iter()
 			.flatten()
 			.collect::<Vec<_>>();
 
 		// Delete the materialized grants.
 		for (creator, expires_at, permission, subject) in entries {
-			Self::delete_grant_index_entry(
-				txn,
-				subspace,
-				&crate::fdb::grant::GrantIndexEntry {
-					creator: creator.as_ref(),
-					expires_at,
-					permission,
-					subject: &subject,
-					resource,
-				},
-				crate::fdb::grant::GrantSource::Materialized,
-				partition_total,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::delete_grant_index_entry(
+					txn,
+					subspace,
+					&crate::fdb::grant::GrantIndexEntry {
+						creator: creator.as_ref(),
+						expires_at,
+						permission,
+						subject: &subject,
+						resource,
+					},
+					crate::fdb::grant::GrantSource::Materialized,
+					partition_total,
+				)
+				.await
+			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn decrement_cache_entry_reference_count(
@@ -1141,22 +1188,21 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::artifact::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = txn.get(&key, false).await? else {
-			return Ok(());
+		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut entry =
-			crate::cache::Entry::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let mut entry = crate::cache::Entry::deserialize(&bytes)?;
 		let reference_count = entry.reference_count;
 		if reference_count > 1 {
 			entry.reference_count = reference_count - 1;
-			let bytes = entry.serialize().map_err(crate::fdb::custom_error)?;
+			let bytes = entry.serialize()?;
 			txn.set(&key, &bytes);
 		} else {
 			entry.reference_count = 0;
-			let bytes = entry.serialize().map_err(crate::fdb::custom_error)?;
+			let bytes = entry.serialize()?;
 			txn.set(&key, &bytes);
 
 			let id_bytes = id.to_bytes();
@@ -1169,7 +1215,7 @@ impl Index {
 			let clean_key = Self::pack(subspace, &key);
 			txn.set(&clean_key, &[]);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(super) async fn decrement_object_reference_count(
@@ -1177,22 +1223,21 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::object::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = txn.get(&key, false).await? else {
-			return Ok(());
+		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut object =
-			crate::object::Object::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let mut object = crate::object::Object::deserialize(&bytes)?;
 		let reference_count = object.reference_count;
 		if reference_count > 1 {
 			object.reference_count = reference_count - 1;
-			let bytes = object.serialize().map_err(crate::fdb::custom_error)?;
+			let bytes = object.serialize()?;
 			txn.set(&key, &bytes);
 		} else {
 			object.reference_count = 0;
-			let bytes = object.serialize().map_err(crate::fdb::custom_error)?;
+			let bytes = object.serialize()?;
 			txn.set(&key, &bytes);
 
 			let id_bytes = id.to_bytes();
@@ -1205,7 +1250,7 @@ impl Index {
 			let clean_key = Self::pack(subspace, &key);
 			txn.set(&clean_key, &[]);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(super) async fn decrement_process_reference_count(
@@ -1213,22 +1258,21 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::process::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = txn.get(&key, false).await? else {
-			return Ok(());
+		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut process =
-			crate::process::Process::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let mut process = crate::process::Process::deserialize(&bytes)?;
 		let reference_count = process.reference_count;
 		if reference_count > 1 {
 			process.reference_count = reference_count - 1;
-			let bytes = process.serialize().map_err(crate::fdb::custom_error)?;
+			let bytes = process.serialize()?;
 			txn.set(&key, &bytes);
 		} else {
 			process.reference_count = 0;
-			let bytes = process.serialize().map_err(crate::fdb::custom_error)?;
+			let bytes = process.serialize()?;
 			txn.set(&key, &bytes);
 
 			let id_bytes = id.to_bytes();
@@ -1241,7 +1285,7 @@ impl Index {
 			let clean_key = Self::pack(subspace, &key);
 			txn.set(&clean_key, &[]);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(super) async fn decrement_sandbox_reference_count(
@@ -1249,16 +1293,15 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::sandbox::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = txn.get(&key, false).await? else {
-			return Ok(());
+		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut sandbox =
-			crate::sandbox::Sandbox::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let mut sandbox = crate::sandbox::Sandbox::deserialize(&bytes)?;
 		sandbox.reference_count = sandbox.reference_count.saturating_sub(1);
-		let bytes = sandbox.serialize().map_err(crate::fdb::custom_error)?;
+		let bytes = sandbox.serialize()?;
 		txn.set(&key, &bytes);
 
 		if sandbox.reference_count == 0
@@ -1278,6 +1321,6 @@ impl Index {
 			txn.set(&key, &[]);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/clean.rs
+++ b/packages/index/src/fdb/clean.rs
@@ -130,7 +130,8 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while candidates.len() < remaining_batch_size {
-				let Some(entry) = crate::fdb::retry!(entries.next().await.transpose()) else {
+				let result = entries.next().await.transpose();
+				let Some(entry) = crate::fdb::retry!(result) else {
 					break;
 				};
 				let key = Self::unpack(subspace, entry.key())?;
@@ -335,7 +336,8 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while args.len() < batch_size {
-				let Some(entry) = crate::fdb::retry!(entries.next().await.transpose()) else {
+				let result = entries.next().await.transpose();
+				let Some(entry) = crate::fdb::retry!(result) else {
 					break;
 				};
 				let key = Self::unpack(subspace, entry.key())?;
@@ -522,10 +524,10 @@ impl Index {
 			Ok::<_, fdb::FdbError>(count)
 		};
 
-		let (cache_entry_object_count, dependency_cache_entry_count) = crate::fdb::retry!(
-			futures::future::try_join(cache_entry_object_future, dependency_cache_entry_future,)
-				.await
-		);
+		let result =
+			futures::future::try_join(cache_entry_object_future, dependency_cache_entry_future)
+				.await;
+		let (cache_entry_object_count, dependency_cache_entry_count) = crate::fdb::retry!(result);
 		let count = cache_entry_object_count + dependency_cache_entry_count;
 
 		Ok(ControlFlow::Break(count))
@@ -587,14 +589,14 @@ impl Index {
 				.unwrap();
 			Ok::<_, fdb::FdbError>(count)
 		};
-		let (child_object_count, object_process_count, target_tag_count) = crate::fdb::retry!(
-			futures::future::try_join3(
-				child_object_future,
-				object_process_future,
-				target_tag_future,
-			)
-			.await
-		);
+		let result = futures::future::try_join3(
+			child_object_future,
+			object_process_future,
+			target_tag_future,
+		)
+		.await;
+		let (child_object_count, object_process_count, target_tag_count) =
+			crate::fdb::retry!(result);
 		let object_account_future = async {
 			let id = id.to_bytes();
 			let prefix = (Kind::ObjectAccount.to_i32().unwrap(), id.as_ref());
@@ -630,9 +632,8 @@ impl Index {
 			}
 			Ok::<_, fdb::FdbError>(count)
 		};
-		let (object_account_count, update_count) = crate::fdb::retry!(
-			futures::future::try_join(object_account_future, update_future).await
-		);
+		let result = futures::future::try_join(object_account_future, update_future).await;
+		let (object_account_count, update_count) = crate::fdb::retry!(result);
 		let count = child_object_count
 			+ object_account_count
 			+ object_process_count
@@ -680,9 +681,8 @@ impl Index {
 				.unwrap();
 			Ok::<_, fdb::FdbError>(count)
 		};
-		let (child_process_count, target_tag_count) = crate::fdb::retry!(
-			futures::future::try_join(child_process_future, target_tag_future).await
-		);
+		let result = futures::future::try_join(child_process_future, target_tag_future).await;
+		let (child_process_count, target_tag_count) = crate::fdb::retry!(result);
 		let process_account_future = async {
 			let id = id.to_bytes();
 			let prefix = (Kind::ProcessAccount.to_i32().unwrap(), id.as_ref());
@@ -718,9 +718,8 @@ impl Index {
 			}
 			Ok::<_, fdb::FdbError>(count)
 		};
-		let (process_account_count, update_count) = crate::fdb::retry!(
-			futures::future::try_join(process_account_future, update_future).await
-		);
+		let result = futures::future::try_join(process_account_future, update_future).await;
+		let (process_account_count, update_count) = crate::fdb::retry!(result);
 		let count = child_process_count + process_account_count + target_tag_count + update_count;
 
 		Ok(ControlFlow::Break(count))
@@ -739,10 +738,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let count = crate::fdb::retry!(txn.get_range(&range, 1, false).await)
-			.len()
-			.to_u64()
-			.unwrap();
+		let result = txn.get_range(&range, 1, false).await;
+		let count = crate::fdb::retry!(result).len().to_u64().unwrap();
 
 		Ok(ControlFlow::Break(count))
 	}
@@ -758,7 +755,8 @@ impl Index {
 			Item::CacheEntry(id) => {
 				let key = crate::fdb::Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+				let result = txn.get(&key, false).await;
+				if let Some(bytes) = crate::fdb::retry!(result) {
 					let mut entry = crate::cache::Entry::deserialize(&bytes)?;
 					entry.reference_count = reference_count;
 					let bytes = entry.serialize()?;
@@ -768,7 +766,8 @@ impl Index {
 			Item::Object(id) => {
 				let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+				let result = txn.get(&key, false).await;
+				if let Some(bytes) = crate::fdb::retry!(result) {
 					let mut object = crate::object::Object::deserialize(&bytes)?;
 					object.reference_count = reference_count;
 					let bytes = object.serialize()?;
@@ -778,7 +777,8 @@ impl Index {
 			Item::Process(id) => {
 				let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+				let result = txn.get(&key, false).await;
+				if let Some(bytes) = crate::fdb::retry!(result) {
 					let mut process = crate::process::Process::deserialize(&bytes)?;
 					process.reference_count = reference_count;
 					let bytes = process.serialize()?;
@@ -788,7 +788,8 @@ impl Index {
 			Item::Sandbox(id) => {
 				let key = crate::fdb::Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 				let key = Self::pack(subspace, &key);
-				if let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) {
+				let result = txn.get(&key, false).await;
+				if let Some(bytes) = crate::fdb::retry!(result) {
 					let mut sandbox = crate::sandbox::Sandbox::deserialize(&bytes)?;
 					sandbox.reference_count = reference_count;
 					let bytes = sandbox.serialize()?;
@@ -837,7 +838,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let dependencies = entries
 			.iter()
 			.map(|entry| {
@@ -897,7 +899,8 @@ impl Index {
 
 		let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let cache_entry = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let cache_entry = crate::fdb::retry!(result)
 			.and_then(|bytes| crate::object::Object::deserialize(&bytes).ok())
 			.and_then(|obj| obj.cache_entry);
 
@@ -912,7 +915,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let children = entries
 			.iter()
 			.map(|entry| {
@@ -990,7 +994,8 @@ impl Index {
 
 		let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let sandbox = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let sandbox = crate::fdb::retry!(result)
 			.map(|bytes| crate::process::Process::deserialize(&bytes))
 			.transpose()?
 			.and_then(|process| process.sandbox);
@@ -1004,7 +1009,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let children = entries
 			.iter()
 			.map(|entry| {
@@ -1042,7 +1048,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let object_processes = entries
 			.iter()
 			.map(|entry| {
@@ -1135,7 +1142,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let values = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let values = crate::fdb::retry!(result);
 		let entries = values
 			.iter()
 			.map(|entry| {
@@ -1191,7 +1199,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Cache(crate::fdb::cache::Key::CacheEntry(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+		let result = txn.get(&key, false).await;
+		let Some(bytes) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let mut entry = crate::cache::Entry::deserialize(&bytes)?;
@@ -1226,7 +1235,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+		let result = txn.get(&key, false).await;
+		let Some(bytes) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let mut object = crate::object::Object::deserialize(&bytes)?;
@@ -1261,7 +1271,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+		let result = txn.get(&key, false).await;
+		let Some(bytes) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let mut process = crate::process::Process::deserialize(&bytes)?;
@@ -1296,7 +1307,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = crate::fdb::Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let Some(bytes) = crate::fdb::retry!(txn.get(&key, false).await) else {
+		let result = txn.get(&key, false).await;
+		let Some(bytes) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let mut sandbox = crate::sandbox::Sandbox::deserialize(&bytes)?;

--- a/packages/index/src/fdb/error.rs
+++ b/packages/index/src/fdb/error.rs
@@ -1,37 +1,43 @@
-use {foundationdb as fdb, tangram_client::prelude::*};
-
-pub(crate) type Result<T> = std::result::Result<T, fdb::FdbBindingError>;
-
-macro_rules! error {
-	($($arg:tt)*) => {
-		crate::fdb::custom_error(tangram_client::error!($($arg)*))
-	};
+macro_rules! propagate {
+	($result:expr) => {{
+		match $result? {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		}
+	}};
 }
-pub(crate) use error;
+pub(crate) use propagate;
 
-#[must_use]
-pub(crate) fn custom_error(error: tg::Error) -> fdb::FdbBindingError {
-	fdb::FdbBindingError::CustomError(error.into())
+macro_rules! retry {
+	($result:expr) => {{
+		match $result {
+			Ok(value) => value,
+			Err(error) => return Ok(ControlFlow::Continue(error)),
+		}
+	}};
 }
+pub(crate) use retry;
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use {foundationdb as fdb, std::ops::ControlFlow, tangram_client::prelude::*};
 
 	#[test]
-	fn preserves_foundationdb_errors() {
+	fn preserves_retryable_foundationdb_errors() {
 		let error = fdb::FdbError::from_code(1007);
 		assert!(error.is_retryable());
-		let error = fdb::FdbBindingError::from(error);
+		let result: std::result::Result<(), _> = Err(error);
 
-		assert_eq!(error.get_fdb_error().map(fdb::FdbError::code), Some(1007));
-	}
+		let output = (|| -> tg::Result<ControlFlow<(), fdb::FdbError>> {
+			retry!(result);
 
-	#[test]
-	fn classifies_tangram_errors_as_custom() {
-		let error = custom_error(tg::error!("a tangram error"));
+			Ok(ControlFlow::Break(()))
+		})();
+		let error = match output.unwrap() {
+			ControlFlow::Break(()) => panic!("expected the transaction to continue"),
+			ControlFlow::Continue(error) => error,
+		};
 
-		assert!(matches!(error, fdb::FdbBindingError::CustomError(_)));
-		assert!(error.get_fdb_error().is_none());
+		assert_eq!(error.code(), 1007);
 	}
 }

--- a/packages/index/src/fdb/grant/delete.rs
+++ b/packages/index/src/fdb/grant/delete.rs
@@ -4,6 +4,7 @@ use {
 		grant::{GrantIndexEntry, GrantSource, GrantValue},
 	},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -25,7 +26,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		args: &[crate::grant::delete::Arg],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			for permission in arg.permissions.iter() {
 				let source = if arg.expires_at.is_some() {
@@ -33,20 +34,22 @@ impl Index {
 				} else {
 					GrantSource::Explicit
 				};
-				let changed = Self::delete_grant_index_entry(
-					txn,
-					subspace,
-					&GrantIndexEntry {
-						creator: arg.creator.as_ref(),
-						expires_at: arg.expires_at,
-						permission,
-						subject: &arg.subject,
-						resource: &arg.resource,
-					},
-					source,
-					partition_total,
-				)
-				.await?;
+				let changed = crate::fdb::propagate!(
+					Self::delete_grant_index_entry(
+						txn,
+						subspace,
+						&GrantIndexEntry {
+							creator: arg.creator.as_ref(),
+							expires_at: arg.expires_at,
+							permission,
+							subject: &arg.subject,
+							resource: &arg.resource,
+						},
+						source,
+						partition_total,
+					)
+					.await
+				);
 				if changed {
 					Self::enqueue_grant_update(
 						txn,
@@ -59,7 +62,7 @@ impl Index {
 				}
 			}
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn delete_grant_index_entry(
@@ -68,7 +71,7 @@ impl Index {
 		entry: &GrantIndexEntry<'_>,
 		source: GrantSource,
 		partition_total: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let mut changed = false;
 		let keys = std::iter::once(Key::Grant(crate::fdb::grant::Key::ResourceGrant {
 			resource: entry.resource.clone(),
@@ -87,10 +90,10 @@ impl Index {
 		.collect::<Vec<_>>();
 		for key in keys {
 			let key = Self::pack(subspace, &key);
-			let Some(value) = txn.get(&key, false).await? else {
+			let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
 				continue;
 			};
-			let mut value = GrantValue::deserialize(&value).map_err(crate::fdb::custom_error)?;
+			let mut value = GrantValue::deserialize(&value)?;
 			let old_expires_at = value.source_expires_at(source).flatten();
 			if !value.delete(source, entry.expires_at) {
 				continue;
@@ -98,7 +101,7 @@ impl Index {
 			if value.is_empty() {
 				txn.clear(&key);
 			} else {
-				let bytes = value.serialize().map_err(crate::fdb::custom_error)?;
+				let bytes = value.serialize()?;
 				txn.set(&key, &bytes);
 			}
 			Self::update_grant_expiration(
@@ -113,7 +116,9 @@ impl Index {
 			changed = true;
 		}
 
-		for id in Self::ancestor_ids_with_transaction(txn, subspace, entry.resource).await? {
+		for id in crate::fdb::propagate!(
+			Self::ancestor_ids_with_transaction(txn, subspace, entry.resource).await
+		) {
 			let key = Key::Grant(crate::fdb::grant::Key::Visibility {
 				resource: id,
 				subject: entry.subject.clone(),
@@ -122,17 +127,17 @@ impl Index {
 				permission: entry.permission,
 			});
 			let key = Self::pack(subspace, &key);
-			let Some(value) = txn.get(&key, false).await? else {
+			let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
 				continue;
 			};
-			let mut value = GrantValue::deserialize(&value).map_err(crate::fdb::custom_error)?;
+			let mut value = GrantValue::deserialize(&value)?;
 			if !value.delete(source, entry.expires_at) {
 				continue;
 			}
 			if value.is_empty() {
 				txn.clear(&key);
 			} else {
-				let bytes = value.serialize().map_err(crate::fdb::custom_error)?;
+				let bytes = value.serialize()?;
 				txn.set(&key, &bytes);
 			}
 		}
@@ -145,6 +150,6 @@ impl Index {
 			None,
 			partition_total,
 		);
-		Ok(changed)
+		Ok(ControlFlow::Break(changed))
 	}
 }

--- a/packages/index/src/fdb/grant/delete.rs
+++ b/packages/index/src/fdb/grant/delete.rs
@@ -90,7 +90,8 @@ impl Index {
 		.collect::<Vec<_>>();
 		for key in keys {
 			let key = Self::pack(subspace, &key);
-			let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			let result = txn.get(&key, false).await;
+			let Some(value) = crate::fdb::retry!(result) else {
 				continue;
 			};
 			let mut value = GrantValue::deserialize(&value)?;
@@ -127,7 +128,8 @@ impl Index {
 				permission: entry.permission,
 			});
 			let key = Self::pack(subspace, &key);
-			let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			let result = txn.get(&key, false).await;
+			let Some(value) = crate::fdb::retry!(result) else {
 				continue;
 			};
 			let mut value = GrantValue::deserialize(&value)?;

--- a/packages/index/src/fdb/grant/get.rs
+++ b/packages/index/src/fdb/grant/get.rs
@@ -27,7 +27,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let grants = entries
 			.iter()
@@ -67,7 +68,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let entries = entries
 			.iter()
@@ -114,7 +116,8 @@ impl Index {
 			limit: Some(1),
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		Ok(ControlFlow::Break(!entries.is_empty()))
 	}

--- a/packages/index/src/fdb/grant/get.rs
+++ b/packages/index/src/fdb/grant/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -11,7 +12,12 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		resource: &tg::Id,
-	) -> crate::fdb::Result<Vec<(tg::authorization::Subject, tg::authorization::Permission)>> {
+	) -> tg::Result<
+		ControlFlow<
+			Vec<(tg::authorization::Subject, tg::authorization::Permission)>,
+			fdb::FdbError,
+		>,
+	> {
 		let bytes = resource.to_bytes();
 		let key = (Kind::ResourceGrant.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -21,7 +27,7 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let grants = entries
 			.iter()
@@ -33,13 +39,13 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok((subject, permission))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(grants)
+		Ok(ControlFlow::Break(grants))
 	}
 
 	pub(crate) async fn get_resource_grant_entries_for_subject_with_transaction(
@@ -47,7 +53,7 @@ impl Index {
 		subspace: &Subspace,
 		resource: &tg::Id,
 		subject: &tg::authorization::Subject,
-	) -> crate::fdb::Result<Vec<crate::fdb::grant::GrantEntry>> {
+	) -> tg::Result<ControlFlow<Vec<crate::fdb::grant::GrantEntry>, fdb::FdbError>> {
 		let bytes = resource.to_bytes();
 		let key = (
 			Kind::ResourceGrant.to_i32().unwrap(),
@@ -61,9 +67,9 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
-		entries
+		let entries = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
@@ -73,10 +79,9 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
-				let value = crate::fdb::grant::GrantValue::deserialize(entry.value())
-					.map_err(crate::fdb::custom_error)?;
+				let value = crate::fdb::grant::GrantValue::deserialize(entry.value())?;
 				Ok(crate::fdb::grant::GrantEntry {
 					explicit: value.explicit,
 					materialized: value.materialized,
@@ -85,7 +90,9 @@ impl Index {
 					temporary: value.temporary,
 				})
 			})
-			.collect()
+			.collect::<tg::Result<Vec<_>>>()?;
+
+		Ok(ControlFlow::Break(entries))
 	}
 
 	pub(crate) async fn try_get_visibility_with_transaction(
@@ -93,7 +100,7 @@ impl Index {
 		subspace: &Subspace,
 		resource: &tg::Id,
 		subject: &tg::authorization::Subject,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let bytes = resource.to_bytes();
 		let key = (
 			Kind::Visibility.to_i32().unwrap(),
@@ -107,7 +114,8 @@ impl Index {
 			limit: Some(1),
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
-		Ok(!entries.is_empty())
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+
+		Ok(ControlFlow::Break(!entries.is_empty()))
 	}
 }

--- a/packages/index/src/fdb/grant/put.rs
+++ b/packages/index/src/fdb/grant/put.rs
@@ -92,7 +92,8 @@ impl Index {
 		.collect::<Vec<_>>();
 		for key in keys {
 			let key = Self::pack(subspace, &key);
-			let mut value = crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			let mut value = crate::fdb::retry!(result)
 				.as_deref()
 				.map_or_else(|| Ok(GrantValue::default()), GrantValue::deserialize)?;
 			let old_expires_at = value.source_expires_at(source).flatten();
@@ -126,7 +127,8 @@ impl Index {
 				permission: entry.permission,
 			});
 			let key = Self::pack(subspace, &key);
-			let mut value = crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			let mut value = crate::fdb::retry!(result)
 				.as_deref()
 				.map_or_else(|| Ok(GrantValue::default()), GrantValue::deserialize)?;
 			if value.put(source, entry.expires_at, time_to_touch) {

--- a/packages/index/src/fdb/grant/put.rs
+++ b/packages/index/src/fdb/grant/put.rs
@@ -4,6 +4,7 @@ use {
 		grant::{GrantIndexEntry, GrantSource, GrantValue},
 	},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -25,7 +26,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		args: &[crate::grant::put::Arg],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			for permission in arg.permissions.iter() {
 				let source = if arg.expires_at.is_some() {
@@ -33,21 +34,23 @@ impl Index {
 				} else {
 					GrantSource::Explicit
 				};
-				let changed = Self::put_grant_index_entry(
-					txn,
-					subspace,
-					&GrantIndexEntry {
-						creator: arg.creator.as_ref(),
-						expires_at: arg.expires_at,
-						permission,
-						subject: &arg.subject,
-						resource: &arg.resource,
-					},
-					source,
-					arg.time_to_touch,
-					partition_total,
-				)
-				.await?;
+				let changed = crate::fdb::propagate!(
+					Self::put_grant_index_entry(
+						txn,
+						subspace,
+						&GrantIndexEntry {
+							creator: arg.creator.as_ref(),
+							expires_at: arg.expires_at,
+							permission,
+							subject: &arg.subject,
+							resource: &arg.resource,
+						},
+						source,
+						arg.time_to_touch,
+						partition_total,
+					)
+					.await
+				);
 				if changed {
 					Self::enqueue_grant_update(
 						txn,
@@ -60,7 +63,7 @@ impl Index {
 				}
 			}
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn put_grant_index_entry(
@@ -70,7 +73,7 @@ impl Index {
 		source: GrantSource,
 		time_to_touch: Option<std::time::Duration>,
 		partition_total: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let mut changed = false;
 		let keys = std::iter::once(Key::Grant(crate::fdb::grant::Key::ResourceGrant {
 			resource: entry.resource.clone(),
@@ -89,15 +92,12 @@ impl Index {
 		.collect::<Vec<_>>();
 		for key in keys {
 			let key = Self::pack(subspace, &key);
-			let mut value = txn
-				.get(&key, false)
-				.await?
+			let mut value = crate::fdb::retry!(txn.get(&key, false).await)
 				.as_deref()
-				.map_or_else(|| Ok(GrantValue::default()), GrantValue::deserialize)
-				.map_err(crate::fdb::custom_error)?;
+				.map_or_else(|| Ok(GrantValue::default()), GrantValue::deserialize)?;
 			let old_expires_at = value.source_expires_at(source).flatten();
 			if value.put(source, entry.expires_at, time_to_touch) {
-				let bytes = value.serialize().map_err(crate::fdb::custom_error)?;
+				let bytes = value.serialize()?;
 				txn.set(&key, &bytes);
 				Self::update_grant_expiration(
 					txn,
@@ -112,10 +112,12 @@ impl Index {
 			}
 		}
 		if !changed {
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		}
 
-		for id in Self::ancestor_ids_with_transaction(txn, subspace, entry.resource).await? {
+		for id in crate::fdb::propagate!(
+			Self::ancestor_ids_with_transaction(txn, subspace, entry.resource).await
+		) {
 			let key = Key::Grant(crate::fdb::grant::Key::Visibility {
 				resource: id,
 				subject: entry.subject.clone(),
@@ -124,18 +126,15 @@ impl Index {
 				permission: entry.permission,
 			});
 			let key = Self::pack(subspace, &key);
-			let mut value = txn
-				.get(&key, false)
-				.await?
+			let mut value = crate::fdb::retry!(txn.get(&key, false).await)
 				.as_deref()
-				.map_or_else(|| Ok(GrantValue::default()), GrantValue::deserialize)
-				.map_err(crate::fdb::custom_error)?;
+				.map_or_else(|| Ok(GrantValue::default()), GrantValue::deserialize)?;
 			if value.put(source, entry.expires_at, time_to_touch) {
-				let bytes = value.serialize().map_err(crate::fdb::custom_error)?;
+				let bytes = value.serialize()?;
 				txn.set(&key, &bytes);
 			}
 		}
-		Ok(changed)
+		Ok(ControlFlow::Break(changed))
 	}
 
 	pub(crate) fn update_grant_expiration(

--- a/packages/index/src/fdb/group/delete.rs
+++ b/packages/index/src/fdb/group/delete.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -38,16 +39,13 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		ids: &[tg::group::Id],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for id in ids {
 			let key = Key::Group(crate::fdb::group::Key::Group(id.clone()));
 			let key = Self::pack(subspace, &key);
-			let group = txn
-				.get(&key, false)
-				.await?
+			let group = crate::fdb::retry!(txn.get(&key, false).await)
 				.map(|bytes| crate::group::Group::deserialize(&bytes))
-				.transpose()
-				.map_err(crate::fdb::custom_error)?;
+				.transpose()?;
 			if let Some(group) = group {
 				let node_key = Key::Node(crate::fdb::node::Key::Node(group.specifier));
 				let node_key = Self::pack(subspace, &node_key);
@@ -55,14 +53,14 @@ impl Index {
 			}
 			txn.clear(&key);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) fn delete_group_members_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::group::member::delete::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::Group(crate::fdb::group::Key::GroupMember {
 				group: arg.group.clone(),
@@ -78,6 +76,6 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/group/delete.rs
+++ b/packages/index/src/fdb/group/delete.rs
@@ -43,7 +43,8 @@ impl Index {
 		for id in ids {
 			let key = Key::Group(crate::fdb::group::Key::Group(id.clone()));
 			let key = Self::pack(subspace, &key);
-			let group = crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			let group = crate::fdb::retry!(result)
 				.map(|bytes| crate::group::Group::deserialize(&bytes))
 				.transpose()?;
 			if let Some(group) = group {

--- a/packages/index/src/fdb/group/get.rs
+++ b/packages/index/src/fdb/group/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -29,35 +30,49 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::group::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::group::Group>>> {
-		futures::future::try_join_all(
-			ids.iter()
-				.map(|id| Self::try_get_group_with_transaction(txn, subspace, id)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::group::Group>>, fdb::FdbError>> {
+		let groups = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_group_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(groups))
 	}
 
 	pub(crate) async fn try_get_group_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::group::Id,
-	) -> crate::fdb::Result<Option<crate::group::Group>> {
+	) -> tg::Result<ControlFlow<Option<crate::group::Group>, fdb::FdbError>> {
 		let key = Key::Group(crate::fdb::group::Key::Group(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::group::Group::deserialize(&bytes).map_err(crate::fdb::custom_error)?,
-		))
+		let group = Some(crate::group::Group::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(group))
 	}
 
 	pub(crate) async fn get_group_members_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		group: &tg::group::Id,
-	) -> crate::fdb::Result<Vec<tg::group::Member>> {
+	) -> tg::Result<ControlFlow<Vec<tg::group::Member>, fdb::FdbError>> {
 		let bytes = tg::Id::from(group.clone()).to_bytes();
 		let key = (Kind::GroupMember.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -67,27 +82,27 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let members = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Group(crate::fdb::group::Key::GroupMember { member, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(member)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(members)
+		Ok(ControlFlow::Break(members))
 	}
 
 	pub(crate) async fn get_member_groups_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		member: &tg::Id,
-	) -> crate::fdb::Result<Vec<tg::group::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::group::Id>, fdb::FdbError>> {
 		let bytes = member.to_bytes();
 		let key = (Kind::MemberGroup.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -97,19 +112,19 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let groups = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Group(crate::fdb::group::Key::MemberGroup { group, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(group)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(groups)
+		Ok(ControlFlow::Break(groups))
 	}
 }

--- a/packages/index/src/fdb/group/get.rs
+++ b/packages/index/src/fdb/group/get.rs
@@ -38,7 +38,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -59,7 +59,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::group::Group>, fdb::FdbError>> {
 		let key = Key::Group(crate::fdb::group::Key::Group(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};
@@ -82,7 +83,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let members = entries
 			.iter()
@@ -112,7 +114,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let groups = entries
 			.iter()

--- a/packages/index/src/fdb/group/put.rs
+++ b/packages/index/src/fdb/group/put.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -38,7 +39,7 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::group::put::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::Group(crate::fdb::group::Key::Group(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
@@ -46,8 +47,7 @@ impl Index {
 				parent: arg.parent.clone(),
 				specifier: arg.specifier.clone(),
 			}
-			.serialize()
-			.map_err(crate::fdb::custom_error)?;
+			.serialize()?;
 			txn.set(&key, &value);
 
 			let key = Key::Node(crate::fdb::node::Key::Node(arg.specifier.clone()));
@@ -55,14 +55,14 @@ impl Index {
 			let value = tg::Id::from(arg.id.clone()).to_bytes();
 			txn.set(&key, value.as_ref());
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) fn put_group_members_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::group::member::put::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::Group(crate::fdb::group::Key::GroupMember {
 				group: arg.group.clone(),
@@ -78,6 +78,6 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.set(&key, &[]);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/log.rs
+++ b/packages/index/src/fdb/log.rs
@@ -74,7 +74,8 @@ impl Index {
 				mode: fdb::options::StreamingMode::WantAll,
 				..Default::default()
 			};
-			let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+			let result = txn.get_range(&range, 1, false).await;
+			let entries = crate::fdb::retry!(result);
 			for entry in entries {
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::LogCompaction(Key::Version {
@@ -123,7 +124,8 @@ impl Index {
 				..Default::default()
 			};
 			async move {
-				let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+				let result = txn.get_range(&range, 1, false).await;
+				let entries = crate::fdb::retry!(result);
 				let Some(entry) = entries.first() else {
 					return Ok(ControlFlow::Break(None));
 				};
@@ -139,7 +141,7 @@ impl Index {
 		let transaction_id = {
 			let result = future::try_join_all(futures).await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -163,7 +165,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let identity = Self::log_compaction_identity_key(&entry.process);
 		let identity_key = Self::pack(subspace, &identity);
-		let value = crate::fdb::retry!(txn.get(&identity_key, false).await);
+		let result = txn.get(&identity_key, false).await;
+		let value = crate::fdb::retry!(result);
 		let Some(value) = value else {
 			return Ok(ControlFlow::Break(()));
 		};
@@ -197,7 +200,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let identity = Self::log_compaction_identity_key(process);
 		let identity_key = Self::pack(subspace, &identity);
-		let exists = crate::fdb::retry!(txn.get(&identity_key, false).await).is_some();
+		let result = txn.get(&identity_key, false).await;
+		let exists = crate::fdb::retry!(result).is_some();
 		if exists {
 			return Ok(ControlFlow::Break(()));
 		}

--- a/packages/index/src/fdb/log.rs
+++ b/packages/index/src/fdb/log.rs
@@ -4,6 +4,7 @@ use {
 	foundationdb_tuple::{self as fdbt, Subspace},
 	futures::future,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -56,7 +57,7 @@ impl Index {
 		batch_size: usize,
 		partition_start: u64,
 		partition_end: u64,
-	) -> crate::fdb::Result<Vec<crate::log::Entry>> {
+	) -> tg::Result<ControlFlow<Vec<crate::log::Entry>, fdb::FdbError>> {
 		let key_kind = KeyKind::LogCompactionVersion.to_i32().unwrap();
 		let mut output = Vec::new();
 		for partition in partition_start..partition_end {
@@ -73,7 +74,7 @@ impl Index {
 				mode: fdb::options::StreamingMode::WantAll,
 				..Default::default()
 			};
-			let entries = txn.get_range(&range, 1, false).await?;
+			let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 			for entry in entries {
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::LogCompaction(Key::Version {
@@ -82,7 +83,7 @@ impl Index {
 					version,
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected log compaction key"));
+					return Err(tg::error!("unexpected log compaction key"));
 				};
 				let version = crate::log::Version::new(*version.as_bytes());
 				output.push(crate::log::Entry {
@@ -92,7 +93,7 @@ impl Index {
 			}
 		}
 
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	pub async fn try_get_oldest_log_compaction_transaction_id(&self) -> tg::Result<Option<u64>> {
@@ -109,7 +110,7 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<u64>> {
+	) -> tg::Result<ControlFlow<Option<u64>, fdb::FdbError>> {
 		let key_kind = KeyKind::LogCompactionVersion.to_i32().unwrap();
 		let futures = (0..partition_total).map(|partition| {
 			let begin = Self::pack(subspace, &(key_kind, partition));
@@ -122,53 +123,62 @@ impl Index {
 				..Default::default()
 			};
 			async move {
-				let entries = txn.get_range(&range, 1, false).await?;
+				let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 				let Some(entry) = entries.first() else {
-					return Ok(None);
+					return Ok(ControlFlow::Break(None));
 				};
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::LogCompaction(Key::Version { version, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected log compaction key"));
+					return Err(tg::error!("unexpected log compaction key"));
 				};
 				let transaction_id =
 					u64::from_be_bytes(version.as_bytes()[..8].try_into().unwrap());
-				Ok(Some(transaction_id))
+				Ok(ControlFlow::Break(Some(transaction_id)))
 			}
 		});
-		let transaction_id = future::try_join_all(futures)
-			.await?
-			.into_iter()
-			.flatten()
-			.min();
+		let transaction_id = {
+			let result = future::try_join_all(futures).await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		}
+		.into_iter()
+		.flatten()
+		.min();
 
-		Ok(transaction_id)
+		Ok(ControlFlow::Break(transaction_id))
 	}
 
 	pub(super) async fn complete_log_compaction_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		entry: &crate::log::Entry,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let identity = Self::log_compaction_identity_key(&entry.process);
 		let identity_key = Self::pack(subspace, &identity);
-		let value = txn.get(&identity_key, false).await?;
+		let value = crate::fdb::retry!(txn.get(&identity_key, false).await);
 		let Some(value) = value else {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		};
-		let (partition, version) =
-			fdbt::unpack::<(u64, fdbt::Versionstamp)>(&value).map_err(|error| {
-				crate::fdb::error!(!error, "failed to unpack the log compaction identity")
-			})?;
+		let (partition, version) = fdbt::unpack::<(u64, fdbt::Versionstamp)>(&value)
+			.map_err(|error| tg::error!(!error, "failed to unpack the log compaction identity"))?;
 		let (entry_partition, entry_version) = match &entry.position {
 			crate::log::Position::Fdb { partition, version } => (*partition, *version),
 			#[cfg(feature = "lmdb")]
 			crate::log::Position::Lmdb { .. } => {
-				return Err(crate::fdb::error!("unexpected log compaction position"));
+				return Err(tg::error!("unexpected log compaction position"));
 			},
 		};
 		let entry_version = fdbt::Versionstamp::from(*entry_version.bytes());
 		if partition != entry_partition || version != entry_version {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 
 		txn.clear(&identity_key);
@@ -176,7 +186,7 @@ impl Index {
 		let version = Self::pack(subspace, &version);
 		txn.clear(&version);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(super) async fn enqueue_log_compaction_with_transaction(
@@ -184,12 +194,12 @@ impl Index {
 		subspace: &Subspace,
 		process: &tg::process::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let identity = Self::log_compaction_identity_key(process);
 		let identity_key = Self::pack(subspace, &identity);
-		let exists = txn.get(&identity_key, false).await?.is_some();
+		let exists = crate::fdb::retry!(txn.get(&identity_key, false).await).is_some();
 		if exists {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 
 		let partition = rand::random_range(0..partition_total);
@@ -209,7 +219,7 @@ impl Index {
 			fdb::options::MutationType::SetVersionstampedKey,
 		);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	fn log_compaction_identity_key(process: &tg::process::Id) -> crate::fdb::Key {

--- a/packages/index/src/fdb/node/get.rs
+++ b/packages/index/src/fdb/node/get.rs
@@ -34,7 +34,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -79,7 +79,7 @@ impl Index {
 				}))
 				.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -158,7 +158,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -230,7 +230,8 @@ impl Index {
 			},
 		};
 		let key = Self::pack(subspace, &key);
-		let value = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let value = crate::fdb::retry!(result);
 		let id = value.map(|_| id.clone());
 
 		Ok(ControlFlow::Break(id))
@@ -286,7 +287,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<tg::Id>, fdb::FdbError>> {
 		let key = Key::Node(crate::fdb::node::Key::Node(specifier.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};

--- a/packages/index/src/fdb/node/get.rs
+++ b/packages/index/src/fdb/node/get.rs
@@ -2,6 +2,7 @@ use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -25,13 +26,27 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::Id],
-	) -> crate::fdb::Result<Vec<bool>> {
-		futures::future::try_join_all(ids.iter().map(|id| async move {
-			Self::try_resolve_id_with_transaction(txn, subspace, id)
-				.await
-				.map(|id| id.is_some())
-		}))
-		.await
+	) -> tg::Result<ControlFlow<Vec<bool>, fdb::FdbError>> {
+		let ids = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_resolve_id_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+		let output = ids.into_iter().map(|id| id.is_some()).collect();
+
+		Ok(ControlFlow::Break(output))
 	}
 
 	pub async fn try_get_ids_for_specifiers(
@@ -56,13 +71,26 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		specifiers: &[tg::Specifier],
-	) -> crate::fdb::Result<Vec<Option<tg::Id>>> {
-		futures::future::try_join_all(
-			specifiers
-				.iter()
-				.map(|specifier| Self::try_get_node_with_transaction(txn, subspace, specifier)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<tg::Id>>, fdb::FdbError>> {
+		let ids = {
+			let result =
+				futures::future::try_join_all(specifiers.iter().map(|specifier| {
+					Self::try_get_node_with_transaction(txn, subspace, specifier)
+				}))
+				.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(ids))
 	}
 
 	pub async fn try_get_specifiers_for_ids(
@@ -87,136 +115,155 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::Id],
-	) -> crate::fdb::Result<Vec<Option<tg::Specifier>>> {
-		futures::future::try_join_all(ids.iter().map(|id| async move {
-			match id.kind() {
-				tg::id::Kind::Group => Self::try_get_group_with_transaction(
-					txn,
-					subspace,
-					&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-				)
-				.await
-				.map(|group| group.map(|group| group.specifier)),
-				tg::id::Kind::Organization => Self::try_get_organization_with_transaction(
-					txn,
-					subspace,
-					&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-				)
-				.await
-				.map(|organization| organization.map(|organization| organization.specifier)),
-				tg::id::Kind::Tag => Self::try_get_tag_with_transaction(
-					txn,
-					subspace,
-					&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-				)
-				.await
-				.map(|tag| tag.map(|tag| tag.specifier)),
-				tg::id::Kind::User => Self::try_get_user_with_transaction(
-					txn,
-					subspace,
-					&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-				)
-				.await
-				.map(|user| user.map(|user| user.specifier)),
-				_ => Ok(None),
+	) -> tg::Result<ControlFlow<Vec<Option<tg::Specifier>>, fdb::FdbError>> {
+		let specifiers = {
+			let result = futures::future::try_join_all(ids.iter().map(|id| async move {
+				let specifier = match id.kind() {
+					tg::id::Kind::Group => crate::fdb::propagate!(
+						Self::try_get_group_with_transaction(
+							txn,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					)
+					.map(|group| group.specifier),
+					tg::id::Kind::Organization => crate::fdb::propagate!(
+						Self::try_get_organization_with_transaction(
+							txn,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					)
+					.map(|organization| organization.specifier),
+					tg::id::Kind::Tag => crate::fdb::propagate!(
+						Self::try_get_tag_with_transaction(txn, subspace, &id.clone().try_into()?,)
+							.await
+					)
+					.map(|tag| tag.specifier),
+					tg::id::Kind::User => crate::fdb::propagate!(
+						Self::try_get_user_with_transaction(
+							txn,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					)
+					.map(|user| user.specifier),
+					_ => None,
+				};
+
+				Ok::<_, tg::Error>(ControlFlow::Break(specifier))
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
 			}
-		}))
-		.await
+			values
+		};
+
+		Ok(ControlFlow::Break(specifiers))
 	}
 
 	pub(crate) async fn try_resolve_resource_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		resource: &tg::Selector<tg::Id>,
-	) -> crate::fdb::Result<Option<(tg::Id, bool)>> {
-		match resource {
-			tg::Selector::Id(id) => Self::try_resolve_id_with_transaction(txn, subspace, id)
-				.await
-				.map(|id| id.map(|id| (id, true))),
+	) -> tg::Result<ControlFlow<Option<(tg::Id, bool)>, fdb::FdbError>> {
+		let output = match resource {
+			tg::Selector::Id(id) => crate::fdb::propagate!(
+				Self::try_resolve_id_with_transaction(txn, subspace, id).await
+			)
+			.map(|id| (id, true)),
 			tg::Selector::Specifier(specifier) => {
 				// Resolve the deepest existing prefix of the specifier.
 				let mut prefixes = specifier.prefixes().collect::<Vec<_>>();
 				prefixes.reverse();
 				for prefix in &prefixes {
-					let id = Self::try_get_node_with_transaction(txn, subspace, prefix).await?;
+					let id = crate::fdb::propagate!(
+						Self::try_get_node_with_transaction(txn, subspace, prefix).await
+					);
 					if let Some(id) = id {
 						let exact = prefix == specifier;
-						return Ok(Some((id, exact)));
+						return Ok(ControlFlow::Break(Some((id, exact))));
 					}
 				}
-				Ok(None)
+				None
 			},
-		}
+		};
+
+		Ok(ControlFlow::Break(output))
 	}
 
 	async fn try_resolve_id_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::Id,
-	) -> crate::fdb::Result<Option<tg::Id>> {
+	) -> tg::Result<ControlFlow<Option<tg::Id>, fdb::FdbError>> {
 		let key = match id.kind {
-			tg::id::Kind::User => Key::User(crate::fdb::user::Key::User(
-				id.clone().try_into().map_err(crate::fdb::custom_error)?,
-			)),
-			tg::id::Kind::Group => Key::Group(crate::fdb::group::Key::Group(
-				id.clone().try_into().map_err(crate::fdb::custom_error)?,
-			)),
-			tg::id::Kind::Organization => {
-				Key::Organization(crate::fdb::organization::Key::Organization(
-					id.clone().try_into().map_err(crate::fdb::custom_error)?,
-				))
+			tg::id::Kind::User => Key::User(crate::fdb::user::Key::User(id.clone().try_into()?)),
+			tg::id::Kind::Group => {
+				Key::Group(crate::fdb::group::Key::Group(id.clone().try_into()?))
 			},
-			tg::id::Kind::Tag => Key::Tag(crate::fdb::tag::Key::Tag(
-				id.clone().try_into().map_err(crate::fdb::custom_error)?,
-			)),
-			tg::id::Kind::Process => Key::Process(crate::fdb::process::Key::Process(
-				id.clone().try_into().map_err(crate::fdb::custom_error)?,
-			)),
-			tg::id::Kind::Sandbox => Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(
-				id.clone().try_into().map_err(crate::fdb::custom_error)?,
-			)),
+			tg::id::Kind::Organization => Key::Organization(
+				crate::fdb::organization::Key::Organization(id.clone().try_into()?),
+			),
+			tg::id::Kind::Tag => Key::Tag(crate::fdb::tag::Key::Tag(id.clone().try_into()?)),
+			tg::id::Kind::Process => {
+				Key::Process(crate::fdb::process::Key::Process(id.clone().try_into()?))
+			},
+			tg::id::Kind::Sandbox => {
+				Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone().try_into()?))
+			},
 			_ => {
 				let Ok(object) = tg::object::Id::try_from(id.clone()) else {
-					return Ok(None);
+					return Ok(ControlFlow::Break(None));
 				};
 				Key::Object(crate::fdb::object::Key::Object(object))
 			},
 		};
 		let key = Self::pack(subspace, &key);
-		let value = txn.get(&key, false).await?;
-		Ok(value.map(|_| id.clone()))
+		let value = crate::fdb::retry!(txn.get(&key, false).await);
+		let id = value.map(|_| id.clone());
+
+		Ok(ControlFlow::Break(id))
 	}
 
 	pub(crate) async fn ancestor_ids_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::Id,
-	) -> crate::fdb::Result<Vec<tg::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::Id>, fdb::FdbError>> {
 		let mut ids = Vec::new();
 		let mut current = Some(id.clone());
 		while let Some(id) = current {
 			match id.kind {
 				tg::id::Kind::Tag => {
-					let Some(tag) = Self::try_get_tag_with_transaction(
-						txn,
-						subspace,
-						&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-					)
-					.await?
-					else {
+					let Some(tag) = crate::fdb::propagate!(
+						Self::try_get_tag_with_transaction(txn, subspace, &id.clone().try_into()?,)
+							.await
+					) else {
 						break;
 					};
 					ids.push(id);
 					current = tag.parent;
 				},
 				tg::id::Kind::Group => {
-					let Some(group) = Self::try_get_group_with_transaction(
-						txn,
-						subspace,
-						&id.clone().try_into().map_err(crate::fdb::custom_error)?,
-					)
-					.await?
-					else {
+					let Some(group) = crate::fdb::propagate!(
+						Self::try_get_group_with_transaction(
+							txn,
+							subspace,
+							&id.clone().try_into()?,
+						)
+						.await
+					) else {
 						break;
 					};
 					ids.push(id);
@@ -229,22 +276,22 @@ impl Index {
 				_ => break,
 			}
 		}
-		Ok(ids)
+		Ok(ControlFlow::Break(ids))
 	}
 
 	pub(crate) async fn try_get_node_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		specifier: &tg::Specifier,
-	) -> crate::fdb::Result<Option<tg::Id>> {
+	) -> tg::Result<ControlFlow<Option<tg::Id>, fdb::FdbError>> {
 		let key = Key::Node(crate::fdb::node::Key::Node(specifier.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
 		let id = tg::Id::from_slice(&bytes)
-			.map_err(|error| crate::fdb::error!(!error, "failed to deserialize the node id"))?;
-		Ok(Some(id))
+			.map_err(|error| tg::error!(!error, "failed to deserialize the node id"))?;
+		Ok(ControlFlow::Break(Some(id)))
 	}
 }

--- a/packages/index/src/fdb/object/get.rs
+++ b/packages/index/src/fdb/object/get.rs
@@ -38,7 +38,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -59,7 +59,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::object::Object>, fdb::FdbError>> {
 		let key = Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};
@@ -82,7 +83,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let children = entries
 			.iter()
@@ -112,7 +114,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let parents = entries
 			.iter()
@@ -143,7 +146,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let processes = entries
 			.iter()

--- a/packages/index/src/fdb/object/get.rs
+++ b/packages/index/src/fdb/object/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -29,35 +30,49 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::object::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::object::Object>>> {
-		futures::future::try_join_all(
-			ids.iter()
-				.map(|id| Self::try_get_object_with_transaction(txn, subspace, id)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::object::Object>>, fdb::FdbError>> {
+		let objects = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_object_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(objects))
 	}
 
 	pub(crate) async fn try_get_object_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::object::Id,
-	) -> crate::fdb::Result<Option<crate::object::Object>> {
+	) -> tg::Result<ControlFlow<Option<crate::object::Object>, fdb::FdbError>> {
 		let key = Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::object::Object::deserialize(&bytes).map_err(crate::fdb::custom_error)?,
-		))
+		let object = Some(crate::object::Object::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(object))
 	}
 
 	pub(crate) async fn get_object_children_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::object::Id,
-	) -> crate::fdb::Result<Vec<tg::object::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::object::Id>, fdb::FdbError>> {
 		let bytes = id.to_bytes();
 		let key = (Kind::ObjectChild.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -67,27 +82,27 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let children = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Object(crate::fdb::object::Key::ObjectChild { child, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(children)
+		Ok(ControlFlow::Break(children))
 	}
 
 	pub(crate) async fn get_object_parents_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::object::Id,
-	) -> crate::fdb::Result<Vec<tg::object::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::object::Id>, fdb::FdbError>> {
 		let bytes = id.to_bytes();
 		let key = (Kind::ChildObject.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -97,27 +112,28 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let parents = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Object(crate::fdb::object::Key::ChildObject { object, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(object)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(parents)
+		Ok(ControlFlow::Break(parents))
 	}
 
 	pub(crate) async fn get_object_processes_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::object::Id,
-	) -> crate::fdb::Result<Vec<(tg::process::Id, crate::process::object::Kind)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::process::Id, crate::process::object::Kind)>, fdb::FdbError>>
+	{
 		let bytes = id.to_bytes();
 		let key = (Kind::ObjectProcess.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -127,7 +143,7 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let processes = entries
 			.iter()
@@ -135,12 +151,12 @@ impl Index {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Object(crate::fdb::object::Key::ObjectProcess { kind, process, .. }) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok((process, kind))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(processes)
+		Ok(ControlFlow::Break(processes))
 	}
 }

--- a/packages/index/src/fdb/object/put.rs
+++ b/packages/index/src/fdb/object/put.rs
@@ -19,7 +19,8 @@ impl Index {
 		let existing = if arg.complete() {
 			None
 		} else {
-			crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			crate::fdb::retry!(result)
 				.and_then(|bytes| crate::object::Object::deserialize(&bytes).ok())
 		};
 

--- a/packages/index/src/fdb/object/put.rs
+++ b/packages/index/src/fdb/object/put.rs
@@ -1,6 +1,7 @@
 use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -10,7 +11,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		arg: &crate::object::put::Arg,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let id = &arg.id;
 		let key = Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
@@ -18,8 +19,7 @@ impl Index {
 		let existing = if arg.complete() {
 			None
 		} else {
-			txn.get(&key, false)
-				.await?
+			crate::fdb::retry!(txn.get(&key, false).await)
 				.and_then(|bytes| crate::object::Object::deserialize(&bytes).ok())
 		};
 
@@ -58,7 +58,7 @@ impl Index {
 				|| existing.stored != stored
 		});
 		if !changed && !touch {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 
 		let value = crate::object::Object {
@@ -68,8 +68,7 @@ impl Index {
 			stored,
 			touched_at,
 		}
-		.serialize()
-		.map_err(crate::fdb::custom_error)?;
+		.serialize()?;
 
 		if existing.is_none() {
 			txn.set_option(fdb::options::TransactionOption::NextWriteNoWriteConflictRange)
@@ -136,17 +135,19 @@ impl Index {
 				&tg::Either::Left(id.clone()),
 				partition_total,
 			);
-			Self::enqueue_account_object_from_parents(
-				txn,
-				subspace,
-				id,
-				partition_total,
-				touched_at,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::enqueue_account_object_from_parents(
+					txn,
+					subspace,
+					id,
+					partition_total,
+					touched_at,
+				)
+				.await
+			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn put_objects_with_transaction(
@@ -154,10 +155,10 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		args: &[crate::object::put::Arg],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for object in args {
-			Self::put_object(txn, subspace, object, partition_total).await?;
+			crate::fdb::propagate!(Self::put_object(txn, subspace, object, partition_total).await);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/object/touch.rs
+++ b/packages/index/src/fdb/object/touch.rs
@@ -123,7 +123,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -147,7 +147,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::object::Object>, fdb::FdbError>> {
 		let key = Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let existing = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let existing = crate::fdb::retry!(result);
 		let existing = existing
 			.as_ref()
 			.map(|bytes| crate::object::Object::deserialize(bytes))
@@ -162,11 +163,8 @@ impl Index {
 
 		let mut key_end = key.clone();
 		key_end.push(0x00);
-		crate::fdb::retry!(txn.add_conflict_range(
-			&key,
-			&key_end,
-			fdb::options::ConflictRangeType::Read,
-		));
+		let result = txn.add_conflict_range(&key, &key_end, fdb::options::ConflictRangeType::Read);
+		crate::fdb::retry!(result);
 
 		object.touched_at = object.touched_at.max(touched_at);
 		let value = object

--- a/packages/index/src/fdb/object/touch.rs
+++ b/packages/index/src/fdb/object/touch.rs
@@ -3,7 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	futures::future,
-	std::time::Duration,
+	std::{ops::ControlFlow, time::Duration},
 	tangram_client::prelude::*,
 };
 
@@ -49,42 +49,53 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Vec<Option<crate::object::Object>>> {
-		let objects = Self::touch_objects_with_transaction(
-			txn,
-			subspace,
-			ids,
-			touched_at,
-			time_to_touch,
-			partition_total,
-		)
-		.await?;
-		if let Some(account) = account {
-			future::try_join_all(
-				std::iter::zip(ids, &objects)
-					.filter(|(_, object)| object.is_some())
-					.map(|(id, _)| {
-						let arg = crate::usage::storage::put::ObjectArg {
-							account: account.clone(),
-							object: id.clone(),
-							touched_at,
-						};
-						async move {
-							Self::touch_account_object(
-								txn,
-								subspace,
-								&arg,
-								time_to_touch,
-								partition_total,
-							)
-							.await
-						}
-					}),
+	) -> tg::Result<ControlFlow<Vec<Option<crate::object::Object>>, fdb::FdbError>> {
+		let objects = crate::fdb::propagate!(
+			Self::touch_objects_with_transaction(
+				txn,
+				subspace,
+				ids,
+				touched_at,
+				time_to_touch,
+				partition_total,
 			)
-			.await?;
+			.await
+		);
+		if let Some(account) = account {
+			{
+				let result = future::try_join_all(
+					std::iter::zip(ids, &objects)
+						.filter(|(_, object)| object.is_some())
+						.map(|(id, _)| {
+							let arg = crate::usage::storage::put::ObjectArg {
+								account: account.clone(),
+								object: id.clone(),
+								touched_at,
+							};
+							async move {
+								Self::touch_account_object(
+									txn,
+									subspace,
+									&arg,
+									time_to_touch,
+									partition_total,
+								)
+								.await
+							}
+						}),
+				)
+				.await;
+				let results = result?;
+				for result in results {
+					match result {
+						ControlFlow::Break(()) => {},
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					}
+				}
+			};
 		}
 
-		Ok(objects)
+		Ok(ControlFlow::Break(objects))
 	}
 
 	pub(crate) async fn touch_objects_with_transaction(
@@ -94,22 +105,36 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Vec<Option<crate::object::Object>>> {
-		future::try_join_all(ids.iter().map(|id| {
-			let subspace = subspace.clone();
-			async move {
-				Self::touch_object_with_transaction(
-					txn,
-					&subspace,
-					id,
-					touched_at,
-					time_to_touch,
-					partition_total,
-				)
-				.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::object::Object>>, fdb::FdbError>> {
+		let objects = {
+			let result = future::try_join_all(ids.iter().map(|id| {
+				let subspace = subspace.clone();
+				async move {
+					Self::touch_object_with_transaction(
+						txn,
+						&subspace,
+						id,
+						touched_at,
+						time_to_touch,
+						partition_total,
+					)
+					.await
+				}
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
 			}
-		}))
-		.await
+			values
+		};
+
+		Ok(ControlFlow::Break(objects))
 	}
 
 	async fn touch_object_with_transaction(
@@ -119,31 +144,34 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<crate::object::Object>> {
+	) -> tg::Result<ControlFlow<Option<crate::object::Object>, fdb::FdbError>> {
 		let key = Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let existing = txn.get(&key, false).await?;
+		let existing = crate::fdb::retry!(txn.get(&key, false).await);
 		let existing = existing
 			.as_ref()
 			.map(|bytes| crate::object::Object::deserialize(bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 		let Some(mut object) = existing else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
 		let time_to_touch = i64::try_from(time_to_touch.as_secs()).unwrap();
 		if touched_at - object.touched_at < time_to_touch {
-			return Ok(Some(object));
+			return Ok(ControlFlow::Break(Some(object)));
 		}
 
 		let mut key_end = key.clone();
 		key_end.push(0x00);
-		txn.add_conflict_range(&key, &key_end, fdb::options::ConflictRangeType::Read)?;
+		crate::fdb::retry!(txn.add_conflict_range(
+			&key,
+			&key_end,
+			fdb::options::ConflictRangeType::Read,
+		));
 
 		object.touched_at = object.touched_at.max(touched_at);
 		let value = object
 			.serialize()
-			.map_err(|error| crate::fdb::error!(!error, "failed to serialize the object"))?;
+			.map_err(|error| tg::error!(!error, "failed to serialize the object"))?;
 		txn.set(&key, &value);
 		if object.reference_count == 0 {
 			let id_bytes = id.to_bytes();
@@ -159,6 +187,6 @@ impl Index {
 			txn.set(&key, &[]);
 		}
 
-		Ok(Some(object))
+		Ok(ControlFlow::Break(Some(object)))
 	}
 }

--- a/packages/index/src/fdb/organization/delete.rs
+++ b/packages/index/src/fdb/organization/delete.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -38,16 +39,13 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		ids: &[tg::organization::Id],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for id in ids {
 			let key = Key::Organization(crate::fdb::organization::Key::Organization(id.clone()));
 			let key = Self::pack(subspace, &key);
-			let organization = txn
-				.get(&key, false)
-				.await?
+			let organization = crate::fdb::retry!(txn.get(&key, false).await)
 				.map(|bytes| crate::organization::Organization::deserialize(&bytes))
-				.transpose()
-				.map_err(crate::fdb::custom_error)?;
+				.transpose()?;
 			if let Some(organization) = organization {
 				let node_key = Key::Node(crate::fdb::node::Key::Node(organization.specifier));
 				let node_key = Self::pack(subspace, &node_key);
@@ -55,14 +53,14 @@ impl Index {
 			}
 			txn.clear(&key);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) fn delete_organization_members_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::organization::member::delete::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::Organization(crate::fdb::organization::Key::OrganizationMember {
 				organization: arg.organization.clone(),
@@ -78,6 +76,6 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/organization/delete.rs
+++ b/packages/index/src/fdb/organization/delete.rs
@@ -43,7 +43,8 @@ impl Index {
 		for id in ids {
 			let key = Key::Organization(crate::fdb::organization::Key::Organization(id.clone()));
 			let key = Self::pack(subspace, &key);
-			let organization = crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			let organization = crate::fdb::retry!(result)
 				.map(|bytes| crate::organization::Organization::deserialize(&bytes))
 				.transpose()?;
 			if let Some(organization) = organization {

--- a/packages/index/src/fdb/organization/get.rs
+++ b/packages/index/src/fdb/organization/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -29,36 +30,49 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::organization::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::organization::Organization>>> {
-		futures::future::try_join_all(
-			ids.iter()
-				.map(|id| Self::try_get_organization_with_transaction(txn, subspace, id)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::organization::Organization>>, fdb::FdbError>> {
+		let organizations = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_organization_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(organizations))
 	}
 
 	pub(crate) async fn try_get_organization_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::organization::Id,
-	) -> crate::fdb::Result<Option<crate::organization::Organization>> {
+	) -> tg::Result<ControlFlow<Option<crate::organization::Organization>, fdb::FdbError>> {
 		let key = Key::Organization(crate::fdb::organization::Key::Organization(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::organization::Organization::deserialize(&bytes)
-				.map_err(crate::fdb::custom_error)?,
-		))
+		let organization = Some(crate::organization::Organization::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(organization))
 	}
 
 	pub(crate) async fn get_organization_members_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		organization: &tg::organization::Id,
-	) -> crate::fdb::Result<Vec<tg::organization::Member>> {
+	) -> tg::Result<ControlFlow<Vec<tg::organization::Member>, fdb::FdbError>> {
 		let bytes = tg::Id::from(organization.clone()).to_bytes();
 		let key = (Kind::OrganizationMember.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -68,7 +82,7 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let members = entries
 			.iter()
@@ -79,20 +93,20 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(member)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(members)
+		Ok(ControlFlow::Break(members))
 	}
 
 	pub(crate) async fn get_member_organizations_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		member: &tg::Id,
-	) -> crate::fdb::Result<Vec<tg::organization::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::organization::Id>, fdb::FdbError>> {
 		let bytes = member.to_bytes();
 		let key = (Kind::MemberOrganization.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -102,7 +116,7 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let organizations = entries
 			.iter()
@@ -113,12 +127,12 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(organization)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(organizations)
+		Ok(ControlFlow::Break(organizations))
 	}
 }

--- a/packages/index/src/fdb/organization/get.rs
+++ b/packages/index/src/fdb/organization/get.rs
@@ -38,7 +38,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -59,7 +59,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::organization::Organization>, fdb::FdbError>> {
 		let key = Key::Organization(crate::fdb::organization::Key::Organization(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};
@@ -82,7 +83,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let members = entries
 			.iter()
@@ -116,7 +118,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let organizations = entries
 			.iter()

--- a/packages/index/src/fdb/organization/put.rs
+++ b/packages/index/src/fdb/organization/put.rs
@@ -47,14 +47,14 @@ impl Index {
 			let key =
 				Key::Organization(crate::fdb::organization::Key::Organization(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
-			let billing = match arg.billing {
-				Some(billing) => billing,
-				None => {
-					crate::fdb::retry!(txn.get(&key, false).await).map_or(Ok(false), |bytes| {
-						crate::organization::Organization::deserialize(&bytes)
-							.map(|organization| organization.billing)
-					})?
-				},
+			let billing = if let Some(billing) = arg.billing {
+				billing
+			} else {
+				let result = txn.get(&key, false).await;
+				crate::fdb::retry!(result).map_or(Ok(false), |bytes| {
+					crate::organization::Organization::deserialize(&bytes)
+						.map(|organization| organization.billing)
+				})?
 			};
 			let value = crate::organization::Organization {
 				billing,

--- a/packages/index/src/fdb/organization/put.rs
+++ b/packages/index/src/fdb/organization/put.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -41,28 +42,25 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::organization::put::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key =
 				Key::Organization(crate::fdb::organization::Key::Organization(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
 			let billing = match arg.billing {
 				Some(billing) => billing,
-				None => txn
-					.get(&key, false)
-					.await?
-					.map_or(Ok(false), |bytes| {
+				None => {
+					crate::fdb::retry!(txn.get(&key, false).await).map_or(Ok(false), |bytes| {
 						crate::organization::Organization::deserialize(&bytes)
 							.map(|organization| organization.billing)
-					})
-					.map_err(crate::fdb::custom_error)?,
+					})?
+				},
 			};
 			let value = crate::organization::Organization {
 				billing,
 				specifier: arg.specifier.clone(),
 			}
-			.serialize()
-			.map_err(crate::fdb::custom_error)?;
+			.serialize()?;
 			txn.set(&key, &value);
 
 			let key = Key::Node(crate::fdb::node::Key::Node(arg.specifier.clone()));
@@ -70,14 +68,14 @@ impl Index {
 			let value = tg::Id::from(arg.id.clone()).to_bytes();
 			txn.set(&key, value.as_ref());
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) fn put_organization_members_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::organization::member::put::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::Organization(crate::fdb::organization::Key::OrganizationMember {
 				organization: arg.organization.clone(),
@@ -93,6 +91,6 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.set(&key, &[]);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/process/get.rs
+++ b/packages/index/src/fdb/process/get.rs
@@ -4,7 +4,7 @@ use {
 	foundationdb_tuple::Subspace,
 	futures::TryStreamExt as _,
 	num_traits::ToPrimitive as _,
-	std::collections::BTreeSet,
+	std::{collections::BTreeSet, ops::ControlFlow},
 	tangram_client::prelude::*,
 };
 
@@ -47,7 +47,7 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		command: &tg::object::Id,
-	) -> crate::fdb::Result<Vec<(tg::process::Id, crate::process::Process)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::process::Id, crate::process::Process)>, fdb::FdbError>> {
 		let command_bytes = command.to_bytes();
 		let prefix = (
 			Kind::CommandCacheableProcess.to_i32().unwrap(),
@@ -59,7 +59,7 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let processes = entries
 			.iter()
 			.map(|entry| {
@@ -68,17 +68,17 @@ impl Index {
 					process, ..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(process)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		drop(entries);
 		let mut output = Vec::new();
 		for process in processes {
-			let Some(data) =
-				Self::try_get_process_with_transaction(txn, subspace, &process).await?
-			else {
+			let Some(data) = crate::fdb::propagate!(
+				Self::try_get_process_with_transaction(txn, subspace, &process).await
+			) else {
 				continue;
 			};
 			if data.data.is_none() {
@@ -91,7 +91,7 @@ impl Index {
 			let b_created_at = b.data.as_ref().unwrap().created_at;
 			a_created_at.cmp(&b_created_at).then_with(|| a_id.cmp(b_id))
 		});
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	pub async fn process_has_ancestor(
@@ -119,26 +119,37 @@ impl Index {
 		subspace: &Subspace,
 		process: &tg::process::Id,
 		ancestor: &tg::process::Id,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let mut seen = BTreeSet::from([process.clone()]);
 		let mut frontier = vec![process.clone()];
 		while !frontier.is_empty() {
-			let parents =
-				futures::future::try_join_all(frontier.iter().map(|process| {
+			let parents = {
+				let result = futures::future::try_join_all(frontier.iter().map(|process| {
 					Self::get_process_parents_with_transaction(txn, subspace, process)
 				}))
-				.await?;
+				.await;
+				let results = result?;
+				let mut values = Vec::new();
+				for result in results {
+					let value = match result {
+						ControlFlow::Break(value) => value,
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					};
+					values.push(value);
+				}
+				values
+			};
 			frontier = Vec::new();
 			for parent in parents.into_iter().flatten() {
 				if &parent == ancestor {
-					return Ok(true);
+					return Ok(ControlFlow::Break(true));
 				}
 				if seen.insert(parent.clone()) {
 					frontier.push(parent);
 				}
 			}
 		}
-		Ok(false)
+		Ok(ControlFlow::Break(false))
 	}
 
 	pub async fn try_get_processes(
@@ -163,35 +174,49 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::process::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::process::Process>>> {
-		futures::future::try_join_all(
-			ids.iter()
-				.map(|id| Self::try_get_process_with_transaction(txn, subspace, id)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::process::Process>>, fdb::FdbError>> {
+		let processes = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_process_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(processes))
 	}
 
 	pub(crate) async fn try_get_process_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::process::Id,
-	) -> crate::fdb::Result<Option<crate::process::Process>> {
+	) -> tg::Result<ControlFlow<Option<crate::process::Process>, fdb::FdbError>> {
 		let key = Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::process::Process::deserialize(&bytes).map_err(crate::fdb::custom_error)?,
-		))
+		let process = Some(crate::process::Process::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(process))
 	}
 
 	pub(crate) async fn get_process_children_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::process::Id,
-	) -> crate::fdb::Result<Vec<tg::process::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::process::Id>, fdb::FdbError>> {
 		let bytes = id.to_bytes();
 		let key = (Kind::ProcessChild.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -201,23 +226,24 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn
-			.get_ranges_keyvalues(range, false)
-			.try_collect::<Vec<_>>()
-			.await?;
+		let entries = crate::fdb::retry!(
+			txn.get_ranges_keyvalues(range, false)
+				.try_collect::<Vec<_>>()
+				.await
+		);
 
 		let children = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Process(crate::fdb::process::Key::ProcessChild { child, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(children)
+		Ok(ControlFlow::Break(children))
 	}
 
 	pub(crate) async fn try_get_process_children_page_with_transaction(
@@ -226,16 +252,18 @@ impl Index {
 		id: &tg::process::Id,
 		position: std::io::SeekFrom,
 		length: u64,
-	) -> crate::fdb::Result<Option<Vec<tg::process::data::Child>>> {
-		let Some(_) = Self::try_get_process_with_transaction(txn, subspace, id).await? else {
-			return Ok(None);
+	) -> tg::Result<ControlFlow<Option<Vec<tg::process::data::Child>>, fdb::FdbError>> {
+		let Some(_) =
+			crate::fdb::propagate!(Self::try_get_process_with_transaction(txn, subspace, id).await)
+		else {
+			return Ok(ControlFlow::Break(None));
 		};
 		if length == 0 {
-			return Ok(Some(Vec::new()));
+			return Ok(ControlFlow::Break(Some(Vec::new())));
 		}
 		let limit = length
 			.to_usize()
-			.ok_or_else(|| crate::fdb::error!("the process child length is too large"))?;
+			.ok_or_else(|| tg::error!("the process child length is too large"))?;
 		let bytes = id.to_bytes();
 		let key = (Kind::ProcessChild.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -244,15 +272,15 @@ impl Index {
 		let position = match position {
 			std::io::SeekFrom::Start(position) => position
 				.to_i64()
-				.ok_or_else(|| crate::fdb::error!("the process child position is too large"))?,
+				.ok_or_else(|| tg::error!("the process child position is too large"))?,
 			std::io::SeekFrom::End(position) => {
 				if position >= 0 {
-					return Ok(Some(Vec::new()));
+					return Ok(ControlFlow::Break(Some(Vec::new())));
 				}
 				let selector = fdb::KeySelector::last_less_than(end.clone());
-				let key = txn.get_key(&selector, false).await?;
+				let key = crate::fdb::retry!(txn.get_key(&selector, false).await);
 				if key.as_ref() < begin.as_slice() {
-					return Err(crate::fdb::error!("invalid process child position"));
+					return Err(tg::error!("invalid process child position"));
 				}
 				let key = Self::unpack(subspace, &key)?;
 				let Key::Process(crate::fdb::process::Key::ProcessChild {
@@ -260,16 +288,16 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				last_position
 					.checked_add(1)
 					.and_then(|children_length| children_length.checked_add(position))
 					.filter(|position| *position >= 0)
-					.ok_or_else(|| crate::fdb::error!("invalid process child position"))?
+					.ok_or_else(|| tg::error!("invalid process child position"))?
 			},
 			std::io::SeekFrom::Current(_) => {
-				return Err(crate::fdb::error!(
+				return Err(tg::error!(
 					"a current process child position is not supported"
 				));
 			},
@@ -289,10 +317,11 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..Default::default()
 		};
-		let entries = txn
-			.get_ranges_keyvalues(range, false)
-			.try_collect::<Vec<_>>()
-			.await?;
+		let entries = crate::fdb::retry!(
+			txn.get_ranges_keyvalues(range, false)
+				.try_collect::<Vec<_>>()
+				.await
+		);
 		let children = entries
 			.iter()
 			.enumerate()
@@ -304,35 +333,34 @@ impl Index {
 					..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				let expected_position = position
 					.checked_add(index.to_i64().unwrap())
-					.ok_or_else(|| crate::fdb::error!("invalid process child position"))?;
+					.ok_or_else(|| tg::error!("invalid process child position"))?;
 				if child_position != expected_position {
-					return Err(crate::fdb::error!("the process child position is invalid"));
+					return Err(tg::error!("the process child position is invalid"));
 				}
 				let child: tg::process::data::Child = tangram_serialize::from_slice(entry.value())
 					.map_err(|error| {
-						crate::fdb::error!(!error, "failed to deserialize the process child")
+						tg::error!(!error, "failed to deserialize the process child")
 					})?;
 				if child.process.node != child_id {
-					return Err(crate::fdb::error!(
-						"the process child value does not match its key"
-					));
+					return Err(tg::error!("the process child value does not match its key"));
 				}
 
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
-		Ok(Some(children))
+			.collect::<tg::Result<Vec<_>>>()?;
+
+		Ok(ControlFlow::Break(Some(children)))
 	}
 
 	pub(crate) async fn get_process_parents_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::process::Id,
-	) -> crate::fdb::Result<Vec<tg::process::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::process::Id>, fdb::FdbError>> {
 		let bytes = id.to_bytes();
 		let key = (Kind::ChildProcess.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -342,7 +370,7 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let parents = entries
 			.iter()
@@ -350,20 +378,21 @@ impl Index {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Process(crate::fdb::process::Key::ChildProcess { parent, .. }) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(parent)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(parents)
+		Ok(ControlFlow::Break(parents))
 	}
 
 	pub(crate) async fn get_process_objects_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::process::Id,
-	) -> crate::fdb::Result<Vec<(tg::object::Id, crate::process::object::Kind)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::object::Id, crate::process::object::Kind)>, fdb::FdbError>>
+	{
 		let bytes = id.to_bytes();
 		let key = (Kind::ProcessObject.to_i32().unwrap(), bytes.as_ref());
 		let prefix = Self::pack(subspace, &key);
@@ -373,7 +402,7 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let objects = entries
 			.iter()
@@ -382,12 +411,12 @@ impl Index {
 				let Key::Process(crate::fdb::process::Key::ProcessObject { kind, object, .. }) =
 					key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok((object, kind))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(objects)
+		Ok(ControlFlow::Break(objects))
 	}
 }

--- a/packages/index/src/fdb/process/get.rs
+++ b/packages/index/src/fdb/process/get.rs
@@ -59,7 +59,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&range_subspace)
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let processes = entries
 			.iter()
 			.map(|entry| {
@@ -129,7 +130,7 @@ impl Index {
 				}))
 				.await;
 				let results = result?;
-				let mut values = Vec::new();
+				let mut values = Vec::with_capacity(results.len());
 				for result in results {
 					let value = match result {
 						ControlFlow::Break(value) => value,
@@ -182,7 +183,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -203,7 +204,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::process::Process>, fdb::FdbError>> {
 		let key = Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};
@@ -226,11 +228,11 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(
-			txn.get_ranges_keyvalues(range, false)
-				.try_collect::<Vec<_>>()
-				.await
-		);
+		let result = txn
+			.get_ranges_keyvalues(range, false)
+			.try_collect::<Vec<_>>()
+			.await;
+		let entries = crate::fdb::retry!(result);
 
 		let children = entries
 			.iter()
@@ -278,7 +280,8 @@ impl Index {
 					return Ok(ControlFlow::Break(Some(Vec::new())));
 				}
 				let selector = fdb::KeySelector::last_less_than(end.clone());
-				let key = crate::fdb::retry!(txn.get_key(&selector, false).await);
+				let result = txn.get_key(&selector, false).await;
+				let key = crate::fdb::retry!(result);
 				if key.as_ref() < begin.as_slice() {
 					return Err(tg::error!("invalid process child position"));
 				}
@@ -317,11 +320,11 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..Default::default()
 		};
-		let entries = crate::fdb::retry!(
-			txn.get_ranges_keyvalues(range, false)
-				.try_collect::<Vec<_>>()
-				.await
-		);
+		let result = txn
+			.get_ranges_keyvalues(range, false)
+			.try_collect::<Vec<_>>()
+			.await;
+		let entries = crate::fdb::retry!(result);
 		let children = entries
 			.iter()
 			.enumerate()
@@ -370,7 +373,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let parents = entries
 			.iter()
@@ -402,7 +406,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let objects = entries
 			.iter()

--- a/packages/index/src/fdb/process/put.rs
+++ b/packages/index/src/fdb/process/put.rs
@@ -19,7 +19,8 @@ impl Index {
 		let key = Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
 
-		let existing = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let existing = crate::fdb::retry!(result)
 			.and_then(|bytes| crate::process::Process::deserialize(&bytes).ok());
 		let merge = !arg.complete();
 
@@ -158,11 +159,11 @@ impl Index {
 				mode: fdb::options::StreamingMode::WantAll,
 				..fdb::RangeOption::from(&range_subspace)
 			};
-			let entries = crate::fdb::retry!(
-				txn.get_ranges_keyvalues(range, false)
-					.try_collect::<Vec<_>>()
-					.await
-			);
+			let result = txn
+				.get_ranges_keyvalues(range, false)
+				.try_collect::<Vec<_>>()
+				.await;
+			let entries = crate::fdb::retry!(result);
 			for entry in &entries {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Process(crate::fdb::process::Key::ProcessChild { child, .. }) = key else {
@@ -206,7 +207,8 @@ impl Index {
 				parent: parent.clone(),
 			});
 			let key = Self::pack(subspace, &key);
-			let exists = crate::fdb::retry!(txn.get(&key, false).await).is_some();
+			let result = txn.get(&key, false).await;
+			let exists = crate::fdb::retry!(result).is_some();
 			if !exists {
 				let parent_bytes = parent.to_bytes();
 				let prefix = (Kind::ProcessChild.to_i32().unwrap(), parent_bytes.as_ref());
@@ -217,7 +219,8 @@ impl Index {
 					reverse: true,
 					..fdb::RangeOption::from(&fdbt::Subspace::from_bytes(prefix))
 				};
-				let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+				let result = txn.get_range(&range, 1, false).await;
+				let entries = crate::fdb::retry!(result);
 				let position = entries
 					.first()
 					.map(|entry| {

--- a/packages/index/src/fdb/process/put.rs
+++ b/packages/index/src/fdb/process/put.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	futures::TryStreamExt as _,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -12,15 +13,13 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		arg: &crate::process::put::Arg,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
-		arg.validate().map_err(crate::fdb::custom_error)?;
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
+		arg.validate()?;
 		let id = &arg.id;
 		let key = Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
 
-		let existing = txn
-			.get(&key, false)
-			.await?
+		let existing = crate::fdb::retry!(txn.get(&key, false).await)
 			.and_then(|bytes| crate::process::Process::deserialize(&bytes).ok());
 		let merge = !arg.complete();
 
@@ -89,7 +88,7 @@ impl Index {
 					|| existing.stored != stored
 			});
 		if !changed && !touch {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 
 		let value = crate::process::Process {
@@ -101,8 +100,7 @@ impl Index {
 			stored,
 			touched_at,
 		}
-		.serialize()
-		.map_err(crate::fdb::custom_error)?;
+		.serialize()?;
 		txn.set(&key, &value);
 
 		if sandbox_changed
@@ -124,13 +122,15 @@ impl Index {
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 
-			Self::decrement_sandbox_reference_count(
-				txn,
-				subspace,
-				existing_sandbox,
-				partition_total,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::decrement_sandbox_reference_count(
+					txn,
+					subspace,
+					existing_sandbox,
+					partition_total,
+				)
+				.await
+			);
 		}
 
 		if sandbox_changed && let Some(sandbox) = &sandbox {
@@ -158,14 +158,15 @@ impl Index {
 				mode: fdb::options::StreamingMode::WantAll,
 				..fdb::RangeOption::from(&range_subspace)
 			};
-			let entries = txn
-				.get_ranges_keyvalues(range, false)
-				.try_collect::<Vec<_>>()
-				.await?;
+			let entries = crate::fdb::retry!(
+				txn.get_ranges_keyvalues(range, false)
+					.try_collect::<Vec<_>>()
+					.await
+			);
 			for entry in &entries {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Process(crate::fdb::process::Key::ProcessChild { child, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				let key = Key::Process(crate::fdb::process::Key::ChildProcess {
 					child,
@@ -179,16 +180,15 @@ impl Index {
 			for (position, child) in children.iter().enumerate() {
 				let child = child.clone().without_location_and_tokens();
 				let position = i64::try_from(position)
-					.map_err(|_| crate::fdb::error!("the process has too many children"))?;
+					.map_err(|_| tg::error!("the process has too many children"))?;
 				let key = Key::Process(crate::fdb::process::Key::ProcessChild {
 					child: child.process.node.clone(),
 					position,
 					process: id.clone(),
 				});
 				let key = Self::pack(subspace, &key);
-				let value = tangram_serialize::to_vec(&child).map_err(|error| {
-					crate::fdb::error!(!error, "failed to serialize the process child")
-				})?;
+				let value = tangram_serialize::to_vec(&child)
+					.map_err(|error| tg::error!(!error, "failed to serialize the process child"))?;
 				txn.set(&key, &value);
 
 				let key = Key::Process(crate::fdb::process::Key::ChildProcess {
@@ -206,7 +206,7 @@ impl Index {
 				parent: parent.clone(),
 			});
 			let key = Self::pack(subspace, &key);
-			let exists = txn.get(&key, false).await?.is_some();
+			let exists = crate::fdb::retry!(txn.get(&key, false).await).is_some();
 			if !exists {
 				let parent_bytes = parent.to_bytes();
 				let prefix = (Kind::ProcessChild.to_i32().unwrap(), parent_bytes.as_ref());
@@ -217,7 +217,7 @@ impl Index {
 					reverse: true,
 					..fdb::RangeOption::from(&fdbt::Subspace::from_bytes(prefix))
 				};
-				let entries = txn.get_range(&range, 1, false).await?;
+				let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 				let position = entries
 					.first()
 					.map(|entry| {
@@ -226,11 +226,11 @@ impl Index {
 							position, ..
 						}) = key
 						else {
-							return Err(crate::fdb::error!("unexpected key type"));
+							return Err(tg::error!("unexpected key type"));
 						};
 						position
 							.checked_add(1)
-							.ok_or_else(|| crate::fdb::error!("the process has too many children"))
+							.ok_or_else(|| tg::error!("the process has too many children"))
 					})
 					.transpose()?
 					.unwrap_or(0);
@@ -245,9 +245,8 @@ impl Index {
 					process: parent.clone(),
 				});
 				let process_child_key = Self::pack(subspace, &process_child_key);
-				let value = tangram_serialize::to_vec(&child).map_err(|error| {
-					crate::fdb::error!(!error, "failed to serialize the process child")
-				})?;
+				let value = tangram_serialize::to_vec(&child)
+					.map_err(|error| tg::error!(!error, "failed to serialize the process child"))?;
 				txn.set(&process_child_key, &value);
 				txn.set(&key, &position.to_be_bytes());
 			}
@@ -340,25 +339,29 @@ impl Index {
 				&tg::Either::Right(id.clone()),
 				partition_total,
 			);
-			Self::enqueue_account_process_from_parents(
-				txn,
-				subspace,
-				id,
-				partition_total,
-				touched_at,
-			)
-			.await?;
-			Self::enqueue_account_process_relationships(
-				txn,
-				subspace,
-				id,
-				partition_total,
-				touched_at,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::enqueue_account_process_from_parents(
+					txn,
+					subspace,
+					id,
+					partition_total,
+					touched_at,
+				)
+				.await
+			);
+			crate::fdb::propagate!(
+				Self::enqueue_account_process_relationships(
+					txn,
+					subspace,
+					id,
+					partition_total,
+					touched_at,
+				)
+				.await
+			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn put_processes_with_transaction(
@@ -366,10 +369,12 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		args: &[crate::process::put::Arg],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for process in args {
-			Self::put_process(txn, subspace, process, partition_total).await?;
+			crate::fdb::propagate!(
+				Self::put_process(txn, subspace, process, partition_total).await
+			);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/process/touch.rs
+++ b/packages/index/src/fdb/process/touch.rs
@@ -3,7 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	futures::future,
-	std::time::Duration,
+	std::{ops::ControlFlow, time::Duration},
 	tangram_client::prelude::*,
 };
 
@@ -71,7 +71,7 @@ impl Index {
 		arg: &crate::fdb::TouchProcesses,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<Vec<Option<crate::process::Process>>> {
+	) -> tg::Result<ControlFlow<Vec<Option<crate::process::Process>>, fdb::FdbError>> {
 		let crate::fdb::TouchProcesses {
 			account,
 			ids,
@@ -79,55 +79,71 @@ impl Index {
 			time_to_touch,
 			touched_at,
 		} = arg;
-		let processes = Self::touch_processes_with_transaction(
-			txn,
-			subspace,
-			ids,
-			*touched_at,
-			*time_to_touch,
-			partition_total,
-		)
-		.await?;
-		if let Some(account) = account.as_ref() {
-			future::try_join_all(
-				std::iter::zip(ids, &processes)
-					.filter(|(_, process)| process.is_some())
-					.map(|(id, _)| {
-						let arg = crate::usage::storage::put::ProcessArg {
-							account: account.clone(),
-							process: id.clone(),
-							touched_at: *touched_at,
-						};
-						async move {
-							if *put_account
-								&& Self::put_account_process(
-									txn,
-									subspace,
-									&arg,
-									partition_total,
-									usage_partition_total,
-									false,
-									None,
-								)
-								.await?
-							{
-								return Ok(());
-							}
-							Self::touch_account_process(
-								txn,
-								subspace,
-								&arg,
-								*time_to_touch,
-								partition_total,
-							)
-							.await
-						}
-					}),
+		let processes = crate::fdb::propagate!(
+			Self::touch_processes_with_transaction(
+				txn,
+				subspace,
+				ids,
+				*touched_at,
+				*time_to_touch,
+				partition_total,
 			)
-			.await?;
+			.await
+		);
+		if let Some(account) = account.as_ref() {
+			{
+				let result = future::try_join_all(
+					std::iter::zip(ids, &processes)
+						.filter(|(_, process)| process.is_some())
+						.map(|(id, _)| {
+							let arg = crate::usage::storage::put::ProcessArg {
+								account: account.clone(),
+								process: id.clone(),
+								touched_at: *touched_at,
+							};
+							async move {
+								if *put_account
+									&& crate::fdb::propagate!(
+										Self::put_account_process(
+											txn,
+											subspace,
+											&arg,
+											partition_total,
+											usage_partition_total,
+											false,
+											None,
+										)
+										.await
+									) {
+									return Ok::<_, tg::Error>(ControlFlow::Break(()));
+								}
+								crate::fdb::propagate!(
+									Self::touch_account_process(
+										txn,
+										subspace,
+										&arg,
+										*time_to_touch,
+										partition_total,
+									)
+									.await
+								);
+
+								Ok::<_, tg::Error>(ControlFlow::Break(()))
+							}
+						}),
+				)
+				.await;
+				let results = result?;
+				for result in results {
+					match result {
+						ControlFlow::Break(()) => {},
+						ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+					}
+				}
+			};
 		}
 
-		Ok(processes)
+		Ok(ControlFlow::Break(processes))
 	}
 
 	pub(crate) async fn touch_processes_with_transaction(
@@ -137,22 +153,36 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Vec<Option<crate::process::Process>>> {
-		future::try_join_all(ids.iter().map(|id| {
-			let subspace = subspace.clone();
-			async move {
-				Self::touch_process_with_transaction(
-					txn,
-					&subspace,
-					id,
-					touched_at,
-					time_to_touch,
-					partition_total,
-				)
-				.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::process::Process>>, fdb::FdbError>> {
+		let processes = {
+			let result = future::try_join_all(ids.iter().map(|id| {
+				let subspace = subspace.clone();
+				async move {
+					Self::touch_process_with_transaction(
+						txn,
+						&subspace,
+						id,
+						touched_at,
+						time_to_touch,
+						partition_total,
+					)
+					.await
+				}
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
 			}
-		}))
-		.await
+			values
+		};
+
+		Ok(ControlFlow::Break(processes))
 	}
 
 	async fn touch_process_with_transaction(
@@ -162,31 +192,34 @@ impl Index {
 		touched_at: i64,
 		time_to_touch: Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<crate::process::Process>> {
+	) -> tg::Result<ControlFlow<Option<crate::process::Process>, fdb::FdbError>> {
 		let key = Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let existing = txn.get(&key, false).await?;
+		let existing = crate::fdb::retry!(txn.get(&key, false).await);
 		let existing = existing
 			.as_ref()
 			.map(|bytes| crate::process::Process::deserialize(bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 		let Some(mut process) = existing else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
 		let time_to_touch = i64::try_from(time_to_touch.as_secs()).unwrap();
 		if touched_at - process.touched_at < time_to_touch {
-			return Ok(Some(process));
+			return Ok(ControlFlow::Break(Some(process)));
 		}
 
 		let mut key_end = key.clone();
 		key_end.push(0x00);
-		txn.add_conflict_range(&key, &key_end, fdb::options::ConflictRangeType::Read)?;
+		crate::fdb::retry!(txn.add_conflict_range(
+			&key,
+			&key_end,
+			fdb::options::ConflictRangeType::Read,
+		));
 
 		process.touched_at = process.touched_at.max(touched_at);
 		let value = process
 			.serialize()
-			.map_err(|error| crate::fdb::error!(!error, "failed to serialize the process"))?;
+			.map_err(|error| tg::error!(!error, "failed to serialize the process"))?;
 		txn.set(&key, &value);
 		if process.reference_count == 0 {
 			let id_bytes = id.to_bytes();
@@ -202,6 +235,6 @@ impl Index {
 			txn.set(&key, &[]);
 		}
 
-		Ok(Some(process))
+		Ok(ControlFlow::Break(Some(process)))
 	}
 }

--- a/packages/index/src/fdb/process/touch.rs
+++ b/packages/index/src/fdb/process/touch.rs
@@ -171,7 +171,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -195,7 +195,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::process::Process>, fdb::FdbError>> {
 		let key = Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let existing = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let existing = crate::fdb::retry!(result);
 		let existing = existing
 			.as_ref()
 			.map(|bytes| crate::process::Process::deserialize(bytes))
@@ -210,11 +211,8 @@ impl Index {
 
 		let mut key_end = key.clone();
 		key_end.push(0x00);
-		crate::fdb::retry!(txn.add_conflict_range(
-			&key,
-			&key_end,
-			fdb::options::ConflictRangeType::Read,
-		));
+		let result = txn.add_conflict_range(&key, &key_end, fdb::options::ConflictRangeType::Read);
+		crate::fdb::retry!(result);
 
 		process.touched_at = process.touched_at.max(touched_at);
 		let value = process

--- a/packages/index/src/fdb/reader.rs
+++ b/packages/index/src/fdb/reader.rs
@@ -1,7 +1,10 @@
 use {
 	super::Index,
 	foundationdb as fdb, foundationdb_tuple as fdbt,
-	futures::{StreamExt as _, future, stream},
+	futures::{
+		StreamExt as _,
+		stream::{self, FuturesUnordered},
+	},
 	std::{ops::ControlFlow, sync::Arc},
 	tangram_client::prelude::*,
 };
@@ -92,43 +95,54 @@ impl Index {
 			Ok(transaction) => transaction,
 		};
 		loop {
-			// Execute the pending requests.
-			let read_requests = requests
-				.iter()
-				.map(|(request, _)| request.clone())
-				.collect::<Vec<_>>();
-			let results = Self::execute_read_requests_with_transaction(
-				authorize,
-				partition_total,
-				&transaction,
-				subspace,
-				read_requests,
-			)
-			.await;
+			let (retry_error, retry_requests) = {
+				// Execute the pending requests concurrently.
+				let transaction = &transaction;
+				let mut futures = requests
+					.into_iter()
+					.map(|(request, sender)| {
+						let read_request = request.clone();
+						async move {
+							let result = Self::execute_read_request(
+								authorize,
+								partition_total,
+								transaction,
+								subspace,
+								read_request,
+							)
+							.await;
 
-			// Send the completed responses and collect the retryable requests.
-			let mut retry_error = None;
-			let mut retry_requests = Vec::new();
-			for (result, (request, sender)) in std::iter::zip(results, requests) {
-				match result {
-					Err(error) => {
-						sender.send(Err(error)).ok();
-					},
-					Ok(ControlFlow::Break(response)) => {
-						sender.send(Ok(response)).ok();
-					},
-					Ok(ControlFlow::Continue(error)) if error.is_retryable() => {
-						if !sender.is_closed() {
-							retry_error.get_or_insert(error);
-							retry_requests.push((request, sender));
+							(result, request, sender)
 						}
-					},
-					Ok(ControlFlow::Continue(error)) => {
-						let error = tg::error!(!error, "failed to execute a read request");
-						sender.send(Err(error)).ok();
-					},
+					})
+					.collect::<FuturesUnordered<_>>();
+
+				// Send each completed response and collect the retryable requests.
+				let mut retry_error = None;
+				let mut retry_requests = Vec::new();
+				while let Some((result, request, sender)) = futures.next().await {
+					match result {
+						Err(error) => {
+							sender.send(Err(error)).ok();
+						},
+						Ok(ControlFlow::Break(response)) => {
+							sender.send(Ok(response)).ok();
+						},
+						Ok(ControlFlow::Continue(error)) if error.is_retryable() => {
+							if !sender.is_closed() {
+								retry_error.get_or_insert(error);
+								retry_requests.push((request, sender));
+							}
+						},
+						Ok(ControlFlow::Continue(error)) => {
+							let error = tg::error!(!error, "failed to execute a read request");
+							sender.send(Err(error)).ok();
+						},
+					}
 				}
-			}
+
+				(retry_error, retry_requests)
+			};
 			let Some(error) = retry_error else {
 				return;
 			};
@@ -147,19 +161,6 @@ impl Index {
 			};
 			requests = retry_requests;
 		}
-	}
-
-	async fn execute_read_requests_with_transaction(
-		authorize: super::AuthorizeConfig,
-		partition_total: u64,
-		transaction: &fdb::Transaction,
-		subspace: &fdbt::Subspace,
-		requests: Vec<crate::read::Request>,
-	) -> Vec<tg::Result<ControlFlow<crate::read::Response, fdb::FdbError>>> {
-		future::join_all(requests.into_iter().map(|request| {
-			Self::execute_read_request(authorize, partition_total, transaction, subspace, request)
-		}))
-		.await
 	}
 
 	async fn execute_read_request(

--- a/packages/index/src/fdb/reader.rs
+++ b/packages/index/src/fdb/reader.rs
@@ -82,7 +82,7 @@ impl Index {
 			.map(|(request, _)| request.clone())
 			.collect::<Vec<_>>();
 		let subspace = subspace.clone();
-		let result = crate::fdb::run(database, |transaction| {
+		let result = crate::fdb::run_read(database, |transaction| {
 			let requests = read_requests.clone();
 			let subspace = subspace.clone();
 			async move {
@@ -101,7 +101,7 @@ impl Index {
 		match result {
 			Ok(responses) => {
 				for (response, (_, sender)) in std::iter::zip(responses, requests) {
-					sender.send(Ok(response)).ok();
+					sender.send(response).ok();
 				}
 			},
 			Err(error) => {
@@ -118,15 +118,20 @@ impl Index {
 		transaction: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		requests: Vec<crate::read::Request>,
-	) -> tg::Result<ControlFlow<Vec<crate::read::Response>, fdb::FdbError>> {
+	) -> tg::Result<ControlFlow<Vec<tg::Result<crate::read::Response>>, fdb::FdbError>> {
 		let results = future::join_all(requests.into_iter().map(|request| {
 			Self::execute_read_request(authorize, partition_total, transaction, subspace, request)
 		}))
 		.await;
 		let mut responses = Vec::with_capacity(results.len());
 		for result in results {
-			let response = crate::fdb::propagate!(result);
-			responses.push(response);
+			match result {
+				Ok(ControlFlow::Break(response)) => responses.push(Ok(response)),
+				Ok(ControlFlow::Continue(error)) => {
+					return Ok(ControlFlow::Continue(error));
+				},
+				Err(error) => responses.push(Err(error)),
+			}
 		}
 
 		Ok(ControlFlow::Break(responses))

--- a/packages/index/src/fdb/reader.rs
+++ b/packages/index/src/fdb/reader.rs
@@ -95,31 +95,29 @@ impl Index {
 			Ok(transaction) => transaction,
 		};
 		loop {
-			let (retry_error, retry_requests) = {
+			let (retry_error, mut retry_requests) = {
 				// Execute the pending requests concurrently.
 				let transaction = &transaction;
+				let request_count = requests.len();
 				let mut futures = requests
 					.into_iter()
-					.map(|(request, sender)| {
-						let read_request = request.clone();
-						async move {
-							let result = Self::execute_read_request(
-								authorize,
-								partition_total,
-								transaction,
-								subspace,
-								read_request,
-							)
-							.await;
+					.map(|(request, sender)| async move {
+						let result = Self::execute_read_request(
+							authorize,
+							partition_total,
+							transaction,
+							subspace,
+							&request,
+						)
+						.await;
 
-							(result, request, sender)
-						}
+						(result, request, sender)
 					})
 					.collect::<FuturesUnordered<_>>();
 
 				// Send each completed response and collect the retryable requests.
 				let mut retry_error = None;
-				let mut retry_requests = Vec::new();
+				let mut retry_requests = Vec::with_capacity(request_count);
 				while let Some((result, request, sender)) = futures.next().await {
 					match result {
 						Err(error) => {
@@ -146,6 +144,10 @@ impl Index {
 			let Some(error) = retry_error else {
 				return;
 			};
+			retry_requests.retain(|(_, sender)| !sender.is_closed());
+			if retry_requests.is_empty() {
+				return;
+			}
 
 			// Reset the transaction for the retryable requests.
 			transaction = match transaction.on_error(error).await {
@@ -168,7 +170,7 @@ impl Index {
 		partition_total: u64,
 		transaction: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
-		request: crate::read::Request,
+		request: &crate::read::Request,
 	) -> tg::Result<ControlFlow<crate::read::Response, fdb::FdbError>> {
 		let response = match request {
 			crate::read::Request::AuthorizeBatch { args, principal } => {
@@ -176,15 +178,15 @@ impl Index {
 					authorize,
 					transaction,
 					subspace,
-					&args,
-					&principal,
+					args,
+					principal,
 				)
 				.await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::AuthorizeBatch(output)
 			},
 			crate::read::Request::ContainsIds { ids } => {
-				let result = Self::contains_ids_with_transaction(transaction, subspace, &ids).await;
+				let result = Self::contains_ids_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::ContainsIds(output)
 			},
@@ -196,9 +198,9 @@ impl Index {
 				let result = Self::log_compaction_batch_with_transaction(
 					transaction,
 					subspace,
-					batch_size,
-					partition_start,
-					partition_end,
+					*batch_size,
+					*partition_start,
+					*partition_end,
 				)
 				.await;
 				let output = crate::fdb::propagate!(result);
@@ -212,9 +214,9 @@ impl Index {
 				let result = Self::try_get_process_children_page_with_transaction(
 					transaction,
 					subspace,
-					&id,
-					position,
-					length,
+					id,
+					*position,
+					*length,
 				)
 				.await;
 				let output = crate::fdb::propagate!(result);
@@ -225,21 +227,21 @@ impl Index {
 			},
 			crate::read::Request::GetRequesterSubjects { principal } => {
 				let result =
-					Self::requester_subjects_with_transaction(transaction, subspace, &principal)
+					Self::requester_subjects_with_transaction(transaction, subspace, principal)
 						.await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::GetRequesterSubjects(output)
 			},
 			crate::read::Request::GetRunnerSandboxes { runner } => {
 				let result =
-					Self::get_runner_sandboxes_with_transaction(transaction, subspace, &runner)
+					Self::get_runner_sandboxes_with_transaction(transaction, subspace, runner)
 						.await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::GetRunnerSandboxes(output)
 			},
 			crate::read::Request::GetSandboxProcesses { sandbox } => {
 				let result =
-					Self::get_sandbox_processes_with_transaction(transaction, subspace, &sandbox)
+					Self::get_sandbox_processes_with_transaction(transaction, subspace, sandbox)
 						.await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::GetSandboxProcesses(output)
@@ -258,7 +260,7 @@ impl Index {
 				let result = Self::list_sandboxes_for_principal_with_transaction(
 					transaction,
 					subspace,
-					&creator,
+					creator,
 					super::Kind::CreatorSandbox,
 				)
 				.await;
@@ -269,7 +271,7 @@ impl Index {
 				let result = Self::list_sandboxes_for_principal_with_transaction(
 					transaction,
 					subspace,
-					&owner,
+					owner,
 					super::Kind::OwnerSandbox,
 				)
 				.await;
@@ -280,8 +282,8 @@ impl Index {
 				let result = Self::process_has_ancestor_with_transaction(
 					transaction,
 					subspace,
-					&process,
-					&ancestor,
+					process,
+					ancestor,
 				)
 				.await;
 				let output = crate::fdb::propagate!(result);
@@ -289,29 +291,26 @@ impl Index {
 			},
 			crate::read::Request::TryGetAncestors { id } => {
 				let result =
-					Self::try_get_ancestors_with_transaction(transaction, subspace, &id).await;
+					Self::try_get_ancestors_with_transaction(transaction, subspace, id).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetAncestors(output)
 			},
 			crate::read::Request::TryGetCacheEntries { ids } => {
 				let result =
-					Self::try_get_cache_entries_with_transaction(transaction, subspace, &ids).await;
+					Self::try_get_cache_entries_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetCacheEntries(output)
 			},
 			crate::read::Request::TryGetCachedProcesses { command } => {
-				let result = Self::try_get_cached_processes_with_transaction(
-					transaction,
-					subspace,
-					&command,
-				)
-				.await;
+				let result =
+					Self::try_get_cached_processes_with_transaction(transaction, subspace, command)
+						.await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetCachedProcesses(output)
 			},
 			crate::read::Request::TryGetGroups { ids } => {
 				let result =
-					Self::try_get_groups_with_transaction(transaction, subspace, &ids).await;
+					Self::try_get_groups_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetGroups(output)
 			},
@@ -319,7 +318,7 @@ impl Index {
 				let result = Self::try_get_ids_for_specifiers_with_transaction(
 					transaction,
 					subspace,
-					&specifiers,
+					specifiers,
 				)
 				.await;
 				let output = crate::fdb::propagate!(result);
@@ -327,7 +326,7 @@ impl Index {
 			},
 			crate::read::Request::TryGetObjects { ids } => {
 				let result =
-					Self::try_get_objects_with_transaction(transaction, subspace, &ids).await;
+					Self::try_get_objects_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetObjects(output)
 			},
@@ -345,7 +344,7 @@ impl Index {
 				let result = Self::try_get_oldest_update_transaction_id_with_transaction(
 					transaction,
 					subspace,
-					kind,
+					*kind,
 					partition_total,
 				)
 				.await;
@@ -354,38 +353,37 @@ impl Index {
 			},
 			crate::read::Request::TryGetOrganizations { ids } => {
 				let result =
-					Self::try_get_organizations_with_transaction(transaction, subspace, &ids).await;
+					Self::try_get_organizations_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetOrganizations(output)
 			},
 			crate::read::Request::TryGetProcesses { ids } => {
 				let result =
-					Self::try_get_processes_with_transaction(transaction, subspace, &ids).await;
+					Self::try_get_processes_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetProcesses(output)
 			},
 			crate::read::Request::TryGetSandboxes { ids } => {
 				let result =
-					Self::try_get_sandboxes_with_transaction(transaction, subspace, &ids).await;
+					Self::try_get_sandboxes_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetSandboxes(output)
 			},
 			crate::read::Request::TryGetSpecifiersForIds { ids } => {
 				let result =
-					Self::try_get_specifiers_for_ids_with_transaction(transaction, subspace, &ids)
+					Self::try_get_specifiers_for_ids_with_transaction(transaction, subspace, ids)
 						.await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetSpecifiersForIds(output)
 			},
 			crate::read::Request::TryGetUsers { ids } => {
-				let result =
-					Self::try_get_users_with_transaction(transaction, subspace, &ids).await;
+				let result = Self::try_get_users_with_transaction(transaction, subspace, ids).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetUsers(output)
 			},
 			crate::read::Request::Visible { ids, principal } => {
 				let result =
-					Self::visible_with_transaction(transaction, subspace, &ids, &principal).await;
+					Self::visible_with_transaction(transaction, subspace, ids, principal).await;
 				let output = crate::fdb::propagate!(result);
 				crate::read::Response::Visible(output)
 			},

--- a/packages/index/src/fdb/reader.rs
+++ b/packages/index/src/fdb/reader.rs
@@ -2,7 +2,7 @@ use {
 	super::Index,
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	futures::{StreamExt as _, future, stream},
-	std::sync::Arc,
+	std::{ops::ControlFlow, sync::Arc},
 	tangram_client::prelude::*,
 };
 
@@ -77,34 +77,59 @@ impl Index {
 		if requests.is_empty() {
 			return;
 		}
-		let transaction = database
-			.create_trx()
-			.map_err(|error| tg::error!(!error, "failed to create the transaction"));
-		let transaction = match transaction {
-			Ok(transaction) => transaction,
+		let read_requests = requests
+			.iter()
+			.map(|(request, _)| request.clone())
+			.collect::<Vec<_>>();
+		let subspace = subspace.clone();
+		let result = crate::fdb::run(database, |transaction| {
+			let requests = read_requests.clone();
+			let subspace = subspace.clone();
+			async move {
+				Self::execute_read_requests_with_transaction(
+					authorize,
+					partition_total,
+					&transaction,
+					&subspace,
+					requests,
+				)
+				.await
+			}
+		})
+		.await
+		.map_err(|error| tg::error!(!error, "failed to execute a read batch"));
+		match result {
+			Ok(responses) => {
+				for (response, (_, sender)) in std::iter::zip(responses, requests) {
+					sender.send(Ok(response)).ok();
+				}
+			},
 			Err(error) => {
 				for (_, sender) in requests {
 					sender.send(Err(error.clone())).ok();
 				}
-				return;
 			},
-		};
-		future::join_all(requests.into_iter().map(|(request, sender)| {
-			let transaction = &transaction;
-			async move {
-				let response = Self::execute_read_request(
-					authorize,
-					partition_total,
-					transaction,
-					subspace,
-					request,
-				)
-				.await
-				.map_err(|error| tg::error!(!error, "failed to execute the read request"));
-				sender.send(response).ok();
-			}
+		}
+	}
+
+	async fn execute_read_requests_with_transaction(
+		authorize: super::AuthorizeConfig,
+		partition_total: u64,
+		transaction: &fdb::Transaction,
+		subspace: &fdbt::Subspace,
+		requests: Vec<crate::read::Request>,
+	) -> tg::Result<ControlFlow<Vec<crate::read::Response>, fdb::FdbError>> {
+		let results = future::join_all(requests.into_iter().map(|request| {
+			Self::execute_read_request(authorize, partition_total, transaction, subspace, request)
 		}))
 		.await;
+		let mut responses = Vec::with_capacity(results.len());
+		for result in results {
+			let response = crate::fdb::propagate!(result);
+			responses.push(response);
+		}
+
+		Ok(ControlFlow::Break(responses))
 	}
 
 	async fn execute_read_request(
@@ -113,22 +138,23 @@ impl Index {
 		transaction: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		request: crate::read::Request,
-	) -> crate::fdb::Result<crate::read::Response> {
+	) -> tg::Result<ControlFlow<crate::read::Response, fdb::FdbError>> {
 		let response = match request {
 			crate::read::Request::AuthorizeBatch { args, principal } => {
-				let output = Self::authorize_batch_with_transaction(
+				let result = Self::authorize_batch_with_transaction(
 					authorize,
 					transaction,
 					subspace,
 					&args,
 					&principal,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::AuthorizeBatch(output)
 			},
 			crate::read::Request::ContainsIds { ids } => {
-				let output =
-					Self::contains_ids_with_transaction(transaction, subspace, &ids).await?;
+				let result = Self::contains_ids_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::ContainsIds(output)
 			},
 			crate::read::Request::FdbLogCompactionBatch {
@@ -136,14 +162,15 @@ impl Index {
 				partition_end,
 				partition_start,
 			} => {
-				let output = Self::log_compaction_batch_with_transaction(
+				let result = Self::log_compaction_batch_with_transaction(
 					transaction,
 					subspace,
 					batch_size,
 					partition_start,
 					partition_end,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::LogCompactionBatch(output)
 			},
 			crate::read::Request::TryGetProcessChildren {
@@ -151,167 +178,188 @@ impl Index {
 				length,
 				position,
 			} => {
-				let output = Self::try_get_process_children_page_with_transaction(
+				let result = Self::try_get_process_children_page_with_transaction(
 					transaction,
 					subspace,
 					&id,
 					position,
 					length,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetProcessChildren(output)
 			},
 			crate::read::Request::LmdbLogCompactionBatch { .. } => {
-				return Err(crate::fdb::error!("unexpected LMDB read request"));
+				return Err(tg::error!("unexpected LMDB read request"));
 			},
 			crate::read::Request::GetRequesterSubjects { principal } => {
-				let output =
+				let result =
 					Self::requester_subjects_with_transaction(transaction, subspace, &principal)
-						.await?;
+						.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::GetRequesterSubjects(output)
 			},
 			crate::read::Request::GetRunnerSandboxes { runner } => {
-				let output =
+				let result =
 					Self::get_runner_sandboxes_with_transaction(transaction, subspace, &runner)
-						.await?;
+						.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::GetRunnerSandboxes(output)
 			},
 			crate::read::Request::GetSandboxProcesses { sandbox } => {
-				let output =
+				let result =
 					Self::get_sandbox_processes_with_transaction(transaction, subspace, &sandbox)
-						.await?;
+						.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::GetSandboxProcesses(output)
 			},
 			crate::read::Request::GetTransactionId => {
-				let output = transaction.get_read_version().await?.cast_unsigned();
+				let result = transaction.get_read_version().await;
+				let output = crate::fdb::retry!(result).cast_unsigned();
 				crate::read::Response::GetTransactionId(output)
 			},
 			crate::read::Request::ListSandboxes => {
-				let output = Self::list_sandboxes_with_transaction(transaction, subspace).await?;
+				let result = Self::list_sandboxes_with_transaction(transaction, subspace).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::ListSandboxes(output)
 			},
 			crate::read::Request::ListSandboxesForCreator { creator } => {
-				let output = Self::list_sandboxes_for_principal_with_transaction(
+				let result = Self::list_sandboxes_for_principal_with_transaction(
 					transaction,
 					subspace,
 					&creator,
 					super::Kind::CreatorSandbox,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::ListSandboxes(output)
 			},
 			crate::read::Request::ListSandboxesForOwner { owner } => {
-				let output = Self::list_sandboxes_for_principal_with_transaction(
+				let result = Self::list_sandboxes_for_principal_with_transaction(
 					transaction,
 					subspace,
 					&owner,
 					super::Kind::OwnerSandbox,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::ListSandboxes(output)
 			},
 			crate::read::Request::ProcessHasAncestor { ancestor, process } => {
-				let output = Self::process_has_ancestor_with_transaction(
+				let result = Self::process_has_ancestor_with_transaction(
 					transaction,
 					subspace,
 					&process,
 					&ancestor,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::ProcessHasAncestor(output)
 			},
 			crate::read::Request::TryGetAncestors { id } => {
-				let output =
-					Self::try_get_ancestors_with_transaction(transaction, subspace, &id).await?;
+				let result =
+					Self::try_get_ancestors_with_transaction(transaction, subspace, &id).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetAncestors(output)
 			},
 			crate::read::Request::TryGetCacheEntries { ids } => {
-				let output =
-					Self::try_get_cache_entries_with_transaction(transaction, subspace, &ids)
-						.await?;
+				let result =
+					Self::try_get_cache_entries_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetCacheEntries(output)
 			},
 			crate::read::Request::TryGetCachedProcesses { command } => {
-				let output = Self::try_get_cached_processes_with_transaction(
+				let result = Self::try_get_cached_processes_with_transaction(
 					transaction,
 					subspace,
 					&command,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetCachedProcesses(output)
 			},
 			crate::read::Request::TryGetGroups { ids } => {
-				let output =
-					Self::try_get_groups_with_transaction(transaction, subspace, &ids).await?;
+				let result =
+					Self::try_get_groups_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetGroups(output)
 			},
 			crate::read::Request::TryGetIdsForSpecifiers { specifiers } => {
-				let output = Self::try_get_ids_for_specifiers_with_transaction(
+				let result = Self::try_get_ids_for_specifiers_with_transaction(
 					transaction,
 					subspace,
 					&specifiers,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetIdsForSpecifiers(output)
 			},
 			crate::read::Request::TryGetObjects { ids } => {
-				let output =
-					Self::try_get_objects_with_transaction(transaction, subspace, &ids).await?;
+				let result =
+					Self::try_get_objects_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetObjects(output)
 			},
 			crate::read::Request::TryGetOldestLogCompactionTransactionId => {
-				let output = Self::try_get_oldest_log_compaction_transaction_id_with_transaction(
+				let result = Self::try_get_oldest_log_compaction_transaction_id_with_transaction(
 					transaction,
 					subspace,
 					partition_total,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetOldestLogCompactionTransactionId(output)
 			},
 			crate::read::Request::TryGetOldestUpdateTransactionId { kind } => {
-				let output = Self::try_get_oldest_update_transaction_id_with_transaction(
+				let result = Self::try_get_oldest_update_transaction_id_with_transaction(
 					transaction,
 					subspace,
 					kind,
 					partition_total,
 				)
-				.await?;
+				.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetOldestUpdateTransactionId(output)
 			},
 			crate::read::Request::TryGetOrganizations { ids } => {
-				let output =
-					Self::try_get_organizations_with_transaction(transaction, subspace, &ids)
-						.await?;
+				let result =
+					Self::try_get_organizations_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetOrganizations(output)
 			},
 			crate::read::Request::TryGetProcesses { ids } => {
-				let output =
-					Self::try_get_processes_with_transaction(transaction, subspace, &ids).await?;
+				let result =
+					Self::try_get_processes_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetProcesses(output)
 			},
 			crate::read::Request::TryGetSandboxes { ids } => {
-				let output =
-					Self::try_get_sandboxes_with_transaction(transaction, subspace, &ids).await?;
+				let result =
+					Self::try_get_sandboxes_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetSandboxes(output)
 			},
 			crate::read::Request::TryGetSpecifiersForIds { ids } => {
-				let output =
+				let result =
 					Self::try_get_specifiers_for_ids_with_transaction(transaction, subspace, &ids)
-						.await?;
+						.await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetSpecifiersForIds(output)
 			},
 			crate::read::Request::TryGetUsers { ids } => {
-				let output =
-					Self::try_get_users_with_transaction(transaction, subspace, &ids).await?;
+				let result =
+					Self::try_get_users_with_transaction(transaction, subspace, &ids).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::TryGetUsers(output)
 			},
 			crate::read::Request::Visible { ids, principal } => {
-				let output =
-					Self::visible_with_transaction(transaction, subspace, &ids, &principal).await?;
+				let result =
+					Self::visible_with_transaction(transaction, subspace, &ids, &principal).await;
+				let output = crate::fdb::propagate!(result);
 				crate::read::Response::Visible(output)
 			},
 		};
 
-		Ok(response)
+		Ok(ControlFlow::Break(response))
 	}
 }

--- a/packages/index/src/fdb/reader.rs
+++ b/packages/index/src/fdb/reader.rs
@@ -70,45 +70,82 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		requests: Vec<(crate::read::Request, crate::read::ResponseSender)>,
 	) {
-		let requests = requests
+		// Remove the closed requests.
+		let mut requests = requests
 			.into_iter()
 			.filter(|(_, sender)| !sender.is_closed())
 			.collect::<Vec<_>>();
 		if requests.is_empty() {
 			return;
 		}
-		let read_requests = requests
-			.iter()
-			.map(|(request, _)| request.clone())
-			.collect::<Vec<_>>();
-		let subspace = subspace.clone();
-		let result = crate::fdb::run_read(database, |transaction| {
-			let requests = read_requests.clone();
-			let subspace = subspace.clone();
-			async move {
-				Self::execute_read_requests_with_transaction(
-					authorize,
-					partition_total,
-					&transaction,
-					&subspace,
-					requests,
-				)
-				.await
-			}
-		})
-		.await
-		.map_err(|error| tg::error!(!error, "failed to execute a read batch"));
-		match result {
-			Ok(responses) => {
-				for (response, (_, sender)) in std::iter::zip(responses, requests) {
-					sender.send(response).ok();
-				}
-			},
+
+		// Create the transaction.
+		let mut transaction = match database.create_trx() {
 			Err(error) => {
+				let error = tg::error!(!error, "failed to create a read transaction");
 				for (_, sender) in requests {
 					sender.send(Err(error.clone())).ok();
 				}
+
+				return;
 			},
+			Ok(transaction) => transaction,
+		};
+		loop {
+			// Execute the pending requests.
+			let read_requests = requests
+				.iter()
+				.map(|(request, _)| request.clone())
+				.collect::<Vec<_>>();
+			let results = Self::execute_read_requests_with_transaction(
+				authorize,
+				partition_total,
+				&transaction,
+				subspace,
+				read_requests,
+			)
+			.await;
+
+			// Send the completed responses and collect the retryable requests.
+			let mut retry_error = None;
+			let mut retry_requests = Vec::new();
+			for (result, (request, sender)) in std::iter::zip(results, requests) {
+				match result {
+					Err(error) => {
+						sender.send(Err(error)).ok();
+					},
+					Ok(ControlFlow::Break(response)) => {
+						sender.send(Ok(response)).ok();
+					},
+					Ok(ControlFlow::Continue(error)) if error.is_retryable() => {
+						if !sender.is_closed() {
+							retry_error.get_or_insert(error);
+							retry_requests.push((request, sender));
+						}
+					},
+					Ok(ControlFlow::Continue(error)) => {
+						let error = tg::error!(!error, "failed to execute a read request");
+						sender.send(Err(error)).ok();
+					},
+				}
+			}
+			let Some(error) = retry_error else {
+				return;
+			};
+
+			// Reset the transaction for the retryable requests.
+			transaction = match transaction.on_error(error).await {
+				Err(error) => {
+					let error = tg::error!(!error, "failed to retry a read transaction");
+					for (_, sender) in retry_requests {
+						sender.send(Err(error.clone())).ok();
+					}
+
+					return;
+				},
+				Ok(transaction) => transaction,
+			};
+			requests = retry_requests;
 		}
 	}
 
@@ -118,23 +155,11 @@ impl Index {
 		transaction: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		requests: Vec<crate::read::Request>,
-	) -> tg::Result<ControlFlow<Vec<tg::Result<crate::read::Response>>, fdb::FdbError>> {
-		let results = future::join_all(requests.into_iter().map(|request| {
+	) -> Vec<tg::Result<ControlFlow<crate::read::Response, fdb::FdbError>>> {
+		future::join_all(requests.into_iter().map(|request| {
 			Self::execute_read_request(authorize, partition_total, transaction, subspace, request)
 		}))
-		.await;
-		let mut responses = Vec::with_capacity(results.len());
-		for result in results {
-			match result {
-				Ok(ControlFlow::Break(response)) => responses.push(Ok(response)),
-				Ok(ControlFlow::Continue(error)) => {
-					return Ok(ControlFlow::Continue(error));
-				},
-				Err(error) => responses.push(Err(error)),
-			}
-		}
-
-		Ok(ControlFlow::Break(responses))
+		.await
 	}
 
 	async fn execute_read_request(

--- a/packages/index/src/fdb/runner/get.rs
+++ b/packages/index/src/fdb/runner/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -26,14 +27,14 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		runner: &tg::runner::Id,
-	) -> crate::fdb::Result<Vec<tg::sandbox::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::sandbox::Id>, fdb::FdbError>> {
 		let runner = runner.to_bytes();
 		let prefix = Self::pack(
 			subspace,
 			&(Kind::RunnerSandbox.to_i32().unwrap(), runner.as_ref()),
 		);
-		let entries = txn
-			.get_range(
+		let entries = crate::fdb::retry!(
+			txn.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -41,17 +42,20 @@ impl Index {
 				1,
 				false,
 			)
-			.await?;
-		entries
+			.await
+		);
+		let sandboxes = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Runner(crate::fdb::runner::Key::RunnerSandbox { sandbox, .. }) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(sandbox)
 			})
-			.collect()
+			.collect::<tg::Result<Vec<_>>>()?;
+
+		Ok(ControlFlow::Break(sandboxes))
 	}
 }

--- a/packages/index/src/fdb/runner/get.rs
+++ b/packages/index/src/fdb/runner/get.rs
@@ -33,8 +33,8 @@ impl Index {
 			subspace,
 			&(Kind::RunnerSandbox.to_i32().unwrap(), runner.as_ref()),
 		);
-		let entries = crate::fdb::retry!(
-			txn.get_range(
+		let result = txn
+			.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -42,8 +42,8 @@ impl Index {
 				1,
 				false,
 			)
-			.await
-		);
+			.await;
+		let entries = crate::fdb::retry!(result);
 		let sandboxes = entries
 			.iter()
 			.map(|entry| {

--- a/packages/index/src/fdb/sandbox/delete.rs
+++ b/packages/index/src/fdb/sandbox/delete.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -23,12 +24,12 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		ids: &[tg::sandbox::Id],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for id in ids {
 			let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 			let key = Self::pack(subspace, &key);
 			txn.clear(&key);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/sandbox/get.rs
+++ b/packages/index/src/fdb/sandbox/get.rs
@@ -33,8 +33,8 @@ impl Index {
 			subspace,
 			&(Kind::SandboxProcess.to_i32().unwrap(), sandbox.as_ref()),
 		);
-		let entries = crate::fdb::retry!(
-			txn.get_range(
+		let result = txn
+			.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -42,8 +42,8 @@ impl Index {
 				1,
 				false,
 			)
-			.await
-		);
+			.await;
+		let entries = crate::fdb::retry!(result);
 		let processes = entries
 			.iter()
 			.map(|entry| {
@@ -94,7 +94,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -115,7 +115,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::sandbox::Sandbox>, fdb::FdbError>> {
 		let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let sandbox = bytes
 			.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
 			.transpose()?;

--- a/packages/index/src/fdb/sandbox/get.rs
+++ b/packages/index/src/fdb/sandbox/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -26,14 +27,14 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		sandbox: &tg::sandbox::Id,
-	) -> crate::fdb::Result<Vec<(tg::process::Id, crate::process::Process)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::process::Id, crate::process::Process)>, fdb::FdbError>> {
 		let sandbox = sandbox.to_bytes();
 		let prefix = Self::pack(
 			subspace,
 			&(Kind::SandboxProcess.to_i32().unwrap(), sandbox.as_ref()),
 		);
-		let entries = txn
-			.get_range(
+		let entries = crate::fdb::retry!(
+			txn.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -41,29 +42,29 @@ impl Index {
 				1,
 				false,
 			)
-			.await?;
+			.await
+		);
 		let processes = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Sandbox(crate::fdb::sandbox::Key::SandboxProcess { process, .. }) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(process)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		drop(entries);
 		let mut output = Vec::with_capacity(processes.len());
 		for process in processes {
-			let data = Self::try_get_process_with_transaction(txn, subspace, &process)
-				.await?
-				.ok_or_else(
-					|| crate::fdb::error!(%process, "failed to find the sandbox process"),
-				)?;
+			let data = crate::fdb::propagate!(
+				Self::try_get_process_with_transaction(txn, subspace, &process).await
+			)
+			.ok_or_else(|| tg::error!(%process, "failed to find the sandbox process"))?;
 			output.push((process, data));
 		}
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	pub async fn try_get_sandboxes(
@@ -85,30 +86,40 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::sandbox::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::sandbox::Sandbox>>> {
-		futures::future::try_join_all(ids.iter().map(|id| async {
-			let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
-			let key = Self::pack(subspace, &key);
-			let bytes = txn.get(&key, false).await?;
-			bytes
-				.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
-				.transpose()
-				.map_err(crate::fdb::custom_error)
-		}))
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::sandbox::Sandbox>>, fdb::FdbError>> {
+		let sandboxes = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_sandbox_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(sandboxes))
 	}
 
 	pub(crate) async fn try_get_sandbox_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &foundationdb_tuple::Subspace,
 		id: &tg::sandbox::Id,
-	) -> crate::fdb::Result<Option<crate::sandbox::Sandbox>> {
+	) -> tg::Result<ControlFlow<Option<crate::sandbox::Sandbox>, fdb::FdbError>> {
 		let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
-		bytes
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let sandbox = bytes
 			.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)
+			.transpose()?;
+
+		Ok(ControlFlow::Break(sandbox))
 	}
 }

--- a/packages/index/src/fdb/sandbox/list.rs
+++ b/packages/index/src/fdb/sandbox/list.rs
@@ -56,8 +56,8 @@ impl Index {
 		subspace: &Subspace,
 	) -> tg::Result<ControlFlow<Vec<(tg::sandbox::Id, crate::sandbox::Sandbox)>, fdb::FdbError>> {
 		let prefix = Self::pack(subspace, &(Kind::Sandbox.to_i32().unwrap(),));
-		let entries = crate::fdb::retry!(
-			txn.get_range(
+		let result = txn
+			.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -65,8 +65,8 @@ impl Index {
 				1,
 				false,
 			)
-			.await
-		);
+			.await;
+		let entries = crate::fdb::retry!(result);
 		let sandboxes = entries
 			.iter()
 			.map(|entry| {
@@ -89,8 +89,8 @@ impl Index {
 		kind: Kind,
 	) -> tg::Result<ControlFlow<Vec<(tg::sandbox::Id, crate::sandbox::Sandbox)>, fdb::FdbError>> {
 		let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), principal.to_string()));
-		let entries = crate::fdb::retry!(
-			txn.get_range(
+		let result = txn
+			.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -98,8 +98,8 @@ impl Index {
 				1,
 				false,
 			)
-			.await
-		);
+			.await;
+		let entries = crate::fdb::retry!(result);
 		let sandboxes = entries
 			.iter()
 			.map(|entry| {

--- a/packages/index/src/fdb/sandbox/list.rs
+++ b/packages/index/src/fdb/sandbox/list.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -53,10 +54,10 @@ impl Index {
 	pub(crate) async fn list_sandboxes_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
-	) -> crate::fdb::Result<Vec<(tg::sandbox::Id, crate::sandbox::Sandbox)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::sandbox::Id, crate::sandbox::Sandbox)>, fdb::FdbError>> {
 		let prefix = Self::pack(subspace, &(Kind::Sandbox.to_i32().unwrap(),));
-		let entries = txn
-			.get_range(
+		let entries = crate::fdb::retry!(
+			txn.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -64,19 +65,21 @@ impl Index {
 				1,
 				false,
 			)
-			.await?;
-		entries
+			.await
+		);
+		let sandboxes = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(id)) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
-				let sandbox = crate::sandbox::Sandbox::deserialize(entry.value())
-					.map_err(crate::fdb::custom_error)?;
+				let sandbox = crate::sandbox::Sandbox::deserialize(entry.value())?;
 				Ok((id, sandbox))
 			})
-			.collect()
+			.collect::<tg::Result<Vec<_>>>()?;
+
+		Ok(ControlFlow::Break(sandboxes))
 	}
 
 	pub(crate) async fn list_sandboxes_for_principal_with_transaction(
@@ -84,10 +87,10 @@ impl Index {
 		subspace: &Subspace,
 		principal: &tg::Principal,
 		kind: Kind,
-	) -> crate::fdb::Result<Vec<(tg::sandbox::Id, crate::sandbox::Sandbox)>> {
+	) -> tg::Result<ControlFlow<Vec<(tg::sandbox::Id, crate::sandbox::Sandbox)>, fdb::FdbError>> {
 		let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), principal.to_string()));
-		let entries = txn
-			.get_range(
+		let entries = crate::fdb::retry!(
+			txn.get_range(
 				&fdb::RangeOption {
 					mode: fdb::options::StreamingMode::WantAll,
 					..fdb::RangeOption::from(&Subspace::from_bytes(prefix))
@@ -95,7 +98,8 @@ impl Index {
 				1,
 				false,
 			)
-			.await?;
+			.await
+		);
 		let sandboxes = entries
 			.iter()
 			.map(|entry| {
@@ -108,21 +112,20 @@ impl Index {
 						Key::Sandbox(crate::fdb::sandbox::Key::OwnerSandbox {
 							sandbox, ..
 						}) if kind == Kind::OwnerSandbox => sandbox,
-						_ => return Err(crate::fdb::error!("unexpected key type")),
+						_ => return Err(tg::error!("unexpected key type")),
 					};
 				Ok(sandbox)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		drop(entries);
 		let mut output = Vec::with_capacity(sandboxes.len());
 		for sandbox in sandboxes {
-			let data = Self::try_get_sandbox_with_transaction(txn, subspace, &sandbox)
-				.await?
-				.ok_or_else(
-					|| crate::fdb::error!(%sandbox, "failed to find the principal sandbox"),
-				)?;
+			let data = crate::fdb::propagate!(
+				Self::try_get_sandbox_with_transaction(txn, subspace, &sandbox).await
+			)
+			.ok_or_else(|| tg::error!(%sandbox, "failed to find the principal sandbox"))?;
 			output.push((sandbox, data));
 		}
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 }

--- a/packages/index/src/fdb/sandbox/put.rs
+++ b/packages/index/src/fdb/sandbox/put.rs
@@ -16,7 +16,8 @@ impl Index {
 		for arg in args {
 			let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
-			let existing = crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			let existing = crate::fdb::retry!(result)
 				.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
 				.transpose()?;
 			let data = arg

--- a/packages/index/src/fdb/sandbox/put.rs
+++ b/packages/index/src/fdb/sandbox/put.rs
@@ -1,6 +1,7 @@
 use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -11,16 +12,13 @@ impl Index {
 		args: &[crate::sandbox::put::Arg],
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::Sandbox(crate::fdb::sandbox::Key::Sandbox(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
-			let existing = txn
-				.get(&key, false)
-				.await?
+			let existing = crate::fdb::retry!(txn.get(&key, false).await)
 				.map(|bytes| crate::sandbox::Sandbox::deserialize(&bytes))
-				.transpose()
-				.map_err(crate::fdb::custom_error)?;
+				.transpose()?;
 			let data = arg
 				.data
 				.clone()
@@ -45,7 +43,7 @@ impl Index {
 				runner,
 				touched_at,
 			};
-			let value = sandbox.serialize().map_err(crate::fdb::custom_error)?;
+			let value = sandbox.serialize()?;
 			txn.set(&key, &value);
 
 			let started = existing
@@ -65,7 +63,12 @@ impl Index {
 					memory,
 					sandbox_count: 1,
 				};
-				Self::put_compute_usage(txn, subspace, arg, usage_partition_total)?;
+				crate::fdb::propagate!(Self::put_compute_usage(
+					txn,
+					subspace,
+					arg,
+					usage_partition_total,
+				));
 			}
 
 			let id_bytes = arg.id.to_bytes();
@@ -178,6 +181,6 @@ impl Index {
 				txn.set(&key, &[]);
 			}
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/tag/delete.rs
+++ b/packages/index/src/fdb/tag/delete.rs
@@ -38,7 +38,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Tag(crate::fdb::tag::Key::Tag(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(()));
 		};

--- a/packages/index/src/fdb/tag/delete.rs
+++ b/packages/index/src/fdb/tag/delete.rs
@@ -1,6 +1,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -22,11 +23,11 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		ids: &[tg::tag::Id],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for id in ids {
-			Self::delete_tag(txn, subspace, id, partition_total).await?;
+			crate::fdb::propagate!(Self::delete_tag(txn, subspace, id, partition_total).await);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn delete_tag(
@@ -34,14 +35,14 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		id: &tg::tag::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Tag(crate::fdb::tag::Key::Tag(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		};
-		let data = crate::tag::Tag::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let data = crate::tag::Tag::deserialize(&bytes)?;
 		let target = match &data.target {
 			tg::Either::Left(id) => id.to_bytes().to_vec(),
 			tg::Either::Right(id) => id.to_bytes().to_vec(),
@@ -75,19 +76,39 @@ impl Index {
 
 		match &data.target {
 			tg::Either::Left(id) => {
-				Self::schedule_object_accounts_for_cleaning(txn, subspace, id, partition_total)
-					.await?;
-				Self::decrement_object_reference_count(txn, subspace, id, partition_total).await?;
+				crate::fdb::propagate!(
+					Self::schedule_object_accounts_for_cleaning(
+						txn,
+						subspace,
+						id,
+						partition_total,
+					)
+					.await
+				);
+				crate::fdb::propagate!(
+					Self::decrement_object_reference_count(txn, subspace, id, partition_total)
+						.await
+				);
 			},
 			tg::Either::Right(id) => {
-				Self::schedule_process_accounts_for_cleaning(txn, subspace, id, partition_total)
-					.await?;
-				Self::decrement_process_reference_count(txn, subspace, id, partition_total).await?;
+				crate::fdb::propagate!(
+					Self::schedule_process_accounts_for_cleaning(
+						txn,
+						subspace,
+						id,
+						partition_total,
+					)
+					.await
+				);
+				crate::fdb::propagate!(
+					Self::decrement_process_reference_count(txn, subspace, id, partition_total)
+						.await
+				);
 			},
 		}
 
 		txn.clear(&key);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/tag/get.rs
+++ b/packages/index/src/fdb/tag/get.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -11,23 +12,23 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::tag::Id,
-	) -> crate::fdb::Result<Option<crate::tag::Tag>> {
+	) -> tg::Result<ControlFlow<Option<crate::tag::Tag>, fdb::FdbError>> {
 		let key = Key::Tag(crate::fdb::tag::Key::Tag(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::tag::Tag::deserialize(&bytes).map_err(crate::fdb::custom_error)?,
-		))
+		let tag = Some(crate::tag::Tag::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(tag))
 	}
 
 	pub(crate) async fn get_target_tags_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		target: &[u8],
-	) -> crate::fdb::Result<Vec<tg::tag::Id>> {
+	) -> tg::Result<ControlFlow<Vec<tg::tag::Id>, fdb::FdbError>> {
 		let key = (Kind::TargetTag.to_i32().unwrap(), target);
 		let prefix = Self::pack(subspace, &key);
 		let range_subspace = Subspace::from_bytes(prefix);
@@ -36,19 +37,19 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 
 		let tags = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Tag(crate::fdb::tag::Key::TargetTag { tag, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(tag)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(tags)
+		Ok(ControlFlow::Break(tags))
 	}
 }

--- a/packages/index/src/fdb/tag/get.rs
+++ b/packages/index/src/fdb/tag/get.rs
@@ -15,7 +15,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::tag::Tag>, fdb::FdbError>> {
 		let key = Key::Tag(crate::fdb::tag::Key::Tag(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};
@@ -37,7 +38,8 @@ impl Index {
 			..fdb::RangeOption::from(&range_subspace)
 		};
 
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 
 		let tags = entries
 			.iter()

--- a/packages/index/src/fdb/tag/put.rs
+++ b/packages/index/src/fdb/tag/put.rs
@@ -38,7 +38,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Tag(crate::fdb::tag::Key::Tag(arg.id.clone()));
 		let key = Self::pack(subspace, &key);
-		let tag = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let tag = crate::fdb::retry!(result)
 			.map(|bytes| crate::tag::Tag::deserialize(&bytes))
 			.transpose()?;
 		if let Some(tag) = tag.as_ref()

--- a/packages/index/src/fdb/tag/put.rs
+++ b/packages/index/src/fdb/tag/put.rs
@@ -1,6 +1,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -22,11 +23,11 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		args: &[crate::tag::put::Arg],
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
-			Self::put_tag(txn, subspace, arg, partition_total).await?;
+			crate::fdb::propagate!(Self::put_tag(txn, subspace, arg, partition_total).await);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn put_tag(
@@ -34,15 +35,12 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		arg: &crate::tag::put::Arg,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Tag(crate::fdb::tag::Key::Tag(arg.id.clone()));
 		let key = Self::pack(subspace, &key);
-		let tag = txn
-			.get(&key, false)
-			.await?
+		let tag = crate::fdb::retry!(txn.get(&key, false).await)
 			.map(|bytes| crate::tag::Tag::deserialize(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 		if let Some(tag) = tag.as_ref()
 			&& (tag.account != arg.account
 				|| tag.specifier != arg.specifier
@@ -50,17 +48,26 @@ impl Index {
 		{
 			match &tag.target {
 				tg::Either::Left(id) => {
-					Self::schedule_object_accounts_for_cleaning(txn, subspace, id, partition_total)
-						.await?;
+					crate::fdb::propagate!(
+						Self::schedule_object_accounts_for_cleaning(
+							txn,
+							subspace,
+							id,
+							partition_total,
+						)
+						.await
+					);
 				},
 				tg::Either::Right(id) => {
-					Self::schedule_process_accounts_for_cleaning(
-						txn,
-						subspace,
-						id,
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::schedule_process_accounts_for_cleaning(
+							txn,
+							subspace,
+							id,
+							partition_total,
+						)
+						.await
+					);
 				},
 			}
 		}
@@ -80,12 +87,16 @@ impl Index {
 
 			match &tag.target {
 				tg::Either::Left(id) => {
-					Self::decrement_object_reference_count(txn, subspace, id, partition_total)
-						.await?;
+					crate::fdb::propagate!(
+						Self::decrement_object_reference_count(txn, subspace, id, partition_total)
+							.await
+					);
 				},
 				tg::Either::Right(id) => {
-					Self::decrement_process_reference_count(txn, subspace, id, partition_total)
-						.await?;
+					crate::fdb::propagate!(
+						Self::decrement_process_reference_count(txn, subspace, id, partition_total)
+							.await
+					);
 				},
 			}
 		}
@@ -126,8 +137,7 @@ impl Index {
 			specifier: arg.specifier.clone(),
 			target: arg.target.clone(),
 		}
-		.serialize()
-		.map_err(crate::fdb::custom_error)?;
+		.serialize()?;
 		txn.set(&key, &value);
 
 		let node_key = Key::Node(crate::fdb::node::Key::Node(arg.specifier.clone()));
@@ -162,6 +172,6 @@ impl Index {
 		let tag_parent_key = Self::pack(subspace, &tag_parent_key);
 		txn.set(&tag_parent_key, &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/transaction.rs
+++ b/packages/index/src/fdb/transaction.rs
@@ -8,59 +8,12 @@ use {
 	tangram_client::prelude::*,
 };
 
-#[derive(Clone, Copy)]
-enum Mode {
-	Read,
-	Write,
-}
-
 #[derive(Clone)]
 pub(crate) struct Transaction {
 	inner: Arc<fdb::Transaction>,
 }
 
 pub(crate) async fn run<T, F, Fut>(database: &fdb::Database, operation: F) -> tg::Result<T>
-where
-	F: Fn(Transaction) -> Fut,
-	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
-{
-	run_with_mode(database, Mode::Write, operation).await
-}
-
-pub(crate) async fn run_read<T, F, Fut>(database: &fdb::Database, operation: F) -> tg::Result<T>
-where
-	F: Fn(Transaction) -> Fut,
-	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
-{
-	run_with_mode(database, Mode::Read, operation).await
-}
-
-impl Transaction {
-	pub(super) fn new(transaction: fdb::Transaction) -> Self {
-		let inner = Arc::new(transaction);
-
-		Self { inner }
-	}
-
-	pub(super) fn take(self) -> tg::Result<fdb::Transaction> {
-		Arc::try_unwrap(self.inner)
-			.map_err(|_| tg::error!("a reference to the transaction was retained"))
-	}
-}
-
-impl Deref for Transaction {
-	type Target = fdb::Transaction;
-
-	fn deref(&self) -> &Self::Target {
-		&self.inner
-	}
-}
-
-async fn run_with_mode<T, F, Fut>(
-	database: &fdb::Database,
-	mode: Mode,
-	operation: F,
-) -> tg::Result<T>
 where
 	F: Fn(Transaction) -> Fut,
 	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
@@ -84,15 +37,6 @@ where
 			},
 		};
 
-		match mode {
-			Mode::Read => {
-				drop(transaction.take()?);
-
-				return Ok(value);
-			},
-			Mode::Write => {},
-		}
-
 		match transaction.take()?.commit().await {
 			Ok(_) => return Ok(value),
 			Err(error) => {
@@ -103,5 +47,26 @@ where
 					.map_err(|error| tg::error!(!error, "failed to retry a transaction"))?;
 			},
 		}
+	}
+}
+
+impl Transaction {
+	pub(super) fn new(transaction: fdb::Transaction) -> Self {
+		let inner = Arc::new(transaction);
+
+		Self { inner }
+	}
+
+	pub(super) fn take(self) -> tg::Result<fdb::Transaction> {
+		Arc::try_unwrap(self.inner)
+			.map_err(|_| tg::error!("a reference to the transaction was retained"))
+	}
+}
+
+impl Deref for Transaction {
+	type Target = fdb::Transaction;
+
+	fn deref(&self) -> &Self::Target {
+		&self.inner
 	}
 }

--- a/packages/index/src/fdb/transaction.rs
+++ b/packages/index/src/fdb/transaction.rs
@@ -8,12 +8,59 @@ use {
 	tangram_client::prelude::*,
 };
 
+#[derive(Clone, Copy)]
+enum Mode {
+	Read,
+	Write,
+}
+
 #[derive(Clone)]
 pub(crate) struct Transaction {
 	inner: Arc<fdb::Transaction>,
 }
 
 pub(crate) async fn run<T, F, Fut>(database: &fdb::Database, operation: F) -> tg::Result<T>
+where
+	F: Fn(Transaction) -> Fut,
+	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
+{
+	run_with_mode(database, Mode::Write, operation).await
+}
+
+pub(crate) async fn run_read<T, F, Fut>(database: &fdb::Database, operation: F) -> tg::Result<T>
+where
+	F: Fn(Transaction) -> Fut,
+	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
+{
+	run_with_mode(database, Mode::Read, operation).await
+}
+
+impl Transaction {
+	pub(super) fn new(transaction: fdb::Transaction) -> Self {
+		let inner = Arc::new(transaction);
+
+		Self { inner }
+	}
+
+	pub(super) fn take(self) -> tg::Result<fdb::Transaction> {
+		Arc::try_unwrap(self.inner)
+			.map_err(|_| tg::error!("a reference to the transaction was retained"))
+	}
+}
+
+impl Deref for Transaction {
+	type Target = fdb::Transaction;
+
+	fn deref(&self) -> &Self::Target {
+		&self.inner
+	}
+}
+
+async fn run_with_mode<T, F, Fut>(
+	database: &fdb::Database,
+	mode: Mode,
+	operation: F,
+) -> tg::Result<T>
 where
 	F: Fn(Transaction) -> Fut,
 	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
@@ -37,6 +84,15 @@ where
 			},
 		};
 
+		match mode {
+			Mode::Read => {
+				drop(transaction.take()?);
+
+				return Ok(value);
+			},
+			Mode::Write => {},
+		}
+
 		match transaction.take()?.commit().await {
 			Ok(_) => return Ok(value),
 			Err(error) => {
@@ -47,26 +103,5 @@ where
 					.map_err(|error| tg::error!(!error, "failed to retry a transaction"))?;
 			},
 		}
-	}
-}
-
-impl Transaction {
-	pub(super) fn new(transaction: fdb::Transaction) -> Self {
-		let inner = Arc::new(transaction);
-
-		Self { inner }
-	}
-
-	pub(super) fn take(self) -> tg::Result<fdb::Transaction> {
-		Arc::try_unwrap(self.inner)
-			.map_err(|_| tg::error!("a reference to the transaction was retained"))
-	}
-}
-
-impl Deref for Transaction {
-	type Target = fdb::Transaction;
-
-	fn deref(&self) -> &Self::Target {
-		&self.inner
 	}
 }

--- a/packages/index/src/fdb/transaction.rs
+++ b/packages/index/src/fdb/transaction.rs
@@ -1,0 +1,72 @@
+use {
+	foundationdb as fdb,
+	std::{
+		future::Future,
+		ops::{ControlFlow, Deref},
+		sync::Arc,
+	},
+	tangram_client::prelude::*,
+};
+
+#[derive(Clone)]
+pub(crate) struct Transaction {
+	inner: Arc<fdb::Transaction>,
+}
+
+pub(crate) async fn run<T, F, Fut>(database: &fdb::Database, operation: F) -> tg::Result<T>
+where
+	F: Fn(Transaction) -> Fut,
+	Fut: Future<Output = tg::Result<ControlFlow<T, fdb::FdbError>>>,
+{
+	let transaction = database
+		.create_trx()
+		.map_err(|error| tg::error!(!error, "failed to create a transaction"))?;
+	let mut transaction = Transaction::new(transaction);
+	loop {
+		let result = operation(transaction.clone()).await?;
+		let value = match result {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => {
+				transaction = transaction
+					.take()?
+					.on_error(error)
+					.await
+					.map(Transaction::new)
+					.map_err(|error| tg::error!(!error, "failed to retry a transaction"))?;
+				continue;
+			},
+		};
+
+		match transaction.take()?.commit().await {
+			Ok(_) => return Ok(value),
+			Err(error) => {
+				transaction = error
+					.on_error()
+					.await
+					.map(Transaction::new)
+					.map_err(|error| tg::error!(!error, "failed to retry a transaction"))?;
+			},
+		}
+	}
+}
+
+impl Transaction {
+	pub(super) fn new(transaction: fdb::Transaction) -> Self {
+		let inner = Arc::new(transaction);
+
+		Self { inner }
+	}
+
+	pub(super) fn take(self) -> tg::Result<fdb::Transaction> {
+		Arc::try_unwrap(self.inner)
+			.map_err(|_| tg::error!("a reference to the transaction was retained"))
+	}
+}
+
+impl Deref for Transaction {
+	type Target = fdb::Transaction;
+
+	fn deref(&self) -> &Self::Target {
+		&self.inner
+	}
+}

--- a/packages/index/src/fdb/transaction.rs
+++ b/packages/index/src/fdb/transaction.rs
@@ -51,13 +51,13 @@ where
 }
 
 impl Transaction {
-	pub(super) fn new(transaction: fdb::Transaction) -> Self {
+	fn new(transaction: fdb::Transaction) -> Self {
 		let inner = Arc::new(transaction);
 
 		Self { inner }
 	}
 
-	pub(super) fn take(self) -> tg::Result<fdb::Transaction> {
+	fn take(self) -> tg::Result<fdb::Transaction> {
 		Arc::try_unwrap(self.inner)
 			.map_err(|_| tg::error!("a reference to the transaction was retained"))
 	}

--- a/packages/index/src/fdb/update.rs
+++ b/packages/index/src/fdb/update.rs
@@ -290,7 +290,8 @@ impl Index {
 				..Default::default()
 			};
 			async move {
-				let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+				let result = txn.get_range(&range, 1, false).await;
+				let entries = crate::fdb::retry!(result);
 				let Some(entry) = entries.first() else {
 					return Ok(ControlFlow::Break(None));
 				};
@@ -309,7 +310,7 @@ impl Index {
 		let transaction_id = {
 			let result = future::try_join_all(futures).await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -376,7 +377,8 @@ impl Index {
 				mode: fdb::options::StreamingMode::WantAll,
 				..Default::default()
 			};
-			let partition_entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+			let result = txn.get_range(&range, 1, false).await;
+			let partition_entries = crate::fdb::retry!(result);
 			for entry in partition_entries {
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::Update(crate::fdb::update::Key::UpdateVersion {
@@ -401,7 +403,8 @@ impl Index {
 					kind: kind.clone(),
 				}),
 			);
-			let value = crate::fdb::retry!(txn.get(&key, false).await);
+			let result = txn.get(&key, false).await;
+			let value = crate::fdb::retry!(result);
 
 			let Some(value) = value else {
 				Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
@@ -819,7 +822,8 @@ impl Index {
 			begin.push(0);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let mut accounts = entries
 			.iter()
 			.map(|entry| match Self::unpack(subspace, entry.key())? {
@@ -873,7 +877,8 @@ impl Index {
 			begin.push(0);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let mut children = entries
 			.iter()
 			.map(|entry| {
@@ -996,11 +1001,11 @@ impl Index {
 			);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = crate::fdb::retry!(
-			txn.get_ranges_keyvalues(range, false)
-				.try_collect::<Vec<_>>()
-				.await
-		);
+		let result = txn
+			.get_ranges_keyvalues(range, false)
+			.try_collect::<Vec<_>>()
+			.await;
+		let entries = crate::fdb::retry!(result);
 		let mut children = entries
 			.iter()
 			.map(|entry| {
@@ -1055,7 +1060,8 @@ impl Index {
 			begin.push(0);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let mut objects = entries
 			.iter()
 			.map(|entry| {
@@ -1123,7 +1129,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(false));
 		};
@@ -1141,7 +1148,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -1284,7 +1291,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -1560,7 +1567,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(false));
 		};
@@ -1587,7 +1595,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -1740,7 +1748,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<ProcessOutput, fdb::FdbError>> {
 		let process_key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let process_key = Self::pack(subspace, &process_key);
-		let bytes = crate::fdb::retry!(txn.get(&process_key, false).await);
+		let result = txn.get(&process_key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			let output = ProcessOutput {
 				changed: false,
@@ -1761,7 +1770,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -2627,7 +2636,8 @@ impl Index {
 				kind: kind.clone(),
 			}),
 		);
-		let source = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let source = crate::fdb::retry!(result)
 			.map(|bytes| deserialize_source_update(kind, &bytes))
 			.transpose()?;
 		if !matches!(source, Some(Source::Put)) {

--- a/packages/index/src/fdb/update.rs
+++ b/packages/index/src/fdb/update.rs
@@ -8,7 +8,7 @@ use {
 	foundationdb_tuple::{self as fdbt, Subspace},
 	futures::{TryStreamExt as _, future},
 	num_traits::ToPrimitive as _,
-	std::collections::BTreeSet,
+	std::{collections::BTreeSet, ops::ControlFlow},
 	tangram_client::prelude::*,
 };
 
@@ -277,7 +277,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		kind: crate::update::Kind,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<u64>> {
+	) -> tg::Result<ControlFlow<Option<u64>, fdb::FdbError>> {
 		let key_kind = update_version_key_kind(kind).to_i32().unwrap();
 		let futures = (0..partition_total).map(|partition| {
 			let begin = Self::pack(subspace, &(key_kind, partition));
@@ -290,29 +290,40 @@ impl Index {
 				..Default::default()
 			};
 			async move {
-				let entries = txn.get_range(&range, 1, false).await?;
+				let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 				let Some(entry) = entries.first() else {
-					return Ok(None);
+					return Ok(ControlFlow::Break(None));
 				};
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::Update(crate::fdb::update::Key::UpdateVersion {
 					version, ..
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected update key"));
+					return Err(tg::error!("unexpected update key"));
 				};
 				let transaction_id =
 					u64::from_be_bytes(version.as_bytes()[..8].try_into().unwrap());
-				Ok(Some(transaction_id))
+				Ok(ControlFlow::Break(Some(transaction_id)))
 			}
 		});
-		let transaction_id = future::try_join_all(futures)
-			.await?
-			.into_iter()
-			.flatten()
-			.min();
+		let transaction_id = {
+			let result = future::try_join_all(futures).await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		}
+		.into_iter()
+		.flatten()
+		.min();
 
-		Ok(transaction_id)
+		Ok(ControlFlow::Break(transaction_id))
 	}
 
 	pub async fn update_batch(
@@ -347,7 +358,7 @@ impl Index {
 		max_process_depth: Option<u64>,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<crate::update::Output> {
+	) -> tg::Result<ControlFlow<crate::update::Output, fdb::FdbError>> {
 		let mut entries = Vec::new();
 
 		let key_kind = update_version_key_kind(kind).to_i32().unwrap();
@@ -365,7 +376,7 @@ impl Index {
 				mode: fdb::options::StreamingMode::WantAll,
 				..Default::default()
 			};
-			let partition_entries = txn.get_range(&range, 1, false).await?;
+			let partition_entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 			for entry in partition_entries {
 				let key = Self::unpack(subspace, entry.key())?;
 				let crate::fdb::Key::Update(crate::fdb::update::Key::UpdateVersion {
@@ -375,7 +386,7 @@ impl Index {
 					kind,
 				}) = key
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				entries.push((partition, version, id, kind));
 			}
@@ -390,7 +401,7 @@ impl Index {
 					kind: kind.clone(),
 				}),
 			);
-			let value = txn.get(&key, false).await?;
+			let value = crate::fdb::retry!(txn.get(&key, false).await);
 
 			let Some(value) = value else {
 				Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
@@ -399,50 +410,48 @@ impl Index {
 			};
 
 			let (cursor, source) = match &kind {
-				Kind::Grant(_) | Kind::Node => (
-					None,
-					Some(
-						deserialize_source_update(&kind, &value)
-							.map_err(crate::fdb::custom_error)?,
-					),
-				),
-				Kind::Storage(_) => (
-					StorageUpdate::deserialize(&value)
-						.map_err(crate::fdb::custom_error)?
-						.cursor,
-					None,
-				),
+				Kind::Grant(_) | Kind::Node => {
+					(None, Some(deserialize_source_update(&kind, &value)?))
+				},
+				Kind::Storage(_) => (StorageUpdate::deserialize(&value)?.cursor, None),
 			};
 			let mut next_cursor = None;
 
 			let changed = match &kind {
 				Kind::Grant(subject) => match &id {
 					tg::Either::Left(id) => {
-						Self::update_object_grants_for_subject(
-							txn,
-							subspace,
-							id,
-							subject,
-							partition_total,
+						crate::fdb::propagate!(
+							Self::update_object_grants_for_subject(
+								txn,
+								subspace,
+								id,
+								subject,
+								partition_total,
+							)
+							.await
 						)
-						.await?
 					},
 					tg::Either::Right(id) => {
-						Self::update_process_grants_for_subject(
-							txn,
-							subspace,
-							id,
-							subject,
-							partition_total,
+						crate::fdb::propagate!(
+							Self::update_process_grants_for_subject(
+								txn,
+								subspace,
+								id,
+								subject,
+								partition_total,
+							)
+							.await
 						)
-						.await?
 					},
 				},
 				Kind::Node => match &id {
-					tg::Either::Left(id) => Self::update_object(txn, subspace, id).await?,
+					tg::Either::Left(id) => {
+						crate::fdb::propagate!(Self::update_object(txn, subspace, id).await)
+					},
 					tg::Either::Right(id) => {
-						let process_output =
-							Self::update_process(txn, subspace, id, max_process_depth).await?;
+						let process_output = crate::fdb::propagate!(
+							Self::update_process(txn, subspace, id, max_process_depth).await
+						);
 						if process_output.depth_exceeded {
 							output.processes_with_depth_exceeded.push(id.clone());
 						}
@@ -454,76 +463,86 @@ impl Index {
 					touched_at,
 				}) => match &id {
 					tg::Either::Left(object) => {
-						Self::put_account_object(
-							txn,
-							subspace,
-							&crate::usage::storage::put::ObjectArg {
-								account: account.clone(),
-								object: object.clone(),
-								touched_at: *touched_at,
-							},
-							partition_total,
-							usage_partition_total,
-							false,
-							Some(&version),
+						crate::fdb::propagate!(
+							Self::put_account_object(
+								txn,
+								subspace,
+								&crate::usage::storage::put::ObjectArg {
+									account: account.clone(),
+									object: object.clone(),
+									touched_at: *touched_at,
+								},
+								partition_total,
+								usage_partition_total,
+								false,
+								Some(&version),
+							)
+							.await
 						)
-						.await?
 					},
 					tg::Either::Right(process) => {
-						Self::put_account_process(
-							txn,
-							subspace,
-							&crate::usage::storage::put::ProcessArg {
-								account: account.clone(),
-								process: process.clone(),
-								touched_at: *touched_at,
-							},
-							partition_total,
-							usage_partition_total,
-							false,
-							Some(&version),
+						crate::fdb::propagate!(
+							Self::put_account_process(
+								txn,
+								subspace,
+								&crate::usage::storage::put::ProcessArg {
+									account: account.clone(),
+									process: process.clone(),
+									touched_at: *touched_at,
+								},
+								partition_total,
+								usage_partition_total,
+								false,
+								Some(&version),
+							)
+							.await
 						)
-						.await?
 					},
 				},
 				Kind::Storage(StorageKind::Clean(account)) => {
-					next_cursor = Self::propagate_storage_clean(
-						txn,
-						subspace,
-						&id,
-						account,
-						cursor.as_ref(),
-						partition_total,
-					)
-					.await?;
+					next_cursor = crate::fdb::propagate!(
+						Self::propagate_storage_clean(
+							txn,
+							subspace,
+							&id,
+							account,
+							cursor.as_ref(),
+							partition_total,
+						)
+						.await
+					);
 					false
 				},
 				Kind::Storage(StorageKind::CleanAll) => {
-					next_cursor = Self::propagate_storage_accounts_clean(
-						txn,
-						subspace,
-						&id,
-						cursor.as_ref(),
-						partition_total,
-					)
-					.await?;
+					next_cursor = crate::fdb::propagate!(
+						Self::propagate_storage_accounts_clean(
+							txn,
+							subspace,
+							&id,
+							cursor.as_ref(),
+							partition_total,
+						)
+						.await
+					);
 					false
 				},
 				Kind::Storage(StorageKind::Propagate {
 					account,
 					touched_at,
 				}) => {
-					next_cursor = Self::propagate_storage_relationships(
-						txn,
-						subspace,
-						&id,
-						account,
-						cursor.as_ref(),
-						partition_total,
-						*touched_at,
-						&version,
-					)
-					.await?;
+					next_cursor = crate::fdb::propagate!(
+						Self::propagate_storage_relationships(
+							txn,
+							subspace,
+							&id,
+							account,
+							cursor.as_ref(),
+							partition_total,
+							*touched_at,
+							&version,
+						)
+						.await
+					);
 					false
 				},
 			};
@@ -533,7 +552,10 @@ impl Index {
 					Source::Put => true,
 					Source::Propagate => changed,
 				} {
-				Self::enqueue_parents(txn, subspace, &id, &kind, &version, partition_total).await?;
+				crate::fdb::propagate!(
+					Self::enqueue_parents(txn, subspace, &id, &kind, &version, partition_total,)
+						.await
+				);
 			}
 
 			let continued = if let Some(cursor) = next_cursor {
@@ -547,10 +569,12 @@ impl Index {
 						kind: kind.clone(),
 					}),
 				);
-				txn.set(&key, &update.serialize().map_err(crate::fdb::custom_error)?);
+				txn.set(&key, &update.serialize()?);
 				true
 			} else {
-				Self::schedule_update_item_clean(txn, subspace, &id, partition_total).await?;
+				crate::fdb::propagate!(
+					Self::schedule_update_item_clean(txn, subspace, &id, partition_total).await
+				);
 				let key = Self::pack(
 					subspace,
 					&crate::fdb::Key::Update(crate::fdb::update::Key::Update {
@@ -568,7 +592,7 @@ impl Index {
 			output.count += 1;
 		}
 
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -581,9 +605,10 @@ impl Index {
 		partition_total: u64,
 		touched_at: i64,
 		version: &fdbt::Versionstamp,
-	) -> crate::fdb::Result<Option<StorageCursor>> {
-		let (relationships, cursor) =
-			Self::get_storage_relationships_page(txn, subspace, id, cursor).await?;
+	) -> tg::Result<ControlFlow<Option<StorageCursor>, fdb::FdbError>> {
+		let (relationships, cursor) = crate::fdb::propagate!(
+			Self::get_storage_relationships_page(txn, subspace, id, cursor).await
+		);
 		let kind = Kind::Storage(StorageKind::Add {
 			account: account.clone(),
 			touched_at,
@@ -604,7 +629,7 @@ impl Index {
 			);
 		}
 
-		Ok(cursor)
+		Ok(ControlFlow::Break(cursor))
 	}
 
 	async fn propagate_storage_clean(
@@ -614,35 +639,47 @@ impl Index {
 		account: &crate::usage::Account,
 		cursor: Option<&StorageCursor>,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<StorageCursor>> {
-		let (relationships, cursor) =
-			Self::get_storage_relationships_page(txn, subspace, id, cursor).await?;
-		future::try_join_all(relationships.iter().map(|relationship| async move {
-			match relationship {
-				StorageRelationship::Object(object) => {
-					Self::schedule_account_object_for_cleaning(
-						txn,
-						subspace,
-						account,
-						object,
-						partition_total,
-					)
-					.await
-				},
-				StorageRelationship::Process(process) => {
-					Self::schedule_account_process_for_cleaning(
-						txn,
-						subspace,
-						account,
-						process,
-						partition_total,
-					)
-					.await
-				},
+	) -> tg::Result<ControlFlow<Option<StorageCursor>, fdb::FdbError>> {
+		let (relationships, cursor) = crate::fdb::propagate!(
+			Self::get_storage_relationships_page(txn, subspace, id, cursor).await
+		);
+		{
+			let result =
+				future::try_join_all(relationships.iter().map(|relationship| async move {
+					match relationship {
+						StorageRelationship::Object(object) => {
+							Self::schedule_account_object_for_cleaning(
+								txn,
+								subspace,
+								account,
+								object,
+								partition_total,
+							)
+							.await
+						},
+						StorageRelationship::Process(process) => {
+							Self::schedule_account_process_for_cleaning(
+								txn,
+								subspace,
+								account,
+								process,
+								partition_total,
+							)
+							.await
+						},
+					}
+				}))
+				.await;
+			let results = result?;
+			for result in results {
+				match result {
+					ControlFlow::Break(()) => {},
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				}
 			}
-		}))
-		.await?;
-		Ok(cursor)
+		};
+
+		Ok(ControlFlow::Break(cursor))
 	}
 
 	async fn propagate_storage_accounts_clean(
@@ -651,35 +688,46 @@ impl Index {
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		cursor: Option<&StorageCursor>,
 		partition_total: u64,
-	) -> crate::fdb::Result<Option<StorageCursor>> {
-		let (accounts, cursor) = Self::get_storage_accounts_page(txn, subspace, id, cursor).await?;
-		future::try_join_all(accounts.iter().map(|account| async move {
-			match id {
-				tg::Either::Left(object) => {
-					Self::schedule_account_object_for_cleaning(
-						txn,
-						subspace,
-						account,
-						object,
-						partition_total,
-					)
-					.await
-				},
-				tg::Either::Right(process) => {
-					Self::schedule_account_process_for_cleaning(
-						txn,
-						subspace,
-						account,
-						process,
-						partition_total,
-					)
-					.await
-				},
+	) -> tg::Result<ControlFlow<Option<StorageCursor>, fdb::FdbError>> {
+		let (accounts, cursor) = crate::fdb::propagate!(
+			Self::get_storage_accounts_page(txn, subspace, id, cursor).await
+		);
+		{
+			let result = future::try_join_all(accounts.iter().map(|account| async move {
+				match id {
+					tg::Either::Left(object) => {
+						Self::schedule_account_object_for_cleaning(
+							txn,
+							subspace,
+							account,
+							object,
+							partition_total,
+						)
+						.await
+					},
+					tg::Either::Right(process) => {
+						Self::schedule_account_process_for_cleaning(
+							txn,
+							subspace,
+							account,
+							process,
+							partition_total,
+						)
+						.await
+					},
+				}
+			}))
+			.await;
+			let results = result?;
+			for result in results {
+				match result {
+					ControlFlow::Break(()) => {},
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				}
 			}
-		}))
-		.await?;
+		};
 
-		Ok(cursor)
+		Ok(ControlFlow::Break(cursor))
 	}
 
 	async fn get_storage_relationships_page(
@@ -687,7 +735,8 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		cursor: Option<&StorageCursor>,
-	) -> crate::fdb::Result<(Vec<StorageRelationship>, Option<StorageCursor>)> {
+	) -> tg::Result<ControlFlow<(Vec<StorageRelationship>, Option<StorageCursor>), fdb::FdbError>>
+	{
 		match id {
 			tg::Either::Left(object) => {
 				let after = match cursor {
@@ -699,9 +748,7 @@ impl Index {
 						| StorageCursor::ProcessObject(_)
 						| StorageCursor::ProcessAccount(_),
 					) => {
-						return Err(
-							crate::fdb::error!(%object, "an object update has an invalid cursor"),
-						);
+						return Err(tg::error!(%object, "an object update has an invalid cursor"));
 					},
 				};
 				Self::get_storage_object_relationships_page(txn, subspace, object, after).await
@@ -715,9 +762,7 @@ impl Index {
 							| StorageCursor::ProcessAccount(_)
 					)
 				) {
-					return Err(
-						crate::fdb::error!(%process, "a process update has an invalid cursor"),
-					);
+					return Err(tg::error!(%process, "a process update has an invalid cursor"));
 				}
 				Self::get_storage_process_relationships_page(txn, subspace, process, cursor).await
 			},
@@ -729,7 +774,8 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		cursor: Option<&StorageCursor>,
-	) -> crate::fdb::Result<(Vec<crate::usage::Account>, Option<StorageCursor>)> {
+	) -> tg::Result<ControlFlow<(Vec<crate::usage::Account>, Option<StorageCursor>), fdb::FdbError>>
+	{
 		let (kind, item, after) = match (id, cursor) {
 			(tg::Either::Left(object), None) => (KeyKind::ObjectAccount, object.to_bytes(), None),
 			(tg::Either::Left(object), Some(StorageCursor::ObjectAccount(account))) => (
@@ -756,14 +802,10 @@ impl Index {
 				)),
 			),
 			(tg::Either::Left(object), Some(_)) => {
-				return Err(
-					crate::fdb::error!(%object, "an object account update has an invalid cursor"),
-				);
+				return Err(tg::error!(%object, "an object account update has an invalid cursor"));
 			},
 			(tg::Either::Right(process), Some(_)) => {
-				return Err(
-					crate::fdb::error!(%process, "a process account update has an invalid cursor"),
-				);
+				return Err(tg::error!(%process, "a process account update has an invalid cursor"));
 			},
 		};
 		let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), item.as_ref()));
@@ -777,7 +819,7 @@ impl Index {
 			begin.push(0);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let mut accounts = entries
 			.iter()
 			.map(|entry| match Self::unpack(subspace, entry.key())? {
@@ -785,9 +827,9 @@ impl Index {
 					crate::fdb::usage::Key::ObjectAccount { account, .. }
 					| crate::fdb::usage::Key::ProcessAccount { account, .. },
 				) => Ok(account),
-				_ => Err(crate::fdb::error!("unexpected key type")),
+				_ => Err(tg::error!("unexpected key type")),
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let cursor = if accounts.len() > STORAGE_RELATION_BATCH_SIZE {
 			accounts.truncate(STORAGE_RELATION_BATCH_SIZE);
 			let account = accounts.last().unwrap().clone();
@@ -799,7 +841,7 @@ impl Index {
 			None
 		};
 
-		Ok((accounts, cursor))
+		Ok(ControlFlow::Break((accounts, cursor)))
 	}
 
 	async fn get_storage_object_relationships_page(
@@ -807,7 +849,8 @@ impl Index {
 		subspace: &Subspace,
 		object: &tg::object::Id,
 		after: Option<&tg::object::Id>,
-	) -> crate::fdb::Result<(Vec<StorageRelationship>, Option<StorageCursor>)> {
+	) -> tg::Result<ControlFlow<(Vec<StorageRelationship>, Option<StorageCursor>), fdb::FdbError>>
+	{
 		let object_bytes = object.to_bytes();
 		let prefix = Self::pack(
 			subspace,
@@ -830,18 +873,18 @@ impl Index {
 			begin.push(0);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let mut children = entries
 			.iter()
 			.map(|entry| {
 				let crate::fdb::Key::Object(crate::fdb::object::Key::ObjectChild { child, .. }) =
 					Self::unpack(subspace, entry.key())?
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(child)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let cursor = if children.len() > STORAGE_RELATION_BATCH_SIZE {
 			children.truncate(STORAGE_RELATION_BATCH_SIZE);
 			Some(StorageCursor::Object(children.last().unwrap().clone()))
@@ -853,7 +896,7 @@ impl Index {
 			.map(StorageRelationship::Object)
 			.collect();
 
-		Ok((relationships, cursor))
+		Ok(ControlFlow::Break((relationships, cursor)))
 	}
 
 	async fn get_storage_process_relationships_page(
@@ -861,7 +904,8 @@ impl Index {
 		subspace: &Subspace,
 		process: &tg::process::Id,
 		cursor: Option<&StorageCursor>,
-	) -> crate::fdb::Result<(Vec<StorageRelationship>, Option<StorageCursor>)> {
+	) -> tg::Result<ControlFlow<(Vec<StorageRelationship>, Option<StorageCursor>), fdb::FdbError>>
+	{
 		let mut relationships = Vec::new();
 		let process_object_cursor = match cursor {
 			None | Some(StorageCursor::ProcessChild(_)) => {
@@ -869,17 +913,21 @@ impl Index {
 					Some(StorageCursor::ProcessChild(position)) => Some(*position),
 					_ => None,
 				};
-				let (children, child_cursor, more) =
-					Self::get_storage_process_children_page(txn, subspace, process, after).await?;
+				let (children, child_cursor, more) = crate::fdb::propagate!(
+					Self::get_storage_process_children_page(txn, subspace, process, after).await
+				);
 				relationships.extend(children.into_iter().map(StorageRelationship::Process));
 				if more {
-					return Ok((
+					return Ok(ControlFlow::Break((
 						relationships,
 						Some(StorageCursor::ProcessChild(child_cursor.unwrap())),
-					));
+					)));
 				}
 				if relationships.len() == STORAGE_RELATION_BATCH_SIZE {
-					return Ok((relationships, Some(StorageCursor::ProcessObject(None))));
+					return Ok(ControlFlow::Break((
+						relationships,
+						Some(StorageCursor::ProcessObject(None)),
+					)));
 				}
 				None
 			},
@@ -891,14 +939,16 @@ impl Index {
 			) => unreachable!(),
 		};
 		let limit = STORAGE_RELATION_BATCH_SIZE - relationships.len();
-		let (objects, more) = Self::get_storage_process_objects_page(
-			txn,
-			subspace,
-			process,
-			process_object_cursor,
-			limit,
-		)
-		.await?;
+		let (objects, more) = crate::fdb::propagate!(
+			Self::get_storage_process_objects_page(
+				txn,
+				subspace,
+				process,
+				process_object_cursor,
+				limit,
+			)
+			.await
+		);
 		let cursor = objects.last().map(|(object, kind)| ProcessObjectCursor {
 			kind: *kind,
 			object: object.clone(),
@@ -910,7 +960,7 @@ impl Index {
 		);
 		let cursor = more.then_some(StorageCursor::ProcessObject(cursor));
 
-		Ok((relationships, cursor))
+		Ok(ControlFlow::Break((relationships, cursor)))
 	}
 
 	async fn get_storage_process_children_page(
@@ -918,7 +968,7 @@ impl Index {
 		subspace: &Subspace,
 		process: &tg::process::Id,
 		after: Option<i64>,
-	) -> crate::fdb::Result<(Vec<tg::process::Id>, Option<i64>, bool)> {
+	) -> tg::Result<ControlFlow<(Vec<tg::process::Id>, Option<i64>, bool), fdb::FdbError>> {
 		let process_bytes = process.to_bytes();
 		let prefix = Self::pack(
 			subspace,
@@ -935,7 +985,7 @@ impl Index {
 		if let Some(after) = after {
 			let position = after
 				.checked_add(1)
-				.ok_or_else(|| crate::fdb::error!("the process has too many children"))?;
+				.ok_or_else(|| tg::error!("the process has too many children"))?;
 			let begin = Self::pack(
 				subspace,
 				&(
@@ -946,10 +996,11 @@ impl Index {
 			);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = txn
-			.get_ranges_keyvalues(range, false)
-			.try_collect::<Vec<_>>()
-			.await?;
+		let entries = crate::fdb::retry!(
+			txn.get_ranges_keyvalues(range, false)
+				.try_collect::<Vec<_>>()
+				.await
+		);
 		let mut children = entries
 			.iter()
 			.map(|entry| {
@@ -959,17 +1010,17 @@ impl Index {
 					..
 				}) = Self::unpack(subspace, entry.key())?
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok((child, position))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let more = children.len() > STORAGE_RELATION_BATCH_SIZE;
 		children.truncate(STORAGE_RELATION_BATCH_SIZE);
 		let cursor = children.last().map(|(_, position)| *position);
 		let children = children.into_iter().map(|(child, _)| child).collect();
 
-		Ok((children, cursor, more))
+		Ok(ControlFlow::Break((children, cursor, more)))
 	}
 
 	async fn get_storage_process_objects_page(
@@ -978,7 +1029,9 @@ impl Index {
 		process: &tg::process::Id,
 		after: Option<&ProcessObjectCursor>,
 		limit: usize,
-	) -> crate::fdb::Result<(Vec<(tg::object::Id, crate::process::object::Kind)>, bool)> {
+	) -> tg::Result<
+		ControlFlow<(Vec<(tg::object::Id, crate::process::object::Kind)>, bool), fdb::FdbError>,
+	> {
 		let process_bytes = process.to_bytes();
 		let prefix = Self::pack(
 			subspace,
@@ -1002,7 +1055,7 @@ impl Index {
 			begin.push(0);
 			range.begin = fdb::KeySelector::first_greater_or_equal(begin);
 		}
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let mut objects = entries
 			.iter()
 			.map(|entry| {
@@ -1012,15 +1065,15 @@ impl Index {
 					..
 				}) = Self::unpack(subspace, entry.key())?
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok((object, kind))
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 		let more = objects.len() > limit;
 		objects.truncate(limit);
 
-		Ok((objects, more))
+		Ok(ControlFlow::Break((objects, more)))
 	}
 
 	async fn schedule_update_item_clean(
@@ -1028,12 +1081,13 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = match id {
 			tg::Either::Left(id) => {
-				let Some(object) = Self::try_get_object_with_transaction(txn, subspace, id).await?
-				else {
-					return Ok(());
+				let Some(object) = crate::fdb::propagate!(
+					Self::try_get_object_with_transaction(txn, subspace, id).await
+				) else {
+					return Ok(ControlFlow::Break(()));
 				};
 				let partition = Self::partition_for_id(id.to_bytes().as_ref(), partition_total);
 				crate::fdb::clean::Key::Object {
@@ -1043,10 +1097,10 @@ impl Index {
 				}
 			},
 			tg::Either::Right(id) => {
-				let Some(process) =
-					Self::try_get_process_with_transaction(txn, subspace, id).await?
-				else {
-					return Ok(());
+				let Some(process) = crate::fdb::propagate!(
+					Self::try_get_process_with_transaction(txn, subspace, id).await
+				) else {
+					return Ok(ControlFlow::Break(()));
 				};
 				let partition = Self::partition_for_id(id.to_bytes().as_ref(), partition_total);
 				crate::fdb::clean::Key::Process {
@@ -1059,31 +1113,44 @@ impl Index {
 		let key = crate::fdb::Key::Clean(key);
 		txn.set(&Self::pack(subspace, &key), &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn update_object(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::object::Id,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let key = crate::fdb::Key::Object(crate::fdb::object::Key::Object(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		};
-		let mut object =
-			crate::object::Object::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let mut object = crate::object::Object::deserialize(&bytes)?;
 
-		let children = Self::get_object_children_with_transaction(txn, subspace, id).await?;
+		let children = crate::fdb::propagate!(
+			Self::get_object_children_with_transaction(txn, subspace, id).await
+		);
 
-		let child_objects: Vec<Option<crate::object::Object>> = future::try_join_all(
-			children
-				.iter()
-				.map(|child| Self::try_get_object_with_transaction(txn, subspace, child)),
-		)
-		.await?;
+		let child_objects = {
+			let result = future::try_join_all(
+				children
+					.iter()
+					.map(|child| Self::try_get_object_with_transaction(txn, subspace, child)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
 		let mut changed = false;
 
 		if !object.stored.subtree {
@@ -1181,11 +1248,11 @@ impl Index {
 		if changed {
 			let value = object
 				.serialize()
-				.map_err(|error| crate::fdb::error!(!error, "failed to serialize the object"))?;
+				.map_err(|error| tg::error!(!error, "failed to serialize the object"))?;
 			txn.set(&key, &value);
 		}
 
-		Ok(changed)
+		Ok(ControlFlow::Break(changed))
 	}
 
 	async fn update_object_grants_for_subject(
@@ -1194,23 +1261,39 @@ impl Index {
 		id: &tg::object::Id,
 		subject: &tg::authorization::Subject,
 		partition_total: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let resource = tg::Id::from(id.clone());
-		let children = Self::get_object_children_with_transaction(txn, subspace, id).await?;
-		let entries = Self::get_resource_grant_entries_for_subject_with_transaction(
-			txn, subspace, &resource, subject,
-		)
-		.await?;
-		let child_entries = future::try_join_all(children.iter().map(|child| {
-			let resource = tg::Id::from(child.clone());
-			async move {
-				Self::get_resource_grant_entries_for_subject_with_transaction(
-					txn, subspace, &resource, subject,
-				)
-				.await
+		let children = crate::fdb::propagate!(
+			Self::get_object_children_with_transaction(txn, subspace, id).await
+		);
+		let entries = crate::fdb::propagate!(
+			Self::get_resource_grant_entries_for_subject_with_transaction(
+				txn, subspace, &resource, subject,
+			)
+			.await
+		);
+		let child_entries = {
+			let result = future::try_join_all(children.iter().map(|child| {
+				let resource = tg::Id::from(child.clone());
+				async move {
+					Self::get_resource_grant_entries_for_subject_with_transaction(
+						txn, subspace, &resource, subject,
+					)
+					.await
+				}
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
 			}
-		}))
-		.await?;
+			values
+		};
 		let node = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Node,
 		);
@@ -1260,7 +1343,7 @@ impl Index {
 		)>,
 		managed: &BTreeSet<tg::authorization::Permission>,
 		partition_total: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let mut changed = false;
 		let current = entries
 			.iter()
@@ -1272,45 +1355,47 @@ impl Index {
 			})
 			.collect::<BTreeSet<_>>();
 		for (subject, permission, expires_at) in current.difference(expected) {
-			if Self::delete_grant_index_entry(
-				txn,
-				subspace,
-				&crate::fdb::grant::GrantIndexEntry {
-					creator: None,
-					expires_at: *expires_at,
-					permission: *permission,
-					subject,
-					resource,
-				},
-				crate::fdb::grant::GrantSource::Materialized,
-				partition_total,
-			)
-			.await?
-			{
+			if crate::fdb::propagate!(
+				Self::delete_grant_index_entry(
+					txn,
+					subspace,
+					&crate::fdb::grant::GrantIndexEntry {
+						creator: None,
+						expires_at: *expires_at,
+						permission: *permission,
+						subject,
+						resource,
+					},
+					crate::fdb::grant::GrantSource::Materialized,
+					partition_total,
+				)
+				.await
+			) {
 				changed = true;
 			}
 		}
 		for (subject, permission, expires_at) in expected.difference(&current) {
-			if Self::put_grant_index_entry(
-				txn,
-				subspace,
-				&crate::fdb::grant::GrantIndexEntry {
-					creator: None,
-					expires_at: *expires_at,
-					permission: *permission,
-					subject,
-					resource,
-				},
-				crate::fdb::grant::GrantSource::Materialized,
-				None,
-				partition_total,
-			)
-			.await?
-			{
+			if crate::fdb::propagate!(
+				Self::put_grant_index_entry(
+					txn,
+					subspace,
+					&crate::fdb::grant::GrantIndexEntry {
+						creator: None,
+						expires_at: *expires_at,
+						permission: *permission,
+						subject,
+						resource,
+					},
+					crate::fdb::grant::GrantSource::Materialized,
+					None,
+					partition_total,
+				)
+				.await
+			) {
 				changed = true;
 			}
 		}
-		Ok(changed)
+		Ok(ControlFlow::Break(changed))
 	}
 
 	async fn update_process_grants(
@@ -1318,7 +1403,7 @@ impl Index {
 		subspace: &Subspace,
 		input: &ProcessGrantInputs<'_>,
 		partition_total: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let object_subtree = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Subtree,
 		);
@@ -1472,42 +1557,61 @@ impl Index {
 		id: &tg::process::Id,
 		subject: &tg::authorization::Subject,
 		partition_total: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		};
-		let process =
-			crate::process::Process::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let process = crate::process::Process::deserialize(&bytes)?;
 		let resource = tg::Id::from(id.clone());
-		let entries = Self::get_resource_grant_entries_for_subject_with_transaction(
-			txn, subspace, &resource, subject,
-		)
-		.await?;
-		let children = Self::get_process_children_with_transaction(txn, subspace, id).await?;
-		let child_entries = future::try_join_all(children.iter().map(|child| {
-			let resource = tg::Id::from(child.clone());
-			async move {
-				Self::get_resource_grant_entries_for_subject_with_transaction(
-					txn, subspace, &resource, subject,
-				)
-				.await
+		let entries = crate::fdb::propagate!(
+			Self::get_resource_grant_entries_for_subject_with_transaction(
+				txn, subspace, &resource, subject,
+			)
+			.await
+		);
+		let children = crate::fdb::propagate!(
+			Self::get_process_children_with_transaction(txn, subspace, id).await
+		);
+		let child_entries = {
+			let result = future::try_join_all(children.iter().map(|child| {
+				let resource = tg::Id::from(child.clone());
+				async move {
+					Self::get_resource_grant_entries_for_subject_with_transaction(
+						txn, subspace, &resource, subject,
+					)
+					.await
+				}
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
 			}
-		}))
-		.await?;
-		let objects = Self::get_process_objects_with_transaction(txn, subspace, id).await?;
+			values
+		};
+		let objects = crate::fdb::propagate!(
+			Self::get_process_objects_with_transaction(txn, subspace, id).await
+		);
 		let mut command_object_entries: Option<Vec<crate::fdb::grant::GrantEntry>> = None;
 		let mut error_object_entries: Vec<Vec<crate::fdb::grant::GrantEntry>> = Vec::new();
 		let mut log_object_entries: Option<Vec<crate::fdb::grant::GrantEntry>> = None;
 		let mut output_object_entries: Vec<Vec<crate::fdb::grant::GrantEntry>> = Vec::new();
 		for (object, kind) in objects {
 			let resource = tg::Id::from(object);
-			let entries = Self::get_resource_grant_entries_for_subject_with_transaction(
-				txn, subspace, &resource, subject,
-			)
-			.await?;
+			let entries = crate::fdb::propagate!(
+				Self::get_resource_grant_entries_for_subject_with_transaction(
+					txn, subspace, &resource, subject,
+				)
+				.await
+			);
 			match kind {
 				crate::process::object::Kind::Command => {
 					command_object_entries = Some(entries);
@@ -1633,35 +1737,52 @@ impl Index {
 		subspace: &Subspace,
 		id: &tg::process::Id,
 		max_process_depth: Option<u64>,
-	) -> crate::fdb::Result<ProcessOutput> {
+	) -> tg::Result<ControlFlow<ProcessOutput, fdb::FdbError>> {
 		let process_key = crate::fdb::Key::Process(crate::fdb::process::Key::Process(id.clone()));
 		let process_key = Self::pack(subspace, &process_key);
-		let bytes = txn.get(&process_key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&process_key, false).await);
 		let Some(bytes) = bytes else {
 			let output = ProcessOutput {
 				changed: false,
 				depth_exceeded: false,
 			};
-			return Ok(output);
+			return Ok(ControlFlow::Break(output));
 		};
-		let mut process =
-			crate::process::Process::deserialize(&bytes).map_err(crate::fdb::custom_error)?;
+		let mut process = crate::process::Process::deserialize(&bytes)?;
 
-		let children = Self::get_process_children_with_transaction(txn, subspace, id).await?;
-		let children = future::try_join_all(
-			children
-				.iter()
-				.map(|child| Self::try_get_process_with_transaction(txn, subspace, child)),
-		)
-		.await?;
+		let children = crate::fdb::propagate!(
+			Self::get_process_children_with_transaction(txn, subspace, id).await
+		);
+		let children = {
+			let result = future::try_join_all(
+				children
+					.iter()
+					.map(|child| Self::try_get_process_with_transaction(txn, subspace, child)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
 
-		let objects = Self::get_process_objects_with_transaction(txn, subspace, id).await?;
+		let objects = crate::fdb::propagate!(
+			Self::get_process_objects_with_transaction(txn, subspace, id).await
+		);
 		let mut command_object: Option<crate::object::Object> = None;
 		let mut error_objects: Vec<Option<crate::object::Object>> = Vec::new();
 		let mut log_object: Option<Option<crate::object::Object>> = None;
 		let mut output_objects: Vec<Option<crate::object::Object>> = Vec::new();
 		for (object_id, kind) in &objects {
-			let object = Self::try_get_object_with_transaction(txn, subspace, object_id).await?;
+			let object = crate::fdb::propagate!(
+				Self::try_get_object_with_transaction(txn, subspace, object_id).await
+			);
 			match kind {
 				crate::process::object::Kind::Command => {
 					command_object = object;
@@ -2414,7 +2535,7 @@ impl Index {
 		if changed {
 			let value = process
 				.serialize()
-				.map_err(|error| crate::fdb::error!(!error, "failed to serialize the process"))?;
+				.map_err(|error| tg::error!(!error, "failed to serialize the process"))?;
 			txn.set(&process_key, &value);
 		}
 
@@ -2423,7 +2544,7 @@ impl Index {
 			depth_exceeded,
 		};
 
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	async fn enqueue_parents(
@@ -2433,51 +2554,62 @@ impl Index {
 		kind: &Kind,
 		version: &fdbt::Versionstamp,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		match id {
 			tg::Either::Left(id) => {
-				let parents = Self::get_object_parents_with_transaction(txn, subspace, id).await?;
+				let parents = crate::fdb::propagate!(
+					Self::get_object_parents_with_transaction(txn, subspace, id).await
+				);
 				for parent in parents {
-					Self::enqueue_update_propagate(
-						txn,
-						subspace,
-						&tg::Either::Left(parent),
-						kind,
-						version,
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::enqueue_update_propagate(
+							txn,
+							subspace,
+							&tg::Either::Left(parent),
+							kind,
+							version,
+							partition_total,
+						)
+						.await
+					);
 				}
-				let process_parents =
-					Self::get_object_processes_with_transaction(txn, subspace, id).await?;
+				let process_parents = crate::fdb::propagate!(
+					Self::get_object_processes_with_transaction(txn, subspace, id).await
+				);
 				for (process, _kind) in process_parents {
-					Self::enqueue_update_propagate(
-						txn,
-						subspace,
-						&tg::Either::Right(process),
-						kind,
-						version,
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::enqueue_update_propagate(
+							txn,
+							subspace,
+							&tg::Either::Right(process),
+							kind,
+							version,
+							partition_total,
+						)
+						.await
+					);
 				}
 			},
 			tg::Either::Right(id) => {
-				let parents = Self::get_process_parents_with_transaction(txn, subspace, id).await?;
+				let parents = crate::fdb::propagate!(
+					Self::get_process_parents_with_transaction(txn, subspace, id).await
+				);
 				for parent in parents {
-					Self::enqueue_update_propagate(
-						txn,
-						subspace,
-						&tg::Either::Right(parent),
-						kind,
-						version,
-						partition_total,
-					)
-					.await?;
+					crate::fdb::propagate!(
+						Self::enqueue_update_propagate(
+							txn,
+							subspace,
+							&tg::Either::Right(parent),
+							kind,
+							version,
+							partition_total,
+						)
+						.await
+					);
 				}
 			},
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn enqueue_update_propagate(
@@ -2487,7 +2619,7 @@ impl Index {
 		kind: &Kind,
 		version: &fdbt::Versionstamp,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Self::pack(
 			subspace,
 			&crate::fdb::Key::Update(crate::fdb::update::Key::Update {
@@ -2495,15 +2627,11 @@ impl Index {
 				kind: kind.clone(),
 			}),
 		);
-		let source = txn
-			.get(&key, false)
-			.await?
+		let source = crate::fdb::retry!(txn.get(&key, false).await)
 			.map(|bytes| deserialize_source_update(kind, &bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 		if !matches!(source, Some(Source::Put)) {
-			let value =
-				serialize_update(kind, Source::Propagate).map_err(crate::fdb::custom_error)?;
+			let value = serialize_update(kind, Source::Propagate)?;
 			txn.set(&key, &value);
 		}
 
@@ -2521,7 +2649,7 @@ impl Index {
 			.unwrap();
 		txn.set(&key, &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	fn clear_update_version(

--- a/packages/index/src/fdb/usage/clean.rs
+++ b/packages/index/src/fdb/usage/clean.rs
@@ -91,7 +91,8 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while keys.len() < arg.batch_size {
-				let Some(entry) = crate::fdb::retry!(entries.try_next().await) else {
+				let result = entries.try_next().await;
+				let Some(entry) = crate::fdb::retry!(result) else {
 					break;
 				};
 				let Key::Usage(crate::fdb::usage::Key::Delta {
@@ -179,7 +180,8 @@ impl Index {
 				};
 				let mut entries = txn.get_ranges_keyvalues(range, false);
 				while keys.len() < arg.batch_size {
-					let Some(entry) = crate::fdb::retry!(entries.try_next().await) else {
+					let result = entries.try_next().await;
+					let Some(entry) = crate::fdb::retry!(result) else {
 						break;
 					};
 					let Key::Usage(crate::fdb::usage::Key::Aggregate {

--- a/packages/index/src/fdb/usage/clean.rs
+++ b/packages/index/src/fdb/usage/clean.rs
@@ -3,7 +3,7 @@ use {
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	futures::TryStreamExt as _,
 	num_traits::ToPrimitive as _,
-	std::collections::BTreeMap,
+	std::{collections::BTreeMap, ops::ControlFlow},
 	tangram_client::prelude::*,
 };
 
@@ -25,26 +25,28 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		arg: &crate::usage::clean::Arg,
 		partition_total: u64,
-	) -> crate::fdb::Result<crate::usage::clean::Output> {
+	) -> tg::Result<ControlFlow<crate::usage::clean::Output, fdb::FdbError>> {
 		if arg.partition_start > arg.partition_end || arg.partition_end > partition_total {
-			return Err(crate::fdb::error!(
-				"the usage cleaning partition range is invalid"
-			));
+			return Err(tg::error!("the usage cleaning partition range is invalid"));
 		}
 		let mut keys = Vec::new();
 		let mut pending = false;
 		let mut unavailable = BTreeMap::new();
-		Self::find_usage_delta_candidates(txn, subspace, arg, &mut keys, &mut pending).await?;
+		crate::fdb::propagate!(
+			Self::find_usage_delta_candidates(txn, subspace, arg, &mut keys, &mut pending).await
+		);
 		if keys.len() < arg.batch_size {
-			Self::find_usage_aggregate_candidates(
-				txn,
-				subspace,
-				arg,
-				&mut keys,
-				&mut pending,
-				&mut unavailable,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::find_usage_aggregate_candidates(
+					txn,
+					subspace,
+					arg,
+					&mut keys,
+					&mut pending,
+					&mut unavailable,
+				)
+				.await
+			);
 		}
 		for ((account, kind, partition), through) in unavailable {
 			Self::mark_usage_unavailable_with_transaction(
@@ -59,7 +61,7 @@ impl Index {
 			done: keys.is_empty() && !pending,
 		};
 
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	async fn find_usage_delta_candidates(
@@ -68,7 +70,7 @@ impl Index {
 		arg: &crate::usage::clean::Arg,
 		keys: &mut Vec<Vec<u8>>,
 		pending: &mut bool,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let cutoff = arg
 			.now
 			.checked_sub(arg.delta_time_to_live)
@@ -89,7 +91,7 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while keys.len() < arg.batch_size {
-				let Some(entry) = entries.try_next().await? else {
+				let Some(entry) = crate::fdb::retry!(entries.try_next().await) else {
 					break;
 				};
 				let Key::Usage(crate::fdb::usage::Key::Delta {
@@ -99,18 +101,21 @@ impl Index {
 					..
 				}) = Self::unpack(subspace, entry.key())?
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
-				let period =
-					crate::usage::Period::from_kind_and_start(crate::usage::PeriodKind::Hour, hour)
-						.map_err(crate::fdb::custom_error)?;
+				let period = crate::usage::Period::from_kind_and_start(
+					crate::usage::PeriodKind::Hour,
+					hour,
+				)?;
 				if period.end() > cutoff {
 					break;
 				}
-				let compacting = Self::contains_usage_compaction_with_transaction(
-					txn, subspace, &account, hour, partition,
-				)
-				.await?;
+				let compacting = crate::fdb::propagate!(
+					Self::contains_usage_compaction_with_transaction(
+						txn, subspace, &account, hour, partition,
+					)
+					.await
+				);
 				if compacting {
 					let current_hour = arg.now.as_second().div_euclid(60 * 60) * 60 * 60;
 					*pending |= hour < current_hour;
@@ -123,7 +128,7 @@ impl Index {
 			}
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn find_usage_aggregate_candidates(
@@ -133,7 +138,7 @@ impl Index {
 		keys: &mut Vec<Vec<u8>>,
 		pending: &mut bool,
 		unavailable: &mut BTreeMap<(crate::usage::Account, crate::usage::PeriodKind, u64), i64>,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for partition in arg.partition_start..arg.partition_end {
 			for kind in [
 				crate::usage::PeriodKind::Hour,
@@ -174,7 +179,7 @@ impl Index {
 				};
 				let mut entries = txn.get_ranges_keyvalues(range, false);
 				while keys.len() < arg.batch_size {
-					let Some(entry) = entries.try_next().await? else {
+					let Some(entry) = crate::fdb::retry!(entries.try_next().await) else {
 						break;
 					};
 					let Key::Usage(crate::fdb::usage::Key::Aggregate {
@@ -183,7 +188,7 @@ impl Index {
 						period,
 					}) = Self::unpack(subspace, entry.key())?
 					else {
-						return Err(crate::fdb::error!("unexpected key type"));
+						return Err(tg::error!("unexpected key type"));
 					};
 					if period.end() > cutoff {
 						break;
@@ -191,28 +196,32 @@ impl Index {
 					let current_hour = arg.now.as_second().div_euclid(60 * 60) * 60 * 60;
 					let (dependency, eligible) = match period {
 						crate::usage::Period::Hour(_) => {
-							let next_hour =
-								period.start().as_second().checked_add(60 * 60).ok_or_else(
-									|| crate::fdb::error!("the usage hour overflowed"),
-								)?;
+							let next_hour = period
+								.start()
+								.as_second()
+								.checked_add(60 * 60)
+								.ok_or_else(|| tg::error!("the usage hour overflowed"))?;
 							let day = crate::usage::Period::containing(
 								crate::usage::PeriodKind::Day,
 								period.start(),
 							);
-							let closing_hour = crate::usage::closing_hour(day)
-								.map_err(crate::fdb::custom_error)?;
-							let next = Self::contains_usage_compaction_with_transaction(
-								txn, subspace, &account, next_hour, partition,
-							)
-							.await?;
-							let closing = Self::contains_usage_compaction_with_transaction(
-								txn,
-								subspace,
-								&account,
-								closing_hour,
-								partition,
-							)
-							.await?;
+							let closing_hour = crate::usage::closing_hour(day)?;
+							let next = crate::fdb::propagate!(
+								Self::contains_usage_compaction_with_transaction(
+									txn, subspace, &account, next_hour, partition,
+								)
+								.await
+							);
+							let closing = crate::fdb::propagate!(
+								Self::contains_usage_compaction_with_transaction(
+									txn,
+									subspace,
+									&account,
+									closing_hour,
+									partition,
+								)
+								.await
+							);
 							let dependency = next || closing;
 							let eligible = (next && next_hour < current_hour)
 								|| (closing && closing_hour < current_hour);
@@ -226,16 +235,17 @@ impl Index {
 								crate::usage::PeriodKind::Month,
 							] {
 								let parent = crate::usage::Period::containing(kind, period.start());
-								let closing_hour = crate::usage::closing_hour(parent)
-									.map_err(crate::fdb::custom_error)?;
-								let contains = Self::contains_usage_compaction_with_transaction(
-									txn,
-									subspace,
-									&account,
-									closing_hour,
-									partition,
-								)
-								.await?;
+								let closing_hour = crate::usage::closing_hour(parent)?;
+								let contains = crate::fdb::propagate!(
+									Self::contains_usage_compaction_with_transaction(
+										txn,
+										subspace,
+										&account,
+										closing_hour,
+										partition,
+									)
+									.await
+								);
 								dependency |= contains;
 								eligible |= contains && closing_hour < current_hour;
 							}
@@ -257,11 +267,11 @@ impl Index {
 					}
 				}
 				if keys.len() == arg.batch_size {
-					return Ok(());
+					return Ok(ControlFlow::Break(()));
 				}
 			}
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/usage/compact.rs
+++ b/packages/index/src/fdb/usage/compact.rs
@@ -3,6 +3,7 @@ use {
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	futures::TryStreamExt as _,
 	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -33,7 +34,7 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		arg: &crate::usage::compact::Arg,
-	) -> crate::fdb::Result<crate::usage::compact::Output> {
+	) -> tg::Result<ControlFlow<crate::usage::compact::Output, fdb::FdbError>> {
 		let current_hour = arg.now.as_second().div_euclid(60 * 60) * 60 * 60;
 		let mut candidates = Vec::new();
 		for partition in arg.partition_start..arg.partition_end {
@@ -56,7 +57,7 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while candidates.len() < arg.batch_size {
-				let Some(entry) = entries.try_next().await? else {
+				let Some(entry) = crate::fdb::retry!(entries.try_next().await) else {
 					break;
 				};
 				let Key::Usage(crate::fdb::usage::Key::Compaction {
@@ -65,7 +66,7 @@ impl Index {
 					partition,
 				}) = Self::unpack(subspace, entry.key())?
 				else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				candidates.push((account, hour, partition));
 			}
@@ -77,15 +78,17 @@ impl Index {
 		let mut count = 0;
 		for (account, _, partition) in &candidates {
 			let limit = arg.batch_size - count;
-			let value = Self::aggregate_usage_compactions_for_account_with_transaction(
-				txn,
-				subspace,
-				account,
-				*partition,
-				current_hour,
-				Some(limit),
-			)
-			.await?;
+			let value = crate::fdb::propagate!(
+				Self::aggregate_usage_compactions_for_account_with_transaction(
+					txn,
+					subspace,
+					account,
+					*partition,
+					current_hour,
+					Some(limit),
+				)
+				.await
+			);
 			count += value;
 			if count == arg.batch_size {
 				break;
@@ -93,7 +96,7 @@ impl Index {
 		}
 		let output = crate::usage::compact::Output { count };
 
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	pub(in crate::fdb) async fn aggregate_usage_compactions_for_account_with_transaction(
@@ -103,27 +106,31 @@ impl Index {
 		partition: u64,
 		end_hour: i64,
 		limit: Option<usize>,
-	) -> crate::fdb::Result<usize> {
+	) -> tg::Result<ControlFlow<usize, fdb::FdbError>> {
 		let mut count = 0;
 		loop {
 			if limit.is_some_and(|limit| count == limit) {
 				break;
 			}
-			let hour = Self::try_get_usage_compaction_for_account_with_transaction(
-				txn, subspace, account, partition, end_hour,
-			)
-			.await?;
+			let hour = crate::fdb::propagate!(
+				Self::try_get_usage_compaction_for_account_with_transaction(
+					txn, subspace, account, partition, end_hour,
+				)
+				.await
+			);
 			let Some(hour) = hour else {
 				break;
 			};
-			Self::aggregate_usage_hour_with_transaction(
-				txn, subspace, account, hour, partition, true,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::aggregate_usage_hour_with_transaction(
+					txn, subspace, account, hour, partition, true,
+				)
+				.await
+			);
 			count += 1;
 		}
 
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	pub(in crate::fdb) async fn aggregate_usage_hour_with_transaction(
@@ -133,50 +140,49 @@ impl Index {
 		hour: i64,
 		partition: u64,
 		clear_compaction: bool,
-	) -> crate::fdb::Result<crate::usage::PartitionAggregate> {
+	) -> tg::Result<ControlFlow<crate::usage::PartitionAggregate, fdb::FdbError>> {
 		let period =
-			crate::usage::Period::from_kind_and_start(crate::usage::PeriodKind::Hour, hour)
-				.map_err(crate::fdb::custom_error)?;
-		let old = Self::try_get_usage_aggregate_with_transaction(
-			txn, subspace, account, partition, period,
+			crate::usage::Period::from_kind_and_start(crate::usage::PeriodKind::Hour, hour)?;
+		let old = crate::fdb::propagate!(
+			Self::try_get_usage_aggregate_with_transaction(
+				txn, subspace, account, partition, period,
+			)
+			.await
 		)
-		.await?
 		.unwrap_or_default();
 		let previous = match hour.checked_sub(60 * 60) {
 			Some(start) => {
 				let period = crate::usage::Period::from_kind_and_start(
 					crate::usage::PeriodKind::Hour,
 					start,
+				)?;
+				crate::fdb::propagate!(
+					Self::try_get_usage_aggregate_with_transaction(
+						txn, subspace, account, partition, period,
+					)
+					.await
 				)
-				.map_err(crate::fdb::custom_error)?;
-				Self::try_get_usage_aggregate_with_transaction(
-					txn, subspace, account, partition, period,
-				)
-				.await?
 				.unwrap_or_default()
 			},
 			None => crate::usage::PartitionAggregate::default(),
 		};
-		let deltas =
-			Self::get_usage_deltas_with_transaction(txn, subspace, account, hour, partition)
-				.await?;
+		let deltas = crate::fdb::propagate!(
+			Self::get_usage_deltas_with_transaction(txn, subspace, account, hour, partition,).await
+		);
 		let sandbox_cpu = u128::try_from(deltas.sandbox_cpu)
-			.map_err(|_| crate::fdb::error!("the sandbox CPU usage is out of range"))?;
+			.map_err(|_| tg::error!("the sandbox CPU usage is out of range"))?;
 		let sandbox_memory = u128::try_from(deltas.sandbox_memory)
-			.map_err(|_| crate::fdb::error!("the sandbox memory usage is out of range"))?;
+			.map_err(|_| tg::error!("the sandbox memory usage is out of range"))?;
 		let aggregate = crate::usage::PartitionAggregate {
-			object_count: apply_delta(previous.object_count, deltas.object_count)
-				.map_err(crate::fdb::custom_error)?,
-			object_size: apply_delta(previous.object_size, deltas.object_size)
-				.map_err(crate::fdb::custom_error)?,
-			process_count: apply_delta(previous.process_count, deltas.process_count)
-				.map_err(crate::fdb::custom_error)?,
+			object_count: apply_delta(previous.object_count, deltas.object_count)?,
+			object_size: apply_delta(previous.object_size, deltas.object_size)?,
+			process_count: apply_delta(previous.process_count, deltas.process_count)?,
 			sandbox_count: deltas.sandbox_count,
 			sandbox_cpu,
 			sandbox_memory,
 		};
 		if !clear_compaction {
-			return Ok(aggregate);
+			return Ok(ControlFlow::Break(aggregate));
 		}
 		Self::put_usage_aggregate_with_transaction(
 			txn, subspace, account, partition, period, aggregate,
@@ -187,16 +193,18 @@ impl Index {
 		if storage_changed(old, aggregate) {
 			let next = hour
 				.checked_add(60 * 60)
-				.ok_or_else(|| crate::fdb::error!("the usage hour overflowed"))?;
+				.ok_or_else(|| tg::error!("the usage hour overflowed"))?;
 			Self::put_usage_compaction_with_transaction(txn, subspace, account, next, partition);
 		}
 		let day = crate::usage::Period::containing(crate::usage::PeriodKind::Day, period.start());
-		let closing_hour = crate::usage::closing_hour(day).map_err(crate::fdb::custom_error)?;
+		let closing_hour = crate::usage::closing_hour(day)?;
 		if hour == closing_hour {
-			Self::aggregate_usage_day_with_transaction(
-				txn, subspace, account, partition, day, hour,
-			)
-			.await?;
+			crate::fdb::propagate!(
+				Self::aggregate_usage_day_with_transaction(
+					txn, subspace, account, partition, day, hour,
+				)
+				.await
+			);
 		} else if changed {
 			Self::put_usage_compaction_with_transaction(
 				txn,
@@ -207,7 +215,7 @@ impl Index {
 			);
 		}
 
-		Ok(aggregate)
+		Ok(ControlFlow::Break(aggregate))
 	}
 
 	pub(in crate::fdb) async fn aggregate_usage_day_with_transaction(
@@ -217,15 +225,18 @@ impl Index {
 		partition: u64,
 		period: crate::usage::Period,
 		hour: i64,
-	) -> crate::fdb::Result<crate::usage::PartitionAggregate> {
-		let old = Self::try_get_usage_aggregate_with_transaction(
-			txn, subspace, account, partition, period,
+	) -> tg::Result<ControlFlow<crate::usage::PartitionAggregate, fdb::FdbError>> {
+		let old = crate::fdb::propagate!(
+			Self::try_get_usage_aggregate_with_transaction(
+				txn, subspace, account, partition, period,
+			)
+			.await
 		)
-		.await?
 		.unwrap_or_default();
-		let aggregate =
-			Self::sum_usage_children_with_transaction(txn, subspace, account, partition, period)
-				.await?;
+		let aggregate = crate::fdb::propagate!(
+			Self::sum_usage_children_with_transaction(txn, subspace, account, partition, period,)
+				.await
+		);
 		Self::put_usage_aggregate_with_transaction(
 			txn, subspace, account, partition, period, aggregate,
 		);
@@ -235,13 +246,14 @@ impl Index {
 			crate::usage::PeriodKind::Month,
 		] {
 			let parent = crate::usage::Period::containing(kind, period.start());
-			let closing_hour =
-				crate::usage::closing_hour(parent).map_err(crate::fdb::custom_error)?;
+			let closing_hour = crate::usage::closing_hour(parent)?;
 			if hour == closing_hour {
-				Self::aggregate_usage_parent_with_transaction(
-					txn, subspace, account, partition, parent,
-				)
-				.await?;
+				crate::fdb::propagate!(
+					Self::aggregate_usage_parent_with_transaction(
+						txn, subspace, account, partition, parent,
+					)
+					.await
+				);
 			} else if aggregate != old {
 				Self::put_usage_compaction_with_transaction(
 					txn,
@@ -253,7 +265,7 @@ impl Index {
 			}
 		}
 
-		Ok(aggregate)
+		Ok(ControlFlow::Break(aggregate))
 	}
 
 	pub(in crate::fdb) async fn aggregate_usage_parent_with_transaction(
@@ -262,15 +274,16 @@ impl Index {
 		account: &crate::usage::Account,
 		partition: u64,
 		period: crate::usage::Period,
-	) -> crate::fdb::Result<crate::usage::PartitionAggregate> {
-		let aggregate =
-			Self::sum_usage_children_with_transaction(txn, subspace, account, partition, period)
-				.await?;
+	) -> tg::Result<ControlFlow<crate::usage::PartitionAggregate, fdb::FdbError>> {
+		let aggregate = crate::fdb::propagate!(
+			Self::sum_usage_children_with_transaction(txn, subspace, account, partition, period,)
+				.await
+		);
 		Self::put_usage_aggregate_with_transaction(
 			txn, subspace, account, partition, period, aggregate,
 		);
 
-		Ok(aggregate)
+		Ok(ControlFlow::Break(aggregate))
 	}
 
 	pub(in crate::fdb) async fn try_get_usage_aggregate_with_transaction(
@@ -279,21 +292,18 @@ impl Index {
 		account: &crate::usage::Account,
 		partition: u64,
 		period: crate::usage::Period,
-	) -> crate::fdb::Result<Option<crate::usage::PartitionAggregate>> {
+	) -> tg::Result<ControlFlow<Option<crate::usage::PartitionAggregate>, fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::Aggregate {
 			account: account.clone(),
 			partition,
 			period,
 		});
 		let key = Self::pack(subspace, &key);
-		let aggregate = txn
-			.get(&key, false)
-			.await?
+		let aggregate = crate::fdb::retry!(txn.get(&key, false).await)
 			.map(|bytes| crate::usage::deserialize_aggregate(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 
-		Ok(aggregate)
+		Ok(ControlFlow::Break(aggregate))
 	}
 
 	pub(in crate::fdb) async fn contains_usage_compaction_with_transaction(
@@ -302,16 +312,16 @@ impl Index {
 		account: &crate::usage::Account,
 		hour: i64,
 		partition: u64,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::Compaction {
 			account: account.clone(),
 			hour,
 			partition,
 		});
 		let key = Self::pack(subspace, &key);
-		let contains = txn.get(&key, false).await?.is_some();
+		let contains = crate::fdb::retry!(txn.get(&key, false).await).is_some();
 
-		Ok(contains)
+		Ok(ControlFlow::Break(contains))
 	}
 
 	pub(in crate::fdb) fn put_usage_aggregate_with_transaction(
@@ -370,7 +380,7 @@ impl Index {
 		account: &crate::usage::Account,
 		hour: i64,
 		partition: u64,
-	) -> crate::fdb::Result<Deltas> {
+	) -> tg::Result<ControlFlow<Deltas, fdb::FdbError>> {
 		let account = account.id().to_bytes();
 		let prefix = Self::pack(
 			subspace,
@@ -387,17 +397,17 @@ impl Index {
 		};
 		let mut entries = txn.get_ranges_keyvalues(range, false);
 		let mut deltas = Deltas::default();
-		while let Some(entry) = entries.try_next().await? {
+		while let Some(entry) = crate::fdb::retry!(entries.try_next().await) {
 			let Key::Usage(crate::fdb::usage::Key::Delta { kind, .. }) =
 				Self::unpack(subspace, entry.key())?
 			else {
-				return Err(crate::fdb::error!("unexpected key type"));
+				return Err(tg::error!("unexpected key type"));
 			};
 			let value = i64::from_le_bytes(
 				entry
 					.value()
 					.try_into()
-					.map_err(|_| crate::fdb::error!("invalid usage delta"))?,
+					.map_err(|_| tg::error!("invalid usage delta"))?,
 			);
 			let value = i128::from(value);
 			let target = match kind {
@@ -410,10 +420,10 @@ impl Index {
 			};
 			*target = target
 				.checked_add(value)
-				.ok_or_else(|| crate::fdb::error!("the usage delta overflowed"))?;
+				.ok_or_else(|| tg::error!("the usage delta overflowed"))?;
 		}
 
-		Ok(deltas)
+		Ok(ControlFlow::Break(deltas))
 	}
 
 	async fn try_get_usage_compaction_for_account_with_transaction(
@@ -422,7 +432,7 @@ impl Index {
 		account: &crate::usage::Account,
 		partition: u64,
 		end_hour: i64,
-	) -> crate::fdb::Result<Option<i64>> {
+	) -> tg::Result<ControlFlow<Option<i64>, fdb::FdbError>> {
 		let start = Self::pack(
 			subspace,
 			&(Kind::UsageCompaction.to_i32().unwrap(), partition),
@@ -436,21 +446,21 @@ impl Index {
 			..fdb::RangeOption::from((start.as_slice(), end.as_slice()))
 		};
 		let mut entries = txn.get_ranges_keyvalues(range, false);
-		while let Some(entry) = entries.try_next().await? {
+		while let Some(entry) = crate::fdb::retry!(entries.try_next().await) {
 			let Key::Usage(crate::fdb::usage::Key::Compaction {
 				account: candidate,
 				hour,
 				..
 			}) = Self::unpack(subspace, entry.key())?
 			else {
-				return Err(crate::fdb::error!("unexpected key type"));
+				return Err(tg::error!("unexpected key type"));
 			};
 			if candidate == *account {
-				return Ok(Some(hour));
+				return Ok(ControlFlow::Break(Some(hour)));
 			}
 		}
 
-		Ok(None)
+		Ok(ControlFlow::Break(None))
 	}
 
 	async fn sum_usage_children_with_transaction(
@@ -459,20 +469,20 @@ impl Index {
 		account: &crate::usage::Account,
 		partition: u64,
 		period: crate::usage::Period,
-	) -> crate::fdb::Result<crate::usage::PartitionAggregate> {
+	) -> tg::Result<ControlFlow<crate::usage::PartitionAggregate, fdb::FdbError>> {
 		let mut aggregate = crate::usage::PartitionAggregate::default();
-		for child in crate::usage::children(period).map_err(crate::fdb::custom_error)? {
-			let child = Self::try_get_usage_aggregate_with_transaction(
-				txn, subspace, account, partition, child,
+		for child in crate::usage::children(period)? {
+			let child = crate::fdb::propagate!(
+				Self::try_get_usage_aggregate_with_transaction(
+					txn, subspace, account, partition, child,
+				)
+				.await
 			)
-			.await?
 			.unwrap_or_default();
-			aggregate
-				.checked_add(child)
-				.map_err(crate::fdb::custom_error)?;
+			aggregate.checked_add(child)?;
 		}
 
-		Ok(aggregate)
+		Ok(ControlFlow::Break(aggregate))
 	}
 }
 

--- a/packages/index/src/fdb/usage/compact.rs
+++ b/packages/index/src/fdb/usage/compact.rs
@@ -57,7 +57,8 @@ impl Index {
 			};
 			let mut entries = txn.get_ranges_keyvalues(range, false);
 			while candidates.len() < arg.batch_size {
-				let Some(entry) = crate::fdb::retry!(entries.try_next().await) else {
+				let result = entries.try_next().await;
+				let Some(entry) = crate::fdb::retry!(result) else {
 					break;
 				};
 				let Key::Usage(crate::fdb::usage::Key::Compaction {
@@ -299,7 +300,8 @@ impl Index {
 			period,
 		});
 		let key = Self::pack(subspace, &key);
-		let aggregate = crate::fdb::retry!(txn.get(&key, false).await)
+		let result = txn.get(&key, false).await;
+		let aggregate = crate::fdb::retry!(result)
 			.map(|bytes| crate::usage::deserialize_aggregate(&bytes))
 			.transpose()?;
 
@@ -319,7 +321,8 @@ impl Index {
 			partition,
 		});
 		let key = Self::pack(subspace, &key);
-		let contains = crate::fdb::retry!(txn.get(&key, false).await).is_some();
+		let result = txn.get(&key, false).await;
+		let contains = crate::fdb::retry!(result).is_some();
 
 		Ok(ControlFlow::Break(contains))
 	}
@@ -397,7 +400,11 @@ impl Index {
 		};
 		let mut entries = txn.get_ranges_keyvalues(range, false);
 		let mut deltas = Deltas::default();
-		while let Some(entry) = crate::fdb::retry!(entries.try_next().await) {
+		loop {
+			let result = entries.try_next().await;
+			let Some(entry) = crate::fdb::retry!(result) else {
+				break;
+			};
 			let Key::Usage(crate::fdb::usage::Key::Delta { kind, .. }) =
 				Self::unpack(subspace, entry.key())?
 			else {
@@ -446,7 +453,11 @@ impl Index {
 			..fdb::RangeOption::from((start.as_slice(), end.as_slice()))
 		};
 		let mut entries = txn.get_ranges_keyvalues(range, false);
-		while let Some(entry) = crate::fdb::retry!(entries.try_next().await) {
+		loop {
+			let result = entries.try_next().await;
+			let Some(entry) = crate::fdb::retry!(result) else {
+				break;
+			};
 			let Key::Usage(crate::fdb::usage::Key::Compaction {
 				account: candidate,
 				hour,

--- a/packages/index/src/fdb/usage/compute.rs
+++ b/packages/index/src/fdb/usage/compute.rs
@@ -1,4 +1,7 @@
-use {crate::fdb::Index, foundationdb as fdb, foundationdb_tuple as fdbt};
+use {
+	crate::fdb::Index, foundationdb as fdb, foundationdb_tuple as fdbt, std::ops::ControlFlow,
+	tangram_client::prelude::*,
+};
 
 impl Index {
 	pub(crate) fn put_compute_usage(
@@ -6,11 +9,11 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		arg: crate::usage::compute::put::Arg<'_>,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let partition = rand::random_range(0..partition_total);
 		if let Some(cpu) = arg.cpu {
-			let delta = i64::try_from(cpu)
-				.map_err(|_| crate::fdb::error!("the compute CPU usage is too large"))?;
+			let delta =
+				i64::try_from(cpu).map_err(|_| tg::error!("the compute CPU usage is too large"))?;
 			Self::add_usage_delta(
 				txn,
 				subspace,
@@ -23,7 +26,7 @@ impl Index {
 		}
 		if let Some(memory) = arg.memory {
 			let delta = i64::try_from(memory)
-				.map_err(|_| crate::fdb::error!("the compute memory usage is too large"))?;
+				.map_err(|_| tg::error!("the compute memory usage is too large"))?;
 			Self::add_usage_delta(
 				txn,
 				subspace,
@@ -35,7 +38,7 @@ impl Index {
 			);
 		}
 		let delta = i64::try_from(arg.sandbox_count)
-			.map_err(|_| crate::fdb::error!("the sandbox count usage is too large"))?;
+			.map_err(|_| tg::error!("the sandbox count usage is too large"))?;
 		Self::add_usage_delta(
 			txn,
 			subspace,
@@ -46,6 +49,6 @@ impl Index {
 			partition,
 		);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/usage/get.rs
+++ b/packages/index/src/fdb/usage/get.rs
@@ -2,6 +2,7 @@ use {
 	crate::fdb::{Index, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	futures::{FutureExt as _, future::BoxFuture, future::try_join_all},
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -32,58 +33,69 @@ impl Index {
 		period: crate::usage::Period,
 		now: jiff::Timestamp,
 		partition_total: u64,
-	) -> crate::fdb::Result<crate::usage::Aggregate> {
-		let started = Self::try_get_usage_started_with_transaction(txn, subspace)
-			.await?
-			.ok_or_else(|| crate::fdb::error!("usage tracking has not started"))?;
+	) -> tg::Result<ControlFlow<crate::usage::Aggregate, fdb::FdbError>> {
+		let started = crate::fdb::propagate!(
+			Self::try_get_usage_started_with_transaction(txn, subspace).await
+		)
+		.ok_or_else(|| tg::error!("usage tracking has not started"))?;
 		if period.start().as_second() < started && period.end() <= now {
-			return Err(crate::fdb::error!(
-				"usage is unavailable for the requested period"
-			));
+			return Err(tg::error!("usage is unavailable for the requested period"));
 		}
-		let cutoffs = try_join_all((0..partition_total).map(|partition| {
-			Self::try_get_usage_unavailable_with_transaction(
-				txn,
-				subspace,
-				account,
-				period.kind(),
-				partition,
-			)
-		}))
-		.await?;
+		let cutoffs = {
+			let result = try_join_all((0..partition_total).map(|partition| {
+				Self::try_get_usage_unavailable_with_transaction(
+					txn,
+					subspace,
+					account,
+					period.kind(),
+					partition,
+				)
+			}))
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
 		if cutoffs
 			.into_iter()
 			.flatten()
 			.any(|cutoff| period.end().as_second() <= cutoff)
 		{
-			return Err(crate::fdb::error!(
-				"usage is unavailable for the requested period"
-			));
+			return Err(tg::error!("usage is unavailable for the requested period"));
 		}
 		if period.start() > now {
-			return Ok(crate::usage::Aggregate::default());
+			return Ok(ControlFlow::Break(crate::usage::Aggregate::default()));
 		}
 
 		let mut aggregate = crate::usage::PartitionAggregate::default();
 		let current_hour = now.as_second().div_euclid(60 * 60) * 60 * 60;
 		let end_hour = period.end().as_second().min(current_hour);
 		for partition in 0..partition_total {
-			Self::aggregate_usage_compactions_for_account_with_transaction(
-				txn, subspace, account, partition, end_hour, None,
-			)
-			.await?;
-			let value = Self::aggregate_usage_period_with_transaction(
-				txn, subspace, account, partition, period, now,
-			)
-			.await?;
-			aggregate
-				.checked_add(value)
-				.map_err(crate::fdb::custom_error)?;
+			crate::fdb::propagate!(
+				Self::aggregate_usage_compactions_for_account_with_transaction(
+					txn, subspace, account, partition, end_hour, None,
+				)
+				.await
+			);
+			let value = crate::fdb::propagate!(
+				Self::aggregate_usage_period_with_transaction(
+					txn, subspace, account, partition, period, now,
+				)
+				.await
+			);
+			aggregate.checked_add(value)?;
 		}
 
-		aggregate
-			.try_into_aggregate()
-			.map_err(crate::fdb::custom_error)
+		let aggregate = aggregate.try_into_aggregate()?;
+
+		Ok(ControlFlow::Break(aggregate))
 	}
 
 	fn aggregate_usage_period_with_transaction<'a>(
@@ -93,47 +105,53 @@ impl Index {
 		partition: u64,
 		period: crate::usage::Period,
 		now: jiff::Timestamp,
-	) -> BoxFuture<'a, crate::fdb::Result<crate::usage::PartitionAggregate>> {
+	) -> BoxFuture<'a, tg::Result<ControlFlow<crate::usage::PartitionAggregate, fdb::FdbError>>> {
 		async move {
 			if period.start() > now {
-				return Ok(crate::usage::PartitionAggregate::default());
+				return Ok(ControlFlow::Break(
+					crate::usage::PartitionAggregate::default(),
+				));
 			}
 			if period.end() <= now {
-				let aggregate = Self::try_get_usage_aggregate_with_transaction(
-					txn, subspace, account, partition, period,
-				)
-				.await?;
+				let aggregate = crate::fdb::propagate!(
+					Self::try_get_usage_aggregate_with_transaction(
+						txn, subspace, account, partition, period,
+					)
+					.await
+				);
 
-				return Ok(aggregate.unwrap_or_default());
+				return Ok(ControlFlow::Break(aggregate.unwrap_or_default()));
 			}
 
 			let aggregate = match period {
 				crate::usage::Period::Hour(_) => {
-					Self::aggregate_usage_hour_with_transaction(
-						txn,
-						subspace,
-						account,
-						period.start().as_second(),
-						partition,
-						period.end() <= now,
+					crate::fdb::propagate!(
+						Self::aggregate_usage_hour_with_transaction(
+							txn,
+							subspace,
+							account,
+							period.start().as_second(),
+							partition,
+							period.end() <= now,
+						)
+						.await
 					)
-					.await?
 				},
 				crate::usage::Period::Day(_)
 				| crate::usage::Period::Month(_)
 				| crate::usage::Period::Week(_) => {
 					let mut aggregate = crate::usage::PartitionAggregate::default();
-					for child in crate::usage::children(period).map_err(crate::fdb::custom_error)? {
+					for child in crate::usage::children(period)? {
 						if child.start() > now {
 							break;
 						}
-						let child = Self::aggregate_usage_period_with_transaction(
-							txn, subspace, account, partition, child, now,
-						)
-						.await?;
-						aggregate
-							.checked_add(child)
-							.map_err(crate::fdb::custom_error)?;
+						let child = crate::fdb::propagate!(
+							Self::aggregate_usage_period_with_transaction(
+								txn, subspace, account, partition, child, now,
+							)
+							.await
+						);
+						aggregate.checked_add(child)?;
 					}
 					if period.end() <= now {
 						Self::put_usage_aggregate_with_transaction(
@@ -144,7 +162,7 @@ impl Index {
 				},
 			};
 
-			Ok(aggregate)
+			Ok(ControlFlow::Break(aggregate))
 		}
 		.boxed()
 	}

--- a/packages/index/src/fdb/usage/get.rs
+++ b/packages/index/src/fdb/usage/get.rs
@@ -53,7 +53,7 @@ impl Index {
 			}))
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,

--- a/packages/index/src/fdb/usage/start.rs
+++ b/packages/index/src/fdb/usage/start.rs
@@ -1,19 +1,19 @@
 use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
 impl Index {
 	pub async fn start_usage(&self, at: jiff::Timestamp) -> tg::Result<()> {
 		let subspace = self.subspace.clone();
-		self.database
-			.run(|txn, _| {
-				let subspace = subspace.clone();
-				async move { Self::start_usage_with_transaction(&txn, &subspace, at).await }
-			})
-			.await
-			.map_err(|error| tg::error!(!error, "failed to start usage tracking"))?;
+		crate::fdb::run(&self.database, |txn| {
+			let subspace = subspace.clone();
+			async move { Self::start_usage_with_transaction(&txn, &subspace, at).await }
+		})
+		.await
+		.map_err(|error| tg::error!(!error, "failed to start usage tracking"))?;
 
 		Ok(())
 	}
@@ -22,30 +22,41 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		at: jiff::Timestamp,
-	) -> crate::fdb::Result<()> {
-		let key = Self::pack(subspace, &Key::Usage(crate::fdb::usage::Key::Started));
-		let value = txn.get(&key, false).await?;
-		if value.is_none() {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
+		let result = Self::usage_started_with_transaction(txn, subspace).await;
+		let started = crate::fdb::propagate!(result);
+		if !started {
+			let key = Self::pack(subspace, &Key::Usage(crate::fdb::usage::Key::Started));
 			let value = crate::usage::serialize_timestamp(at.as_second());
 			txn.set(&key, &value);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
+	}
+
+	async fn usage_started_with_transaction(
+		txn: &fdb::Transaction,
+		subspace: &fdbt::Subspace,
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
+		let key = Self::pack(subspace, &Key::Usage(crate::fdb::usage::Key::Started));
+		let result = txn.get(&key, false).await;
+		let value = crate::fdb::retry!(result);
+		let started = value.is_some();
+
+		Ok(ControlFlow::Break(started))
 	}
 
 	pub(in crate::fdb) async fn try_get_usage_started_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
-	) -> crate::fdb::Result<Option<i64>> {
+	) -> tg::Result<ControlFlow<Option<i64>, fdb::FdbError>> {
 		let key = Self::pack(subspace, &Key::Usage(crate::fdb::usage::Key::Started));
-		let value = txn
-			.get(&key, false)
-			.await?
+		let result = txn.get(&key, false).await;
+		let value = crate::fdb::retry!(result)
 			.map(|bytes| crate::usage::deserialize_timestamp(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 
-		Ok(value)
+		Ok(ControlFlow::Break(value))
 	}
 
 	pub(in crate::fdb) async fn try_get_usage_unavailable_with_transaction(
@@ -54,21 +65,19 @@ impl Index {
 		account: &crate::usage::Account,
 		kind: crate::usage::PeriodKind,
 		partition: u64,
-	) -> crate::fdb::Result<Option<i64>> {
+	) -> tg::Result<ControlFlow<Option<i64>, fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::Unavailable {
 			account: account.clone(),
 			kind,
 			partition,
 		});
 		let key = Self::pack(subspace, &key);
-		let value = txn
-			.get(&key, false)
-			.await?
+		let result = txn.get(&key, false).await;
+		let value = crate::fdb::retry!(result)
 			.map(|bytes| crate::usage::deserialize_timestamp(&bytes))
-			.transpose()
-			.map_err(crate::fdb::custom_error)?;
+			.transpose()?;
 
-		Ok(value)
+		Ok(ControlFlow::Break(value))
 	}
 
 	pub(in crate::fdb) fn mark_usage_unavailable_with_transaction(

--- a/packages/index/src/fdb/usage/storage/clean.rs
+++ b/packages/index/src/fdb/usage/storage/clean.rs
@@ -163,7 +163,8 @@ impl Index {
 		};
 		let entry_key = Self::pack(subspace, &entry_key);
 		let clean_key = Self::pack(subspace, &clean_key);
-		let Some(value) = crate::fdb::retry!(txn.get(&entry_key, false).await) else {
+		let result = txn.get(&entry_key, false).await;
+		let Some(value) = crate::fdb::retry!(result) else {
 			txn.clear(&clean_key);
 			return Ok(ControlFlow::Break(()));
 		};
@@ -269,7 +270,8 @@ impl Index {
 		);
 		let object_bytes = object.to_bytes();
 		let tags_future = Self::count_account_tags(txn, subspace, account, object_bytes.as_ref());
-		let entries = crate::fdb::retry!(entries_future.await);
+		let result = entries_future.await;
+		let entries = crate::fdb::retry!(result);
 		let tag_count = crate::fdb::propagate!(tags_future.await);
 		let entry_count = entries.iter().filter(|value| value.is_some()).count();
 		let count = u64::try_from(entry_count).unwrap() + tag_count;
@@ -302,7 +304,8 @@ impl Index {
 		);
 		let process_bytes = process.to_bytes();
 		let tags_future = Self::count_account_tags(txn, subspace, account, process_bytes.as_ref());
-		let entries = crate::fdb::retry!(entries_future.await);
+		let result = entries_future.await;
+		let entries = crate::fdb::retry!(result);
 		let tag_count = crate::fdb::propagate!(tags_future.await);
 		let entry_count = entries.iter().filter(|value| value.is_some()).count();
 		let count = u64::try_from(entry_count).unwrap() + tag_count;
@@ -326,7 +329,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -477,9 +480,8 @@ impl Index {
 			account: account.clone(),
 			object: object.clone(),
 		});
-		let Some(value) =
-			crate::fdb::retry!(txn.get(&Self::pack(subspace, &entry_key), false).await)
-		else {
+		let result = txn.get(&Self::pack(subspace, &entry_key), false).await;
+		let Some(value) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let entry = crate::usage::storage::Entry::deserialize(&value)?;
@@ -506,9 +508,8 @@ impl Index {
 			account: account.clone(),
 			process: process.clone(),
 		});
-		let Some(value) =
-			crate::fdb::retry!(txn.get(&Self::pack(subspace, &entry_key), false).await)
-		else {
+		let result = txn.get(&Self::pack(subspace, &entry_key), false).await;
+		let Some(value) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let entry = crate::usage::storage::Entry::deserialize(&value)?;

--- a/packages/index/src/fdb/usage/storage/clean.rs
+++ b/packages/index/src/fdb/usage/storage/clean.rs
@@ -1,6 +1,7 @@
 use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -25,7 +26,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		object: &tg::object::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		Self::enqueue_update_with_kind(
 			txn,
 			subspace,
@@ -35,7 +36,7 @@ impl Index {
 			partition_total,
 		);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn schedule_process_accounts_for_cleaning(
@@ -43,7 +44,7 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		process: &tg::process::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		Self::enqueue_update_with_kind(
 			txn,
 			subspace,
@@ -53,7 +54,7 @@ impl Index {
 			partition_total,
 		);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -67,7 +68,7 @@ impl Index {
 		touched_at: i64,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let candidate = Candidate::Object {
 			account: account.clone(),
 			object: object.clone(),
@@ -96,7 +97,7 @@ impl Index {
 		touched_at: i64,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let candidate = Candidate::Process {
 			account: account.clone(),
 			partition,
@@ -121,7 +122,7 @@ impl Index {
 		now: i64,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let (entry_key, clean_key, touched_at) = match candidate {
 			Candidate::Object {
 				account,
@@ -162,71 +163,76 @@ impl Index {
 		};
 		let entry_key = Self::pack(subspace, &entry_key);
 		let clean_key = Self::pack(subspace, &clean_key);
-		let Some(value) = txn.get(&entry_key, false).await? else {
+		let Some(value) = crate::fdb::retry!(txn.get(&entry_key, false).await) else {
 			txn.clear(&clean_key);
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut entry =
-			crate::usage::storage::Entry::deserialize(&value).map_err(crate::fdb::custom_error)?;
+		let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 		if entry.touched_at != touched_at {
 			txn.clear(&clean_key);
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 		let reference_count = match candidate {
 			Candidate::Object {
 				account, object, ..
 			} => {
-				Self::compute_account_object_reference_count(txn, subspace, account, object).await?
+				crate::fdb::propagate!(
+					Self::compute_account_object_reference_count(txn, subspace, account, object)
+						.await
+				)
 			},
 			Candidate::Process {
 				account, process, ..
 			} => {
-				Self::compute_account_process_reference_count(txn, subspace, account, process)
-					.await?
+				crate::fdb::propagate!(
+					Self::compute_account_process_reference_count(txn, subspace, account, process,)
+						.await
+				)
 			},
 		};
 		if reference_count > 0 {
 			entry.reference_count = reference_count;
-			txn.set(
-				&entry_key,
-				&entry.serialize().map_err(crate::fdb::custom_error)?,
-			);
+			txn.set(&entry_key, &entry.serialize()?);
 			txn.clear(&clean_key);
-			return Ok(());
+			return Ok(ControlFlow::Break(()));
 		}
 		match candidate {
 			Candidate::Object {
 				account, object, ..
 			} => {
-				Self::delete_account_object(
-					txn,
-					subspace,
-					account,
-					object,
-					now,
-					partition_total,
-					usage_partition_total,
-				)
-				.await?;
+				crate::fdb::propagate!(
+					Self::delete_account_object(
+						txn,
+						subspace,
+						account,
+						object,
+						now,
+						partition_total,
+						usage_partition_total,
+					)
+					.await
+				);
 			},
 			Candidate::Process {
 				account, process, ..
 			} => {
-				Self::delete_account_process(
-					txn,
-					subspace,
-					account,
-					process,
-					now,
-					partition_total,
-					usage_partition_total,
-				)
-				.await?;
+				crate::fdb::propagate!(
+					Self::delete_account_process(
+						txn,
+						subspace,
+						account,
+						process,
+						now,
+						partition_total,
+						usage_partition_total,
+					)
+					.await
+				);
 			},
 		}
 		txn.clear(&clean_key);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn compute_account_object_reference_count(
@@ -234,12 +240,13 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		account: &crate::usage::Account,
 		object: &tg::object::Id,
-	) -> crate::fdb::Result<u64> {
-		let (parents, processes) = futures::future::try_join(
-			Self::get_object_parents_with_transaction(txn, subspace, object),
-			Self::get_object_processes_with_transaction(txn, subspace, object),
-		)
-		.await?;
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
+		let parents = crate::fdb::propagate!(
+			Self::get_object_parents_with_transaction(txn, subspace, object).await
+		);
+		let processes = crate::fdb::propagate!(
+			Self::get_object_processes_with_transaction(txn, subspace, object).await
+		);
 		let keys = parents
 			.into_iter()
 			.map(|object| {
@@ -256,17 +263,18 @@ impl Index {
 			}))
 			.map(|key| Self::pack(subspace, &key))
 			.collect::<Vec<_>>();
-		let entries_future =
-			futures::future::try_join_all(keys.iter().map(|key| async move {
-				Ok::<_, fdb::FdbBindingError>(txn.get(key, false).await?)
-			}));
+		let entries_future = futures::future::try_join_all(
+			keys.iter()
+				.map(|key| async move { txn.get(key, false).await }),
+		);
 		let object_bytes = object.to_bytes();
 		let tags_future = Self::count_account_tags(txn, subspace, account, object_bytes.as_ref());
-		let (entries, tag_count) = futures::future::try_join(entries_future, tags_future).await?;
+		let entries = crate::fdb::retry!(entries_future.await);
+		let tag_count = crate::fdb::propagate!(tags_future.await);
 		let entry_count = entries.iter().filter(|value| value.is_some()).count();
 		let count = u64::try_from(entry_count).unwrap() + tag_count;
 
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn compute_account_process_reference_count(
@@ -274,8 +282,10 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		account: &crate::usage::Account,
 		process: &tg::process::Id,
-	) -> crate::fdb::Result<u64> {
-		let parents = Self::get_process_parents_with_transaction(txn, subspace, process).await?;
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
+		let parents = crate::fdb::propagate!(
+			Self::get_process_parents_with_transaction(txn, subspace, process).await
+		);
 		let keys = parents
 			.into_iter()
 			.map(|process| {
@@ -286,17 +296,18 @@ impl Index {
 				Self::pack(subspace, &key)
 			})
 			.collect::<Vec<_>>();
-		let entries_future =
-			futures::future::try_join_all(keys.iter().map(|key| async move {
-				Ok::<_, fdb::FdbBindingError>(txn.get(key, false).await?)
-			}));
+		let entries_future = futures::future::try_join_all(
+			keys.iter()
+				.map(|key| async move { txn.get(key, false).await }),
+		);
 		let process_bytes = process.to_bytes();
 		let tags_future = Self::count_account_tags(txn, subspace, account, process_bytes.as_ref());
-		let (entries, tag_count) = futures::future::try_join(entries_future, tags_future).await?;
+		let entries = crate::fdb::retry!(entries_future.await);
+		let tag_count = crate::fdb::propagate!(tags_future.await);
 		let entry_count = entries.iter().filter(|value| value.is_some()).count();
 		let count = u64::try_from(entry_count).unwrap() + tag_count;
 
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	async fn count_account_tags(
@@ -304,20 +315,34 @@ impl Index {
 		subspace: &fdbt::Subspace,
 		account: &crate::usage::Account,
 		target: &[u8],
-	) -> crate::fdb::Result<u64> {
-		let tags = Self::get_target_tags_with_transaction(txn, subspace, target).await?;
-		let tags = futures::future::try_join_all(
-			tags.iter()
-				.map(|tag| Self::try_get_tag_with_transaction(txn, subspace, tag)),
-		)
-		.await?;
+	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
+		let tags = crate::fdb::propagate!(
+			Self::get_target_tags_with_transaction(txn, subspace, target).await
+		);
+		let tags = {
+			let result = futures::future::try_join_all(
+				tags.iter()
+					.map(|tag| Self::try_get_tag_with_transaction(txn, subspace, tag)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
 		let count = tags
 			.iter()
 			.filter(|tag| tag.as_ref().and_then(|tag| tag.account.as_ref()) == Some(account))
 			.count();
 		let count = u64::try_from(count).unwrap();
 
-		Ok(count)
+		Ok(ControlFlow::Break(count))
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -329,7 +354,7 @@ impl Index {
 		now: i64,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::AccountObject {
 			account: account.clone(),
 			object: object.clone(),
@@ -360,13 +385,12 @@ impl Index {
 			crate::fdb::update::Source::Put,
 			partition_total,
 		);
-		let value = Self::try_get_object_with_transaction(txn, subspace, object)
-			.await?
-			.ok_or_else(
-				|| crate::fdb::error!(%object, "an object with a storage entry is missing"),
-			)?;
+		let value = crate::fdb::propagate!(
+			Self::try_get_object_with_transaction(txn, subspace, object).await
+		)
+		.ok_or_else(|| tg::error!(%object, "an object with a storage entry is missing"))?;
 		let size = i64::try_from(value.metadata.node.size)
-			.map_err(|_| crate::fdb::error!("the object size is too large"))?;
+			.map_err(|_| tg::error!("the object size is too large"))?;
 		Self::add_usage_delta(
 			txn,
 			subspace,
@@ -384,7 +408,7 @@ impl Index {
 		});
 		txn.set(&Self::pack(subspace, &key), &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -396,7 +420,7 @@ impl Index {
 		now: i64,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::AccountProcess {
 			account: account.clone(),
 			process: process.clone(),
@@ -427,11 +451,10 @@ impl Index {
 			crate::fdb::update::Source::Put,
 			partition_total,
 		);
-		let value = Self::try_get_process_with_transaction(txn, subspace, process)
-			.await?
-			.ok_or_else(
-				|| crate::fdb::error!(%process, "a process with a storage entry is missing"),
-			)?;
+		let value = crate::fdb::propagate!(
+			Self::try_get_process_with_transaction(txn, subspace, process).await
+		)
+		.ok_or_else(|| tg::error!(%process, "a process with a storage entry is missing"))?;
 		let partition = Self::partition_for_id(process.to_bytes().as_ref(), partition_total);
 		let key = Key::Clean(crate::fdb::clean::Key::Process {
 			id: process.clone(),
@@ -440,7 +463,7 @@ impl Index {
 		});
 		txn.set(&Self::pack(subspace, &key), &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(in crate::fdb) async fn schedule_account_object_for_cleaning(
@@ -449,16 +472,17 @@ impl Index {
 		account: &crate::usage::Account,
 		object: &tg::object::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let entry_key = Key::Usage(crate::fdb::usage::Key::AccountObject {
 			account: account.clone(),
 			object: object.clone(),
 		});
-		let Some(value) = txn.get(&Self::pack(subspace, &entry_key), false).await? else {
-			return Ok(());
+		let Some(value) =
+			crate::fdb::retry!(txn.get(&Self::pack(subspace, &entry_key), false).await)
+		else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let entry =
-			crate::usage::storage::Entry::deserialize(&value).map_err(crate::fdb::custom_error)?;
+		let entry = crate::usage::storage::Entry::deserialize(&value)?;
 		let partition = Self::partition_for_id(object.to_bytes().as_ref(), partition_total);
 		let key = Key::Clean(crate::fdb::clean::Key::AccountObject {
 			account: account.clone(),
@@ -468,7 +492,7 @@ impl Index {
 		});
 		txn.set(&Self::pack(subspace, &key), &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(in crate::fdb) async fn schedule_account_process_for_cleaning(
@@ -477,16 +501,17 @@ impl Index {
 		account: &crate::usage::Account,
 		process: &tg::process::Id,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let entry_key = Key::Usage(crate::fdb::usage::Key::AccountProcess {
 			account: account.clone(),
 			process: process.clone(),
 		});
-		let Some(value) = txn.get(&Self::pack(subspace, &entry_key), false).await? else {
-			return Ok(());
+		let Some(value) =
+			crate::fdb::retry!(txn.get(&Self::pack(subspace, &entry_key), false).await)
+		else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let entry =
-			crate::usage::storage::Entry::deserialize(&value).map_err(crate::fdb::custom_error)?;
+		let entry = crate::usage::storage::Entry::deserialize(&value)?;
 		let partition = Self::partition_for_id(process.to_bytes().as_ref(), partition_total);
 		let key = Key::Clean(crate::fdb::clean::Key::AccountProcess {
 			account: account.clone(),
@@ -496,6 +521,6 @@ impl Index {
 		});
 		txn.set(&Self::pack(subspace, &key), &[]);
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/usage/storage/clean.rs
+++ b/packages/index/src/fdb/usage/storage/clean.rs
@@ -242,12 +242,19 @@ impl Index {
 		account: &crate::usage::Account,
 		object: &tg::object::Id,
 	) -> tg::Result<ControlFlow<u64, fdb::FdbError>> {
-		let parents = crate::fdb::propagate!(
-			Self::get_object_parents_with_transaction(txn, subspace, object).await
-		);
-		let processes = crate::fdb::propagate!(
-			Self::get_object_processes_with_transaction(txn, subspace, object).await
-		);
+		let (parents, processes) = futures::future::try_join(
+			Self::get_object_parents_with_transaction(txn, subspace, object),
+			Self::get_object_processes_with_transaction(txn, subspace, object),
+		)
+		.await?;
+		let parents = match parents {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		};
+		let processes = match processes {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		};
 		let keys = parents
 			.into_iter()
 			.map(|object| {
@@ -264,15 +271,27 @@ impl Index {
 			}))
 			.map(|key| Self::pack(subspace, &key))
 			.collect::<Vec<_>>();
-		let entries_future = futures::future::try_join_all(
-			keys.iter()
-				.map(|key| async move { txn.get(key, false).await }),
-		);
+		let entries_future = async {
+			let result = futures::future::try_join_all(
+				keys.iter()
+					.map(|key| async move { txn.get(key, false).await }),
+			)
+			.await;
+			let entries = crate::fdb::retry!(result);
+
+			Ok::<_, tg::Error>(ControlFlow::Break(entries))
+		};
 		let object_bytes = object.to_bytes();
 		let tags_future = Self::count_account_tags(txn, subspace, account, object_bytes.as_ref());
-		let result = entries_future.await;
-		let entries = crate::fdb::retry!(result);
-		let tag_count = crate::fdb::propagate!(tags_future.await);
+		let (entries, tag_count) = futures::future::try_join(entries_future, tags_future).await?;
+		let entries = match entries {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		};
+		let tag_count = match tag_count {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		};
 		let entry_count = entries.iter().filter(|value| value.is_some()).count();
 		let count = u64::try_from(entry_count).unwrap() + tag_count;
 
@@ -298,15 +317,27 @@ impl Index {
 				Self::pack(subspace, &key)
 			})
 			.collect::<Vec<_>>();
-		let entries_future = futures::future::try_join_all(
-			keys.iter()
-				.map(|key| async move { txn.get(key, false).await }),
-		);
+		let entries_future = async {
+			let result = futures::future::try_join_all(
+				keys.iter()
+					.map(|key| async move { txn.get(key, false).await }),
+			)
+			.await;
+			let entries = crate::fdb::retry!(result);
+
+			Ok::<_, tg::Error>(ControlFlow::Break(entries))
+		};
 		let process_bytes = process.to_bytes();
 		let tags_future = Self::count_account_tags(txn, subspace, account, process_bytes.as_ref());
-		let result = entries_future.await;
-		let entries = crate::fdb::retry!(result);
-		let tag_count = crate::fdb::propagate!(tags_future.await);
+		let (entries, tag_count) = futures::future::try_join(entries_future, tags_future).await?;
+		let entries = match entries {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		};
+		let tag_count = match tag_count {
+			ControlFlow::Break(value) => value,
+			ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+		};
 		let entry_count = entries.iter().filter(|value| value.is_some()).count();
 		let count = u64::try_from(entry_count).unwrap() + tag_count;
 

--- a/packages/index/src/fdb/usage/storage/put.rs
+++ b/packages/index/src/fdb/usage/storage/put.rs
@@ -19,7 +19,8 @@ impl Index {
 			object: arg.object.clone(),
 		});
 		let key = Self::pack(subspace, &key);
-		let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
+		let result = txn.get(&key, false).await;
+		let Some(value) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
@@ -45,7 +46,8 @@ impl Index {
 			process: arg.process.clone(),
 		});
 		let key = Self::pack(subspace, &key);
-		let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
+		let result = txn.get(&key, false).await;
+		let Some(value) = crate::fdb::retry!(result) else {
 			return Ok(ControlFlow::Break(()));
 		};
 		let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
@@ -177,7 +179,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&fdbt::Subspace::from_bytes(prefix))
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let accounts = entries
 			.iter()
 			.map(|entry| {
@@ -209,7 +212,8 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&fdbt::Subspace::from_bytes(prefix))
 		};
-		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
 		let accounts = entries
 			.iter()
 			.map(|entry| {
@@ -238,7 +242,8 @@ impl Index {
 			object: arg.object.clone(),
 		});
 		let entry_key = Self::pack(subspace, &entry_key);
-		if let Some(value) = crate::fdb::retry!(txn.get(&entry_key, false).await) {
+		let result = txn.get(&entry_key, false).await;
+		if let Some(value) = crate::fdb::retry!(result) {
 			let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 			if touch_existing && arg.touched_at > entry.touched_at {
 				entry.touched_at = arg.touched_at;
@@ -327,7 +332,8 @@ impl Index {
 			process: arg.process.clone(),
 		});
 		let entry_key = Self::pack(subspace, &entry_key);
-		if let Some(value) = crate::fdb::retry!(txn.get(&entry_key, false).await) {
+		let result = txn.get(&entry_key, false).await;
+		if let Some(value) = crate::fdb::retry!(result) {
 			let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 			if touch_existing && arg.touched_at > entry.touched_at {
 				entry.touched_at = arg.touched_at;

--- a/packages/index/src/fdb/usage/storage/put.rs
+++ b/packages/index/src/fdb/usage/storage/put.rs
@@ -2,7 +2,7 @@ use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	num_traits::ToPrimitive as _,
-	std::collections::BTreeSet,
+	std::{collections::BTreeSet, ops::ControlFlow},
 	tangram_client::prelude::*,
 };
 
@@ -13,25 +13,24 @@ impl Index {
 		arg: &crate::usage::storage::put::ObjectArg,
 		time_to_touch: std::time::Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::AccountObject {
 			account: arg.account.clone(),
 			object: arg.object.clone(),
 		});
 		let key = Self::pack(subspace, &key);
-		let Some(value) = txn.get(&key, false).await? else {
-			return Ok(());
+		let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut entry =
-			crate::usage::storage::Entry::deserialize(&value).map_err(crate::fdb::custom_error)?;
+		let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 		let time_to_touch = i64::try_from(time_to_touch.as_secs()).unwrap();
 		if arg.touched_at.saturating_sub(entry.touched_at) >= time_to_touch {
 			entry.touched_at = arg.touched_at;
-			txn.set(&key, &entry.serialize().map_err(crate::fdb::custom_error)?);
+			txn.set(&key, &entry.serialize()?);
 			Self::put_account_object_clean_key(txn, subspace, arg, partition_total);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn touch_account_process(
@@ -40,25 +39,24 @@ impl Index {
 		arg: &crate::usage::storage::put::ProcessArg,
 		time_to_touch: std::time::Duration,
 		partition_total: u64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let key = Key::Usage(crate::fdb::usage::Key::AccountProcess {
 			account: arg.account.clone(),
 			process: arg.process.clone(),
 		});
 		let key = Self::pack(subspace, &key);
-		let Some(value) = txn.get(&key, false).await? else {
-			return Ok(());
+		let Some(value) = crate::fdb::retry!(txn.get(&key, false).await) else {
+			return Ok(ControlFlow::Break(()));
 		};
-		let mut entry =
-			crate::usage::storage::Entry::deserialize(&value).map_err(crate::fdb::custom_error)?;
+		let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 		let time_to_touch = i64::try_from(time_to_touch.as_secs()).unwrap();
 		if arg.touched_at.saturating_sub(entry.touched_at) >= time_to_touch {
 			entry.touched_at = arg.touched_at;
-			txn.set(&key, &entry.serialize().map_err(crate::fdb::custom_error)?);
+			txn.set(&key, &entry.serialize()?);
 			Self::put_account_process_clean_key(txn, subspace, arg, partition_total);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn enqueue_account_object_from_parents(
@@ -67,18 +65,23 @@ impl Index {
 		object: &tg::object::Id,
 		partition_total: u64,
 		touched_at: i64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let mut accounts = BTreeSet::new();
-		let parents = Self::get_object_parents_with_transaction(txn, subspace, object).await?;
+		let parents = crate::fdb::propagate!(
+			Self::get_object_parents_with_transaction(txn, subspace, object).await
+		);
 		for parent in parents {
-			accounts
-				.extend(Self::get_object_accounts_with_transaction(txn, subspace, &parent).await?);
+			accounts.extend(crate::fdb::propagate!(
+				Self::get_object_accounts_with_transaction(txn, subspace, &parent).await
+			));
 		}
-		let processes = Self::get_object_processes_with_transaction(txn, subspace, object).await?;
+		let processes = crate::fdb::propagate!(
+			Self::get_object_processes_with_transaction(txn, subspace, object).await
+		);
 		for (process, _) in processes {
-			accounts.extend(
-				Self::get_process_accounts_with_transaction(txn, subspace, &process).await?,
-			);
+			accounts.extend(crate::fdb::propagate!(
+				Self::get_process_accounts_with_transaction(txn, subspace, &process).await
+			));
 		}
 		for account in accounts {
 			Self::enqueue_update_with_kind(
@@ -94,7 +97,7 @@ impl Index {
 			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn enqueue_account_process_from_parents(
@@ -103,12 +106,15 @@ impl Index {
 		process: &tg::process::Id,
 		partition_total: u64,
 		touched_at: i64,
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		let mut accounts = BTreeSet::new();
-		let parents = Self::get_process_parents_with_transaction(txn, subspace, process).await?;
+		let parents = crate::fdb::propagate!(
+			Self::get_process_parents_with_transaction(txn, subspace, process).await
+		);
 		for parent in parents {
-			accounts
-				.extend(Self::get_process_accounts_with_transaction(txn, subspace, &parent).await?);
+			accounts.extend(crate::fdb::propagate!(
+				Self::get_process_accounts_with_transaction(txn, subspace, &parent).await
+			));
 		}
 		for account in accounts {
 			Self::enqueue_update_with_kind(
@@ -124,7 +130,7 @@ impl Index {
 			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	pub(crate) async fn enqueue_account_process_relationships(
@@ -133,8 +139,10 @@ impl Index {
 		process: &tg::process::Id,
 		partition_total: u64,
 		touched_at: i64,
-	) -> crate::fdb::Result<()> {
-		let accounts = Self::get_process_accounts_with_transaction(txn, subspace, process).await?;
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
+		let accounts = crate::fdb::propagate!(
+			Self::get_process_accounts_with_transaction(txn, subspace, process).await
+		);
 		for account in accounts {
 			Self::enqueue_update_with_kind(
 				txn,
@@ -149,14 +157,14 @@ impl Index {
 			);
 		}
 
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 
 	async fn get_object_accounts_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		object: &tg::object::Id,
-	) -> crate::fdb::Result<Vec<crate::usage::Account>> {
+	) -> tg::Result<ControlFlow<Vec<crate::usage::Account>, fdb::FdbError>> {
 		let object_bytes = object.to_bytes();
 		let prefix = Self::pack(
 			subspace,
@@ -169,26 +177,26 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&fdbt::Subspace::from_bytes(prefix))
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let accounts = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Usage(crate::fdb::usage::Key::ObjectAccount { account, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(account)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(accounts)
+		Ok(ControlFlow::Break(accounts))
 	}
 
 	async fn get_process_accounts_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		process: &tg::process::Id,
-	) -> crate::fdb::Result<Vec<crate::usage::Account>> {
+	) -> tg::Result<ControlFlow<Vec<crate::usage::Account>, fdb::FdbError>> {
 		let process_bytes = process.to_bytes();
 		let prefix = Self::pack(
 			subspace,
@@ -201,19 +209,19 @@ impl Index {
 			mode: fdb::options::StreamingMode::WantAll,
 			..fdb::RangeOption::from(&fdbt::Subspace::from_bytes(prefix))
 		};
-		let entries = txn.get_range(&range, 1, false).await?;
+		let entries = crate::fdb::retry!(txn.get_range(&range, 1, false).await);
 		let accounts = entries
 			.iter()
 			.map(|entry| {
 				let key = Self::unpack(subspace, entry.key())?;
 				let Key::Usage(crate::fdb::usage::Key::ProcessAccount { account, .. }) = key else {
-					return Err(crate::fdb::error!("unexpected key type"));
+					return Err(tg::error!("unexpected key type"));
 				};
 				Ok(account)
 			})
-			.collect::<crate::fdb::Result<Vec<_>>>()?;
+			.collect::<tg::Result<Vec<_>>>()?;
 
-		Ok(accounts)
+		Ok(ControlFlow::Break(accounts))
 	}
 
 	pub(crate) async fn put_account_object(
@@ -224,38 +232,39 @@ impl Index {
 		usage_partition_total: u64,
 		touch_existing: bool,
 		version: Option<&fdbt::Versionstamp>,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let entry_key = Key::Usage(crate::fdb::usage::Key::AccountObject {
 			account: arg.account.clone(),
 			object: arg.object.clone(),
 		});
 		let entry_key = Self::pack(subspace, &entry_key);
-		if let Some(value) = txn.get(&entry_key, false).await? {
-			let mut entry = crate::usage::storage::Entry::deserialize(&value)
-				.map_err(crate::fdb::custom_error)?;
+		if let Some(value) = crate::fdb::retry!(txn.get(&entry_key, false).await) {
+			let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 			if touch_existing && arg.touched_at > entry.touched_at {
 				entry.touched_at = arg.touched_at;
-				let value = entry.serialize().map_err(crate::fdb::custom_error)?;
+				let value = entry.serialize()?;
 				txn.set(&entry_key, &value);
 				Self::put_account_object_clean_key(txn, subspace, arg, partition_total);
 			}
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		}
 
-		let object = Self::try_get_object_with_transaction(txn, subspace, &arg.object).await?;
+		let object = crate::fdb::propagate!(
+			Self::try_get_object_with_transaction(txn, subspace, &arg.object).await
+		);
 		let Some(object) = object else {
 			if touch_existing {
 				return Err(
-					crate::fdb::error!(object = %arg.object, "cannot add a missing object to a usage account"),
+					tg::error!(object = %arg.object, "cannot add a missing object to a usage account"),
 				);
 			}
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		};
 		let entry = crate::usage::storage::Entry {
 			reference_count: 0,
 			touched_at: arg.touched_at,
 		};
-		let value = entry.serialize().map_err(crate::fdb::custom_error)?;
+		let value = entry.serialize()?;
 		txn.set(&entry_key, &value);
 
 		let reverse_key = Key::Usage(crate::fdb::usage::Key::ObjectAccount {
@@ -276,9 +285,8 @@ impl Index {
 			1,
 			usage_partition,
 		);
-		let size = i64::try_from(object.metadata.node.size).map_err(
-			|_| crate::fdb::error!(object = %arg.object, "the object size is too large"),
-		)?;
+		let size = i64::try_from(object.metadata.node.size)
+			.map_err(|_| tg::error!(object = %arg.object, "the object size is too large"))?;
 		Self::add_usage_delta(
 			txn,
 			subspace,
@@ -302,7 +310,7 @@ impl Index {
 			version,
 		);
 
-		Ok(true)
+		Ok(ControlFlow::Break(true))
 	}
 
 	pub(crate) async fn put_account_process(
@@ -313,38 +321,39 @@ impl Index {
 		usage_partition_total: u64,
 		touch_existing: bool,
 		version: Option<&fdbt::Versionstamp>,
-	) -> crate::fdb::Result<bool> {
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
 		let entry_key = Key::Usage(crate::fdb::usage::Key::AccountProcess {
 			account: arg.account.clone(),
 			process: arg.process.clone(),
 		});
 		let entry_key = Self::pack(subspace, &entry_key);
-		if let Some(value) = txn.get(&entry_key, false).await? {
-			let mut entry = crate::usage::storage::Entry::deserialize(&value)
-				.map_err(crate::fdb::custom_error)?;
+		if let Some(value) = crate::fdb::retry!(txn.get(&entry_key, false).await) {
+			let mut entry = crate::usage::storage::Entry::deserialize(&value)?;
 			if touch_existing && arg.touched_at > entry.touched_at {
 				entry.touched_at = arg.touched_at;
-				let value = entry.serialize().map_err(crate::fdb::custom_error)?;
+				let value = entry.serialize()?;
 				txn.set(&entry_key, &value);
 				Self::put_account_process_clean_key(txn, subspace, arg, partition_total);
 			}
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		}
 
-		let process = Self::try_get_process_with_transaction(txn, subspace, &arg.process).await?;
+		let process = crate::fdb::propagate!(
+			Self::try_get_process_with_transaction(txn, subspace, &arg.process).await
+		);
 		if process.is_none() {
 			if touch_existing {
 				return Err(
-					crate::fdb::error!(process = %arg.process, "cannot add a missing process to a usage account"),
+					tg::error!(process = %arg.process, "cannot add a missing process to a usage account"),
 				);
 			}
-			return Ok(false);
+			return Ok(ControlFlow::Break(false));
 		}
 		let entry = crate::usage::storage::Entry {
 			reference_count: 0,
 			touched_at: arg.touched_at,
 		};
-		let value = entry.serialize().map_err(crate::fdb::custom_error)?;
+		let value = entry.serialize()?;
 		txn.set(&entry_key, &value);
 
 		let reverse_key = Key::Usage(crate::fdb::usage::Key::ProcessAccount {
@@ -379,7 +388,7 @@ impl Index {
 			version,
 		);
 
-		Ok(true)
+		Ok(ControlFlow::Break(true))
 	}
 
 	fn put_account_object_clean_key(

--- a/packages/index/src/fdb/user/delete.rs
+++ b/packages/index/src/fdb/user/delete.rs
@@ -28,7 +28,8 @@ impl Index {
 		for id in ids {
 			let key = Key::User(crate::fdb::user::Key::User(id.clone()));
 			let key = Self::pack(subspace, &key);
-			let user = crate::fdb::retry!(txn.get(&key, false).await)
+			let result = txn.get(&key, false).await;
+			let user = crate::fdb::retry!(result)
 				.map(|bytes| crate::user::User::deserialize(&bytes))
 				.transpose()?;
 			if let Some(user) = user {

--- a/packages/index/src/fdb/user/delete.rs
+++ b/packages/index/src/fdb/user/delete.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -23,16 +24,13 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		ids: &[tg::user::Id],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for id in ids {
 			let key = Key::User(crate::fdb::user::Key::User(id.clone()));
 			let key = Self::pack(subspace, &key);
-			let user = txn
-				.get(&key, false)
-				.await?
+			let user = crate::fdb::retry!(txn.get(&key, false).await)
 				.map(|bytes| crate::user::User::deserialize(&bytes))
-				.transpose()
-				.map_err(crate::fdb::custom_error)?;
+				.transpose()?;
 			if let Some(user) = user {
 				let node_key = Key::Node(crate::fdb::node::Key::Node(user.specifier));
 				let node_key = Self::pack(subspace, &node_key);
@@ -40,6 +38,6 @@ impl Index {
 			}
 			txn.clear(&key);
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/user/get.rs
+++ b/packages/index/src/fdb/user/get.rs
@@ -2,6 +2,7 @@ use {
 	crate::fdb::{Index, Key},
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -28,27 +29,41 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		ids: &[tg::user::Id],
-	) -> crate::fdb::Result<Vec<Option<crate::user::User>>> {
-		futures::future::try_join_all(
-			ids.iter()
-				.map(|id| Self::try_get_user_with_transaction(txn, subspace, id)),
-		)
-		.await
+	) -> tg::Result<ControlFlow<Vec<Option<crate::user::User>>, fdb::FdbError>> {
+		let users = {
+			let result = futures::future::try_join_all(
+				ids.iter()
+					.map(|id| Self::try_get_user_with_transaction(txn, subspace, id)),
+			)
+			.await;
+			let results = result?;
+			let mut values = Vec::new();
+			for result in results {
+				let value = match result {
+					ControlFlow::Break(value) => value,
+					ControlFlow::Continue(error) => return Ok(ControlFlow::Continue(error)),
+				};
+				values.push(value);
+			}
+			values
+		};
+
+		Ok(ControlFlow::Break(users))
 	}
 
 	pub(crate) async fn try_get_user_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::user::Id,
-	) -> crate::fdb::Result<Option<crate::user::User>> {
+	) -> tg::Result<ControlFlow<Option<crate::user::User>, fdb::FdbError>> {
 		let key = Key::User(crate::fdb::user::Key::User(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = txn.get(&key, false).await?;
+		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
 		let Some(bytes) = bytes else {
-			return Ok(None);
+			return Ok(ControlFlow::Break(None));
 		};
-		Ok(Some(
-			crate::user::User::deserialize(&bytes).map_err(crate::fdb::custom_error)?,
-		))
+		let user = Some(crate::user::User::deserialize(&bytes)?);
+
+		Ok(ControlFlow::Break(user))
 	}
 }

--- a/packages/index/src/fdb/user/get.rs
+++ b/packages/index/src/fdb/user/get.rs
@@ -37,7 +37,7 @@ impl Index {
 			)
 			.await;
 			let results = result?;
-			let mut values = Vec::new();
+			let mut values = Vec::with_capacity(results.len());
 			for result in results {
 				let value = match result {
 					ControlFlow::Break(value) => value,
@@ -58,7 +58,8 @@ impl Index {
 	) -> tg::Result<ControlFlow<Option<crate::user::User>, fdb::FdbError>> {
 		let key = Key::User(crate::fdb::user::Key::User(id.clone()));
 		let key = Self::pack(subspace, &key);
-		let bytes = crate::fdb::retry!(txn.get(&key, false).await);
+		let result = txn.get(&key, false).await;
+		let bytes = crate::fdb::retry!(result);
 		let Some(bytes) = bytes else {
 			return Ok(ControlFlow::Break(None));
 		};

--- a/packages/index/src/fdb/user/put.rs
+++ b/packages/index/src/fdb/user/put.rs
@@ -3,6 +3,7 @@
 use {
 	crate::fdb::{Index, Key, Request, Response},
 	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
 	tangram_client::prelude::*,
 };
 
@@ -23,26 +24,22 @@ impl Index {
 		txn: &fdb::Transaction,
 		subspace: &fdbt::Subspace,
 		args: &[crate::user::put::Arg],
-	) -> crate::fdb::Result<()> {
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		for arg in args {
 			let key = Key::User(crate::fdb::user::Key::User(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
 			let billing = match arg.billing {
 				Some(billing) => billing,
-				None => txn
-					.get(&key, false)
-					.await?
+				None => crate::fdb::retry!(txn.get(&key, false).await)
 					.map_or(Ok(false), |bytes| {
 						crate::user::User::deserialize(&bytes).map(|user| user.billing)
-					})
-					.map_err(crate::fdb::custom_error)?,
+					})?,
 			};
 			let value = crate::user::User {
 				billing,
 				specifier: arg.specifier.clone(),
 			}
-			.serialize()
-			.map_err(crate::fdb::custom_error)?;
+			.serialize()?;
 			txn.set(&key, &value);
 
 			let key = Key::Node(crate::fdb::node::Key::Node(arg.specifier.clone()));
@@ -50,6 +47,6 @@ impl Index {
 			let value = tg::Id::from(arg.id.clone()).to_bytes();
 			txn.set(&key, value.as_ref());
 		}
-		Ok(())
+		Ok(ControlFlow::Break(()))
 	}
 }

--- a/packages/index/src/fdb/user/put.rs
+++ b/packages/index/src/fdb/user/put.rs
@@ -28,12 +28,13 @@ impl Index {
 		for arg in args {
 			let key = Key::User(crate::fdb::user::Key::User(arg.id.clone()));
 			let key = Self::pack(subspace, &key);
-			let billing = match arg.billing {
-				Some(billing) => billing,
-				None => crate::fdb::retry!(txn.get(&key, false).await)
-					.map_or(Ok(false), |bytes| {
-						crate::user::User::deserialize(&bytes).map(|user| user.billing)
-					})?,
+			let billing = if let Some(billing) = arg.billing {
+				billing
+			} else {
+				let result = txn.get(&key, false).await;
+				crate::fdb::retry!(result).map_or(Ok(false), |bytes| {
+					crate::user::User::deserialize(&bytes).map(|user| user.billing)
+				})?
 			};
 			let value = crate::user::User {
 				billing,

--- a/packages/index/src/fdb/visible.rs
+++ b/packages/index/src/fdb/visible.rs
@@ -2,7 +2,10 @@ use {
 	crate::fdb::Index,
 	foundationdb as fdb,
 	foundationdb_tuple::Subspace,
-	std::collections::{HashSet, VecDeque},
+	std::{
+		collections::{HashSet, VecDeque},
+		ops::ControlFlow,
+	},
 	tangram_client::prelude::*,
 };
 
@@ -47,37 +50,37 @@ impl Index {
 		subspace: &Subspace,
 		ids: &[tg::Id],
 		principal: &tg::Principal,
-	) -> crate::fdb::Result<Vec<bool>> {
+	) -> tg::Result<ControlFlow<Vec<bool>, fdb::FdbError>> {
 		if matches!(principal, tg::Principal::Root) {
-			return Ok(vec![true; ids.len()]);
+			return Ok(ControlFlow::Break(vec![true; ids.len()]));
 		}
-		let subjects = Self::requester_subjects_with_transaction(txn, subspace, principal).await?;
+		let subjects = crate::fdb::propagate!(
+			Self::requester_subjects_with_transaction(txn, subspace, principal).await
+		);
 		let mut output = Vec::with_capacity(ids.len());
 		for id in ids {
 			let mut visible = false;
 			for subject in &subjects {
-				if Self::try_get_visibility_with_transaction(txn, subspace, id, subject).await? {
+				if crate::fdb::propagate!(
+					Self::try_get_visibility_with_transaction(txn, subspace, id, subject).await
+				) {
 					visible = true;
 					break;
 				}
 			}
 			output.push(visible);
 		}
-		Ok(output)
+		Ok(ControlFlow::Break(output))
 	}
 
 	pub(crate) async fn requester_subjects_with_transaction(
 		txn: &fdb::Transaction,
 		subspace: &Subspace,
 		principal: &tg::Principal,
-	) -> crate::fdb::Result<Vec<tg::authorization::Subject>> {
+	) -> tg::Result<ControlFlow<Vec<tg::authorization::Subject>, fdb::FdbError>> {
 		let mut subjects = vec![tg::authorization::Subject::Public];
 		if !matches!(principal, tg::Principal::Anonymous) {
-			subjects.push(
-				principal
-					.try_to_subject()
-					.map_err(crate::fdb::custom_error)?,
-			);
+			subjects.push(principal.try_to_subject()?);
 		}
 		let id = match principal {
 			tg::Principal::Group(id) => Some(tg::Id::from(id.clone())),
@@ -93,7 +96,9 @@ impl Index {
 			let mut queue = VecDeque::from([id.clone()]);
 			let mut visited = HashSet::from([id]);
 			while let Some(id) = queue.pop_front() {
-				let groups = Self::get_member_groups_with_transaction(txn, subspace, &id).await?;
+				let groups = crate::fdb::propagate!(
+					Self::get_member_groups_with_transaction(txn, subspace, &id).await
+				);
 				for group in groups {
 					let id = tg::Id::from(group.clone());
 					if visited.insert(id.clone()) {
@@ -101,8 +106,9 @@ impl Index {
 						queue.push_back(id);
 					}
 				}
-				let organizations =
-					Self::get_member_organizations_with_transaction(txn, subspace, &id).await?;
+				let organizations = crate::fdb::propagate!(
+					Self::get_member_organizations_with_transaction(txn, subspace, &id).await
+				);
 				for organization in organizations {
 					let id = tg::Id::from(organization.clone());
 					if visited.insert(id.clone()) {
@@ -112,6 +118,6 @@ impl Index {
 				}
 			}
 		}
-		Ok(subjects)
+		Ok(ControlFlow::Break(subjects))
 	}
 }

--- a/packages/index/src/fdb/writer.rs
+++ b/packages/index/src/fdb/writer.rs
@@ -8,10 +8,7 @@ use {
 	opentelemetry as otel,
 	std::{
 		ops::ControlFlow,
-		sync::{
-			Arc, Mutex,
-			atomic::{AtomicU64, Ordering},
-		},
+		sync::{Arc, Mutex},
 	},
 	tangram_client::prelude::*,
 };
@@ -1027,7 +1024,7 @@ impl Index {
 		metrics: &Metrics,
 	) -> std::result::Result<Vec<Response>, TransactionError> {
 		let start = std::time::Instant::now();
-		let retry_count = AtomicU64::new(0);
+		let mut attempt_count = 0;
 
 		let priority_batch = requests.iter().all(|request| {
 			matches!(
@@ -1058,9 +1055,9 @@ impl Index {
 		let result = match transaction {
 			Err(error) => Err(TransactionError::FoundationDb(error)),
 			Ok(transaction) => {
-				let mut transaction = super::Transaction::new(transaction);
+				let mut transaction = transaction;
 				loop {
-					retry_count.fetch_add(1, Ordering::Relaxed);
+					attempt_count += 1;
 					let result = Self::execute_requests_with_transaction(
 						&transaction,
 						subspace,
@@ -1075,27 +1072,19 @@ impl Index {
 						Err(error) => break Err(TransactionError::Tangram(error)),
 						Ok(ControlFlow::Break(responses)) => responses,
 						Ok(ControlFlow::Continue(error)) => {
-							let raw_transaction = match transaction.take() {
-								Ok(transaction) => transaction,
-								Err(error) => break Err(TransactionError::Tangram(error)),
-							};
-							match raw_transaction.on_error(error).await {
+							match transaction.on_error(error).await {
 								Ok(value) => {
-									transaction = super::Transaction::new(value);
+									transaction = value;
 									continue;
 								},
 								Err(error) => break Err(TransactionError::FoundationDb(error)),
 							}
 						},
 					};
-					let raw_transaction = match transaction.take() {
-						Ok(transaction) => transaction,
-						Err(error) => break Err(TransactionError::Tangram(error)),
-					};
-					match raw_transaction.commit().await {
+					match transaction.commit().await {
 						Ok(_) => break Ok(responses),
 						Err(error) => match error.on_error().await {
-							Ok(value) => transaction = super::Transaction::new(value),
+							Ok(value) => transaction = value,
 							Err(error) => break Err(TransactionError::FoundationDb(error)),
 						},
 					}
@@ -1107,9 +1096,10 @@ impl Index {
 		metrics.commit_duration.record(duration, &[]);
 		metrics.transactions.add(1, &[]);
 
-		let attempts = retry_count.load(Ordering::Relaxed);
-		if attempts > 1 {
-			metrics.transaction_conflict_retry.add(attempts - 1, &[]);
+		if attempt_count > 1 {
+			metrics
+				.transaction_conflict_retry
+				.add(attempt_count - 1, &[]);
 		}
 		if matches!(
 			&result,

--- a/packages/index/src/fdb/writer.rs
+++ b/packages/index/src/fdb/writer.rs
@@ -6,9 +6,12 @@ use {
 	foundationdb as fdb, foundationdb_tuple as fdbt,
 	futures::{StreamExt as _, stream},
 	opentelemetry as otel,
-	std::sync::{
-		Arc, Mutex,
-		atomic::{AtomicU64, Ordering},
+	std::{
+		ops::ControlFlow,
+		sync::{
+			Arc, Mutex,
+			atomic::{AtomicU64, Ordering},
+		},
 	},
 	tangram_client::prelude::*,
 };
@@ -48,6 +51,11 @@ struct RequestTracker {
 struct Batch {
 	requests: Vec<Request>,
 	trackers: Vec<Arc<Mutex<RequestTracker>>>,
+}
+
+enum TransactionError {
+	FoundationDb(fdb::FdbError),
+	Tangram(tg::Error),
 }
 
 impl Index {
@@ -876,7 +884,7 @@ impl Index {
 					Self::complete_tracker(tracker, Ok(response));
 				}
 			},
-			Err(error) if Self::is_transaction_too_large(&error) => {
+			Err(TransactionError::FoundationDb(error)) if Self::is_transaction_too_large(error) => {
 				if batch.requests.len() > 1 {
 					let mid = batch.requests.len() / 2;
 					let mut requests = batch.requests;
@@ -934,7 +942,12 @@ impl Index {
 				}
 			},
 			Err(error) => {
-				let error = tg::error!(!error, "failed to execute batch");
+				let error = match error {
+					TransactionError::FoundationDb(error) => {
+						tg::error!(!error, "failed to execute a batch")
+					},
+					TransactionError::Tangram(error) => error,
+				};
 				for tracker in &batch.trackers {
 					Self::fail_tracker(tracker, &error);
 				}
@@ -976,7 +989,9 @@ impl Index {
 						return Err(tg::error!("unexpected write response"));
 					};
 				},
-				Err(error) if Self::is_transaction_too_large(&error) => {
+				Err(TransactionError::FoundationDb(error))
+					if Self::is_transaction_too_large(error) =>
+				{
 					let Request::Batch(arg) = request else {
 						unreachable!();
 					};
@@ -987,7 +1002,15 @@ impl Index {
 					pending.push(right);
 					pending.push(left);
 				},
-				Err(error) => return Err(tg::error!(!error, "failed to execute batch")),
+				Err(error) => {
+					let error = match error {
+						TransactionError::FoundationDb(error) => {
+							tg::error!(!error, "failed to execute a batch")
+						},
+						TransactionError::Tangram(error) => error,
+					};
+					return Err(error);
+				},
 			}
 		}
 
@@ -1002,7 +1025,7 @@ impl Index {
 		partition_total: u64,
 		usage_partition_total: u64,
 		metrics: &Metrics,
-	) -> crate::fdb::Result<Vec<Response>> {
+	) -> std::result::Result<Vec<Response>, TransactionError> {
 		let start = std::time::Instant::now();
 		let retry_count = AtomicU64::new(0);
 
@@ -1031,33 +1054,54 @@ impl Index {
 			)
 		});
 
-		let result = database
-			.run(|txn, _maybe_committed| {
-				retry_count.fetch_add(1, Ordering::Relaxed);
-				let requests = requests.to_vec();
-				let subspace = subspace.clone();
-				async move {
-					if priority_batch {
-						txn.set_option(fdb::options::TransactionOption::PriorityBatch)
-							.unwrap();
+		let transaction = database.create_trx();
+		let result = match transaction {
+			Err(error) => Err(TransactionError::FoundationDb(error)),
+			Ok(transaction) => {
+				let mut transaction = super::Transaction::new(transaction);
+				loop {
+					retry_count.fetch_add(1, Ordering::Relaxed);
+					let result = Self::execute_requests_with_transaction(
+						&transaction,
+						subspace,
+						requests,
+						max_process_depth,
+						partition_total,
+						usage_partition_total,
+						priority_batch,
+					)
+					.await;
+					let responses = match result {
+						Err(error) => break Err(TransactionError::Tangram(error)),
+						Ok(ControlFlow::Break(responses)) => responses,
+						Ok(ControlFlow::Continue(error)) => {
+							let raw_transaction = match transaction.take() {
+								Ok(transaction) => transaction,
+								Err(error) => break Err(TransactionError::Tangram(error)),
+							};
+							match raw_transaction.on_error(error).await {
+								Ok(value) => {
+									transaction = super::Transaction::new(value);
+									continue;
+								},
+								Err(error) => break Err(TransactionError::FoundationDb(error)),
+							}
+						},
+					};
+					let raw_transaction = match transaction.take() {
+						Ok(transaction) => transaction,
+						Err(error) => break Err(TransactionError::Tangram(error)),
+					};
+					match raw_transaction.commit().await {
+						Ok(_) => break Ok(responses),
+						Err(error) => match error.on_error().await {
+							Ok(value) => transaction = super::Transaction::new(value),
+							Err(error) => break Err(TransactionError::FoundationDb(error)),
+						},
 					}
-					let mut responses = Vec::new();
-					for request in requests {
-						let response = Self::execute_request(
-							&txn,
-							&subspace,
-							&request,
-							max_process_depth,
-							partition_total,
-							usage_partition_total,
-						)
-						.await?;
-						responses.push(response);
-					}
-					Ok(responses)
 				}
-			})
-			.await;
+			},
+		};
 
 		let duration = start.elapsed().as_secs_f64();
 		metrics.commit_duration.record(duration, &[]);
@@ -1067,15 +1111,45 @@ impl Index {
 		if attempts > 1 {
 			metrics.transaction_conflict_retry.add(attempts - 1, &[]);
 		}
-		if result
-			.as_ref()
-			.err()
-			.is_some_and(Self::is_transaction_too_large)
-		{
+		if matches!(
+			&result,
+			Err(TransactionError::FoundationDb(error)) if Self::is_transaction_too_large(*error)
+		) {
 			metrics.transaction_too_large.add(1, &[]);
 		}
 
 		result
+	}
+
+	async fn execute_requests_with_transaction(
+		txn: &fdb::Transaction,
+		subspace: &fdbt::Subspace,
+		requests: &[Request],
+		max_process_depth: Option<u64>,
+		partition_total: u64,
+		usage_partition_total: u64,
+		priority_batch: bool,
+	) -> tg::Result<ControlFlow<Vec<Response>, fdb::FdbError>> {
+		if priority_batch {
+			txn.set_option(fdb::options::TransactionOption::PriorityBatch)
+				.unwrap();
+		}
+		let mut responses = Vec::with_capacity(requests.len());
+		for request in requests {
+			let result = Self::execute_request(
+				txn,
+				subspace,
+				request,
+				max_process_depth,
+				partition_total,
+				usage_partition_total,
+			)
+			.await;
+			let response = crate::fdb::propagate!(result);
+			responses.push(response);
+		}
+
+		Ok(ControlFlow::Break(responses))
 	}
 
 	async fn execute_request(
@@ -1085,18 +1159,19 @@ impl Index {
 		max_process_depth: Option<u64>,
 		partition_total: u64,
 		usage_partition_total: u64,
-	) -> crate::fdb::Result<Response> {
-		match request {
+	) -> tg::Result<ControlFlow<Response, fdb::FdbError>> {
+		let response = match request {
 			Request::Batch(arg) => {
-				Self::batch_with_transaction(
+				let result = Self::batch_with_transaction(
 					txn,
 					subspace,
 					arg,
 					partition_total,
 					usage_partition_total,
 				)
-				.await?;
-				Ok(Response::Unit)
+				.await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::Clean(crate::fdb::Clean {
 				batch_size,
@@ -1120,189 +1195,240 @@ impl Index {
 					usage_partition_total,
 					txn,
 				};
-				Self::clean_with_transaction(arg)
-					.await
-					.map(Response::CleanOutput)
+				let result = Self::clean_with_transaction(arg).await;
+				let output = crate::fdb::propagate!(result);
+				Response::CleanOutput(output)
 			},
 			Request::CleanUsage(arg) => {
-				Self::clean_usage_with_transaction(txn, subspace, arg, usage_partition_total)
-					.await
-					.map(Response::CleanUsageOutput)
+				let result =
+					Self::clean_usage_with_transaction(txn, subspace, arg, usage_partition_total)
+						.await;
+				let output = crate::fdb::propagate!(result);
+				Response::CleanUsageOutput(output)
 			},
-			Request::CompactUsage(arg) => Self::compact_usage_with_transaction(txn, subspace, arg)
-				.await
-				.map(Response::CompactUsageOutput),
+			Request::CompactUsage(arg) => {
+				let result = Self::compact_usage_with_transaction(txn, subspace, arg).await;
+				let output = crate::fdb::propagate!(result);
+				Response::CompactUsageOutput(output)
+			},
 			Request::CompleteLogCompaction(entry) => {
-				Self::complete_log_compaction_with_transaction(txn, subspace, entry).await?;
-				Ok(Response::Unit)
+				let result =
+					Self::complete_log_compaction_with_transaction(txn, subspace, entry).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteGrants(args) => {
-				Self::delete_grants_with_transaction(txn, subspace, args, partition_total).await?;
-				Ok(Response::Unit)
+				let result =
+					Self::delete_grants_with_transaction(txn, subspace, args, partition_total)
+						.await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteGroupMembers(args) => {
-				Self::delete_group_members_with_transaction(txn, subspace, args)?;
-				Ok(Response::Unit)
+				let result = Self::delete_group_members_with_transaction(txn, subspace, args);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteGroups(ids) => {
-				Self::delete_groups_with_transaction(txn, subspace, ids).await?;
-				Ok(Response::Unit)
+				let result = Self::delete_groups_with_transaction(txn, subspace, ids).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteOrganizationMembers(args) => {
-				Self::delete_organization_members_with_transaction(txn, subspace, args)?;
-				Ok(Response::Unit)
+				let result =
+					Self::delete_organization_members_with_transaction(txn, subspace, args);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteOrganizations(ids) => {
-				Self::delete_organizations_with_transaction(txn, subspace, ids).await?;
-				Ok(Response::Unit)
+				let result = Self::delete_organizations_with_transaction(txn, subspace, ids).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteSandboxes(ids) => {
-				Self::delete_sandboxes_with_transaction(txn, subspace, ids)?;
-				Ok(Response::Unit)
+				let result = Self::delete_sandboxes_with_transaction(txn, subspace, ids);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteUsers(ids) => {
-				Self::delete_users_with_transaction(txn, subspace, ids).await?;
-				Ok(Response::Unit)
+				let result = Self::delete_users_with_transaction(txn, subspace, ids).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::DeleteTags(tags) => {
-				Self::delete_tags_with_transaction(txn, subspace, tags, partition_total)
-					.await
-					.map(|()| Response::Unit)
+				let result =
+					Self::delete_tags_with_transaction(txn, subspace, tags, partition_total).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::EnqueueLogCompaction(process) => {
-				Self::enqueue_log_compaction_with_transaction(
+				let result = Self::enqueue_log_compaction_with_transaction(
 					txn,
 					subspace,
 					process,
 					partition_total,
 				)
-				.await?;
-				Ok(Response::Unit)
+				.await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::GetUsage {
 				account,
 				now,
 				period,
-			} => Self::get_usage_with_transaction(
-				txn,
-				subspace,
-				account,
-				*period,
-				*now,
-				usage_partition_total,
-			)
-			.await
-			.map(Response::Usage),
+			} => {
+				let result = Self::get_usage_with_transaction(
+					txn,
+					subspace,
+					account,
+					*period,
+					*now,
+					usage_partition_total,
+				)
+				.await;
+				let output = crate::fdb::propagate!(result);
+				Response::Usage(output)
+			},
 			Request::PutCacheEntries(args) => {
-				Self::put_cache_entries_with_transaction(txn, subspace, args, partition_total)?;
-				Ok(Response::Unit)
+				let result =
+					Self::put_cache_entries_with_transaction(txn, subspace, args, partition_total);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutGrants(args) => {
-				Self::put_grants_with_transaction(txn, subspace, args, partition_total).await?;
-				Ok(Response::Unit)
+				let result =
+					Self::put_grants_with_transaction(txn, subspace, args, partition_total).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutGroupMembers(args) => {
-				Self::put_group_members_with_transaction(txn, subspace, args)?;
-				Ok(Response::Unit)
+				let result = Self::put_group_members_with_transaction(txn, subspace, args);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutGroups(args) => {
-				Self::put_groups_with_transaction(txn, subspace, args)?;
-				Ok(Response::Unit)
+				let result = Self::put_groups_with_transaction(txn, subspace, args);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutObjects(args) => {
-				Self::put_objects_with_transaction(txn, subspace, args, partition_total).await?;
-				Ok(Response::Unit)
+				let result =
+					Self::put_objects_with_transaction(txn, subspace, args, partition_total).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutOrganizationMembers(args) => {
-				Self::put_organization_members_with_transaction(txn, subspace, args)?;
-				Ok(Response::Unit)
+				let result = Self::put_organization_members_with_transaction(txn, subspace, args);
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutOrganizations(args) => {
-				Self::put_organizations_with_transaction(txn, subspace, args).await?;
-				Ok(Response::Unit)
+				let result = Self::put_organizations_with_transaction(txn, subspace, args).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutProcesses(args) => {
-				Self::put_processes_with_transaction(txn, subspace, args, partition_total).await?;
-				Ok(Response::Unit)
+				let result =
+					Self::put_processes_with_transaction(txn, subspace, args, partition_total)
+						.await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutSandboxes(args) => {
-				Self::put_sandboxes_with_transaction(
+				let result = Self::put_sandboxes_with_transaction(
 					txn,
 					subspace,
 					args,
 					partition_total,
 					usage_partition_total,
 				)
-				.await?;
-				Ok(Response::Unit)
+				.await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutTags(args) => {
-				Self::put_tags_with_transaction(txn, subspace, args, partition_total)
-					.await
-					.map(|()| Response::Unit)
+				let result =
+					Self::put_tags_with_transaction(txn, subspace, args, partition_total).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::PutUsers(args) => {
-				Self::put_users_with_transaction(txn, subspace, args).await?;
-				Ok(Response::Unit)
+				let result = Self::put_users_with_transaction(txn, subspace, args).await;
+				crate::fdb::propagate!(result);
+				Response::Unit
 			},
 			Request::TouchCacheEntries(crate::fdb::TouchCacheEntries {
 				ids,
 				time_to_touch,
 				touched_at,
-			}) => Self::touch_cache_entries_with_transaction(
-				txn,
-				subspace,
-				ids,
-				*touched_at,
-				*time_to_touch,
-				partition_total,
-			)
-			.await
-			.map(Response::CacheEntries),
+			}) => {
+				let result = Self::touch_cache_entries_with_transaction(
+					txn,
+					subspace,
+					ids,
+					*touched_at,
+					*time_to_touch,
+					partition_total,
+				)
+				.await;
+				let output = crate::fdb::propagate!(result);
+				Response::CacheEntries(output)
+			},
 			Request::TouchObjects(crate::fdb::TouchObjects {
 				account,
 				ids,
 				time_to_touch,
 				touched_at,
-			}) => Self::touch_objects_with_account_with_transaction(
-				txn,
-				subspace,
-				ids,
-				account.as_ref(),
-				*touched_at,
-				*time_to_touch,
-				partition_total,
-			)
-			.await
-			.map(Response::Objects),
-			Request::TouchProcesses(arg) => Self::touch_processes_with_account_with_transaction(
-				txn,
-				subspace,
-				arg,
-				partition_total,
-				usage_partition_total,
-			)
-			.await
-			.map(Response::Processes),
+			}) => {
+				let result = Self::touch_objects_with_account_with_transaction(
+					txn,
+					subspace,
+					ids,
+					account.as_ref(),
+					*touched_at,
+					*time_to_touch,
+					partition_total,
+				)
+				.await;
+				let output = crate::fdb::propagate!(result);
+				Response::Objects(output)
+			},
+			Request::TouchProcesses(arg) => {
+				let result = Self::touch_processes_with_account_with_transaction(
+					txn,
+					subspace,
+					arg,
+					partition_total,
+					usage_partition_total,
+				)
+				.await;
+				let output = crate::fdb::propagate!(result);
+				Response::Processes(output)
+			},
 			Request::Update(crate::fdb::Update {
 				batch_size,
 				kind,
 				partition_start,
 				partition_end,
-			}) => Self::update_with_transaction(
-				txn,
-				subspace,
-				*batch_size,
-				*kind,
-				*partition_start,
-				*partition_end,
-				max_process_depth,
-				partition_total,
-				usage_partition_total,
-			)
-			.await
-			.map(Response::UpdateOutput),
-		}
+			}) => {
+				let result = Self::update_with_transaction(
+					txn,
+					subspace,
+					*batch_size,
+					*kind,
+					*partition_start,
+					*partition_end,
+					max_process_depth,
+					partition_total,
+					usage_partition_total,
+				)
+				.await;
+				let output = crate::fdb::propagate!(result);
+				Response::UpdateOutput(output)
+			},
+		};
+
+		Ok(ControlFlow::Break(response))
 	}
 
 	fn try_split_batch_arg(
@@ -1317,10 +1443,8 @@ impl Index {
 		Some((arg, right))
 	}
 
-	fn is_transaction_too_large(error: &fdb::FdbBindingError) -> bool {
-		error
-			.get_fdb_error()
-			.is_some_and(|error| error.code() == 2101)
+	fn is_transaction_too_large(error: fdb::FdbError) -> bool {
+		error.code() == 2101
 	}
 
 	fn complete_tracker(tracker: &Arc<Mutex<RequestTracker>>, result: tg::Result<Response>) {

--- a/packages/index/src/read.rs
+++ b/packages/index/src/read.rs
@@ -6,7 +6,6 @@ pub(crate) type Receiver = tokio::sync::mpsc::Receiver<(Request, ResponseSender)
 pub(crate) type ResponseSender = tokio::sync::oneshot::Sender<tg::Result<Response>>;
 pub(crate) type Sender = tokio::sync::mpsc::Sender<(Request, ResponseSender)>;
 
-#[derive(Clone)]
 pub(crate) enum Request {
 	AuthorizeBatch {
 		args: Vec<crate::authorize::Arg>,

--- a/packages/index/src/read.rs
+++ b/packages/index/src/read.rs
@@ -6,6 +6,7 @@ pub(crate) type Receiver = tokio::sync::mpsc::Receiver<(Request, ResponseSender)
 pub(crate) type ResponseSender = tokio::sync::oneshot::Sender<tg::Result<Response>>;
 pub(crate) type Sender = tokio::sync::mpsc::Sender<(Request, ResponseSender)>;
 
+#[derive(Clone)]
 pub(crate) enum Request {
 	AuthorizeBatch {
 		args: Vec<crate::authorize::Arg>,


### PR DESCRIPTION
## Summary

- make FDB transaction helpers return `tg::Result<ControlFlow<T, fdb::FdbError>>`
- add small `retry!` and `propagate!` macros so raw FDB failures and child-helper retries remain explicit
- add Tangram-native retry loops for shared read batches and writes
- preserve adaptive handling and metrics for transaction-too-large writer errors
- remove the `FdbBindingError::CustomError` bridge from the FDB index implementation

## Root cause

The FoundationDB `Database::run` API requires closure errors to use `FdbBindingError`. Contextual Tangram errors were represented as `CustomError`, which prevented FoundationDB from recognizing an underlying retryable error such as `transaction_too_old`.

The new transaction boundaries keep retryable failures as `fdb::FdbError` in `ControlFlow::Continue` until the retry loop calls FoundationDB `on_error`. Tangram failures remain `tg::Error`, preserving their sources, locations, and values. Fixed transaction options continue to use `unwrap()` because failures there are programming or API invariants rather than retryable transaction failures.

## Impact

The writer replays the complete write attempt only when FoundationDB accepts an error for retry. Shared read batches execute concurrently and send successful or terminal responses as soon as each request completes; only requests that return retryable FDB errors wait for the transaction reset and are retried. Read-only transactions are dropped without committing.

The implementation avoids cloning read requests across attempts, skips canceled retry requests before resetting a transaction, uses a local writer attempt counter, and reserves result vector capacity when the size is known.

## Validation

- `bun run format`
- `bun run check`

The test suite was not run because it does not exercise the FoundationDB backend.