### PR TITLE
feat(sandbox): mount a tmpfs on /dev/shm

### DIFF
--- a/packages/cli/tests/sandbox_dev_shm.nu
+++ b/packages/cli/tests/sandbox_dev_shm.nu
@@ -1,0 +1,18 @@
+use ../test.nu *
+
+# A container sandbox has a tmpfs on /dev/shm. LMDB guards its reader table with POSIX semaphores, which are files there, so a server started in a sandbox fails to open its index without it.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+
+let directory = mktemp --directory
+let uid = ^id -u | str trim
+let gid = ^id -g | str trim
+let output = tg sandbox container run --dev /dev --gid $gid --index 0 --uid $uid --unshare-all -- tangram --directory $directory --no-remotes server start | complete
+
+# The server reports why it failed to start in its log rather than to the client.
+let log = try { open --raw ($directory | path join 'log') } catch { '' }
+success $output $"the server failed to start in the sandbox: ($log)"
+
+tg --directory $directory server stop

--- a/packages/sandbox/src/container/mount.rs
+++ b/packages/sandbox/src/container/mount.rs
@@ -315,6 +315,23 @@ fn mount_dev(target: &Path) -> tg::Result<()> {
 		pts_data.as_ptr().cast::<std::ffi::c_void>().cast_mut(),
 	)
 	.map_err(|error| tg::error!(!error, "failed to create the devpts mount"))?;
+
+	let shm = target.join("shm");
+	std::fs::create_dir_all(&shm)
+		.map_err(|error| tg::error!(!error, "failed to create the shm mountpoint"))?;
+	let shm_source = cstring("tmpfs");
+	let shm_target = cstring(&shm);
+	let shm_fstype = cstring("tmpfs");
+	let shm_data = cstring("mode=1777");
+	mount_raw(
+		Some(&shm_source),
+		&shm_target,
+		Some(&shm_fstype),
+		libc::MS_NODEV | libc::MS_NOSUID,
+		shm_data.as_ptr().cast::<std::ffi::c_void>().cast_mut(),
+	)
+	.map_err(|error| tg::error!(!error, "failed to create the shm mount"))?;
+
 	for (path, file) in &devices {
 		let source = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
 		let target = target.join(Path::new(path).file_name().unwrap());


### PR DESCRIPTION
Stacked on #1064. Review that first; the second commit is the only new change here.

POSIX semaphores and shared memory objects are files under `/dev/shm`, so `sem_open` and `shm_open` fail with ENOENT without it. LMDB guards its reader table with POSIX semaphores when heed is built with `posix-sem`, so no server can open its index in a sandbox. Give it a tmpfs of its own rather than a directory in the dev tmpfs, which is capped at 64k.

The flags are `MS_NODEV | MS_NOSUID` and mode `1777`, matching how the host and mainstream distros mount `/dev/shm`.

## Test

`packages/cli/tests/sandbox_dev_shm.nu` starts a real Tangram server inside a container sandbox. It fails on `main` and passes here. The test reads the server log into the assertion message, so the red output names the cause directly:

```
failed to create the index -> failed to open the lmdb environment -> No such file or directory (os error 2)
```

## Notes

The VM backend still has no `/dev/shm`. `packages/sandbox/src/vm/init.rs` mounts `devtmpfs` for its own `/dev`, so it does not share this code path and is not covered here.
