### PR TITLE
server: route remaining mutations to the primary region

### DIFF
--- a/packages/clients/rust/src/handle/dynamic/remote.rs
+++ b/packages/clients/rust/src/handle/dynamic/remote.rs
@@ -24,11 +24,11 @@ impl tg::handle::Remote for Handle {
 		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.put_remote(name, arg)) }
 	}
 
-	fn delete_remote(
+	fn try_delete_remote(
 		&self,
 		name: &str,
 		arg: tg::remote::delete::Arg,
-	) -> impl Future<Output = tg::Result<()>> {
-		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.delete_remote(name, arg)) }
+	) -> impl Future<Output = tg::Result<Option<()>>> {
+		unsafe { std::mem::transmute::<_, BoxFuture<'_, _>>(self.0.try_delete_remote(name, arg)) }
 	}
 }

--- a/packages/clients/rust/src/handle/either/remote.rs
+++ b/packages/clients/rust/src/handle/either/remote.rs
@@ -37,14 +37,14 @@ where
 		}
 	}
 
-	fn delete_remote(
+	fn try_delete_remote(
 		&self,
 		name: &str,
 		arg: tg::remote::delete::Arg,
-	) -> impl Future<Output = tg::Result<()>> {
+	) -> impl Future<Output = tg::Result<Option<()>>> {
 		match self {
-			tg::Either::Left(s) => s.delete_remote(name, arg).left_future(),
-			tg::Either::Right(s) => s.delete_remote(name, arg).right_future(),
+			tg::Either::Left(s) => s.try_delete_remote(name, arg).left_future(),
+			tg::Either::Right(s) => s.try_delete_remote(name, arg).right_future(),
 		}
 	}
 }

--- a/packages/clients/rust/src/handle/erased/remote.rs
+++ b/packages/clients/rust/src/handle/erased/remote.rs
@@ -21,11 +21,11 @@ pub trait Remote: Send + Sync + 'static {
 		arg: tg::remote::put::Arg,
 	) -> BoxFuture<'a, tg::Result<()>>;
 
-	fn delete_remote<'a>(
+	fn try_delete_remote<'a>(
 		&'a self,
 		name: &'a str,
 		arg: tg::remote::delete::Arg,
-	) -> BoxFuture<'a, tg::Result<()>>;
+	) -> BoxFuture<'a, tg::Result<Option<()>>>;
 }
 
 impl<T> Remote for T
@@ -55,11 +55,11 @@ where
 		self.put_remote(name, arg).boxed()
 	}
 
-	fn delete_remote<'a>(
+	fn try_delete_remote<'a>(
 		&'a self,
 		name: &'a str,
 		arg: tg::remote::delete::Arg,
-	) -> BoxFuture<'a, tg::Result<()>> {
-		self.delete_remote(name, arg).boxed()
+	) -> BoxFuture<'a, tg::Result<Option<()>>> {
+		self.try_delete_remote(name, arg).boxed()
 	}
 }

--- a/packages/clients/rust/src/handle/remote.rs
+++ b/packages/clients/rust/src/handle/remote.rs
@@ -22,7 +22,19 @@ pub trait Remote: Clone + Unpin + Send + Sync + 'static {
 		&self,
 		name: &str,
 		arg: tg::remote::delete::Arg,
-	) -> impl Future<Output = tg::Result<()>> + Send;
+	) -> impl Future<Output = tg::Result<()>> + Send {
+		async move {
+			self.try_delete_remote(name, arg)
+				.await?
+				.ok_or_else(|| tg::error!("failed to find the remote"))
+		}
+	}
+
+	fn try_delete_remote(
+		&self,
+		name: &str,
+		arg: tg::remote::delete::Arg,
+	) -> impl Future<Output = tg::Result<Option<()>>> + Send;
 }
 
 impl tg::handle::Remote for tg::Client {
@@ -45,7 +57,11 @@ impl tg::handle::Remote for tg::Client {
 		self.session(&self.context).put_remote(name, arg).await
 	}
 
-	async fn delete_remote(&self, name: &str, arg: tg::remote::delete::Arg) -> tg::Result<()> {
-		self.session(&self.context).delete_remote(name, arg).await
+	async fn try_delete_remote(
+		&self,
+		name: &str,
+		arg: tg::remote::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		self.session(&self.context).try_delete_remote(name, arg).await
 	}
 }

--- a/packages/clients/rust/src/http.rs
+++ b/packages/clients/rust/src/http.rs
@@ -515,7 +515,7 @@ impl tg::Session {
 		}
 	}
 
