### PR TITLE
fix(util): use rustix rename_noreplace on macOS

### DIFF
--- a/packages/cli/tests/checkin/concurrent_destructive_same_id.nu
+++ b/packages/cli/tests/checkin/concurrent_destructive_same_id.nu
@@ -1,0 +1,55 @@
+use ../../test.nu *
+
+# Two destructive checkins of identical content race to rename their roots to the same checkout path. The loser must treat the existing destination as already checked out rather than failing.
+#
+# The destination is only made read-only after the rename, so the loser must be released while the destination is still writable. A rename that is not no-replace reports ENOTEMPTY there rather than the tolerated EEXIST, because the destination is a non-empty directory.
+
+let server = spawn --config {
+	advanced: {
+		checkpoints: true,
+	},
+}
+
+let first = artifact { a.txt: 'hello' }
+let second = artifact { a.txt: 'hello' }
+
+def checkin_background [path: path] {
+	job spawn {
+		let job_id = job id
+		let output = tg checkin --destructive --no-ignore $path | complete
+		$output | job send --tag $job_id 0
+	}
+}
+
+let rename_watch = (
+	tg checkpoint watch checkin.checkout.destructive.rename
+	| from json
+	| get watch
+)
+let renamed_watch = (
+	tg checkpoint watch checkin.checkout.destructive.renamed
+	| from json
+	| get watch
+)
+
+let checkins = [$first $second] | each { |path| checkin_background $path }
+
+# Park both checkins before they rename their roots.
+tg checkpoint wait checkin.checkout.destructive.rename $rename_watch 0 | ignore
+tg checkpoint wait checkin.checkout.destructive.rename $rename_watch 1 | ignore
+
+# Let the winner rename, then hold it before it makes the destination read-only.
+tg checkpoint continue checkin.checkout.destructive.rename $rename_watch 0
+tg checkpoint wait checkin.checkout.destructive.renamed $renamed_watch 0 | ignore
+
+# The loser renames while the destination is still writable.
+tg checkpoint continue checkin.checkout.destructive.rename $rename_watch 1
+
+tg checkpoint continue checkin.checkout.destructive.renamed $renamed_watch 0
+tg checkpoint unwatch checkin.checkout.destructive.renamed $renamed_watch
+tg checkpoint unwatch checkin.checkout.destructive.rename $rename_watch
+
+for checkin in $checkins {
+	let output = job recv --tag $checkin --timeout 10sec
+	success $output "the losing destructive checkin should succeed"
+}

--- a/packages/server/src/checkin/checkout.rs
+++ b/packages/server/src/checkin/checkout.rs
@@ -131,8 +131,22 @@ impl Session {
 				|error| tg::error!(!error, path = %src.display(), "failed to set permissions"),
 			)?;
 		}
+		crate::checkpoint!(
+			self.server,
+			"checkin.checkout.destructive.rename",
+			id = %id,
+		)
+		.await;
 		let done = match tangram_util::fs::rename_noreplace(src, &dst).await {
-			Ok(()) => false,
+			Ok(()) => {
+				crate::checkpoint!(
+					self.server,
+					"checkin.checkout.destructive.renamed",
+					id = %id,
+				)
+				.await;
+				false
+			},
 			Err(error) if error.raw_os_error() == Some(libc::EXDEV) => {
 				self.checkin_checkout_destructive_copy(src, &dst).await?
 			},

--- a/packages/util/src/fs.rs
+++ b/packages/util/src/fs.rs
@@ -162,44 +162,15 @@ pub fn remove_sync(path: impl AsRef<Path>) -> std::io::Result<()> {
 
 /// Rename a file or directory atomically, failing if the destination already exists.
 pub fn rename_noreplace_sync(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-	// #[cfg(target_os = "macos")]
-	// {
-	// 	let src = std::ffi::CString::new(src.as_ref().as_os_str().as_encoded_bytes())
-	// 		.map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
-	// 	let dst = std::ffi::CString::new(dst.as_ref().as_os_str().as_encoded_bytes())
-	// 		.map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidInput, error))?;
-	// 	const RENAME_EXCL: libc::c_uint = 1;
-	// 	let result = unsafe {
-	// 		libc::renameatx_np(
-	// 			libc::AT_FDCWD,
-	// 			src.as_ptr(),
-	// 			libc::AT_FDCWD,
-	// 			dst.as_ptr(),
-	// 			RENAME_EXCL,
-	// 		)
-	// 	};
-	// 	if result != 0 {
-	// 		let err = std::io::Error::last_os_error();
-	// 		return Err(err);
-	// 	}
-	// }
-
-	#[cfg(target_os = "macos")]
-	{
-		std::fs::rename(src, dst)?;
-	}
-
-	#[cfg(target_os = "linux")]
-	{
-		rustix::fs::renameat_with(
-			rustix::fs::CWD,
-			src.as_ref(),
-			rustix::fs::CWD,
-			dst.as_ref(),
-			rustix::fs::RenameFlags::NOREPLACE,
-		)
-		.map_err(std::io::Error::from)?;
-	}
+	// On macOS, rustix maps NOREPLACE to renameatx_np's RENAME_EXCL, so both platforms report EEXIST when the destination exists.
+	rustix::fs::renameat_with(
+		rustix::fs::CWD,
+		src.as_ref(),
+		rustix::fs::CWD,
+		dst.as_ref(),
+		rustix::fs::RenameFlags::NOREPLACE,
+	)
+	.map_err(std::io::Error::from)?;
 
 	Ok(())
 }


### PR DESCRIPTION
On main, the `rename_noreplace_sync` code on macOS was falling through to plain `std::fs::rename` which does not have the intended `noreplace` semantics. The rustix code already used for Linux handles this correctly - it maps the `NOREPLACE` flag to `RENAME_EXCL` on macOS. We can use the same code block on both platforms for the intended semantics across the board. 

The included regression test demonstrates a case where the `std::fs::rename` semantics cause a problematic race. Two concurrent checkins of identical content race to rename into the same checkout path. On macOS the loser saw `ENOTEMPTY`, which callers do not tolerate, instead of the tolerated `EEXIST`.