### PR TITLE
database: split postgres read and write connections

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -440,10 +440,20 @@ pub struct PostgresDatabase {
 	pub outbox: Option<DatabaseOutbox>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub pool: Option<DatabasePool>,
+	pub read: Option<PostgresDatabaseConnection>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub retry: Option<Retry>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub write: Option<PostgresDatabaseConnection>,
+}
+
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostgresDatabaseConnection {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub pool: Option<DatabasePool>,
 
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub url: Option<Uri>,
@@ -2318,11 +2328,24 @@ fn resolve_postgres_database(source: PostgresDatabase) -> server::PostgresDataba
 	if let Some(source) = source.outbox {
 		target.outbox = resolve_database_outbox(source);
 	}
-	if let Some(source) = source.pool {
-		target.pool = resolve_database_pool(source);
+	if let Some(source) = source.read {
+		target.read = resolve_postgres_database_connection(source, target.read);
 	}
 	if let Some(source) = source.retry {
 		target.retry = resolve_retry_with_default(source, target.retry);
+	}
+	if let Some(source) = source.write {
+		target.write = resolve_postgres_database_connection(source, target.write);
+	}
+	target
+}
+
+fn resolve_postgres_database_connection(
+	source: PostgresDatabaseConnection,
+	mut target: server::PostgresDatabaseConnection,
+) -> server::PostgresDatabaseConnection {
+	if let Some(source) = source.pool {
+		target.pool = resolve_database_pool(source);
 	}
 	if let Some(value) = source.url {
 		target.url = value;
@@ -3553,6 +3576,33 @@ mod tests {
 		assert_eq!(target.primary_region.as_deref(), Some("ash0"));
 		assert_eq!(target.region.as_deref(), Some("ewr0"));
 		assert!(!target.is_primary_region());
+	}
+
+	#[test]
+	fn parses_postgres_read_and_write_connections() {
+		let source: Config = serde_json::from_value(serde_json::json!({
+			"database": {
+				"kind": "postgres",
+				"read": {
+					"pool": { "max": 8 },
+					"url": "postgres://read.local:5432/tangram",
+				},
+				"write": {
+					"pool": { "max": 4 },
+					"url": "postgres://write.primary:5432/tangram",
+				},
+			},
+		}))
+		.unwrap();
+		let target = resolve_server_config(&source).unwrap();
+		let server::Database::Postgres(database) = target.database else {
+			panic!("expected postgres");
+		};
+
+		assert_eq!(database.read.pool.max, Some(8));
+		assert_eq!(database.read.url.host(), Some("read.local"));
+		assert_eq!(database.write.pool.max, Some(4));
+		assert_eq!(database.write.url.host(), Some("write.primary"));
 	}
 
 	#[test]

--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -1517,10 +1517,18 @@ export def --env spawn [
 			advanced: $advanced,
 			database: {
 				kind: 'postgres',
-				pool: {
-					max: 1,
+				read: {
+					pool: {
+						max: 1,
+					},
+					url: $'postgres://root@127.0.0.1:26257/database_($id)?sslmode=disable',
 				},
-				url: $'postgres://root@127.0.0.1:26257/database_($id)?sslmode=disable',
+				write: {
+					pool: {
+						max: 1,
+					},
+					url: $'postgres://root@127.0.0.1:26257/database_($id)?sslmode=disable',
+				},
 			},
 			index: {
 				cluster: $cluster,

--- a/packages/clients/rust/src/health.rs
+++ b/packages/clients/rust/src/health.rs
@@ -40,6 +40,12 @@ pub struct Processes {
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Database {
 	pub available_connections: u64,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub read_available_connections: Option<u64>,
+
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub write_available_connections: Option<u64>,
 }
 
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/packages/database/src/postgres.rs
+++ b/packages/database/src/postgres.rs
@@ -24,9 +24,15 @@ pub enum Error {
 
 #[derive(Clone, Debug)]
 pub struct DatabaseOptions {
+	pub read: PoolOptions,
+	pub retry: tangram_futures::retry::Options,
+	pub write: PoolOptions,
+}
+
+#[derive(Clone, Debug)]
+pub struct PoolOptions {
 	pub max: usize,
 	pub min: usize,
-	pub retry: tangram_futures::retry::Options,
 	pub ttl: Option<Duration>,
 	pub url: Uri,
 }
@@ -36,14 +42,15 @@ pub struct ConnectionOptions {
 	pub url: Uri,
 }
 
+pub struct Database {
+	read_pool: Pool<Connection, Error>,
+	retry: tangram_futures::retry::Options,
+	write_pool: Pool<Connection, Error>,
+}
+
 #[derive(Default)]
 pub struct Cache {
 	statements: tokio::sync::Mutex<HashMap<CacheKey, postgres::Statement, fnv::FnvBuildHasher>>,
-}
-
-pub struct Database {
-	pool: Pool<Connection, Error>,
-	retry: tangram_futures::retry::Options,
 }
 
 pub struct Connection {
@@ -75,39 +82,25 @@ impl Cache {
 
 impl Database {
 	pub async fn new(options: DatabaseOptions) -> Result<Self, Error> {
-		let connection_options = ConnectionOptions {
-			url: options.url.clone(),
-		};
-		let create = {
-			let connection_options = connection_options.clone();
-			move || {
-				let connection_options = connection_options.clone();
-				async move { Connection::connect(connection_options).await }
-			}
-		};
-		let pool = Pool::new(
-			pool::Options {
-				min: options.min,
-				max: options.max,
-				shared: 1,
-				ttl: options.ttl,
-			},
-			create,
-		);
-		for _ in 0..options.min {
-			let connection = Connection::connect(connection_options.clone()).await?;
-			pool.add(connection);
-		}
+		let read_pool = create_pool(options.read).await?;
+		let write_pool = create_pool(options.write).await?;
 		let database = Self {
-			pool,
+			read_pool,
 			retry: options.retry,
+			write_pool,
 		};
+
 		Ok(database)
 	}
 
 	#[must_use]
-	pub fn pool(&self) -> &Pool<Connection, Error> {
-		&self.pool
+	pub fn read_pool(&self) -> &Pool<Connection, Error> {
+		&self.read_pool
+	}
+
+	#[must_use]
+	pub fn write_pool(&self) -> &Pool<Connection, Error> {
+		&self.write_pool
 	}
 
 	pub async fn sync(&self) -> Result<(), Error> {
@@ -123,7 +116,10 @@ impl Database {
 	{
 		let options = self.retry.clone();
 		tangram_futures::retry::retry(&options, || async {
-			let mut connection = self.pool.get_exclusive(pool::Priority::default()).await?;
+			let mut connection = self
+				.write_pool
+				.get_exclusive(pool::Priority::default())
+				.await?;
 			if connection.client.is_closed() {
 				connection.reconnect().await?;
 			}
@@ -144,6 +140,34 @@ impl Database {
 		})
 		.await
 	}
+}
+
+async fn create_pool(options: PoolOptions) -> Result<Pool<Connection, Error>, Error> {
+	let connection_options = ConnectionOptions {
+		url: options.url.clone(),
+	};
+	let create = {
+		let connection_options = connection_options.clone();
+		move || {
+			let connection_options = connection_options.clone();
+			async move { Connection::connect(connection_options).await }
+		}
+	};
+	let pool = Pool::new(
+		pool::Options {
+			min: options.min,
+			max: options.max,
+			shared: 1,
+			ttl: options.ttl,
+		},
+		create,
+	);
+	for _ in 0..options.min {
+		let connection = Connection::connect(connection_options.clone()).await?;
+		pool.add(connection);
+	}
+
+	Ok(pool)
 }
 
 impl Connection {
@@ -233,7 +257,11 @@ impl super::Database for Database {
 		&self,
 		options: super::ConnectionOptions,
 	) -> Result<Self::Connection, Self::Error> {
-		let mut connection = self.pool.get_exclusive(options.priority).await?;
+		let pool = match options.kind {
+			crate::ConnectionKind::Read => &self.read_pool,
+			crate::ConnectionKind::Write => &self.write_pool,
+		};
+		let mut connection = pool.get_exclusive(options.priority).await?;
 		if connection.client.is_closed() {
 			connection.reconnect().await?;
 		}

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -292,9 +292,16 @@ pub struct DatabaseOutbox {
 pub struct PostgresDatabase {
 	pub outbox: DatabaseOutbox,
 
-	pub pool: DatabasePool,
+	pub read: PostgresDatabaseConnection,
 
 	pub retry: Retry,
+
+	pub write: PostgresDatabaseConnection,
+}
+
+#[derive(Clone, Debug)]
+pub struct PostgresDatabaseConnection {
+	pub pool: DatabasePool,
 
 	pub url: Uri,
 }
@@ -1224,10 +1231,20 @@ impl Default for DatabaseOutbox {
 
 impl Default for PostgresDatabase {
 	fn default() -> Self {
+		let connection = PostgresDatabaseConnection::default();
 		Self {
 			outbox: DatabaseOutbox::default(),
-			pool: DatabasePool::default(),
+			read: connection.clone(),
 			retry: database_retry_default(),
+			write: connection,
+		}
+	}
+}
+
+impl Default for PostgresDatabaseConnection {
+	fn default() -> Self {
+		Self {
+			pool: DatabasePool::default(),
 			url: "postgres://localhost:5432".parse().unwrap(),
 		}
 	}

--- a/packages/server/src/health.rs
+++ b/packages/server/src/health.rs
@@ -57,20 +57,28 @@ impl Session {
 		};
 
 		let database = if include_database {
-			let available_connections = match &self.server.database {
-				#[cfg(feature = "postgres")]
-				Database::Postgres(database) => database.pool().available().to_u64().unwrap(),
-				#[cfg(feature = "sqlite")]
-				Database::Sqlite(database) => {
-					database.read_pool().available().to_u64().unwrap()
-						+ database.write_pool().available().to_u64().unwrap()
-				},
-				#[cfg(feature = "turso")]
-				Database::Turso(database) => database.pool().available().to_u64().unwrap(),
-			};
+			let (available_connections, read_available_connections, write_available_connections) =
+				match &self.server.database {
+					#[cfg(feature = "postgres")]
+					Database::Postgres(database) => {
+						let read = database.read_pool().available().to_u64().unwrap();
+						let write = database.write_pool().available().to_u64().unwrap();
+						(read + write, Some(read), Some(write))
+					},
+					#[cfg(feature = "sqlite")]
+					Database::Sqlite(database) => {
+						let read = database.read_pool().available().to_u64().unwrap();
+						let write = database.write_pool().available().to_u64().unwrap();
+						(read + write, Some(read), Some(write))
+					},
+					#[cfg(feature = "turso")]
+					Database::Turso(database) => (database.pool().available().to_u64().unwrap(), None, None),
+				};
 
 			Some(tg::health::Database {
 				available_connections,
+				read_available_connections,
+				write_available_connections,
 			})
 		} else {
 			None

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -524,11 +524,19 @@ impl Server {
 				#[cfg(feature = "postgres")]
 				{
 					let options = db::postgres::DatabaseOptions {
-						max: options.pool.max.unwrap_or(parallelism),
-						min: options.pool.min.unwrap_or(0),
+						read: db::postgres::PoolOptions {
+							max: options.read.pool.max.unwrap_or(parallelism),
+							min: options.read.pool.min.unwrap_or(0),
+							ttl: options.read.pool.ttl,
+							url: options.read.url.clone(),
+						},
 						retry: options.retry.clone().into(),
-						ttl: options.pool.ttl,
-						url: options.url.clone(),
+						write: db::postgres::PoolOptions {
+							max: options.write.pool.max.unwrap_or(parallelism),
+							min: options.write.pool.min.unwrap_or(0),
+							ttl: options.write.pool.ttl,
+							url: options.write.url.clone(),
+						},
 					};
 					let database = db::postgres::Database::new(options)
 						.await

--- a/scripts/cloud/server.nu
+++ b/scripts/cloud/server.nu
@@ -8,7 +8,12 @@ let config = {
 	},
 	database: {
 		kind: 'postgres',
-		url: 'postgres://root@localhost:26257/database?sslmode=disable',
+		read: {
+			url: 'postgres://root@localhost:26257/database?sslmode=disable',
+		},
+		write: {
+			url: 'postgres://root@localhost:26257/database?sslmode=disable',
+		},
 	},
 	checkouts: false,
 	http: {


### PR DESCRIPTION
## Summary

- configure independent PostgreSQL read and write connections
- keep reads inside write transactions on the write connection
- report health separately for both pools
- preserve SQLite and Turso behavior

## Testing

- `bun run check`
- targeted all-features tests

## Stack

2 of 6. Depends on #1053. The next PR targets this branch.