### PR TITLE
fix(sandbox): eagerly construct reader and unify task error handling/tracing

### DIFF
--- a/packages/cli/tests/run/stdio_read_after_sandbox_destroy.nu
+++ b/packages/cli/tests/run/stdio_read_after_sandbox_destroy.nu
@@ -1,0 +1,47 @@
+use ../../test.nu *
+
+# A piped stdio read that arrives after the process's sandbox is destroyed receives the
+# process's buffered output rather than failing to create the stream.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true,
+	},
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default () => {
+			console.log("hello from the sandbox");
+		};
+	',
+}
+
+let read_watch = (
+	tg checkpoint watch process.stdio.read.request --params '{"stream":"stdout"}'
+	| from json
+	| get watch
+)
+let destroyed_watch = (
+	tg checkpoint watch runner.sandbox.destroyed
+	| from json
+	| get watch
+)
+
+let run = job spawn {
+	let job_id = job id
+	let output = tg run --sandbox $path | complete
+	$output | job send --tag $job_id 0
+}
+
+# Hold the first stdout read until the process has exited and its sandbox is destroyed.
+tg checkpoint wait process.stdio.read.request $read_watch 0 | ignore
+tg checkpoint wait runner.sandbox.destroyed $destroyed_watch 0 | ignore
+tg checkpoint continue runner.sandbox.destroyed $destroyed_watch 0
+tg checkpoint unwatch runner.sandbox.destroyed $destroyed_watch
+tg checkpoint continue process.stdio.read.request $read_watch 0
+tg checkpoint unwatch process.stdio.read.request $read_watch
+
+let output = job recv --tag $run --timeout 10sec
+success $output
+assert ($output.stdout | str contains "hello from the sandbox")

--- a/packages/cli/tests/run/stdio_reader_creation_after_sandbox_destroy.nu
+++ b/packages/cli/tests/run/stdio_reader_creation_after_sandbox_destroy.nu
@@ -1,0 +1,84 @@
+use ../../test.nu *
+
+# A process's sandbox must remain alive until its piped stdio is buffered.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true,
+	},
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default () => {
+			console.log("hello from the sandbox");
+		};
+	',
+}
+
+let reader_watch = (
+	tg checkpoint watch runner.process.control.reader.create --params '{"stream":"stdout"}'
+	| from json
+	| get watch
+)
+let finish_watch = (
+	tg checkpoint watch runner.process.finish
+	| from json
+	| get watch
+)
+let buffered_watch = (
+	tg checkpoint watch runner.process.buffered
+	| from json
+	| get watch
+)
+let destroyed_watch = (
+	tg checkpoint watch runner.sandbox.destroyed
+	| from json
+	| get watch
+)
+
+let run = job spawn {
+	let job_id = job id
+	let output = tg run --sandbox $path | complete
+	$output | job send --tag $job_id 0
+}
+let destroyed = job spawn {
+	let job_id = job id
+	let output = tg checkpoint wait runner.sandbox.destroyed $destroyed_watch 0 | complete
+	$output | job send --tag $job_id 0
+}
+
+# Hold stdout reader creation while allowing the process to exit.
+tg checkpoint wait runner.process.control.reader.create $reader_watch 0 | ignore
+tg checkpoint wait runner.process.finish $finish_watch 0 | ignore
+tg checkpoint continue runner.process.finish $finish_watch 0
+tg checkpoint unwatch runner.process.finish $finish_watch
+
+# The sandbox cannot be destroyed before its stdout reader exists.
+let early = try {
+	job recv --tag $destroyed --timeout 250ms
+} catch {
+	null
+}
+assert ($early == null) "the sandbox must wait for its stdout reader"
+tg checkpoint continue runner.process.control.reader.create $reader_watch 0
+tg checkpoint unwatch runner.process.control.reader.create $reader_watch
+
+# Hold the buffered event and confirm it gates sandbox destruction.
+tg checkpoint wait runner.process.buffered $buffered_watch 0 | ignore
+let early = try {
+	job recv --tag $destroyed --timeout 250ms
+} catch {
+	null
+}
+assert ($early == null) "the sandbox must wait for the buffered event"
+tg checkpoint continue runner.process.buffered $buffered_watch 0
+tg checkpoint unwatch runner.process.buffered $buffered_watch
+
+success (job recv --tag $destroyed --timeout 10sec)
+tg checkpoint continue runner.sandbox.destroyed $destroyed_watch 0
+tg checkpoint unwatch runner.sandbox.destroyed $destroyed_watch
+
+let output = job recv --tag $run --timeout 10sec
+success $output
+assert ($output.stdout | str contains "hello from the sandbox")

--- a/packages/server/src/control.rs
+++ b/packages/server/src/control.rs
@@ -32,8 +32,9 @@ pub(crate) struct Stream<I, O> {
 }
 
 pub(crate) struct Sender<I, O> {
-	_marker: PhantomData<fn() -> I>,
 	inner: tokio::sync::mpsc::Sender<O>,
+	_marker: PhantomData<fn() -> I>,
+	notify: Arc<tokio::sync::Notify>,
 	outbox: Arc<DashMap<String, O>>,
 }
 
