### PR TITLE
fix(server): assert SIGINT waits for a running process and SIGTERM does not

### DIFF
--- a/packages/cli/src/server/run.rs
+++ b/packages/cli/src/server/run.rs
@@ -8,7 +8,7 @@ use {
 		path::PathBuf,
 	},
 	tangram_client::prelude::*,
-	tangram_server::Owned as Server,
+	tangram_server::{Owned as Server, Shutdown},
 	tangram_uri::Uri,
 };
 
@@ -143,19 +143,18 @@ impl Cli {
 			let shutdown = tokio::select! {
 				result = server.wait() => {
 					result.unwrap();
-					false
+					None
 				},
 				_ = interrupt.recv() => {
-					server.stop();
-					true
+					Some(Shutdown::Interrupt)
 				},
 				_ = terminate.recv() => {
-					server.terminate();
-					true
+					Some(Shutdown::Terminate)
 				},
 			};
 
-			if shutdown {
+			if let Some(shutdown) = shutdown {
+				server.shutdown(shutdown);
 				tokio::select! {
 					result = server.wait() => {
 						result.unwrap();

--- a/packages/cli/src/server/run.rs
+++ b/packages/cli/src/server/run.rs
@@ -150,7 +150,7 @@ impl Cli {
 					true
 				},
 				_ = terminate.recv() => {
-					server.stop();
+					server.terminate();
 					true
 				},
 			};

--- a/packages/cli/tests/server/sigint_waits_for_running_process.nu
+++ b/packages/cli/tests/server/sigint_waits_for_running_process.nu
@@ -1,0 +1,29 @@
+use ../../test.nu *
+
+# SIGINT shuts the server down gracefully, so it waits for a running process to finish before it exits.
+
+let server = server spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			console.log("started");
+			await tg.sleep(10);
+		};
+	'
+}
+
+# Wait until the process is running, so that the server is signaled with work in flight.
+let process = tg build --detach $path | str trim
+wait_until { (tg log $process | complete).stdout | str contains 'started' } "the process must start"
+
+# Send SIGINT to the server.
+let pid = open ($server.directory | path join 'lock') | into int
+kill --signal 2 $pid
+
+# The server must keep running while the process runs.
+sleep 2sec
+assert (ps | where pid == $pid | is-not-empty) "the server must wait for the running process"
+
+# The server must exit once the process finishes.
+wait_until --timeout 30sec { ps | where pid == $pid | is-empty } "the server must exit after the process finishes"

--- a/packages/cli/tests/server/sigterm_does_not_wait_for_running_process.nu
+++ b/packages/cli/tests/server/sigterm_does_not_wait_for_running_process.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# SIGTERM shuts the server down immediately, so it must not wait for a running process to finish. It currently waits, because the CLI's signal handler treats SIGTERM exactly like SIGINT and calls Server::stop for both, and the shutdown then awaits the runner task, which waits for every running sandbox.
+# SIGTERM shuts the server down immediately, so it does not wait for a running process to finish.
 
 let server = server spawn
 

--- a/packages/cli/tests/server/sigterm_does_not_wait_for_running_process.nu
+++ b/packages/cli/tests/server/sigterm_does_not_wait_for_running_process.nu
@@ -1,0 +1,25 @@
+use ../../test.nu *
+
+# SIGTERM shuts the server down immediately, so it must not wait for a running process to finish. It currently waits, because the CLI's signal handler treats SIGTERM exactly like SIGINT and calls Server::stop for both, and the shutdown then awaits the runner task, which waits for every running sandbox.
+
+let server = server spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			console.log("started");
+			await tg.sleep(60);
+		};
+	'
+}
+
+# Wait until the process is running, so that the server is signaled with work in flight.
+let process = tg build --detach $path | str trim
+wait_until { (tg log $process | complete).stdout | str contains 'started' } "the process must start"
+
+# Send SIGTERM to the server.
+let pid = open ($server.directory | path join 'lock') | into int
+kill --signal 15 $pid
+
+# The server must exit rather than wait for the process to finish.
+wait_until --timeout 20sec { ps | where pid == $pid | is-empty } "the server must exit without waiting for the running process"