-	pub(crate) async fn send<B>(
+	pub async fn send<B>(
 		&self,
 		mut request: http::Request<B>,
 	) -> tg::Result<http::Response<tangram_http::body::Boxed>>

--- a/packages/clients/rust/src/remote/delete.rs
+++ b/packages/clients/rust/src/remote/delete.rs
@@ -11,7 +11,11 @@ pub struct Arg {
 }
 
 impl tg::Session {
-	pub async fn delete_remote(&self, name: &str, arg: tg::remote::delete::Arg) -> tg::Result<()> {
+	pub async fn try_delete_remote(
+		&self,
+		name: &str,
+		arg: tg::remote::delete::Arg,
+	) -> tg::Result<Option<()>> {
 		let method = http::Method::DELETE;
 		let path = format!("/remotes/{name}");
 		let uri = Uri::builder()
@@ -30,7 +34,7 @@ impl tg::Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to send the request"))?;
 		if response.status() == http::StatusCode::NOT_FOUND {
-			return Err(tg::error!("failed to find the remote"));
+			return Ok(None);
 		}
 		if !response.status().is_success() {
 			let status = response.status();
@@ -41,6 +45,7 @@ impl tg::Session {
 			let error = tg::error!(!error, status = %status, "the request failed");
 			return Err(error);
 		}
-		Ok(())
+
+		Ok(Some(()))
 	}
 }

--- a/packages/clients/rust/src/session/remote.rs
+++ b/packages/clients/rust/src/session/remote.rs
@@ -24,11 +24,11 @@ impl tg::handle::Remote for tg::Session {
 		self.put_remote(name, arg)
 	}
 
-	fn delete_remote(
+	fn try_delete_remote(
 		&self,
 		name: &str,
 		arg: tg::remote::delete::Arg,
-	) -> impl Future<Output = tg::Result<()>> {
-		self.delete_remote(name, arg)
+	) -> impl Future<Output = tg::Result<Option<()>>> {
+		self.try_delete_remote(name, arg)
 	}
 }

--- a/packages/server/src/billing/stripe.rs
+++ b/packages/server/src/billing/stripe.rs
@@ -237,6 +237,10 @@ impl Session {
 		&self,
 		request: http::Request<BoxBody>,
 	) -> tg::Result<http::Response<BoxBody>> {
+		if !self.server.is_primary_region() {
+			return self.forward_request_to_primary_region(request).await;
+		}
+
 		// Get the signature and body.
 		let signature = request
 			.headers()

--- a/packages/server/src/cleaner.rs
+++ b/packages/server/src/cleaner.rs
@@ -67,7 +67,13 @@ impl Server {
 				})
 			});
 
-			let clean_database_future = self.clean_stripe_webhooks(now);
+			let clean_database_future = async {
+				if self.is_primary_region() {
+					self.clean_stripe_webhooks(now).await?;
+				}
+
+				Ok(())
+			};
 			let clean_index_future = future::try_join_all(futures);
 			let clean_usage_future = self.index.clean_usage(tangram_index::usage::clean::Arg {
 				batch_size: n,

--- a/packages/server/src/handle/remote.rs
+++ b/packages/server/src/handle/remote.rs
@@ -20,7 +20,11 @@ impl tg::handle::Remote for Server {
 		self.session(&self.context).put_remote(name, arg).await
 	}
 
-	async fn delete_remote(&self, name: &str, arg: tg::remote::delete::Arg) -> tg::Result<()> {
-		self.session(&self.context).delete_remote(name, arg).await
+	async fn try_delete_remote(
+		&self,
+		name: &str,
+		arg: tg::remote::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		self.session(&self.context).try_delete_remote(name, arg).await
 	}
 }

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -967,7 +967,9 @@ impl Server {
 		}
 
 		// Set the remotes if specified in the config.
-		if let Some(remotes) = &server.config.remotes {
+		if server.is_primary_region()
+			&& let Some(remotes) = &server.config.remotes
+		{
 			let remotes = remotes.clone();
 			server
 				.database

--- a/packages/server/src/organization/billing/manage.rs
+++ b/packages/server/src/organization/billing/manage.rs
@@ -21,6 +21,10 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.manage_organization_billing_primary_region(organization, arg)
+					.await
+			},
 			tg::Location::Local(_) => self.manage_organization_billing_local(organization).await,
 			tg::Location::Remote(remote) => {
 				self.manage_organization_billing_remote(organization, arg, remote)
@@ -146,6 +150,29 @@ impl Session {
 		};
 
 		Ok(ControlFlow::Break(stripe_customer_id))
+	}
+
+	async fn manage_organization_billing_primary_region(
+		&self,
+		organization: &tg::organization::Selector,
+		mut arg: tg::organization::billing::manage::Arg,
+	) -> tg::Result<tg::organization::billing::manage::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client
+			.manage_organization_billing(organization, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to manage organization billing in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn manage_organization_billing_remote(

--- a/packages/server/src/region.rs
+++ b/packages/server/src/region.rs
@@ -33,6 +33,24 @@ impl Session {
 		let session = client.session(&context);
 		Ok(session)
 	}
+
+	pub(crate) async fn forward_request_to_primary_region(
+		&self,
+		request: http::Request<tangram_http::body::Boxed>,
+	) -> tg::Result<http::Response<tangram_http::body::Boxed>> {
+		let region = self
+			.server
+			.config()
+			.primary_region()
+			.ok_or_else(|| tg::error!("the primary region is not configured"))?;
+		let client = self.server.get_region_client(region).await?;
+		let context = client.context().clone();
+		context.set_token(self.context.token.clone());
+		let session = client.session(&context);
+		let response = session.send(request).await?;
+
+		Ok(response)
+	}
 }
 
 impl Server {

--- a/packages/server/src/remote/delete.rs
+++ b/packages/server/src/remote/delete.rs
@@ -11,23 +11,14 @@ use {
 };
 
 impl Session {
-	pub(crate) async fn delete_remote(
+	pub(crate) async fn try_delete_remote(
 		&self,
 		name: &str,
 		arg: tg::remote::delete::Arg,
-	) -> tg::Result<()> {
-		let deleted = self.delete_remote_inner(name, arg).await?;
-		if !deleted {
-			return Err(tg::error!("failed to find the remote"));
+	) -> tg::Result<Option<()>> {
+		if !self.server.is_primary_region() {
+			return self.delete_remote_primary_region(name, arg).await;
 		}
-		Ok(())
-	}
-
-	async fn delete_remote_inner(
-		&self,
-		name: &str,
-		arg: tg::remote::delete::Arg,
-	) -> tg::Result<bool> {
 		self.verify_request_can_mutate_remotes()?;
 		if matches!(self.context.principal, tg::Principal::Anonymous) {
 			return Err(tg::error!("unauthenticated"));
@@ -49,11 +40,28 @@ impl Session {
 			})
 			.await
 			.map_err(|error| tg::error!(!error, "failed to delete the remote"))?;
-		if n != 0 {
-			self.delete_remote_cache(&name).await?;
+		if n == 0 {
+			return Ok(None);
 		}
+		self.delete_remote_cache(&name).await?;
 
-		Ok(n != 0)
+		Ok(Some(()))
+	}
+
+	async fn delete_remote_primary_region(
+		&self,
+		name: &str,
+		arg: tg::remote::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let deleted = client.try_delete_remote(name, arg).await.map_err(|error| {
+			tg::error!(!error, "failed to delete the remote in the primary region")
+		})?;
+
+		Ok(deleted)
 	}
 
 	async fn delete_remote_with_transaction(
@@ -97,10 +105,10 @@ impl Session {
 
 		// Delete the remote.
 		let deleted = self
-			.delete_remote_inner(name, arg)
+			.try_delete_remote(name, arg)
 			.await
 			.map_err(|error| tg::error!(!error, %name, "failed to delete the remote"))?;
-		if !deleted {
+		if deleted.is_none() {
 			return Ok(http::Response::builder()
 				.not_found()
 				.empty()

--- a/packages/server/src/remote/put.rs
+++ b/packages/server/src/remote/put.rs
@@ -12,6 +12,9 @@ use {
 
 impl Session {
 	pub(crate) async fn put_remote(&self, name: &str, arg: tg::remote::put::Arg) -> tg::Result<()> {
+		if !self.server.is_primary_region() {
+			return self.put_remote_primary_region(name, arg).await;
+		}
 		self.verify_request_can_mutate_remotes()?;
 		if matches!(self.context.principal, tg::Principal::Anonymous) {
 			return Err(tg::error!("unauthenticated"));
@@ -40,6 +43,22 @@ impl Session {
 			.await
 			.map_err(|error| tg::error!(!error, "failed to put the remote"))?;
 		self.delete_remote_cache(&name).await?;
+
+		Ok(())
+	}
+
+	async fn put_remote_primary_region(
+		&self,
+		name: &str,
+		arg: tg::remote::put::Arg,
+	) -> tg::Result<()> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		client.put_remote(name, arg).await.map_err(|error| {
+			tg::error!(!error, "failed to put the remote in the primary region")
+		})?;
 
 		Ok(())
 	}

--- a/packages/server/src/runner/create.rs
+++ b/packages/server/src/runner/create.rs
@@ -13,6 +13,9 @@ impl Session {
 		&self,
 		arg: tg::runner::create::Arg,
 	) -> tg::Result<tg::runner::create::Output> {
+		if !self.server.is_primary_region() {
+			return self.create_runner_primary_region(arg).await;
+		}
 		let owner = match arg.owner {
 			Some(owner) => Some(self.resolve_runner_owner(&owner).await?),
 			None => None,
@@ -56,6 +59,21 @@ impl Session {
 		let token = tg::runner::token::create::Output { data, token };
 
 		Ok(tg::runner::create::Output { runner, token })
+	}
+
+	async fn create_runner_primary_region(
+		&self,
+		arg: tg::runner::create::Arg,
+	) -> tg::Result<tg::runner::create::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client.create_runner(arg).await.map_err(|error| {
+			tg::error!(!error, "failed to create the runner in the primary region")
+		})?;
+
+		Ok(output)
 	}
 
 	async fn create_runner_with_transaction(

--- a/packages/server/src/runner/delete.rs
+++ b/packages/server/src/runner/delete.rs
@@ -11,8 +11,11 @@ impl Session {
 	pub(crate) async fn try_delete_runner(
 		&self,
 		runner: &tg::runner::Id,
-		_arg: tg::runner::delete::Arg,
+		arg: tg::runner::delete::Arg,
 	) -> tg::Result<Option<()>> {
+		if !self.server.is_primary_region() {
+			return self.try_delete_runner_primary_region(runner, arg).await;
+		}
 		let Some(data) = self.try_get_runner_data(runner).await? else {
 			return Ok(None);
 		};
@@ -29,6 +32,25 @@ impl Session {
 			.await?;
 
 		Ok(Some(()))
+	}
+
+	async fn try_delete_runner_primary_region(
+		&self,
+		runner: &tg::runner::Id,
+		arg: tg::runner::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client
+			.try_delete_runner(runner, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(!error, "failed to delete the runner in the primary region")
+			})?;
+
+		Ok(output)
 	}
 
 	async fn delete_runner_with_transaction(

--- a/packages/server/src/runner/token/create.rs
+++ b/packages/server/src/runner/token/create.rs
@@ -12,8 +12,11 @@ impl Session {
 	pub(crate) async fn create_runner_token(
 		&self,
 		runner: &tg::runner::Id,
-		_arg: tg::runner::token::create::Arg,
+		arg: tg::runner::token::create::Arg,
 	) -> tg::Result<tg::runner::token::create::Output> {
+		if !self.server.is_primary_region() {
+			return self.create_runner_token_primary_region(runner, arg).await;
+		}
 		self.get_authorized_runner(runner).await?;
 		let created_at = self.server.clock.unix_timestamp()?;
 		let (id, token) = crate::token::create();
@@ -41,6 +44,28 @@ impl Session {
 		let data = tg::runner::token::Data { created_at, id };
 
 		Ok(tg::runner::token::create::Output { data, token })
+	}
+
+	async fn create_runner_token_primary_region(
+		&self,
+		runner: &tg::runner::Id,
+		arg: tg::runner::token::create::Arg,
+	) -> tg::Result<tg::runner::token::create::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client
+			.create_runner_token(runner, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to create the runner token in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn create_runner_token_with_transaction(

--- a/packages/server/src/runner/token/delete.rs
+++ b/packages/server/src/runner/token/delete.rs
@@ -13,8 +13,13 @@ impl Session {
 		&self,
 		runner: &tg::runner::Id,
 		token: &tg::token::Id,
-		_arg: tg::runner::token::delete::Arg,
+		arg: tg::runner::token::delete::Arg,
 	) -> tg::Result<Option<()>> {
+		if !self.server.is_primary_region() {
+			return self
+				.try_delete_runner_token_primary_region(runner, token, arg)
+				.await;
+		}
 		self.get_authorized_runner(runner).await?;
 		let runner = runner.clone();
 		let token = token.clone();
@@ -32,6 +37,29 @@ impl Session {
 			.await?;
 
 		Ok(deleted.then_some(()))
+	}
+
+	async fn try_delete_runner_token_primary_region(
+		&self,
+		runner: &tg::runner::Id,
+		token: &tg::token::Id,
+		arg: tg::runner::token::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client
+			.try_delete_runner_token(runner, token, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to delete the runner token in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn delete_runner_token_with_transaction(

--- a/packages/server/src/session/remote.rs
+++ b/packages/server/src/session/remote.rs
@@ -20,7 +20,11 @@ impl tg::handle::Remote for Session {
 		self.put_remote(name, arg).await
 	}
 
-	async fn delete_remote(&self, name: &str, arg: tg::remote::delete::Arg) -> tg::Result<()> {
-		self.delete_remote(name, arg).await
+	async fn try_delete_remote(
+		&self,
+		name: &str,
+		arg: tg::remote::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		self.try_delete_remote(name, arg).await
 	}
 }

--- a/packages/server/src/user/billing/manage.rs
+++ b/packages/server/src/user/billing/manage.rs
@@ -20,6 +20,9 @@ impl Session {
 			.location(arg.location.as_ref())
 			.map_err(|error| tg::error!(!error, "failed to resolve the location"))?;
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.manage_user_billing_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.manage_user_billing_local().await,
 			tg::Location::Remote(remote) => self.manage_user_billing_remote(arg, remote).await,
 		}
@@ -129,6 +132,25 @@ impl Session {
 		};
 
 		Ok(ControlFlow::Break(stripe_customer_id))
+	}
+
+	async fn manage_user_billing_primary_region(
+		&self,
+		mut arg: tg::user::billing::manage::Arg,
+	) -> tg::Result<tg::user::billing::manage::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client.manage_user_billing(arg).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to manage user billing in the primary region"
+			)
+		})?;
+
+		Ok(output)
 	}
 
 	async fn manage_user_billing_remote(

--- a/packages/server/src/user/login/create.rs
+++ b/packages/server/src/user/login/create.rs
@@ -23,6 +23,9 @@ impl Session {
 
 		// Start the login.
 		match location {
+			tg::Location::Local(_) if !self.server.is_primary_region() => {
+				self.create_login_primary_region(arg).await
+			},
 			tg::Location::Local(_) => self.create_login_local(arg).await,
 			tg::Location::Remote(remote) => {
 				let client = self.get_remote_session(&remote.name).await?;
@@ -33,6 +36,22 @@ impl Session {
 				client.create_login(arg).await
 			},
 		}
+	}
+
+	async fn create_login_primary_region(
+		&self,
+		mut arg: tg::user::login::create::Arg,
+	) -> tg::Result<tg::user::login::create::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		arg.location = Some(tg::Location::Local(tg::location::Local::default()).into());
+		let output = client.create_login(arg).await.map_err(|error| {
+			tg::error!(!error, "failed to create the login in the primary region")
+		})?;
+
+		Ok(output)
 	}
 
 	async fn create_login_local(

--- a/packages/server/src/user/logout.rs
+++ b/packages/server/src/user/logout.rs
@@ -10,6 +10,9 @@ use {
 
 impl Session {
 	pub(crate) async fn logout(&self) -> tg::Result<()> {
+		if !self.server.is_primary_region() {
+			return self.logout_primary_region().await;
+		}
 		let tg::Principal::User(user) = &self.context.principal else {
 			return Err(tg::error!("not logged in"));
 		};
@@ -29,6 +32,19 @@ impl Session {
 					.boxed()
 			})
 			.await?;
+
+		Ok(())
+	}
+
+	async fn logout_primary_region(&self) -> tg::Result<()> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		client
+			.logout()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to log out in the primary region"))?;
 
 		Ok(())
 	}

--- a/packages/server/src/user/oauth/github.rs
+++ b/packages/server/src/user/oauth/github.rs
@@ -31,6 +31,9 @@ impl Session {
 		&self,
 		request: http::Request<BoxBody>,
 	) -> tg::Result<http::Response<BoxBody>> {
+		if !self.server.is_primary_region() {
+			return self.forward_request_to_primary_region(request).await;
+		}
 		self.verify_request_with_network_access()?;
 
 		// Get the GitHub config.
@@ -127,6 +130,9 @@ impl Session {
 		&self,
 		request: http::Request<BoxBody>,
 	) -> tg::Result<http::Response<BoxBody>> {
+		if !self.server.is_primary_region() {
+			return self.forward_request_to_primary_region(request).await;
+		}
 		self.verify_request_with_network_access()?;
 
 		// Get the GitHub config.

--- a/packages/server/src/user/token/create.rs
+++ b/packages/server/src/user/token/create.rs
@@ -11,8 +11,11 @@ use {
 impl Session {
 	pub(crate) async fn create_user_token(
 		&self,
-		_arg: tg::user::token::create::Arg,
+		arg: tg::user::token::create::Arg,
 	) -> tg::Result<tg::user::token::create::Output> {
+		if !self.server.is_primary_region() {
+			return self.create_user_token_primary_region(arg).await;
+		}
 		let user = self.authenticated_user()?.clone();
 		let (id, token) = crate::token::create();
 		let created_at = self.server.clock.unix_timestamp()?;
@@ -38,6 +41,24 @@ impl Session {
 			.await?;
 		let data = tg::user::token::Data { created_at, id };
 		let output = tg::user::token::create::Output { data, token };
+
+		Ok(output)
+	}
+
+	async fn create_user_token_primary_region(
+		&self,
+		arg: tg::user::token::create::Arg,
+	) -> tg::Result<tg::user::token::create::Output> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client.create_user_token(arg).await.map_err(|error| {
+			tg::error!(
+				!error,
+				"failed to create the user token in the primary region"
+			)
+		})?;
 
 		Ok(output)
 	}

--- a/packages/server/src/user/token/delete.rs
+++ b/packages/server/src/user/token/delete.rs
@@ -12,8 +12,11 @@ impl Session {
 	pub(crate) async fn try_delete_user_token(
 		&self,
 		token: &tg::token::Id,
-		_arg: tg::user::token::delete::Arg,
+		arg: tg::user::token::delete::Arg,
 	) -> tg::Result<Option<()>> {
+		if !self.server.is_primary_region() {
+			return self.try_delete_user_token_primary_region(token, arg).await;
+		}
 		let user = self.authenticated_user()?.clone();
 		let token = token.clone();
 		let deleted = self
@@ -30,6 +33,28 @@ impl Session {
 			.await?;
 
 		Ok(deleted.then_some(()))
+	}
+
+	async fn try_delete_user_token_primary_region(
+		&self,
+		token: &tg::token::Id,
+		arg: tg::user::token::delete::Arg,
+	) -> tg::Result<Option<()>> {
+		let client = self
+			.get_primary_region_session()
+			.await
+			.map_err(|error| tg::error!(!error, "failed to get the primary region session"))?;
+		let output = client
+			.try_delete_user_token(token, arg)
+			.await
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					"failed to delete the user token in the primary region"
+				)
+			})?;
+
+		Ok(output)
 	}
 
 	async fn delete_user_token_with_transaction(


### PR DESCRIPTION
## Summary

- route remote, runner, user, token, login, logout, and billing mutations to the primary region
- keep outbox acknowledgements on the database write connection
- preserve local execution after primary-region forwarding

## Testing

- `bun run check`
- targeted all-features tests

## Stack

4 of 6. Depends on #1055. The next PR targets this branch.