### PR TITLE
server: route namespace mutations to the primary region

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -3575,7 +3575,6 @@ mod tests {
 
 		assert_eq!(target.primary_region.as_deref(), Some("ash0"));
 		assert_eq!(target.region.as_deref(), Some("ewr0"));
-		assert!(!target.is_primary_region());
 	}
 
 	#[test]

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -1089,13 +1089,6 @@ pub struct Write {
 
 impl Config {
 	#[must_use]
-	pub fn is_primary_region(&self) -> bool {
-		self.primary_region
-			.as_ref()
-			.is_none_or(|primary_region| self.region.as_ref() == Some(primary_region))
-	}
-
-	#[must_use]
 	pub fn primary_region(&self) -> Option<&str> {
 		self.primary_region.as_deref()
 	}

--- a/packages/server/src/grant.rs
+++ b/packages/server/src/grant.rs
@@ -12,6 +12,9 @@ use {
 
 impl Session {
 	pub(crate) async fn create_grant(&self, arg: tg::grant::create::Arg) -> tg::Result<tg::Grant> {
+		if !self.server.is_primary_region() {
+			return self.create_grant_primary_region(arg).await;
+		}
 		let resource = self.resolve_resource(&arg.resource.node).await?;
 		let permissions = Self::normalize_grant_permissions(&resource, arg.permissions.clone())?;
 		let authorization_resource = tg::Referent::with_node_and_tokens(
@@ -73,6 +76,21 @@ impl Session {
 		Ok(grant)
 	}
 
+	async fn create_grant_primary_region(
+		&self,
+		arg: tg::grant::create::Arg,
+	) -> tg::Result<tg::Grant> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let grant = client.create_grant(arg).await.map_err(|error| {
+			tg::error!(!error, "failed to create the grant in the primary region")
+		})?;
+
+		Ok(grant)
+	}
+
 	async fn create_grant_local_with_transaction(
 		&self,
 		transaction: &crate::database::Transaction<'_>,
@@ -104,6 +122,9 @@ impl Session {
 	}
 
 	pub(crate) async fn delete_grant(&self, arg: tg::grant::delete::Arg) -> tg::Result<Option<()>> {
+		if !self.server.is_primary_region() {
+			return self.delete_grant_primary_region(arg).await;
+		}
 		let resource = self.resolve_resource(&arg.resource.node).await?;
 		let permissions = Self::normalize_grant_permissions(&resource, arg.permissions.clone())?;
 		let authorization_resource = tg::Referent::with_node_and_tokens(
@@ -143,6 +164,21 @@ impl Session {
 			.await?;
 		self.server
 			.spawn_publish_database_outbox_notification_task();
+		Ok(output)
+	}
+
+	async fn delete_grant_primary_region(
+		&self,
+		arg: tg::grant::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client.delete_grant(arg).await.map_err(|error| {
+			tg::error!(!error, "failed to delete the grant in the primary region")
+		})?;
+
 		Ok(output)
 	}
 

--- a/packages/server/src/group/create.rs
+++ b/packages/server/src/group/create.rs
@@ -18,6 +18,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.create_group_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.create_group_local(arg).await,
 			tg::Location::Remote(remote) => self.create_group_remote(arg, remote).await,
 		}
@@ -88,6 +91,22 @@ impl Session {
 		let output = tg::group::create::Output { group };
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn create_group_primary_region(
+		&self,
+		mut arg: tg::group::create::Arg,
+	) -> tg::Result<tg::group::create::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client.create_group(arg).await.map_err(|error| {
+			tg::error!(!error, "failed to create the group in the primary region")
+		})?;
+
+		Ok(output)
 	}
 
 	async fn create_group_remote(

--- a/packages/server/src/group/delete.rs
+++ b/packages/server/src/group/delete.rs
@@ -21,6 +21,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.try_delete_group_primary_region(group, arg).await
+			},
 			tg::Location::Local(_) => self.try_delete_group_local(group).await,
 			tg::Location::Remote(remote) => self.try_delete_group_remote(group, arg, remote).await,
 		}
@@ -79,6 +82,23 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn try_delete_group_primary_region(
+		&self,
+		group: &tg::group::Selector,
+		mut arg: tg::group::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client.try_delete_group(group, arg).await.map_err(|error| {
+			tg::error!(!error, "failed to delete the group in the primary region")
+		})?;
+
+		Ok(output)
 	}
 
 	async fn try_delete_group_remote(

--- a/packages/server/src/group/members/add.rs
+++ b/packages/server/src/group/members/add.rs
@@ -21,6 +21,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.add_group_member_primary_region(group, arg).await
+			},
 			tg::Location::Local(_) => self.add_group_member_local(group, &arg.member).await,
 			tg::Location::Remote(remote) => self.add_group_member_remote(group, arg, remote).await,
 		}
@@ -83,6 +86,26 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(()))
+	}
+
+	async fn add_group_member_primary_region(
+		&self,
+		group: &tg::group::Selector,
+		mut arg: tg::group::members::add::Arg,
+	) -> tg::Result<()> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		client.add_group_member(group, arg).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to add the group member in the primary region"
+			)
+		})?;
+
+		Ok(())
 	}
 
 	async fn add_group_member_remote(

--- a/packages/server/src/group/members/remove.rs
+++ b/packages/server/src/group/members/remove.rs
@@ -22,6 +22,10 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.remove_group_member_primary_region(group, member, arg)
+					.await
+			},
 			tg::Location::Local(_) => self.remove_group_member_local(group, member).await,
 			tg::Location::Remote(remote) => {
 				self.remove_group_member_remote(group, member, arg, remote)
@@ -88,6 +92,30 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn remove_group_member_primary_region(
+		&self,
+		group: &tg::group::Selector,
+		member: &tg::group::Member,
+		mut arg: tg::group::members::remove::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client
+			.remove_group_member(group, member, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to remove the group member in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn remove_group_member_remote(

--- a/packages/server/src/organization/create.rs
+++ b/packages/server/src/organization/create.rs
@@ -18,6 +18,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.create_organization_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.create_organization_local(arg).await,
 			tg::Location::Remote(remote) => self.create_organization_remote(arg, remote).await,
 		}
@@ -74,6 +77,25 @@ impl Session {
 		let output = tg::organization::create::Output { organization };
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn create_organization_primary_region(
+		&self,
+		mut arg: tg::organization::create::Arg,
+	) -> tg::Result<tg::organization::create::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client.create_organization(arg).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to create the organization in the primary region"
+			)
+		})?;
+
+		Ok(output)
 	}
 
 	async fn create_organization_remote(

--- a/packages/server/src/organization/delete.rs
+++ b/packages/server/src/organization/delete.rs
@@ -21,6 +21,10 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.try_delete_organization_primary_region(organization, arg)
+					.await
+			},
 			tg::Location::Local(_) => self.try_delete_organization_local(organization).await,
 			tg::Location::Remote(remote) => {
 				self.try_delete_organization_remote(organization, arg, remote)
@@ -85,6 +89,29 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn try_delete_organization_primary_region(
+		&self,
+		organization: &tg::organization::Selector,
+		mut arg: tg::organization::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client
+			.try_delete_organization(organization, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to delete the organization in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn try_delete_organization_remote(

--- a/packages/server/src/organization/members/add.rs
+++ b/packages/server/src/organization/members/add.rs
@@ -21,6 +21,10 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.add_organization_member_primary_region(organization, arg)
+					.await
+			},
 			tg::Location::Local(_) => {
 				self.add_organization_member_local(organization, &arg.member)
 					.await
@@ -93,6 +97,29 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(()))
+	}
+
+	async fn add_organization_member_primary_region(
+		&self,
+		organization: &tg::organization::Selector,
+		mut arg: tg::organization::members::add::Arg,
+	) -> tg::Result<()> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		client
+			.add_organization_member(organization, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to add the organization member in the primary region"
+				)
+			})?;
+
+		Ok(())
 	}
 
 	async fn add_organization_member_remote(

--- a/packages/server/src/organization/members/remove.rs
+++ b/packages/server/src/organization/members/remove.rs
@@ -22,6 +22,10 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.remove_organization_member_primary_region(organization, member, arg)
+					.await
+			},
 			tg::Location::Local(_) => {
 				self.remove_organization_member_local(organization, member)
 					.await
@@ -100,6 +104,30 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn remove_organization_member_primary_region(
+		&self,
+		organization: &tg::organization::Selector,
+		member: &tg::organization::Member,
+		mut arg: tg::organization::members::remove::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client
+			.remove_organization_member(organization, member, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to remove the organization member in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn remove_organization_member_remote(

--- a/packages/server/src/region.rs
+++ b/packages/server/src/region.rs
@@ -36,6 +36,14 @@ impl Session {
 }
 
 impl Server {
+	#[must_use]
+	pub fn is_primary_region(&self) -> bool {
+		let config = self.config();
+		config
+			.primary_region()
+			.is_none_or(|primary_region| config.region.as_deref() == Some(primary_region))
+	}
+
 	pub async fn get_region_client(&self, region: &str) -> tg::Result<tg::Client> {
 		self.try_get_region_client(region)
 			.await?

--- a/packages/server/src/tag/batch.rs
+++ b/packages/server/src/tag/batch.rs
@@ -18,6 +18,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.post_tag_batch_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.post_tag_batch_local(arg).await,
 			tg::Location::Remote(remote) => self.post_tag_batch_remote(arg, remote).await,
 		}
@@ -156,6 +159,20 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(()))
+	}
+
+	async fn post_tag_batch_primary_region(&self, mut arg: tg::tag::batch::Arg) -> tg::Result<()> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		client
+			.post_tag_batch(arg)
+			.await
+			.map_err(|error| tg::error!(!error, "failed to put the tags in the primary region"))?;
+
+		Ok(())
 	}
 
 	async fn post_tag_batch_remote(

--- a/packages/server/src/tag/delete.rs
+++ b/packages/server/src/tag/delete.rs
@@ -18,6 +18,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.delete_tags_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.delete_tags_local(arg).await,
 			tg::Location::Remote(remote) => self.delete_tags_remote(arg, remote).await,
 		}
@@ -225,6 +228,22 @@ impl Session {
 		}
 
 		Ok(ControlFlow::Break(()))
+	}
+
+	async fn delete_tags_primary_region(
+		&self,
+		mut arg: tg::tag::delete::Arg,
+	) -> tg::Result<tg::tag::delete::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client.delete_tags(arg).await.map_err(|error| {
+			tg::error!(!error, "failed to delete the tags in the primary region")
+		})?;
+
+		Ok(output)
 	}
 
 	async fn delete_tags_remote(

--- a/packages/server/src/tag/put.rs
+++ b/packages/server/src/tag/put.rs
@@ -20,6 +20,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.put_tag_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.put_tag_local(arg).await,
 			tg::Location::Remote(remote) => self.put_tag_remote(arg, remote).await,
 		}
@@ -289,6 +292,20 @@ impl Session {
 		};
 
 		Ok(ControlFlow::Break(data))
+	}
+
+	async fn put_tag_primary_region(&self, mut arg: tg::tag::put::Arg) -> tg::Result<()> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		client
+			.put_tag(arg)
+			.await
+			.map_err(|error| tg::error!(!error, "failed to put the tag in the primary region"))?;
+
+		Ok(())
 	}
 
 	async fn put_tag_remote(


### PR DESCRIPTION
## Summary

- forward group, organization, membership, grant, and tag mutations to the primary region
- reuse the existing regional session routing path
- execute mutations locally once they reach the primary region

## Testing

- `bun run check`
- targeted all-features tests

## Stack

3 of 6. Depends on #1054. The next PR targets this branch.