--- a/packages/cli/tests/server/sigterm_during_process_control_connection.nu
+++ b/packages/cli/tests/server/sigterm_during_process_control_connection.nu
@@ -1,0 +1,49 @@
+use ../../test.nu *
+
+# SIGTERM terminates a process that starts before its process control stream connects.
+
+let server = server spawn --config {
+	advanced: { checkpoints: true },
+}
+
+let control_watch = (
+	tg checkpoint watch runner.process.control.connect
+	| from json
+	| get watch
+)
+let start_watch = (
+	tg checkpoint watch runner.process.start
+	| from json
+	| get watch
+)
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			await tg.sleep(60);
+		};
+	'
+}
+let build = job spawn {
+	let job_id = job id
+	let output = tg build $path | complete
+	$output | job send --tag $job_id 0
+}
+
+# Hold process control before it connects, then allow the process to start.
+let output = timeout 10s tg checkpoint wait runner.process.control.connect $control_watch 0 | complete
+success $output "process control must reach the connection checkpoint"
+let output = timeout 10s tg checkpoint wait runner.process.start $start_watch 0 | complete
+success $output "the process must reach the start checkpoint"
+tg checkpoint continue runner.process.start $start_watch 0
+tg checkpoint unwatch runner.process.start $start_watch
+sleep 1sec
+
+# Send SIGTERM to the server while process control remains blocked.
+let pid = open ($server.directory | path join 'lock') | into int
+kill --signal 15 $pid
+
+# The server and build request must exit without process control connecting.
+wait_until --timeout 20sec { ps | where pid == $pid | is-empty } "the server must exit without waiting for process control"
+let output = job recv --tag $build --timeout 10sec
+assert ($output != null) "the build request must exit with the server"

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -20,7 +20,7 @@ use {
 	},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
-	tangram_futures::task::{Stopper, Task},
+	tangram_futures::task::Task,
 	tangram_index::Index as _,
 	tangram_uri::Uri,
 	tangram_util::fs::remove,
