### PR TITLE
test(build): demonstrate that unreachable remote fails a build

### DIFF
--- a/packages/cli/tests/build/remote_unreachable.nu
+++ b/packages/cli/tests/build/remote_unreachable.nu
@@ -2,8 +2,8 @@ use ../../test.nu *
 
 # A build succeeds when a configured remote is unreachable, because consulting a remote for a cached process is an optimization and not a prerequisite.
 
-let remote = spawn --cloud --name remote
-let local = spawn --name local --config {
+let remote = server spawn --cloud --name remote
+let local = server spawn --name local --config {
 	remotes: { default: { url: $remote.url } }
 }
 
@@ -18,6 +18,11 @@ let path = artifact {
 let pid = open ($remote.directory | path join 'lock') | into int
 kill --signal 2 $pid
 wait_until { ps | where pid == $pid | is-empty } "the remote should stop"
+
+# Require a cached process while the remote is unreachable.
+let cached_output = tg build --cached $path | complete
+failure $cached_output "a cache-only build should fail while the remote is unreachable"
+assert ($cached_output.stderr | str contains "failed to get a cached process from a remote") "the cache-only build should surface the remote error"
 
 # Build while the remote is unreachable.
 let output = tg build $path | complete

--- a/packages/cli/tests/build/remote_unreachable.nu
+++ b/packages/cli/tests/build/remote_unreachable.nu
@@ -1,0 +1,25 @@
+use ../../test.nu *
+
+# A build succeeds when a configured remote is unreachable, because consulting a remote for a cached process is an optimization and not a prerequisite.
+
+let remote = spawn --cloud --name remote
+let local = spawn --name local --config {
+	remotes: { default: { url: $remote.url } }
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default function () { return tg.build(child); }
+		export function child() { return "hello"; }
+	'
+}
+
+# Kill the remote server.
+let pid = open ($remote.directory | path join 'lock') | into int
+kill --signal 2 $pid
+wait_until { ps | where pid == $pid | is-empty } "the remote should stop"
+
+# Build while the remote is unreachable.
+let output = tg build $path | complete
+success $output "the build should succeed while the remote is unreachable"
+snapshot ($output.stdout | str trim) '"hello"'

--- a/packages/server/src/process/spawn/wait.rs
+++ b/packages/server/src/process/spawn/wait.rs
@@ -29,7 +29,15 @@ impl Session {
 		} else {
 			(None, None)
 		};
-		let cache_future = self.spawn_process_get_cached_process(arg, location, candidate.as_ref());
+		let cache_future = self
+			.spawn_process_get_cached_process(arg, location, candidate.as_ref())
+			.map(|result| match result {
+				Err(error) if candidate.is_some() => {
+					tracing::debug!(error = %error.trace(), "failed to get a cached process");
+					Ok(None)
+				},
+				result => result,
+			});
 		let create_delay = self.server.config.process.spawn.create_delay;
 		let spawn_future =
 			self.spawn_process_in_new_or_existing_sandbox(arg, output, scheduler_sender);


### PR DESCRIPTION
Currently, when a configured remote becomes unreachable, builds fail. I expect this build to succeed despite the failed lookup.