### PR TITLE
fix(server): fall back to the index when the runner cannot answer a process get

### DIFF
--- a/packages/cli/tests/process/get_after_runner_lost.nu
+++ b/packages/cli/tests/process/get_after_runner_lost.nu
@@ -1,0 +1,62 @@
+use ../../test.nu *
+
+# Getting a process whose runner is gone must return the record the index already
+# has. The get races the index against a control request to the runner, and when
+# the index answers first with a process it has not yet seen finish, it blocks on
+# a runner that will never answer.
+
+let root_token = random chars
+let remote = server spawn --name remote --config {
+	authentication: { root: { token: $root_token } },
+	roles: [cleaner http indexer scheduler],
+	scheduler: {
+		heartbeat_ttl: 10.0,
+		runner_ttl: 10.0,
+	},
+}
+let created = tg --url $remote.url --token $root_token runner create | from json
+let runner = server spawn --name runner --config {
+	remotes: {
+		default: {
+			token: $created.token.token,
+			url: $remote.url,
+		},
+	},
+	runner: {
+		cpus: 1,
+		id: $created.runner.id,
+		memory: 1_073_741_824,
+		remote: "default",
+		token: $created.token.token,
+	},
+}
+let local = server spawn --name local --config {
+	remotes: {
+		default: {
+			token: $root_token,
+			url: $remote.url,
+		},
+	},
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			await tg.sleep(120);
+		}
+	'
+}
+
+let id = tg --url $local.url build --remote --detach $path | str trim
+let started = tg --url $remote.url --token $root_token get $id | from json
+assert ($started.status == 'started') "the process must be started"
+
+# Lose the runner. The index keeps the started process until the scheduler expires
+# its heartbeat, so the get has an answer to give the whole time.
+job kill $runner.job
+
+let start = (date now)
+let process = tg --url $remote.url --token $root_token get $id | from json
+let elapsed = (((date now) - $start) / 1sec | math round -p 2)
+assert ($elapsed < 5) $"getting a process without a runner took ($elapsed)s"
+assert ($process.command == $started.command) "the get must return the process"

--- a/packages/cli/tests/process/get_after_runner_lost.nu
+++ b/packages/cli/tests/process/get_after_runner_lost.nu
@@ -60,3 +60,4 @@ let process = tg --url $remote.url --token $root_token get $id | from json
 let elapsed = (((date now) - $start) / 1sec | math round -p 2)
 assert ($elapsed < 5) $"getting a process without a runner took ($elapsed)s"
 assert ($process.command == $started.command) "the get must return the process"
+assert ($process.status == 'started') "the get must return the indexed process state"

--- a/packages/server/src/process/get.rs
+++ b/packages/server/src/process/get.rs
@@ -256,8 +256,11 @@ impl Session {
 					let data = indexed.data.unwrap();
 					self.create_process_get_output(id, data, metadata.then_some(indexed.metadata))
 				} else {
-					// The runner has the freshest data, but it may have released the process, so fall back to the index.
-					let Ok(data) = control_future.await else {
+					// Give the runner a short opportunity to provide fresher data before falling back to the index.
+					let Ok(Ok(data)) =
+						tokio::time::timeout(std::time::Duration::from_secs(1), control_future)
+							.await
+					else {
 						let data = indexed
 							.data
 							.ok_or_else(|| tg::error!(%id, "missing the process data"))?;
@@ -290,7 +293,6 @@ impl Session {
 				}
 			},
 			future::Either::Right((data, index_future)) => {
-				// The runner has the freshest data, but it may have released the process, so fall back to the index.
 				let Ok(data) = data else {
 					let Some(indexed) = index_future.await? else {
 						return Ok(None);
@@ -356,14 +358,13 @@ impl Session {
 		let request = tg::process::control::ServerRequestArg::Get(
 			tg::process::control::GetServerRequestArg {},
 		);
-		// A runner that has released the process never answers, so bound the request.
 		let retry = tangram_futures::retry::Options {
-			max_retries: 1,
+			max_retries: u64::MAX,
 			..Default::default()
 		};
 		let options = crate::control::Options {
 			retry,
-			timeout: std::time::Duration::from_secs(1),
+			timeout: std::time::Duration::from_secs(10),
 		};
 		let response = self
 			.send_process_control_request(id, request, options)

--- a/packages/server/src/process/get.rs
+++ b/packages/server/src/process/get.rs
@@ -256,7 +256,18 @@ impl Session {
 					let data = indexed.data.unwrap();
 					self.create_process_get_output(id, data, metadata.then_some(indexed.metadata))
 				} else {
-					let data = control_future.await?;
+					// The runner has the freshest data, but it may have released the process, so fall back to the index.
+					let Ok(data) = control_future.await else {
+						let data = indexed
+							.data
+							.ok_or_else(|| tg::error!(%id, "missing the process data"))?;
+						let output = self.create_process_get_output(
+							id,
+							data,
+							metadata.then_some(indexed.metadata),
+						);
+						return Ok(Some(output));
+					};
 					if data.status.is_finished() {
 						let Some(indexed) = self.try_get_process_from_index(id).await? else {
 							return Ok(None);
@@ -279,7 +290,21 @@ impl Session {
 				}
 			},
 			future::Either::Right((data, index_future)) => {
-				let data = data?;
+				// The runner has the freshest data, but it may have released the process, so fall back to the index.
+				let Ok(data) = data else {
+					let Some(indexed) = index_future.await? else {
+						return Ok(None);
+					};
+					let data = indexed
+						.data
+						.ok_or_else(|| tg::error!(%id, "missing the process data"))?;
+					let output = self.create_process_get_output(
+						id,
+						data,
+						metadata.then_some(indexed.metadata),
+					);
+					return Ok(Some(output));
+				};
 				if data.status.is_finished() {
 					let Some(indexed) = self.try_get_process_from_index(id).await? else {
 						return Ok(None);
@@ -331,13 +356,14 @@ impl Session {
 		let request = tg::process::control::ServerRequestArg::Get(
 			tg::process::control::GetServerRequestArg {},
 		);
+		// A runner that has released the process never answers, so bound the request.
 		let retry = tangram_futures::retry::Options {
-			max_retries: u64::MAX,
+			max_retries: 1,
 			..Default::default()
 		};
 		let options = crate::control::Options {
 			retry,
-			timeout: std::time::Duration::from_secs(10),
+			timeout: std::time::Duration::from_secs(1),
 		};
 		let response = self
 			.send_process_control_request(id, request, options)

--- a/packages/server/src/process/get.rs
+++ b/packages/server/src/process/get.rs
@@ -256,7 +256,6 @@ impl Session {
 					let data = indexed.data.unwrap();
 					self.create_process_get_output(id, data, metadata.then_some(indexed.metadata))
 				} else {
-					// Give the runner a short opportunity to provide fresher data before falling back to the index.
 					let Ok(Ok(data)) =
 						tokio::time::timeout(std::time::Duration::from_secs(1), control_future)
 							.await


### PR DESCRIPTION
`try_get_process_local_inner_attempt` races the index against a control request to the runner. When the index answers first with a process it has not seen finish,
the get awaits the runner with unbounded retries and propagates whatever it returns. A runner that has released the process answers "failed to find the
process" and fails the get; a runner that is gone never answers and blocks it until the scheduler expires the heartbeat.

Bound the control request and treat its failure as the absence of live data, answering from the index record already in hand.