@@ -101,6 +101,12 @@ pub struct Owned {
 #[derive(Clone)]
 pub struct Server(Arc<State>);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Shutdown {
+	Interrupt,
+	Terminate,
+}
+
 pub struct State {
 	authentication_tokens: Tokens,
 	authorization_tokens: Tokens,
@@ -141,9 +147,9 @@ pub struct State {
 	sandbox_vm_image_lock: tokio::sync::Mutex<bool>,
 	#[cfg(target_os = "linux")]
 	sandbox_vm_snapshot_lock: tokio::sync::Mutex<()>,
+	shutdown: tokio::sync::watch::Sender<Option<Shutdown>>,
 	tangram_path: PathBuf,
 	temps: DashSet<PathBuf, fnv::FnvBuildHasher>,
-	terminate: Stopper,
 	version: String,
 	vfs: Mutex<Option<self::vfs::Server>>,
 	watches: DashMap<self::watch::Key, Watch, fnv::FnvBuildHasher>,
@@ -155,14 +161,11 @@ pub struct Tokens {
 }
 
 impl Owned {
-	/// Stop the server, waiting for running processes to finish.
-	pub fn stop(&self) {
-		self.task.stop();
-	}
-
-	/// Stop the server without waiting for running processes to finish.
-	pub fn terminate(&self) {
-		self.server.terminate.stop();
+	pub fn shutdown(&self, shutdown: Shutdown) {
+		self.server.shutdown.send_replace(Some(shutdown));
+		if let Some(task) = self.server.runner.task().lock().unwrap().as_ref() {
+			task.stop();
+		}
 		self.task.stop();
 	}
 
@@ -880,8 +883,8 @@ impl Server {
 		// Create the temp paths.
 		let temps = DashSet::default();
 
-		// Create the terminate stopper.
-		let terminate = Stopper::new();
+		// Create the shutdown channel.
+		let (shutdown, _) = tokio::sync::watch::channel(None);
 
 		// Get the version.
 		let version = config
@@ -957,9 +960,9 @@ impl Server {
 			sandbox_vm_image_lock: tokio::sync::Mutex::new(false),
 			#[cfg(target_os = "linux")]
 			sandbox_vm_snapshot_lock: tokio::sync::Mutex::new(()),
+			shutdown,
 			tangram_path,
 			temps,
-			terminate,
 			version,
 			vfs,
 			watches,
@@ -1282,9 +1285,17 @@ impl Server {
 			async move {
 				tracing::trace!("started");
 
-				// Stop and await the HTTP task.
-				if let Some(task) = http_task {
+				// Stop the HTTP and runner tasks.
+				if let Some(task) = &http_task {
 					task.stop();
+				}
+				let runner_task = server.runner.task().lock().unwrap().take();
+				if let Some(task) = &runner_task {
+					task.stop();
+				}
+
+				// Await the HTTP task.
+				if let Some(task) = http_task {
 					let result = task.wait().await;
 					if let Err(error) = result
 						&& !error.is_cancelled()
@@ -1294,10 +1305,8 @@ impl Server {
 					tracing::trace!("http task");
 				}
 
-				// Stop the runner task.
-				let runner_task = server.runner.task().lock().unwrap().take();
+				// Await the runner task.
 				if let Some(task) = runner_task {
-					task.stop();
 					let result = task.wait().await;
 					if let Err(error) = result
 						&& !error.is_cancelled()

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -20,7 +20,7 @@ use {
 	},
 	tangram_client::prelude::*,
 	tangram_database::{self as db, prelude::*},
-	tangram_futures::task::Task,
+	tangram_futures::task::{Stopper, Task},
 	tangram_index::Index as _,
 	tangram_uri::Uri,
 	tangram_util::fs::remove,
@@ -143,6 +143,7 @@ pub struct State {
 	sandbox_vm_snapshot_lock: tokio::sync::Mutex<()>,
 	tangram_path: PathBuf,
 	temps: DashSet<PathBuf, fnv::FnvBuildHasher>,
+	terminate: Stopper,
 	version: String,
 	vfs: Mutex<Option<self::vfs::Server>>,
 	watches: DashMap<self::watch::Key, Watch, fnv::FnvBuildHasher>,
@@ -154,7 +155,14 @@ pub struct Tokens {
 }
 
 impl Owned {
+	/// Stop the server, waiting for running processes to finish.
 	pub fn stop(&self) {
+		self.task.stop();
+	}
+
+	/// Stop the server without waiting for running processes to finish.
+	pub fn terminate(&self) {
+		self.server.terminate.stop();
 		self.task.stop();
 	}
 
@@ -872,6 +880,9 @@ impl Server {
 		// Create the temp paths.
 		let temps = DashSet::default();
 
+		// Create the terminate stopper.
+		let terminate = Stopper::new();
+
 		// Get the version.
 		let version = config
 			.version
@@ -948,6 +959,7 @@ impl Server {
 			sandbox_vm_snapshot_lock: tokio::sync::Mutex::new(()),
 			tangram_path,
 			temps,
+			terminate,
 			version,
 			vfs,
 			watches,

--- a/packages/server/src/runner.rs
+++ b/packages/server/src/runner.rs
@@ -1,6 +1,6 @@
 use {
-	crate::Session,
-	futures::{FutureExt as _, StreamExt as _, future},
+	crate::{Session, Shutdown},
+	futures::{FutureExt as _, StreamExt as _, future, stream::FuturesUnordered},
 	std::{
 		ops::ControlFlow,
 		pin::pin,
@@ -242,12 +242,54 @@ impl Session {
 			}
 		}
 
-		// Stop the sandbox pool.
-		self.stop_sandbox_pool().await;
+		let shutdown = self
+			.server
+			.shutdown
+			.borrow()
+			.expect("the shutdown mode was not set");
 
-		// Stop retaining finished sandbox state and wait for running sandboxes to finish.
-		self.server.sandbox_tasks.stop_all();
-		let results = self.server.sandbox_tasks.wait().await;
+		// Stop the sandbox pool.
+		self.shutdown_sandbox_pool(shutdown).await;
+
+		// Shut down the sandbox tasks.
+		let sandboxes = match shutdown {
+			Shutdown::Interrupt => {
+				self.server.sandbox_tasks.stop_all();
+				Vec::new()
+			},
+			Shutdown::Terminate => {
+				let sandboxes = self
+					.server
+					.runner
+					.state
+					.sandboxes
+					.iter()
+					.filter_map(|sandbox| {
+						for process in sandbox.processes.iter() {
+							process.stopper.stop();
+						}
+						let id = sandbox.id.clone();
+						let sandbox = sandbox.sandbox.clone()?;
+
+						Some((id, sandbox))
+					})
+					.collect::<Vec<_>>();
+				self.server.sandbox_tasks.abort_all();
+
+				sandboxes
+			},
+		};
+		let wait_future = self.server.sandbox_tasks.wait();
+		let terminate_future = sandboxes
+			.into_iter()
+			.map(|(id, sandbox)| async move {
+				if let Err(error) = sandbox.destroy().await {
+					tracing::error!(?id, error = %error.trace(), "failed to terminate a sandbox");
+				}
+			})
+			.collect::<FuturesUnordered<_>>()
+			.collect::<()>();
+		let (results, ()) = tokio::join!(wait_future, terminate_future);
 		for result in results {
 			if let Err(error) = result
 				&& !error.is_cancelled()
@@ -261,8 +303,12 @@ impl Session {
 		self.server.runner.sandbox_pool.start(self);
 	}
 
+	pub(crate) async fn shutdown_sandbox_pool(&self, shutdown: Shutdown) {
+		self.server.runner.sandbox_pool.shutdown(shutdown).await;
+	}
+
 	pub(crate) async fn stop_sandbox_pool(&self) {
-		self.server.runner.sandbox_pool.stop().await;
+		self.shutdown_sandbox_pool(Shutdown::Interrupt).await;
 	}
 
 	async fn runner_task_inner(&self, id: &tg::runner::Id, stopper: Stopper) -> tg::Result<()> {

--- a/packages/server/src/runner/process.rs
+++ b/packages/server/src/runner/process.rs
@@ -168,7 +168,11 @@ impl Session {
 				sandbox_id_receiver,
 				sandbox_stopper,
 			};
-			let result = session.process_task(arg).boxed().await;
+			let result = if session.server.shutdown.borrow().is_some() {
+				Err(tg::error!("the server is shutting down"))
+			} else {
+				session.process_task(arg).boxed().await
+			};
 			if let Err(error) = &result {
 				event_sender.send(Err(error.clone())).ok();
 			}

--- a/packages/server/src/runner/sandbox.rs
+++ b/packages/server/src/runner/sandbox.rs
@@ -1003,6 +1003,11 @@ impl Session {
 				() = current_timer_future => {
 					break;
 				},
+
+				// If the server is terminating, then break and destroy the sandbox.
+				() = self.server.terminate.wait() => {
+					break;
+				},
 			}
 		}
 
@@ -1195,7 +1200,10 @@ impl Session {
 					let message = message
 						.map_err(|error| tg::error!(!error, %id, "failed to receive a sandbox control message"))?;
 					let Some(message) = message else {
-						retention_future.await;
+						tokio::select! {
+							() = &mut retention_future => {},
+							() = stopper.wait() => {},
+						}
 						break;
 					};
 					match message {

--- a/packages/server/src/runner/sandbox.rs
+++ b/packages/server/src/runner/sandbox.rs
@@ -146,7 +146,11 @@ impl Server {
 					stopper,
 					token: arg.token,
 				};
-				let result = session.sandbox_task(arg).boxed().await;
+				let result = if server.shutdown.borrow().is_some() {
+					Err(tg::error!("the server is shutting down"))
+				} else {
+					session.sandbox_task(arg).boxed().await
+				};
 				if let Err(error) = &result {
 					event_sender.send(Err(error.clone())).ok();
 				}
@@ -1003,11 +1007,6 @@ impl Session {
 				() = current_timer_future => {
 					break;
 				},
-
-				// If the server is terminating, then break and destroy the sandbox.
-				() = self.server.terminate.wait() => {
-					break;
-				},
 			}
 		}
 
@@ -1200,10 +1199,7 @@ impl Session {
 					let message = message
 						.map_err(|error| tg::error!(!error, %id, "failed to receive a sandbox control message"))?;
 					let Some(message) = message else {
-						tokio::select! {
-							() = &mut retention_future => {},
-							() = stopper.wait() => {},
-						}
+						retention_future.await;
 						break;
 					};
 					match message {

--- a/packages/server/src/runner/sandbox/pool.rs
+++ b/packages/server/src/runner/sandbox/pool.rs
@@ -1,6 +1,7 @@
 use {
 	super::{CreateSandboxArg, CreateSandboxOutput},
-	crate::Session,
+	crate::{Session, Shutdown},
+	futures::{StreamExt as _, stream::FuturesUnordered},
 	std::{collections::VecDeque, sync::Mutex},
 	tangram_client::prelude::*,
 	tangram_futures::task::Task,
@@ -45,27 +46,40 @@ impl Pool {
 		Some(task)
 	}
 
-	pub(in crate::runner) async fn stop(&self) {
+	pub(in crate::runner) async fn shutdown(&self, shutdown: Shutdown) {
 		let tasks = self.inner.lock().unwrap().drain(..).collect::<Vec<_>>();
-		for task in tasks {
-			match task.wait().await {
-				Ok(Ok(output)) => {
-					if let Err(error) = destroy(output).await {
-						tracing::error!(
-							error = %error.trace(),
-							"failed to destroy a pooled sandbox",
-						);
-					}
-				},
-				Ok(Err(error)) => {
-					tracing::error!(error = %error.trace(), "failed to warm a sandbox");
-				},
-				Err(error) if error.is_cancelled() => {},
-				Err(error) => {
-					tracing::error!(?error, "a sandbox pool task panicked");
-				},
-			}
+		match shutdown {
+			Shutdown::Interrupt => {},
+			Shutdown::Terminate => {
+				for task in &tasks {
+					task.abort();
+				}
+			},
 		}
+		tasks
+			.into_iter()
+			.map(|task| async move {
+				match task.wait().await {
+					Ok(Ok(output)) => {
+						if let Err(error) = destroy(output).await {
+							tracing::error!(
+								error = %error.trace(),
+								"failed to destroy a pooled sandbox",
+							);
+						}
+					},
+					Ok(Err(error)) => {
+						tracing::error!(error = %error.trace(), "failed to warm a sandbox");
+					},
+					Err(error) if error.is_cancelled() => {},
+					Err(error) => {
+						tracing::error!(?error, "a sandbox pool task panicked");
+					},
+				}
+			})
+			.collect::<FuturesUnordered<_>>()
+			.collect::<()>()
+			.await;
 	}
 
 	#[must_use]


### PR DESCRIPTION
The SIGINT test passes and the SIGTERM one fails today, as there is no difference in behavior.