### PR TITLE
server: add primary region configuration

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -67,6 +67,9 @@ pub struct Config {
 	pub object: Option<Object>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub primary_region: Option<String>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub process: Option<Process>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1971,6 +1974,9 @@ fn resolve_server_config(source: &Config) -> tg::Result<server::Config> {
 	if let Some(source) = source.object {
 		target.object = resolve_object(source)?;
 	}
+	if let Some(primary_region) = source.primary_region {
+		target.primary_region = Some(primary_region);
+	}
 	if let Some(source) = source.process {
 		target.process = resolve_process(source);
 	}
@@ -3534,6 +3540,20 @@ fn required<T>(value: Option<T>, field: &'static str) -> tg::Result<T> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn parses_primary_region() {
+		let source: Config = serde_json::from_value(serde_json::json!({
+			"primary_region": "ash0",
+			"region": "ewr0",
+		}))
+		.unwrap();
+		let target = resolve_server_config(&source).unwrap();
+
+		assert_eq!(target.primary_region.as_deref(), Some("ash0"));
+		assert_eq!(target.region.as_deref(), Some("ewr0"));
+		assert!(!target.is_primary_region());
+	}
 
 	#[test]
 	fn parses_bool_or_configs() {

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -41,6 +41,8 @@ pub struct Config {
 
 	pub object: Object,
 
+	pub primary_region: Option<String>,
+
 	pub process: Process,
 
 	pub region: Option<String>,
@@ -1080,6 +1082,18 @@ pub struct Write {
 
 impl Config {
 	#[must_use]
+	pub fn is_primary_region(&self) -> bool {
+		self.primary_region
+			.as_ref()
+			.is_none_or(|primary_region| self.region.as_ref() == Some(primary_region))
+	}
+
+	#[must_use]
+	pub fn primary_region(&self) -> Option<&str> {
+		self.primary_region.as_deref()
+	}
+
+	#[must_use]
 	pub fn with_directory(directory: PathBuf) -> Self {
 		Self {
 			directory: Some(directory),
@@ -1106,6 +1120,7 @@ impl Default for Config {
 			logs: Logs::default(),
 			messenger: Messenger::default(),
 			object: Object::default(),
+			primary_region: None,
 			process: Process::default(),
 			region: None,
 			regions: None,

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -413,12 +413,34 @@ impl Server {
 		if config.region.as_ref().is_some_and(String::is_empty) {
 			return Err(tg::error!("the region must not be empty"));
 		}
+		if config.primary_region.as_ref().is_some_and(String::is_empty) {
+			return Err(tg::error!("the primary region must not be empty"));
+		}
 		if config
 			.regions
 			.as_ref()
 			.is_some_and(|regions| regions.iter().any(|region| region.name.is_empty()))
 		{
 			return Err(tg::error!("the region name must not be empty"));
+		}
+		if config
+			.regions
+			.as_ref()
+			.is_some_and(|regions| !regions.is_empty())
+			&& config.primary_region.is_none()
+		{
+			return Err(tg::error!(
+				"the primary region must be configured when regions are configured"
+			));
+		}
+		if let Some(primary_region) = &config.primary_region {
+			let primary_region_is_configured = config.region.as_ref() == Some(primary_region)
+				|| config.regions.as_ref().is_some_and(|regions| {
+					regions.iter().any(|region| &region.name == primary_region)
+				});
+			if !primary_region_is_configured {
+				return Err(tg::error!("the primary region is not configured"));
+			}
 		}
 
 		if config.roles.contains(&self::config::Role::Scheduler) {

--- a/packages/server/src/region.rs
+++ b/packages/server/src/region.rs
@@ -4,6 +4,15 @@ use {
 };
 
 impl Session {
+	pub(crate) async fn get_primary_region_session(&self) -> tg::Result<tg::Session> {
+		let region = self
+			.server
+			.config()
+			.primary_region()
+			.ok_or_else(|| tg::error!("the primary region is not configured"))?;
+		self.get_region_session(region).await
+	}
+
 	pub(crate) async fn get_region_session(&self, region: &str) -> tg::Result<tg::Session> {
 		self.verify_request_with_network_access()?;
 		self.get_region_session_inner(region).await


### PR DESCRIPTION
## Summary

- add `primary_region` to the CLI and server configuration
- validate that the configured primary region exists
- add server helpers for identifying and connecting to the primary region
- preserve standalone behavior when regional routing is not configured

## Testing

- `bun run check`
- targeted all-features tests

## Stack

1 of 6. This PR targets `main`; the next PR targets this branch.