### PR TITLE
fix(cli): --remote=false adds local, local=false adds remote

### DIFF
--- a/packages/cli/src/location.rs
+++ b/packages/cli/src/location.rs
@@ -86,6 +86,13 @@ impl Args {
 				arg.0.push(tg::location::arg::Component::Local(
 					tg::location::arg::LocalComponent::default(),
 				));
+			} else if self.remotes.is_none() {
+				arg.0.push(tg::location::arg::Component::Remote(
+					tg::location::arg::RemoteComponent {
+						name: "default".to_owned(),
+						regions: None,
+					},
+				));
 			}
 		}
 
@@ -100,7 +107,13 @@ impl Args {
 						},
 					));
 				},
-				[remote] if remote == "false" => (),
+				[remote] if remote == "false" => {
+					if self.local.is_none() {
+						arg.0.push(tg::location::arg::Component::Local(
+							tg::location::arg::LocalComponent::default(),
+						));
+					}
+				},
 				_ => {
 					arg.0.extend(remotes.iter().cloned().map(|name| {
 						tg::location::arg::Component::Remote(tg::location::arg::RemoteComponent {

--- a/packages/cli/tests/build/local_false.nu
+++ b/packages/cli/tests/build/local_false.nu
@@ -1,0 +1,19 @@
+use ../../test.nu *
+
+# A build with --local=false runs on the default remote rather than on the local server.
+
+let remote = spawn --name remote
+let local = spawn --name local
+
+tg remote put default $remote.url
+
+let path = artifact {
+	tangram.ts: 'export default function () { return 42; }'
+}
+
+let id = tg build --local=false --detach $path
+let output = tg wait $id | from json
+assert equal $output.exit 0 "the build should succeed"
+
+let seen = tg --url $remote.url process get $id | complete
+success $seen "the process should exist on the remote"

--- a/packages/cli/tests/build/remote_false.nu
+++ b/packages/cli/tests/build/remote_false.nu
@@ -1,0 +1,12 @@
+use ../../test.nu *
+
+# A build with --remote=false selects no remotes rather than failing to resolve a location.
+
+let server = spawn
+
+let path = artifact {
+	tangram.ts: 'export default function () { return 42; }'
+}
+
+let output = tg build --remote=false $path
+assert equal $output '42' "the build should run with no remotes"


### PR DESCRIPTION
Currently, using either `--remote=false` or `--local=false` results in `error: failed to spawn the process -> expected exactly one location`.

This PR includes tests demonstrating this, and a fix that treats a `false` on either as an implicit `true` for the other, which I believe matches the intent.

Combinations work as expected:

-  `--local --remote=false` still yields just `Local`.
- `--local=false --remote=foo` still yields just `Remote(foo)`.
- `--local=false --remote=false` will still yield the `expected exactly one location` message.