### PR TITLE
fix(sandbox): bind the device nodes from open file descriptors

### DIFF
--- a/packages/cli/tests/sandbox_dev_nodes.nu
+++ b/packages/cli/tests/sandbox_dev_nodes.nu
@@ -1,0 +1,13 @@
+use ../test.nu *
+
+# A container sandbox binds the host's device nodes into its dev mount. The dev mount must not shadow its own bind sources when the target is the current /dev.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+
+let uid = ^id -u | str trim
+let gid = ^id -g | str trim
+let program = '[ -c /dev/null ] && [ -c /dev/zero ] && [ -c /dev/full ] && [ -c /dev/random ] && [ -c /dev/urandom ] && [ -c /dev/tty ]'
+let output = tg sandbox container run --dev /dev --gid $gid --index 0 --uid $uid --unshare-all -- /bin/sh -c $program | complete
+success $output

--- a/packages/sandbox/src/container/mount.rs
+++ b/packages/sandbox/src/container/mount.rs
@@ -4,7 +4,10 @@ use {
 	num::ToPrimitive,
 	std::{
 		ffi::{CString, OsStr},
-		os::unix::ffi::OsStrExt as _,
+		os::{
+			fd::AsRawFd as _,
+			unix::{ffi::OsStrExt as _, fs::OpenOptionsExt as _},
+		},
 		path::{Path, PathBuf},
 	},
 	tangram_client::prelude::*,
@@ -261,6 +264,23 @@ fn mount_tmpfs(target: &Path) -> tg::Result<()> {
 }
 
 fn mount_dev(target: &Path) -> tg::Result<()> {
+	let mut devices = Vec::new();
+	for path in [
+		"/dev/null",
+		"/dev/zero",
+		"/dev/full",
+		"/dev/random",
+		"/dev/urandom",
+		"/dev/tty",
+	] {
+		let file = std::fs::File::options()
+			.custom_flags(libc::O_PATH)
+			.read(true)
+			.open(path)
+			.map_err(|error| tg::error!(!error, %path, "failed to open the device"))?;
+		devices.push((path, file));
+	}
+
 	std::fs::create_dir_all(target).map_err(|error| {
 		tg::error!(
 			!error,
@@ -295,25 +315,19 @@ fn mount_dev(target: &Path) -> tg::Result<()> {
 		pts_data.as_ptr().cast::<std::ffi::c_void>().cast_mut(),
 	)
 	.map_err(|error| tg::error!(!error, "failed to create the devpts mount"))?;
-	for source in [
-		"/dev/null",
-		"/dev/zero",
-		"/dev/full",
-		"/dev/random",
-		"/dev/urandom",
-		"/dev/tty",
-	] {
-		let source = Path::new(source);
-		let target = target.join(source.file_name().unwrap());
+	for (path, file) in &devices {
+		let source = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+		let target = target.join(Path::new(path).file_name().unwrap());
 		mount_bind(
 			&Bind {
-				source: source.to_owned(),
+				source,
 				target: target.clone(),
 			},
 			&target,
 			false,
 		)?;
 	}
+
 	configure_dev(target)
 }
 


### PR DESCRIPTION
The dev mount shadows its own bind sources when its target is the current `/dev`, which happens whenever a container runs without an overlay to `/`. Every device then binds a freshly created empty regular file onto itself and succeeds silently, so `/dev/urandom` returns EOF rather than random bytes.

The fix opens the devices before mounting the tmpfs and binds them from `/proc/self/fd`. We use `O_PATH` so that opening `/dev/tty` doesn't require a controlling terminal.