### PR TITLE
feat(sandbox): mount cgroup2 on /sys/fs/cgroup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8260,6 +8260,7 @@ dependencies = [
  "neli",
  "num",
  "rand 0.10.2",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "serde_with",

--- a/packages/cli/tests/sandbox_sys_cgroup.nu
+++ b/packages/cli/tests/sandbox_sys_cgroup.nu
@@ -8,7 +8,14 @@ if $nu.os-info.name != 'linux' {
 
 let uid = ^id -u | str trim
 let gid = ^id -g | str trim
+let outer_cgroup = $'tangram-test-(random uuid)'
+let nested_cgroup = $'tangram-test-(random uuid)'
+
+# A cgroup requires the mount namespace to be unshared.
+let output = ^tangram sandbox container run --cgroup $outer_cgroup --gid $gid --index 0 --uid $uid -- /bin/true | complete
+failure $output
+assert ($output.stderr | str contains 'mount operations require --unshare-all')
 
 # Mask /sys with a tmpfs. A real sandbox overlays the rootfs onto /, where /sys is an empty directory, so without this the outer sandbox inherits the host's cgroup mount and the nested one succeeds for the wrong reason.
-let output = tg sandbox container run --cgroup outer --dev /dev --gid $gid --index 0 --tmpfs /sys --uid $uid --unshare-all -- tangram sandbox container run --cgroup nested --gid $gid --index 0 --uid $uid --unshare-all -- /bin/sh -c 'exit 0' | complete
+let output = tg sandbox container run --cgroup $outer_cgroup --dev /dev --gid $gid --index 0 --tmpfs /sys --uid $uid --unshare-all -- tangram sandbox container run --cgroup $nested_cgroup --gid $gid --index 0 --uid $uid --unshare-all -- /bin/sh -c 'exit 0' | complete
 success $output 'a nested sandbox failed to create its cgroup'

--- a/packages/cli/tests/sandbox_sys_cgroup.nu
+++ b/packages/cli/tests/sandbox_sys_cgroup.nu
@@ -1,0 +1,14 @@
+use ../test.nu *
+
+# A container sandbox has cgroup v2 mounted at /sys/fs/cgroup. A server creates a cgroup for every sandbox it spawns, so a server running in a sandbox cannot spawn one without it.
+
+if $nu.os-info.name != 'linux' {
+	skip_test 'this test requires linux'
+}
+
+let uid = ^id -u | str trim
+let gid = ^id -g | str trim
+
+# Mask /sys with a tmpfs. A real sandbox overlays the rootfs onto /, where /sys is an empty directory, so without this the outer sandbox inherits the host's cgroup mount and the nested one succeeds for the wrong reason.
+let output = tg sandbox container run --cgroup outer --dev /dev --gid $gid --index 0 --tmpfs /sys --uid $uid --unshare-all -- tangram sandbox container run --cgroup nested --gid $gid --index 0 --uid $uid --unshare-all -- /bin/sh -c 'exit 0' | complete
+success $output 'a nested sandbox failed to create its cgroup'

--- a/packages/cli/tests/sandbox_sys_cgroup.nu
+++ b/packages/cli/tests/sandbox_sys_cgroup.nu
@@ -14,7 +14,10 @@ let nested_cgroup = $'tangram-test-(random uuid)'
 # A cgroup requires the mount namespace to be unshared.
 let output = ^tangram sandbox container run --cgroup $outer_cgroup --gid $gid --index 0 --uid $uid -- /bin/true | complete
 failure $output
-assert ($output.stderr | str contains 'mount operations require --unshare-all')
+snapshot $output.stderr '
+	-> mount operations require --unshare-all
+
+'
 
 # Mask /sys with a tmpfs. A real sandbox overlays the rootfs onto /, where /sys is an empty directory, so without this the outer sandbox inherits the host's cgroup mount and the nested one succeeds for the wrong reason.
 let output = tg sandbox container run --cgroup $outer_cgroup --dev /dev --gid $gid --index 0 --tmpfs /sys --uid $uid --unshare-all -- tangram sandbox container run --cgroup $nested_cgroup --gid $gid --index 0 --uid $uid --unshare-all -- /bin/sh -c 'exit 0' | complete

--- a/packages/sandbox/Cargo.toml
+++ b/packages/sandbox/Cargo.toml
@@ -35,6 +35,7 @@ libc = { workspace = true }
 mime = { workspace = true }
 num = { workspace = true }
 rand = { workspace = true }
+rustix = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }

--- a/packages/sandbox/src/container/cgroup.rs
+++ b/packages/sandbox/src/container/cgroup.rs
@@ -41,6 +41,8 @@ impl Cgroup {
 			validate_controller_enabled(&current, "pids")?;
 		}
 		let name = sanitize_name(name);
+		// Hold the parent directory open so the cgroup can be removed even after the sandbox replaces the cgroup mount it was resolved through.
+		let parent = open_directory(&current)?;
 		let path = current.join(&name);
 		std::fs::create_dir(&path).map_err(|error| {
 			tg::error!(
@@ -49,8 +51,6 @@ impl Cgroup {
 				"failed to create the cgroup"
 			)
 		})?;
-		// Hold the parent directory open so the cgroup can be removed even after the sandbox replaces the cgroup mount it was resolved through.
-		let parent = open_directory(&current)?;
 		let cgroup = Self {
 			name,
 			parent,

--- a/packages/sandbox/src/container/cgroup.rs
+++ b/packages/sandbox/src/container/cgroup.rs
@@ -23,6 +23,7 @@ pub struct Options {
 
 impl Cgroup {
 	pub fn new(name: &str, options: Options) -> tg::Result<Self> {
+		use std::os::unix::fs::OpenOptionsExt as _;
 		let root = Path::new("/sys/fs/cgroup");
 		if !root.join("cgroup.controllers").exists() {
 			return Err(tg::error!("cgroup v2 is not available"));
@@ -42,7 +43,18 @@ impl Cgroup {
 		}
 		let name = sanitize_name(name);
 		// Hold the parent directory open so the cgroup can be removed even after the sandbox replaces the cgroup mount it was resolved through.
-		let parent = open_directory(&current)?;
+		let parent = std::fs::OpenOptions::new()
+			.read(true)
+			.custom_flags(libc::O_DIRECTORY | libc::O_PATH)
+			.open(&current)
+			.map_err(|error| {
+				tg::error!(
+					!error,
+					path = %current.display(),
+					"failed to open the cgroup directory",
+				)
+			})?;
+		let parent = OwnedFd::from(parent);
 		let path = current.join(&name);
 		std::fs::create_dir(&path).map_err(|error| {
 			tg::error!(
@@ -143,22 +155,6 @@ impl Drop for Cgroup {
 			tracing::error!(%error, path = %self.path.display(), "failed to remove cgroup");
 		}
 	}
-}
-
-fn open_directory(path: &Path) -> tg::Result<OwnedFd> {
-	use std::os::unix::fs::OpenOptionsExt as _;
-	let file = std::fs::OpenOptions::new()
-		.read(true)
-		.custom_flags(libc::O_DIRECTORY | libc::O_PATH)
-		.open(path)
-		.map_err(|error| {
-			tg::error!(
-				!error,
-				path = %path.display(),
-				"failed to open the cgroup directory",
-			)
-		})?;
-	Ok(OwnedFd::from(file))
 }
 
 fn sanitize_name(name: &str) -> String {

--- a/packages/sandbox/src/container/cgroup.rs
+++ b/packages/sandbox/src/container/cgroup.rs
@@ -1,7 +1,7 @@
 use {
+	rustix::fs::{AtFlags, unlinkat},
 	std::{
-		ffi::CString,
-		os::fd::{AsRawFd as _, OwnedFd},
+		os::fd::OwnedFd,
 		path::{Path, PathBuf},
 	},
 	tangram_client::prelude::*,
@@ -139,12 +139,7 @@ impl Cgroup {
 
 impl Drop for Cgroup {
 	fn drop(&mut self) {
-		let name = CString::new(self.name.as_bytes()).unwrap();
-		// SAFETY: The descriptor and name remain valid for the duration of the syscall.
-		let result =
-			unsafe { libc::unlinkat(self.parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
-		if result != 0 {
-			let error = std::io::Error::last_os_error();
+		if let Err(error) = unlinkat(&self.parent, self.name.as_str(), AtFlags::REMOVEDIR) {
 			tracing::error!(%error, path = %self.path.display(), "failed to remove cgroup");
 		}
 	}

--- a/packages/sandbox/src/container/cgroup.rs
+++ b/packages/sandbox/src/container/cgroup.rs
@@ -1,12 +1,15 @@
 use {
 	std::{
-		os::fd::OwnedFd,
+		ffi::CString,
+		os::fd::{AsRawFd as _, OwnedFd},
 		path::{Path, PathBuf},
 	},
 	tangram_client::prelude::*,
 };
 
 pub struct Cgroup {
+	name: String,
+	parent: OwnedFd,
 	path: PathBuf,
 }
 
@@ -37,7 +40,8 @@ impl Cgroup {
 		if options.pids.is_some() {
 			validate_controller_enabled(&current, "pids")?;
 		}
-		let path = current.join(sanitize_name(name));
+		let name = sanitize_name(name);
+		let path = current.join(&name);
 		std::fs::create_dir(&path).map_err(|error| {
 			tg::error!(
 				!error,
@@ -45,7 +49,13 @@ impl Cgroup {
 				"failed to create the cgroup"
 			)
 		})?;
-		let cgroup = Self { path: path.clone() };
+		// Hold the parent directory open so the cgroup can be removed even after the sandbox replaces the cgroup mount it was resolved through.
+		let parent = open_directory(&current)?;
+		let cgroup = Self {
+			name,
+			parent,
+			path: path.clone(),
+		};
 
 		if let Some(cpu) = options.cpu {
 			let quota = cpu
@@ -129,12 +139,31 @@ impl Cgroup {
 
 impl Drop for Cgroup {
 	fn drop(&mut self) {
-		std::fs::remove_dir(&self.path)
-			.inspect_err(
-				|error| tracing::error!(%error, path = %self.path.display(), "failed to remove cgroup"),
-			)
-			.ok();
+		let name = CString::new(self.name.as_bytes()).unwrap();
+		// SAFETY: The descriptor and name remain valid for the duration of the syscall.
+		let result =
+			unsafe { libc::unlinkat(self.parent.as_raw_fd(), name.as_ptr(), libc::AT_REMOVEDIR) };
+		if result != 0 {
+			let error = std::io::Error::last_os_error();
+			tracing::error!(%error, path = %self.path.display(), "failed to remove cgroup");
+		}
 	}
+}
+
+fn open_directory(path: &Path) -> tg::Result<OwnedFd> {
+	use std::os::unix::fs::OpenOptionsExt as _;
+	let file = std::fs::OpenOptions::new()
+		.read(true)
+		.custom_flags(libc::O_DIRECTORY | libc::O_PATH)
+		.open(path)
+		.map_err(|error| {
+			tg::error!(
+				!error,
+				path = %path.display(),
+				"failed to open the cgroup directory",
+			)
+		})?;
+	Ok(OwnedFd::from(file))
 }
 
 fn sanitize_name(name: &str) -> String {

--- a/packages/sandbox/src/container/mount.rs
+++ b/packages/sandbox/src/container/mount.rs
@@ -69,6 +69,10 @@ pub fn apply(arg: &Arg, root: Option<&Path>) -> tg::Result<()> {
 		mount_proc(&map_target(root, target)?)?;
 	}
 
+	if arg.cgroup.is_some() {
+		mount_cgroup(&map_target(root, Path::new("/sys/fs/cgroup"))?)?;
+	}
+
 	for overlay in overlays
 		.into_iter()
 		.filter(|overlay| overlay.target != Path::new("/"))
@@ -408,6 +412,39 @@ fn mount_proc(target: &Path) -> tg::Result<()> {
 		std::ptr::null_mut(),
 	)
 	.map_err(|error| tg::error!(!error, "failed to create the proc mount"))?;
+	Ok(())
+}
+
+fn mount_cgroup(target: &Path) -> tg::Result<()> {
+	std::fs::create_dir_all(target).map_err(|error| {
+		tg::error!(
+			!error,
+			path = %target.display(),
+			"failed to create the cgroup mountpoint"
+		)
+	})?;
+	let target = cstring(target);
+	// Mount a tmpfs first. An enclosing sandbox mounts cgroup2 at this path too, and the kernel refuses to mount a filesystem on its own mountpoint. That mount cannot be detached instead, because a mount inherited into an unprivileged mount namespace is locked.
+	let underlay_source = cstring("tmpfs");
+	let underlay_fstype = cstring("tmpfs");
+	mount_raw(
+		Some(&underlay_source),
+		&target,
+		Some(&underlay_fstype),
+		libc::MS_NODEV | libc::MS_NOEXEC | libc::MS_NOSUID,
+		std::ptr::null_mut(),
+	)
+	.map_err(|error| tg::error!(!error, "failed to create the cgroup underlay mount"))?;
+	let source = cstring("cgroup2");
+	let fstype = cstring("cgroup2");
+	mount_raw(
+		Some(&source),
+		&target,
+		Some(&fstype),
+		libc::MS_NODEV | libc::MS_NOEXEC | libc::MS_NOSUID,
+		std::ptr::null_mut(),
+	)
+	.map_err(|error| tg::error!(!error, "failed to create the cgroup mount"))?;
 	Ok(())
 }
 

--- a/packages/sandbox/src/container/run.rs
+++ b/packages/sandbox/src/container/run.rs
@@ -215,8 +215,12 @@ pub fn run(arg: &Arg) -> tg::Result<ExitCode> {
 		(fork()?, false)
 	};
 	if child == 0 {
-		let child_cgroup = move_child_to_cgroup.then(|| cgroup.as_ref().unwrap());
-		match child_main(arg, child_cgroup, root_path.as_ref()) {
+		match child_main(
+			arg,
+			cgroup.as_ref(),
+			move_child_to_cgroup,
+			root_path.as_ref(),
+		) {
 			Ok(()) => std::process::exit(0),
 			Err(error) => {
 				eprintln!("{error}");
@@ -278,6 +282,7 @@ fn clone3_cgroup_should_fallback(source: &std::io::Error) -> bool {
 fn child_main(
 	arg: &Arg,
 	cgroup: Option<&cgroup::Cgroup>,
+	move_self: bool,
 	root: Option<&PathBuf>,
 ) -> tg::Result<()> {
 	unsafe {
@@ -297,7 +302,14 @@ fn child_main(
 		crate::util::set_parent_death_signal(libc::SIGKILL)?;
 	}
 	if let Some(cgroup) = cgroup {
-		cgroup.move_self()?;
+		if move_self {
+			cgroup.move_self()?;
+		}
+		// Unshare the cgroup namespace only once the process is in its cgroup, so that cgroup becomes the namespace root and the mount below exposes nothing above it.
+		unshare(
+			libc::CLONE_NEWCGROUP,
+			"failed to unshare the cgroup namespace",
+		)?;
 	}
 	if arg.new_session {
 		start_session()?;

--- a/packages/sandbox/src/container/validate.rs
+++ b/packages/sandbox/src/container/validate.rs
@@ -188,6 +188,7 @@ fn validate_mount_target(path: &std::path::Path) -> tg::Result<()> {
 
 fn has_mounts(arg: &Arg) -> bool {
 	!arg.binds.is_empty()
+		|| arg.cgroup.is_some()
 		|| !arg.ro_binds.is_empty()
 		|| !arg.devs.is_empty()
 		|| !arg.overlay_sources.is_empty()


### PR DESCRIPTION
 Container sandboxes overlay the root filesystem, leaving `/sys/fs/cgroup` unavailable. This prevents a Tangram server running inside a sandbox from creating cgroups for nested sandboxes.

Mount cgroup v2 at `/sys/fs/cgroup` after moving the child into its cgroup and unsharing the cgroup namespace, exposing only the sandbox’s subtree. Use a tmpfs underlay to support locked inherited mounts, retain the parent directory descriptor for reliable cleanup, and require `--unshare-all` for cgroup mounts.

Add CLI coverage for validation and nested sandbox creation using collision-resistant cgroup names.