@@ -75,8 +76,9 @@ where
 		let inbox = Arc::new(DashMap::new());
 		let sender = Sender {
 			inner: sender,
-			outbox: Arc::new(DashMap::new()),
 			_marker: PhantomData,
+			notify: Arc::new(tokio::sync::Notify::new()),
+			outbox: Arc::new(DashMap::new()),
 		};
 		let send_task = tokio::spawn({
 			let sender = sender.clone();
@@ -148,8 +150,9 @@ impl<I, O> Clone for Sender<I, O> {
 	fn clone(&self) -> Self {
 		Self {
 			inner: self.inner.clone(),
-			outbox: self.outbox.clone(),
 			_marker: PhantomData,
+			notify: self.notify.clone(),
+			outbox: self.outbox.clone(),
 		}
 	}
 }
@@ -170,7 +173,19 @@ where
 	}
 
 	pub(crate) fn remove(&self, id: &str) {
-		self.outbox.remove(id);
+		if self.outbox.remove(id).is_some() && self.outbox.is_empty() {
+			self.notify.notify_waiters();
+		}
+	}
+
+	pub(crate) async fn wait_for_empty(&self) {
+		loop {
+			let notified = self.notify.notified();
+			if self.outbox.is_empty() {
+				return;
+			}
+			notified.await;
+		}
 	}
 
 	fn messages(&self) -> Vec<O> {

--- a/packages/server/src/process/stdio/read.rs
+++ b/packages/server/src/process/stdio/read.rs
@@ -307,7 +307,14 @@ impl Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to get the process"))?;
 
-		if output.data.status.is_finished() {
+		if output.data.status.is_finished()
+			&& self
+				.server
+				.runner
+				.state()
+				.try_get_process_sandbox(id)
+				.is_none()
+		{
 			sender
 				.send(Ok(tg::process::stdio::read::Event::End))
 				.await

--- a/packages/server/src/process/stdio/read.rs
+++ b/packages/server/src/process/stdio/read.rs
@@ -346,6 +346,14 @@ impl Session {
 				return Ok(());
 			}
 
+			crate::checkpoint!(
+				self.server,
+				"process.stdio.read.request",
+				process = %id,
+				stream = %stream,
+			)
+			.await;
+
 			let request = tg::process::control::ServerRequestArg::Read(
 				tg::process::control::ReadServerRequestArg {
 					stream,

--- a/packages/server/src/runner/process.rs
+++ b/packages/server/src/runner/process.rs
@@ -54,6 +54,7 @@ struct ProcessTaskArg {
 }
 
 struct FinishProcessTaskArg {
+	buffered_task: Task<tg::Result<()>>,
 	control_task: Task<tg::Result<()>>,
 	finish_sender: tokio::sync::oneshot::Sender<tg::process::Data>,
 	id: tg::process::Id,
@@ -72,8 +73,10 @@ struct CollectProcessOutputArg<'a> {
 }
 
 pub(super) enum Event {
+	Buffered,
 	Connected(ConnectedEvent),
 	Exited,
+	Released,
 }
 
 #[derive(Clone, Debug)]
@@ -310,19 +313,30 @@ impl Session {
 		// Start the process task concurrently with the control stream.
 		let (sandbox_process_sender, sandbox_process_receiver) =
 			tokio::sync::watch::channel::<Option<Arc<tangram_sandbox::Process>>>(None);
-		let log_task = log_sender.map(|log_sender| {
-			Task::spawn({
+		let (log_buffered_sender, log_buffered_receiver) = tokio::sync::oneshot::channel();
+		let log_task = match log_sender {
+			None => {
+				log_buffered_sender.send(Ok(())).ok();
+
+				None
+			},
+			Some(log_sender) => Some(Task::spawn({
 				let log_streams = log_streams.clone();
 				let process_stopper = process_stopper.clone();
 				let sandbox = sandbox.clone();
 				let mut sandbox_process = sandbox_process_receiver.clone();
 				move |_| async move {
+					let mut log_buffered_sender = Some(log_buffered_sender);
 					let result = async {
 						let sandbox_process = loop {
 							if let Some(process) = sandbox_process.borrow().clone() {
 								break process;
 							}
 							if sandbox_process.changed().await.is_err() {
+								if let Some(sender) = log_buffered_sender.take() {
+									sender.send(Ok(())).ok();
+								}
+
 								return Ok(());
 							}
 						};
@@ -353,6 +367,10 @@ impl Session {
 						let mut input = std::pin::pin!(input);
 						while let Some(event) = input.try_next().await? {
 							if matches!(event, tg::process::stdio::read::Event::End) {
+								if let Some(sender) = log_buffered_sender.take() {
+									sender.send(Ok(())).ok();
+								}
+
 								continue;
 							}
 							log_sender
@@ -366,14 +384,20 @@ impl Session {
 						Ok::<_, tg::Error>(())
 					}
 					.await;
+					if let Some(sender) = log_buffered_sender {
+						let error = result.as_ref().err().cloned().unwrap_or_else(|| {
+							tg::error!("the sandbox stdio stream ended unexpectedly")
+						});
+						sender.send(Err(error)).ok();
+					}
 					if result.is_err() {
 						process_stopper.stop();
 					}
 
 					result
 				}
-			})
-		});
+			})),
+		};
 		let mut run_task = Some(Task::spawn({
 			let command = command.clone();
 			let guest_url = guest_url.clone();
@@ -610,6 +634,8 @@ impl Session {
 
 		// Spawn the process control task.
 		let (finish_sender, finish_receiver) = tokio::sync::oneshot::channel();
+		let (stderr_buffered_sender, stderr_buffered_receiver) = tokio::sync::oneshot::channel();
+		let (stdout_buffered_sender, stdout_buffered_receiver) = tokio::sync::oneshot::channel();
 		let stdin_blob = command
 			.clone()
 			.await
@@ -631,10 +657,12 @@ impl Session {
 						sandbox_process: sandbox_process_receiver,
 						sender: control_sender,
 						stderr,
+						stderr_buffered: stderr_buffered_sender,
 						stderr_progress,
 						stdin,
 						stdin_blob,
 						stdout,
+						stdout_buffered: stdout_buffered_sender,
 					})
 					.await
 					.inspect_err(|error| {
@@ -691,7 +719,61 @@ impl Session {
 		)
 		.await;
 		event_sender.send(Ok(Event::Exited)).ok();
+		let buffered_task = Task::spawn({
+			let event_sender = event_sender.clone();
+			let id = id.clone();
+			let server = session.server.clone();
+			move |_| async move {
+				let result = async {
+					let log_buffered = match log_buffered_receiver.await {
+						Ok(result) => {
+							result?;
+							true
+						},
+						Err(_) => false,
+					};
+					let stderr_buffered = match stderr_buffered_receiver.await {
+						Ok(result) => {
+							result?;
+							true
+						},
+						Err(_) => false,
+					};
+					let stdout_buffered = match stdout_buffered_receiver.await {
+						Ok(result) => {
+							result?;
+							true
+						},
+						Err(_) => false,
+					};
+					let buffered = log_buffered && stderr_buffered && stdout_buffered;
+
+					Ok::<_, tg::Error>(buffered)
+				}
+				.await;
+				match &result {
+					Ok(true) => {
+						crate::checkpoint!(
+							server,
+							"runner.process.buffered",
+							process = %id,
+						)
+						.await;
+						event_sender.send(Ok(Event::Buffered)).ok();
+					},
+					Ok(false) => {
+						event_sender.send(Ok(Event::Released)).ok();
+					},
+					Err(error) => {
+						event_sender.send(Err(error.clone())).ok();
+					},
+				}
+
+				result.map(|_| ())
+			}
+		});
 		let arg = FinishProcessTaskArg {
+			buffered_task,
 			control_task,
 			finish_sender,
 			id,
@@ -708,6 +790,7 @@ impl Session {
 
 	async fn finish_process_task(&self, arg: FinishProcessTaskArg) -> tg::Result<()> {
 		let FinishProcessTaskArg {
+			buffered_task,
 			control_task,
 			finish_sender,
 			id,
@@ -1001,6 +1084,10 @@ impl Session {
 		finish_sender
 			.send(data)
 			.map_err(|_| tg::error!(%id, "failed to send the finished process data"))?;
+		buffered_task
+			.wait()
+			.await
+			.map_err(|error| tg::error!(!error, %id, "the process buffered task panicked"))??;
 		control_task
 			.wait()
 			.await

--- a/packages/server/src/runner/process/control.rs
+++ b/packages/server/src/runner/process/control.rs
@@ -6,13 +6,14 @@ use {
 	},
 	crate::session::Session,
 	bytes::Bytes,
-	futures::{
-		StreamExt as _, TryFutureExt as _, TryStreamExt as _,
-		stream::{self, BoxStream},
-	},
+	futures::{StreamExt as _, TryFutureExt as _, TryStreamExt as _, stream::BoxStream},
 	std::{pin::pin, sync::Arc},
 	tangram_client::prelude::*,
-	tangram_futures::task::{Stopper, Task},
+	tangram_futures::{
+		stream::Ext as _,
+		task::{Stopper, Task},
+	},
+	tokio_stream::wrappers::UnboundedReceiverStream,
 };
 
 mod signal;
@@ -26,6 +27,8 @@ pub(super) type ProcessControlSender = crate::control::Sender<
 	tg::process::control::ClientMessage,
 >;
 
+const PROCESS_CONTROL_READER_BUFFER_CAPACITY: usize = 4096;
+
 pub(crate) struct RunProcessControlTaskArg {
 	pub finish: tokio::sync::oneshot::Receiver<tg::process::Data>,
 	pub requests: BoxStream<'static, tg::Result<tg::process::control::ServerMessage>>,
@@ -34,17 +37,25 @@ pub(crate) struct RunProcessControlTaskArg {
 	pub sandbox_process: tokio::sync::watch::Receiver<Option<Arc<tangram_sandbox::Process>>>,
 	pub sender: tokio::sync::mpsc::Sender<tg::process::control::ClientMessage>,
 	pub stderr: tg::process::Stdio,
+	pub stderr_buffered: tokio::sync::oneshot::Sender<tg::Result<()>>,
 	pub stderr_progress: Option<BoxStream<'static, tg::Result<Bytes>>>,
 	pub stdin: tg::process::Stdio,
 	pub stdin_blob: Option<tg::Blob>,
 	pub stdout: tg::process::Stdio,
+	pub stdout_buffered: tokio::sync::oneshot::Sender<tg::Result<()>>,
 }
 
 pub(super) struct Reader {
 	pub(super) buffer: Bytes,
 	pub(super) eof: bool,
 	pub(super) offset: usize,
-	pub(super) stream: BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>,
+	permit: Option<tokio::sync::OwnedSemaphorePermit>,
+	stream: BoxStream<'static, tg::Result<BufferedChunk>>,
+}
+
+struct BufferedChunk {
+	bytes: Bytes,
+	permit: tokio::sync::OwnedSemaphorePermit,
 }
 
 struct RunProcessControlHandlerTaskArg {
@@ -54,6 +65,7 @@ struct RunProcessControlHandlerTaskArg {
 	>,
 	response_sender: tokio::sync::mpsc::Sender<tg::process::control::ServerResponse>,
 	sender: ProcessControlSender,
+	shared_tty: bool,
 	signal_sender:
 		tokio::sync::mpsc::Sender<(String, tg::process::control::SignalServerRequestArg)>,
 	stderr_sender: tokio::sync::mpsc::Sender<(String, tg::process::control::ReadServerRequestArg)>,
@@ -152,11 +164,20 @@ impl Session {
 			sandbox_process,
 			sender,
 			stderr,
+			stderr_buffered,
 			stderr_progress,
 			stdin,
 			stdin_blob,
 			stdout,
+			stdout_buffered,
 		} = arg;
+		let shared_tty =
+			matches!(stderr, tg::process::Stdio::Tty) && matches!(stdout, tg::process::Stdio::Tty);
+		let (stderr, stderr_progress, stdout_progress) = if shared_tty {
+			(tg::process::Stdio::Null, None, stderr_progress)
+		} else {
+			(stderr, stderr_progress, None)
+		};
 
 		let control =
 			crate::control::Stream::new(requests, sender, crate::control::stream_options());
@@ -166,6 +187,8 @@ impl Session {
 		let (stdout_sender, stdout_receiver) =
 			tokio::sync::mpsc::channel::<(String, tg::process::control::ReadServerRequestArg)>(256);
 		let stdout_task = self.spawn_process_control_stdout_task(RunProcessControlStdoutTaskArg {
+			buffered: stdout_buffered,
+			progress: stdout_progress,
 			receiver: stdout_receiver,
 			sandbox: sandbox.clone(),
 			sandbox_process: sandbox_process.clone(),
@@ -176,6 +199,7 @@ impl Session {
 		let (stderr_sender, stderr_receiver) =
 			tokio::sync::mpsc::channel::<(String, tg::process::control::ReadServerRequestArg)>(256);
 		let stderr_task = self.spawn_process_control_stderr_task(RunProcessControlStderrTaskArg {
+			buffered: stderr_buffered,
 			receiver: stderr_receiver,
 			sandbox: sandbox.clone(),
 			sandbox_process: sandbox_process.clone(),
@@ -222,6 +246,7 @@ impl Session {
 				control,
 				response_sender,
 				sender: sender.clone(),
+				shared_tty,
 				signal_sender,
 				stderr_sender,
 				stdin_sender,
@@ -265,16 +290,28 @@ impl Session {
 			.try_unwrap_finish()
 			.map_err(|_| tg::error!("expected a finish process response"))?;
 
+		let stdio_tasks = async {
+			let (stderr_result, stdout_result) =
+				tokio::join!(stderr_task.wait(), stdout_task.wait());
+			stderr_result.map_err(|error| {
+				tg::error!(!error, "the process control stderr task panicked")
+			})??;
+			stdout_result.map_err(|error| {
+				tg::error!(!error, "the process control stdout task panicked")
+			})??;
+			sender.wait_for_empty().await;
+
+			Ok::<_, tg::Error>(())
+		};
 		let retention_ttl = self.server.config.runner.process_state_ttl;
 		tokio::select! {
+			result = stdio_tasks => result?,
 			() = retention_stopper.wait() => {},
 			() = tokio::time::sleep(retention_ttl) => {},
 		}
 
 		// Abort the other tasks.
 		handler_task.abort();
-		stdout_task.abort();
-		stderr_task.abort();
 		stdin_task.abort();
 		signal_task.abort();
 		tty_task.abort();
@@ -302,6 +339,7 @@ impl Session {
 			mut control,
 			response_sender,
 			sender,
+			shared_tty,
 			signal_sender,
 			stderr_sender,
 			stdin_sender,
@@ -404,7 +442,11 @@ impl Session {
 								stdout_sender.send((request_id, read)).await.ok();
 							},
 							tg::process::stdio::Stream::Stderr => {
-								stderr_sender.send((request_id, read)).await.ok();
+								if shared_tty {
+									stdout_sender.send((request_id, read)).await.ok();
+								} else {
+									stderr_sender.send((request_id, read)).await.ok();
+								}
 							},
 							tg::process::stdio::Stream::Stdin => {
 								let error = tg::error!("cannot read the stdin of a process");
@@ -480,6 +522,7 @@ impl Session {
 			}
 
 			if reader.offset >= reader.buffer.len() {
+				reader.permit = None;
 				if reader.eof {
 					return Ok(tg::process::control::ReadClientResponseOutput {
 						stream: request.stream,
@@ -487,29 +530,29 @@ impl Session {
 					});
 				}
 
-				let event = reader
+				let chunk = reader
 					.stream
 					.try_next()
 					.await
 					.map_err(|source| tg::error!(!source, "failed to get the next event"))?;
-				let Some(event) = event else {
+				let Some(chunk) = chunk else {
 					reader.eof = true;
 					continue;
 				};
-				match event {
-					tg::process::stdio::read::Event::Chunk(chunk) => {
-						reader.offset = 0;
-						reader.buffer = chunk.bytes;
-					},
-					tg::process::stdio::read::Event::End => {
-						reader.eof = true;
-					},
-				}
+				reader.buffer = chunk.bytes;
+				reader.offset = 0;
+				reader.permit = Some(chunk.permit);
 			}
 
 			let amount = (reader.buffer.len() - reader.offset).min(request.length);
 			let bytes = reader.buffer.slice(reader.offset..reader.offset + amount);
 			reader.offset += amount;
+			let permit = reader
+				.permit
+				.as_mut()
+				.and_then(|permit| permit.split(amount))
+				.ok_or_else(|| tg::error!("the process stdio buffer is inconsistent"))?;
+			drop(permit);
 
 			return Ok(tg::process::control::ReadClientResponseOutput {
 				stream: request.stream,
@@ -519,29 +562,131 @@ impl Session {
 	}
 
 	pub(super) async fn create_process_control_reader(
+		&self,
+		buffered: tokio::sync::oneshot::Sender<tg::Result<()>>,
 		sandbox: &tangram_sandbox::Sandbox,
 		sandbox_process: Option<&tangram_sandbox::Process>,
 		stream: tg::process::stdio::Stream,
-		writes: &mut Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
+		writes: Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
 	) -> tg::Result<Reader> {
-		// A process that was never spawned produces no output, so its reader begins at the end of the stream.
-		let stream = match sandbox_process {
-			Some(sandbox_process) => sandbox
-				.read_stdio(sandbox_process, vec![stream])
-				.await
-				.map_err(|source| tg::error!(!source, "failed to create the stream"))?
-				.boxed(),
-			None => stream::empty().boxed(),
-		};
-		let stream = match writes.take() {
-			Some(writes) => stream::select(stream, writes).boxed(),
-			None => stream,
-		};
+		crate::checkpoint!(
+			self.server,
+			"runner.process.control.reader.create",
+			stream = %stream,
+		)
+		.await;
+
+		let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+		let semaphore = Arc::new(tokio::sync::Semaphore::new(
+			PROCESS_CONTROL_READER_BUFFER_CAPACITY,
+		));
+		let mut tasks = Vec::new();
+
+		// Drain the sandbox stream into the bounded buffer.
+		if let Some(sandbox_process) = sandbox_process {
+			let input = match sandbox.read_stdio(sandbox_process, vec![stream]).await {
+				Ok(input) => input.boxed(),
+				Err(source) => {
+					let error = tg::error!(!source, "failed to create the stream");
+					buffered.send(Err(error.clone())).ok();
+
+					return Err(error);
+				},
+			};
+			let sender = sender.clone();
+			let semaphore = semaphore.clone();
+			let task = Task::spawn(move |_| async move {
+				let result =
+					Self::run_process_control_reader_task(input, sender.clone(), semaphore).await;
+				if let Err(error) = &result {
+					sender.send(Err(error.clone())).ok();
+				}
+				buffered.send(result).ok();
+			});
+			tasks.push(task);
+		} else {
+			// A process that was never spawned produces no sandbox output.
+			buffered.send(Ok(())).ok();
+		}
+
+		// Buffer progress independently because it can outlive the sandbox stream.
+		if let Some(mut writes) = writes {
+			let sender = sender.clone();
+			let semaphore = semaphore.clone();
+			let task = Task::spawn(move |_| async move {
+				while let Some(event) = writes.next().await {
+					match event {
+						Ok(tg::process::stdio::read::Event::Chunk(chunk)) => {
+							if Self::buffer_process_control_chunk(chunk.bytes, &sender, &semaphore)
+								.await
+								.is_err()
+							{
+								break;
+							}
+						},
+						Ok(tg::process::stdio::read::Event::End) => break,
+						Err(error) => {
+							sender.send(Err(error)).ok();
+
+							break;
+						},
+					}
+				}
+			});
+			tasks.push(task);
+		}
+		drop(sender);
+
+		let stream = UnboundedReceiverStream::new(receiver).attach(tasks).boxed();
 		Ok(Reader {
 			buffer: Bytes::new(),
 			eof: false,
 			offset: 0,
+			permit: None,
 			stream,
 		})
+	}
+
+	async fn run_process_control_reader_task(
+		mut input: BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>,
+		sender: tokio::sync::mpsc::UnboundedSender<tg::Result<BufferedChunk>>,
+		semaphore: Arc<tokio::sync::Semaphore>,
+	) -> tg::Result<()> {
+		loop {
+			let event = input
+				.try_next()
+				.await
+				.map_err(|source| tg::error!(!source, "failed to get the next event"))?
+				.ok_or_else(|| tg::error!("the sandbox stdio stream ended unexpectedly"))?;
+			match event {
+				tg::process::stdio::read::Event::Chunk(chunk) => {
+					Self::buffer_process_control_chunk(chunk.bytes, &sender, &semaphore).await?;
+				},
+				tg::process::stdio::read::Event::End => break,
+			}
+		}
+
+		Ok(())
+	}
+
+	async fn buffer_process_control_chunk(
+		mut bytes: Bytes,
+		sender: &tokio::sync::mpsc::UnboundedSender<tg::Result<BufferedChunk>>,
+		semaphore: &Arc<tokio::sync::Semaphore>,
+	) -> tg::Result<()> {
+		while !bytes.is_empty() {
+			let length = bytes.len().min(PROCESS_CONTROL_READER_BUFFER_CAPACITY);
+			let permit = semaphore
+				.clone()
+				.acquire_many_owned(length.try_into().unwrap())
+				.await
+				.map_err(|_| tg::error!("the process stdio buffer was closed"))?;
+			let bytes = bytes.split_to(length);
+			sender
+				.send(Ok(BufferedChunk { bytes, permit }))
+				.map_err(|_| tg::error!("failed to buffer process stdio"))?;
+		}
+
+		Ok(())
 	}
 }

--- a/packages/server/src/runner/process/control.rs
+++ b/packages/server/src/runner/process/control.rs
@@ -7,7 +7,7 @@ use {
 	crate::session::Session,
 	bytes::Bytes,
 	futures::{
-		StreamExt as _, TryStreamExt as _,
+		StreamExt as _, TryFutureExt as _, TryStreamExt as _,
 		stream::{self, BoxStream},
 	},
 	std::{pin::pin, sync::Arc},
@@ -287,7 +287,11 @@ impl Session {
 		arg: RunProcessControlHandlerTaskArg,
 	) -> Task<tg::Result<()>> {
 		let session = self.clone();
-		Task::spawn(move |_| async move { session.run_process_control_handler_task(arg).await })
+		Task::spawn(move |_| {
+			async move { session.run_process_control_handler_task(arg).await }.inspect_err(
+				|error| tracing::error!(error = %error.trace(), "the process control handler task failed"),
+			)
+		})
 	}
 
 	async fn run_process_control_handler_task(
@@ -459,11 +463,8 @@ impl Session {
 	}
 
 	pub(super) async fn handle_process_control_read_request(
-		sandbox: &tangram_sandbox::Sandbox,
-		sandbox_process: &tangram_sandbox::Process,
 		request: tg::process::control::ReadServerRequestArg,
-		reader: &mut Option<Reader>,
-		writes: &mut Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
+		reader: &mut Reader,
 	) -> tg::Result<tg::process::control::ReadClientResponseOutput> {
 		if matches!(request.stream, tg::process::stdio::Stream::Stdin) {
 			return Err(tg::error!("cannot read the stdin of a process"));
@@ -478,48 +479,37 @@ impl Session {
 				return Err(tg::error!("lost connection to the sandbox i/o"));
 			}
 
-			if reader.is_none() {
-				reader.replace(
-					Self::create_process_control_reader(sandbox, sandbox_process, &request, writes)
-						.await?,
-				);
-			}
-
-			let reader_mut = reader.as_mut().unwrap();
-
-			if reader_mut.offset >= reader_mut.buffer.len() {
-				if reader_mut.eof {
+			if reader.offset >= reader.buffer.len() {
+				if reader.eof {
 					return Ok(tg::process::control::ReadClientResponseOutput {
 						stream: request.stream,
 						bytes: Bytes::new(),
 					});
 				}
 
-				let event = reader_mut
+				let event = reader
 					.stream
 					.try_next()
 					.await
 					.map_err(|source| tg::error!(!source, "failed to get the next event"))?;
 				let Some(event) = event else {
-					reader.take();
+					reader.eof = true;
 					continue;
 				};
 				match event {
 					tg::process::stdio::read::Event::Chunk(chunk) => {
-						reader_mut.offset = 0;
-						reader_mut.buffer = chunk.bytes;
+						reader.offset = 0;
+						reader.buffer = chunk.bytes;
 					},
 					tg::process::stdio::read::Event::End => {
-						reader_mut.eof = true;
+						reader.eof = true;
 					},
 				}
 			}
 
-			let amount = (reader_mut.buffer.len() - reader_mut.offset).min(request.length);
-			let bytes = reader_mut
-				.buffer
-				.slice(reader_mut.offset..reader_mut.offset + amount);
-			reader_mut.offset += amount;
+			let amount = (reader.buffer.len() - reader.offset).min(request.length);
+			let bytes = reader.buffer.slice(reader.offset..reader.offset + amount);
+			reader.offset += amount;
 
 			return Ok(tg::process::control::ReadClientResponseOutput {
 				stream: request.stream,
@@ -528,14 +518,14 @@ impl Session {
 		}
 	}
 
-	async fn create_process_control_reader(
+	pub(super) async fn create_process_control_reader(
 		sandbox: &tangram_sandbox::Sandbox,
 		sandbox_process: &tangram_sandbox::Process,
-		request: &tg::process::control::ReadServerRequestArg,
+		stream: tg::process::stdio::Stream,
 		writes: &mut Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
 	) -> tg::Result<Reader> {
 		let stream = sandbox
-			.read_stdio(sandbox_process, vec![request.stream])
+			.read_stdio(sandbox_process, vec![stream])
 			.await
 			.map_err(|source| tg::error!(!source, "failed to create the stream"))?
 			.boxed();

--- a/packages/server/src/runner/process/control.rs
+++ b/packages/server/src/runner/process/control.rs
@@ -520,15 +520,19 @@ impl Session {
 
 	pub(super) async fn create_process_control_reader(
 		sandbox: &tangram_sandbox::Sandbox,
-		sandbox_process: &tangram_sandbox::Process,
+		sandbox_process: Option<&tangram_sandbox::Process>,
 		stream: tg::process::stdio::Stream,
 		writes: &mut Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
 	) -> tg::Result<Reader> {
-		let stream = sandbox
-			.read_stdio(sandbox_process, vec![stream])
-			.await
-			.map_err(|source| tg::error!(!source, "failed to create the stream"))?
-			.boxed();
+		// A process that was never spawned produces no output, so its reader begins at the end of the stream.
+		let stream = match sandbox_process {
+			Some(sandbox_process) => sandbox
+				.read_stdio(sandbox_process, vec![stream])
+				.await
+				.map_err(|source| tg::error!(!source, "failed to create the stream"))?
+				.boxed(),
+			None => stream::empty().boxed(),
+		};
 		let stream = match writes.take() {
 			Some(writes) => stream::select(stream, writes).boxed(),
 			None => stream,

--- a/packages/server/src/runner/process/control/signal.rs
+++ b/packages/server/src/runner/process/control/signal.rs
@@ -38,15 +38,16 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
-			.as_ref()
-			.cloned()
-			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
+			.ok()
+			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
 		while let Some((id, request)) = receiver.recv().await {
-			let result =
-				Self::handle_process_control_signal_request(&sandbox, &sandbox_process, request)
-					.await;
+			let result = if let Some(sandbox_process) = &sandbox_process {
+				Self::handle_process_control_signal_request(&sandbox, sandbox_process, request)
+					.await
+			} else {
+				Err(tg::error!("the process was not spawned"))
+			};
 			let response = result.map(|()| {
 				tg::process::control::ClientResponseOutput::Signal(
 					tg::process::control::SignalClientResponseOutput {},

--- a/packages/server/src/runner/process/control/signal.rs
+++ b/packages/server/src/runner/process/control/signal.rs
@@ -1,6 +1,6 @@
 use {
-	super::ProcessControlSender, crate::session::Session, std::sync::Arc,
-	tangram_client::prelude::*, tangram_futures::task::Task,
+	super::ProcessControlSender, crate::session::Session, futures::TryFutureExt as _,
+	std::sync::Arc, tangram_client::prelude::*, tangram_futures::task::Task,
 };
 
 pub(super) struct RunProcessControlSignalTaskArg {
@@ -17,7 +17,11 @@ impl Session {
 		arg: RunProcessControlSignalTaskArg,
 	) -> Task<tg::Result<()>> {
 		let session = self.clone();
-		Task::spawn(move |_| async move { session.run_process_control_signal_task(arg).await })
+		Task::spawn(move |_| {
+			async move { session.run_process_control_signal_task(arg).await }.inspect_err(
+				|error| tracing::error!(error = %error.trace(), "the process control signal task failed"),
+			)
+		})
 	}
 
 	async fn run_process_control_signal_task(
@@ -34,16 +38,15 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.ok()
-			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
+			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
+			.as_ref()
+			.cloned()
+			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
 
 		while let Some((id, request)) = receiver.recv().await {
-			let result = if let Some(sandbox_process) = &sandbox_process {
-				Self::handle_process_control_signal_request(&sandbox, sandbox_process, request)
-					.await
-			} else {
-				Err(tg::error!("the process was not spawned"))
-			};
+			let result =
+				Self::handle_process_control_signal_request(&sandbox, &sandbox_process, request)
+					.await;
 			let response = result.map(|()| {
 				tg::process::control::ClientResponseOutput::Signal(
 					tg::process::control::SignalClientResponseOutput {},

--- a/packages/server/src/runner/process/control/stderr.rs
+++ b/packages/server/src/runner/process/control/stderr.rs
@@ -9,6 +9,7 @@ use {
 };
 
 pub(super) struct RunProcessControlStderrTaskArg {
+	pub(super) buffered: tokio::sync::oneshot::Sender<tg::Result<()>>,
 	pub(super) receiver:
 		tokio::sync::mpsc::Receiver<(String, tg::process::control::ReadServerRequestArg)>,
 	pub(super) sandbox: tangram_sandbox::Sandbox,
@@ -36,6 +37,7 @@ impl Session {
 		arg: RunProcessControlStderrTaskArg,
 	) -> tg::Result<()> {
 		let RunProcessControlStderrTaskArg {
+			buffered,
 			mut receiver,
 			sandbox,
 			mut sandbox_process,
@@ -45,6 +47,8 @@ impl Session {
 		} = arg;
 
 		if !matches!(stderr, tg::process::Stdio::Pipe | tg::process::Stdio::Tty) {
+			buffered.send(Ok(())).ok();
+
 			return Ok(());
 		}
 
@@ -54,7 +58,7 @@ impl Session {
 			.ok()
 			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
-		let mut writes = stderr_progress.map(|progress| {
+		let writes = stderr_progress.map(|progress| {
 			progress
 				.map_ok(|bytes| {
 					tg::process::stdio::read::Event::Chunk(tg::process::stdio::Chunk {
@@ -66,13 +70,15 @@ impl Session {
 				.boxed()
 		});
 
-		let mut reader = Self::create_process_control_reader(
-			&sandbox,
-			sandbox_process.as_deref(),
-			tg::process::stdio::Stream::Stderr,
-			&mut writes,
-		)
-		.await?;
+		let mut reader = self
+			.create_process_control_reader(
+				buffered,
+				&sandbox,
+				sandbox_process.as_deref(),
+				tg::process::stdio::Stream::Stderr,
+				writes,
+			)
+			.await?;
 		while let Some((id, request)) = receiver.recv().await {
 			let response =
 				Self::handle_process_control_stderr_read_request(request, &mut reader).await;

--- a/packages/server/src/runner/process/control/stderr.rs
+++ b/packages/server/src/runner/process/control/stderr.rs
@@ -51,10 +51,8 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
-			.as_ref()
-			.cloned()
-			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
+			.ok()
+			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
 		let mut writes = stderr_progress.map(|progress| {
 			progress
@@ -70,7 +68,7 @@ impl Session {
 
 		let mut reader = Self::create_process_control_reader(
 			&sandbox,
-			&sandbox_process,
+			sandbox_process.as_deref(),
 			tg::process::stdio::Stream::Stderr,
 			&mut writes,
 		)

--- a/packages/server/src/runner/process/control/stderr.rs
+++ b/packages/server/src/runner/process/control/stderr.rs
@@ -2,7 +2,7 @@ use {
 	super::{ProcessControlSender, Reader},
 	crate::session::Session,
 	bytes::Bytes,
-	futures::{StreamExt as _, TryStreamExt as _, stream::BoxStream},
+	futures::{StreamExt as _, TryFutureExt as _, TryStreamExt as _, stream::BoxStream},
 	std::sync::Arc,
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
@@ -24,7 +24,11 @@ impl Session {
 		arg: RunProcessControlStderrTaskArg,
 	) -> Task<tg::Result<()>> {
 		let session = self.clone();
-		Task::spawn(move |_| async move { session.run_process_control_stderr_task(arg).await })
+		Task::spawn(move |_| {
+			async move { session.run_process_control_stderr_task(arg).await }.inspect_err(
+				|error| tracing::error!(error = %error.trace(), "the process control stderr task failed"),
+			)
+		})
 	}
 
 	async fn run_process_control_stderr_task(
@@ -47,8 +51,10 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.ok()
-			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
+			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
+			.as_ref()
+			.cloned()
+			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
 
 		let mut writes = stderr_progress.map(|progress| {
 			progress
@@ -62,23 +68,16 @@ impl Session {
 				.boxed()
 		});
 
-		let mut reader = None;
+		let mut reader = Self::create_process_control_reader(
+			&sandbox,
+			&sandbox_process,
+			tg::process::stdio::Stream::Stderr,
+			&mut writes,
+		)
+		.await?;
 		while let Some((id, request)) = receiver.recv().await {
-			let response = if let Some(sandbox_process) = &sandbox_process {
-				Self::handle_process_control_stderr_read_request(
-					&sandbox,
-					sandbox_process,
-					request,
-					&mut reader,
-					&mut writes,
-				)
-				.await
-			} else {
-				Ok(tg::process::control::ReadClientResponseOutput {
-					stream: request.stream,
-					bytes: Bytes::new(),
-				})
-			};
+			let response =
+				Self::handle_process_control_stderr_read_request(request, &mut reader).await;
 			let eof = response
 				.as_ref()
 				.is_ok_and(|response| response.bytes.is_empty());
@@ -94,13 +93,9 @@ impl Session {
 	}
 
 	async fn handle_process_control_stderr_read_request(
-		sandbox: &tangram_sandbox::Sandbox,
-		sandbox_process: &tangram_sandbox::Process,
 		request: tg::process::control::ReadServerRequestArg,
-		reader: &mut Option<Reader>,
-		writes: &mut Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
+		reader: &mut Reader,
 	) -> tg::Result<tg::process::control::ReadClientResponseOutput> {
-		Self::handle_process_control_read_request(sandbox, sandbox_process, request, reader, writes)
-			.await
+		Self::handle_process_control_read_request(request, reader).await
 	}
 }

--- a/packages/server/src/runner/process/control/stdin.rs
+++ b/packages/server/src/runner/process/control/stdin.rs
@@ -47,12 +47,12 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
-			.as_ref()
-			.cloned()
-			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
+			.ok()
+			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
-		if let Some(blob) = stdin_blob {
+		if let Some(blob) = stdin_blob
+			&& let Some(sandbox_process) = &sandbox_process
+		{
 			let reader = blob
 				.read_with_handle(self, tg::read::Options::default())
 				.await
@@ -69,7 +69,7 @@ impl Session {
 				.boxed();
 			let stream = sandbox
 				.write_stdio(
-					&sandbox_process,
+					sandbox_process,
 					vec![tg::process::stdio::Stream::Stdin],
 					stream,
 				)
@@ -91,13 +91,17 @@ impl Session {
 		}
 
 		while let Some((id, request)) = receiver.recv().await {
-			let response = if request.bytes.is_empty() {
-				Self::handle_process_control_stdin_close_request(&sandbox, &sandbox_process)
-					.await
-					.map(|()| tg::process::control::WriteClientResponseOutput { length: 0 })
+			let response = if let Some(sandbox_process) = &sandbox_process {
+				if request.bytes.is_empty() {
+					Self::handle_process_control_stdin_close_request(&sandbox, sandbox_process)
+						.await
+						.map(|()| tg::process::control::WriteClientResponseOutput { length: 0 })
+				} else {
+					Self::handle_process_control_write_request(&sandbox, sandbox_process, request)
+						.await
+				}
 			} else {
-				Self::handle_process_control_write_request(&sandbox, &sandbox_process, request)
-					.await
+				Ok(tg::process::control::WriteClientResponseOutput { length: 0 })
 			};
 			let eof = response.as_ref().is_ok_and(|response| response.length == 0);
 			let response = response.map(tg::process::control::ClientResponseOutput::Write);

--- a/packages/server/src/runner/process/control/stdin.rs
+++ b/packages/server/src/runner/process/control/stdin.rs
@@ -1,7 +1,7 @@
 use {
 	super::ProcessControlSender,
 	crate::session::Session,
-	futures::{StreamExt as _, TryStreamExt as _, future, stream},
+	futures::{StreamExt as _, TryFutureExt as _, TryStreamExt as _, future, stream},
 	std::{pin::pin, sync::Arc},
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
@@ -24,7 +24,11 @@ impl Session {
 		arg: RunProcessControlStdinTaskArg,
 	) -> Task<tg::Result<()>> {
 		let session = self.clone();
-		Task::spawn(move |_| async move { session.run_process_control_stdin_task(arg).await })
+		Task::spawn(move |_| {
+			async move { session.run_process_control_stdin_task(arg).await }.inspect_err(
+				|error| tracing::error!(error = %error.trace(), "the process control stdin task failed"),
+			)
+		})
 	}
 
 	async fn run_process_control_stdin_task(
@@ -43,12 +47,12 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.ok()
-			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
+			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
+			.as_ref()
+			.cloned()
+			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
 
-		if let Some(blob) = stdin_blob
-			&& let Some(sandbox_process) = &sandbox_process
-		{
+		if let Some(blob) = stdin_blob {
 			let reader = blob
 				.read_with_handle(self, tg::read::Options::default())
 				.await
@@ -65,7 +69,7 @@ impl Session {
 				.boxed();
 			let stream = sandbox
 				.write_stdio(
-					sandbox_process,
+					&sandbox_process,
 					vec![tg::process::stdio::Stream::Stdin],
 					stream,
 				)
@@ -87,17 +91,13 @@ impl Session {
 		}
 
 		while let Some((id, request)) = receiver.recv().await {
-			let response = if let Some(sandbox_process) = &sandbox_process {
-				if request.bytes.is_empty() {
-					Self::handle_process_control_stdin_close_request(&sandbox, sandbox_process)
-						.await
-						.map(|()| tg::process::control::WriteClientResponseOutput { length: 0 })
-				} else {
-					Self::handle_process_control_write_request(&sandbox, sandbox_process, request)
-						.await
-				}
+			let response = if request.bytes.is_empty() {
+				Self::handle_process_control_stdin_close_request(&sandbox, &sandbox_process)
+					.await
+					.map(|()| tg::process::control::WriteClientResponseOutput { length: 0 })
 			} else {
-				Ok(tg::process::control::WriteClientResponseOutput { length: 0 })
+				Self::handle_process_control_write_request(&sandbox, &sandbox_process, request)
+					.await
 			};
 			let eof = response.as_ref().is_ok_and(|response| response.length == 0);
 			let response = response.map(tg::process::control::ClientResponseOutput::Write);

--- a/packages/server/src/runner/process/control/stdout.rs
+++ b/packages/server/src/runner/process/control/stdout.rs
@@ -1,8 +1,7 @@
 use {
 	super::{ProcessControlSender, Reader},
 	crate::session::Session,
-	bytes::Bytes,
-	futures::stream::BoxStream,
+	futures::TryFutureExt as _,
 	std::sync::Arc,
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
@@ -23,7 +22,11 @@ impl Session {
 		arg: RunProcessControlStdoutTaskArg,
 	) -> Task<tg::Result<()>> {
 		let session = self.clone();
-		Task::spawn(move |_| async move { session.run_process_control_stdout_task(arg).await })
+		Task::spawn(move |_| {
+			async move { session.run_process_control_stdout_task(arg).await }.inspect_err(
+				|error| tracing::error!(error = %error.trace(), "the process control stdout task failed"),
+			)
+		})
 	}
 
 	async fn run_process_control_stdout_task(
@@ -45,27 +48,22 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.ok()
-			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
+			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
+			.as_ref()
+			.cloned()
+			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
 
 		let mut writes = None;
-		let mut reader = None;
+		let mut reader = Self::create_process_control_reader(
+			&sandbox,
+			&sandbox_process,
+			tg::process::stdio::Stream::Stdout,
+			&mut writes,
+		)
+		.await?;
 		while let Some((id, request)) = receiver.recv().await {
-			let response = if let Some(sandbox_process) = &sandbox_process {
-				Self::handle_process_control_stdout_read_request(
-					&sandbox,
-					sandbox_process,
-					request,
-					&mut reader,
-					&mut writes,
-				)
-				.await
-			} else {
-				Ok(tg::process::control::ReadClientResponseOutput {
-					stream: request.stream,
-					bytes: Bytes::new(),
-				})
-			};
+			let response =
+				Self::handle_process_control_stdout_read_request(request, &mut reader).await;
 			let eof = response
 				.as_ref()
 				.is_ok_and(|response| response.bytes.is_empty());
@@ -81,13 +79,9 @@ impl Session {
 	}
 
 	async fn handle_process_control_stdout_read_request(
-		sandbox: &tangram_sandbox::Sandbox,
-		sandbox_process: &tangram_sandbox::Process,
 		request: tg::process::control::ReadServerRequestArg,
-		reader: &mut Option<Reader>,
-		writes: &mut Option<BoxStream<'static, tg::Result<tg::process::stdio::read::Event>>>,
+		reader: &mut Reader,
 	) -> tg::Result<tg::process::control::ReadClientResponseOutput> {
-		Self::handle_process_control_read_request(sandbox, sandbox_process, request, reader, writes)
-			.await
+		Self::handle_process_control_read_request(request, reader).await
 	}
 }

--- a/packages/server/src/runner/process/control/stdout.rs
+++ b/packages/server/src/runner/process/control/stdout.rs
@@ -1,13 +1,16 @@
 use {
 	super::{ProcessControlSender, Reader},
 	crate::session::Session,
-	futures::TryFutureExt as _,
+	bytes::Bytes,
+	futures::{StreamExt as _, TryFutureExt as _, TryStreamExt as _, stream::BoxStream},
 	std::sync::Arc,
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
 };
 
 pub(super) struct RunProcessControlStdoutTaskArg {
+	pub(super) buffered: tokio::sync::oneshot::Sender<tg::Result<()>>,
+	pub(super) progress: Option<BoxStream<'static, tg::Result<Bytes>>>,
 	pub(super) receiver:
 		tokio::sync::mpsc::Receiver<(String, tg::process::control::ReadServerRequestArg)>,
 	pub(super) sandbox: tangram_sandbox::Sandbox,
@@ -34,6 +37,8 @@ impl Session {
 		arg: RunProcessControlStdoutTaskArg,
 	) -> tg::Result<()> {
 		let RunProcessControlStdoutTaskArg {
+			buffered,
+			progress,
 			mut receiver,
 			sandbox,
 			mut sandbox_process,
@@ -42,6 +47,8 @@ impl Session {
 		} = arg;
 
 		if !matches!(stdout, tg::process::Stdio::Pipe | tg::process::Stdio::Tty) {
+			buffered.send(Ok(())).ok();
+
 			return Ok(());
 		}
 
@@ -51,14 +58,26 @@ impl Session {
 			.ok()
 			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
-		let mut writes = None;
-		let mut reader = Self::create_process_control_reader(
-			&sandbox,
-			sandbox_process.as_deref(),
-			tg::process::stdio::Stream::Stdout,
-			&mut writes,
-		)
-		.await?;
+		let writes = progress.map(|progress| {
+			progress
+				.map_ok(|bytes| {
+					tg::process::stdio::read::Event::Chunk(tg::process::stdio::Chunk {
+						bytes,
+						position: None,
+						stream: tg::process::stdio::Stream::Stderr,
+					})
+				})
+				.boxed()
+		});
+		let mut reader = self
+			.create_process_control_reader(
+				buffered,
+				&sandbox,
+				sandbox_process.as_deref(),
+				tg::process::stdio::Stream::Stdout,
+				writes,
+			)
+			.await?;
 		while let Some((id, request)) = receiver.recv().await {
 			let response =
 				Self::handle_process_control_stdout_read_request(request, &mut reader).await;

--- a/packages/server/src/runner/process/control/stdout.rs
+++ b/packages/server/src/runner/process/control/stdout.rs
@@ -48,15 +48,13 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
-			.as_ref()
-			.cloned()
-			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
+			.ok()
+			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
 		let mut writes = None;
 		let mut reader = Self::create_process_control_reader(
 			&sandbox,
-			&sandbox_process,
+			sandbox_process.as_deref(),
 			tg::process::stdio::Stream::Stdout,
 			&mut writes,
 		)

--- a/packages/server/src/runner/process/control/tty.rs
+++ b/packages/server/src/runner/process/control/tty.rs
@@ -38,14 +38,15 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
-			.as_ref()
-			.cloned()
-			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
+			.ok()
+			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
 
 		while let Some((id, request)) = receiver.recv().await {
-			let result =
-				Self::handle_process_control_tty_request(&sandbox, &sandbox_process, request).await;
+			let result = if let Some(sandbox_process) = &sandbox_process {
+				Self::handle_process_control_tty_request(&sandbox, sandbox_process, request).await
+			} else {
+				Err(tg::error!("the process was not spawned"))
+			};
 			let response = result.map(|()| {
 				tg::process::control::ClientResponseOutput::Tty(
 					tg::process::control::TtyClientResponseOutput {},

--- a/packages/server/src/runner/process/control/tty.rs
+++ b/packages/server/src/runner/process/control/tty.rs
@@ -1,6 +1,6 @@
 use {
-	super::ProcessControlSender, crate::session::Session, std::sync::Arc,
-	tangram_client::prelude::*, tangram_futures::task::Task,
+	super::ProcessControlSender, crate::session::Session, futures::TryFutureExt as _,
+	std::sync::Arc, tangram_client::prelude::*, tangram_futures::task::Task,
 };
 
 pub(super) struct RunProcessControlTtyTaskArg {
@@ -17,7 +17,11 @@ impl Session {
 		arg: RunProcessControlTtyTaskArg,
 	) -> Task<tg::Result<()>> {
 		let session = self.clone();
-		Task::spawn(move |_| async move { session.run_process_control_tty_task(arg).await })
+		Task::spawn(move |_| {
+			async move { session.run_process_control_tty_task(arg).await }.inspect_err(
+				|error| tracing::error!(error = %error.trace(), "the process control tty task failed"),
+			)
+		})
 	}
 
 	async fn run_process_control_tty_task(
@@ -34,15 +38,14 @@ impl Session {
 		let sandbox_process = sandbox_process
 			.wait_for(Option::is_some)
 			.await
-			.ok()
-			.and_then(|sandbox_process| sandbox_process.as_ref().cloned());
+			.map_err(|source| tg::error!(!source, "failed to get the sandboxed process"))?
+			.as_ref()
+			.cloned()
+			.ok_or_else(|| tg::error!("failed to get the sandboxed process"))?;
 
 		while let Some((id, request)) = receiver.recv().await {
-			let result = if let Some(sandbox_process) = &sandbox_process {
-				Self::handle_process_control_tty_request(&sandbox, sandbox_process, request).await
-			} else {
-				Err(tg::error!("the process was not spawned"))
-			};
+			let result =
+				Self::handle_process_control_tty_request(&sandbox, &sandbox_process, request).await;
 			let response = result.map(|()| {
 				tg::process::control::ClientResponseOutput::Tty(
 					tg::process::control::TtyClientResponseOutput {},

--- a/packages/server/src/runner/sandbox.rs
+++ b/packages/server/src/runner/sandbox.rs
@@ -949,16 +949,13 @@ impl Session {
 					}
 				},
 
-				// Handle an underlying process exiting.
+				// Handle an underlying process event.
 				event = process_events.next(), if !process_events.is_empty() => {
 					let Some((process, event)) = event else {
 						break;
 					};
 					match event? {
-						ProcessEvent::Connected(_) => {
-							return Err(tg::error!(%process, "received a duplicate process connected event"));
-						},
-						ProcessEvent::Exited => {
+						ProcessEvent::Buffered | ProcessEvent::Released => {
 							process_events.remove(&process);
 							if process_events.is_empty() {
 								if !reusable {
@@ -969,6 +966,10 @@ impl Session {
 								}
 							}
 						},
+						ProcessEvent::Connected(_) => {
+							return Err(tg::error!(%process, "received a duplicate process connected event"));
+						},
+						ProcessEvent::Exited => {},
 					}
 				},
 
@@ -991,14 +992,15 @@ impl Session {
 		process_stopper.stop();
 		while let Some((process, event)) = process_events.next().await {
 			match event? {
+				ProcessEvent::Buffered | ProcessEvent::Released => {
+					process_events.remove(&process);
+				},
 				ProcessEvent::Connected(_) => {
 					return Err(
 						tg::error!(%process, "received a duplicate process connected event"),
 					);
 				},
-				ProcessEvent::Exited => {
-					process_events.remove(&process);
-				},
+				ProcessEvent::Exited => {},
 			}
 		}
 

--- a/packages/server/src/runner/sandbox.rs
+++ b/packages/server/src/runner/sandbox.rs
@@ -1128,6 +1128,12 @@ impl Session {
 				tg::sandbox::control::ServerMessage::Response(_) => {},
 			}
 		}
+		crate::checkpoint!(
+			self.server,
+			"runner.sandbox.destroyed",
+			sandbox = %id,
+		)
+		.await;
 		event_sender.send(Ok(Event::Destroyed)).ok();
 
 		let output = RetainSandboxTaskArg {


### PR DESCRIPTION
- Do not wait until first stdout/stderr tasks to construct a reader
- Report errors due to dropped request channels and trace them accordingly in stdio/signal/tty tasks. 
- Add test