### PR TITLE
sync: carry tag target authorization tokens

### DIFF
--- a/packages/clients/rust/src/sync.rs
+++ b/packages/clients/rust/src/sync.rs
@@ -290,9 +290,6 @@ pub struct PutNodeTagMessage {
 	#[tangram_serialize(id = 0)]
 	pub id: tg::tag::Id,
 
-	#[tangram_serialize(id = 1)]
-	pub target: tg::Id,
-
 	#[tangram_serialize(id = 2)]
 	pub name: String,
 
@@ -301,6 +298,12 @@ pub struct PutNodeTagMessage {
 
 	#[tangram_serialize(id = 4)]
 	pub specifier: tg::Specifier,
+
+	#[tangram_serialize(id = 1)]
+	pub target: tg::Id,
+
+	#[tangram_serialize(default, id = 5, skip_serializing_if = "Option::is_none")]
+	pub token: Option<tg::authorization::Token>,
 }
 
 #[derive(Clone, Debug, tangram_serialize::Deserialize, tangram_serialize::Serialize)]

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -171,7 +171,7 @@ impl Session {
 			.all(|permission| token.body.grants(permission))
 	}
 
-	fn verify_token(&self, token: &tg::authorization::Token) -> bool {
+	pub(crate) fn verify_token(&self, token: &tg::authorization::Token) -> bool {
 		let Ok(now) = self.server.clock.unix_timestamp() else {
 			return false;
 		};

--- a/packages/server/src/sync/get/database.rs
+++ b/packages/server/src/sync/get/database.rs
@@ -372,6 +372,10 @@ impl Session {
 			let tg::sync::PutNodeMessage::Tag(message) = node else {
 				continue;
 			};
+			if message.token.is_some() {
+				self.sync_get_database_tag_permissions_from_token(message)?;
+				continue;
+			}
 			if let Ok(id) = tg::object::Id::try_from(message.target.clone()) {
 				objects.insert(id);
 			} else if let Ok(id) = tg::process::Id::try_from(message.target.clone()) {
@@ -428,6 +432,10 @@ impl Session {
 			let tg::sync::PutNodeMessage::Tag(message) = node else {
 				continue;
 			};
+			if let Some(permissions) = self.sync_get_database_tag_permissions_from_token(message)? {
+				outputs.insert(message.id.clone(), permissions);
+				continue;
+			}
 			let (aspects, permissions) = if let Ok(id) =
 				tg::object::Id::try_from(message.target.clone())
 			{
@@ -478,6 +486,50 @@ impl Session {
 		}
 
 		Ok(outputs)
+	}
+
+	fn sync_get_database_tag_permissions_from_token(
+		&self,
+		message: &tg::sync::PutNodeTagMessage,
+	) -> tg::Result<Option<Vec<tg::authorization::Permission>>> {
+		let Some(token) = &message.token else {
+			return Ok(None);
+		};
+		if token.body.resource != message.target || !self.verify_token(token) {
+			return Err(tg::error!("invalid tag target token"));
+		}
+		let valid =
+			if message.target.kind().is_object() {
+				token.body.permissions.iter().all(|permission| {
+					matches!(permission, tg::authorization::Permission::Object(_))
+				})
+			} else if message.target.kind() == tg::id::Kind::Process {
+				token.body.permissions.iter().all(|permission| {
+					matches!(
+						permission,
+						tg::authorization::Permission::Process(
+							tg::authorization::permission::process::Permission::Node
+								| tg::authorization::permission::process::Permission::NodeCommand
+								| tg::authorization::permission::process::Permission::NodeError
+								| tg::authorization::permission::process::Permission::NodeLog
+								| tg::authorization::permission::process::Permission::NodeOutput
+								| tg::authorization::permission::process::Permission::Subtree
+								| tg::authorization::permission::process::Permission::SubtreeCommand
+								| tg::authorization::permission::process::Permission::SubtreeError
+								| tg::authorization::permission::process::Permission::SubtreeLog
+								| tg::authorization::permission::process::Permission::SubtreeOutput
+						)
+					)
+				})
+			} else {
+				false
+			};
+		if !valid {
+			return Err(tg::error!("invalid tag target token permissions"));
+		}
+		let permissions = token.body.permissions.clone();
+
+		Ok(Some(permissions))
 	}
 
 	async fn sync_get_database_namespace_with_transaction(

--- a/packages/server/src/sync/put/database.rs
+++ b/packages/server/src/sync/put/database.rs
@@ -257,6 +257,7 @@ impl Session {
 						parent: data.parent,
 						specifier: data.specifier,
 						target,
+						token: None,
 					})
 				},
 				tg::id::Kind::User => {


### PR DESCRIPTION
## Summary

- add an optional authorization token to `PutNodeTagMessage`
- verify tag-target authorization tokens when the receiving server writes tags
- retain the existing target authorization path when no token is present

The generic sync path does not mint tokens. This prepares the protocol and receiving path for #1058, which attaches tokens only when starting a sync to the primary region, where the servers share a signing key.

## Testing

- `bun run check`
- targeted all-features tests

## Stack

5 of 6. Depends on #1056. The final PR targets this branch.