### PR TITLE
fix(index/authorize): visit the search frontier in depth order

### DIFF
--- a/packages/cli/tests/grants/process_input_authorize_exhausted.nu
+++ b/packages/cli/tests/grants/process_input_authorize_exhausted.nu
@@ -1,0 +1,26 @@
+use ../../test.nu *
+
+# A process must be able to check out a file its command references. The command that grants the process is one hop from the file in both directions, but the searches walk depth first, so the ancestor search climbs the file's directory parent instead of taking the command beside it, and the descendant search walks the command's directory child instead of taking the file beside it. Each abandons a proof it has already enqueued, and the authorization reports an error instead of an answer.
+
+let server = server spawn
+
+let deep = 0..<18 | reduce --fold 'tg.file("loader")' {|_, expr| ['tg.directory({ "a": ', $expr, ' })'] | str join }
+tg put $deep
+tg index
+
+let path = artifact {
+	tangram.ts: '
+		export const read = async (bulk: tg.Directory, loader: tg.File) => "ok";
+
+		export default async () => {
+			const entries: Record<string, tg.File> = {};
+			for (let i = 0; i < 600; i++) {
+				entries[`f${i}`] = tg.file(`${i}`);
+			}
+			return await tg.build(read, await tg.directory(entries), await tg.file("loader"));
+		}
+	'
+}
+
+let output = tg build $path | str trim
+assert equal $output '"ok"' 'a process must be able to check out a file its command references'

--- a/packages/index/src/fdb/authorize.rs
+++ b/packages/index/src/fdb/authorize.rs
@@ -704,12 +704,12 @@ impl Index {
 		if !budget.add_node(0) {
 			return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 		}
-		let mut stack = vec![AncestorTask::Node {
+		let mut queue = VecDeque::from([AncestorTask::Node {
 			depth: 0,
 			key: root.clone(),
-		}];
+		}]);
 		let mut visited = HashSet::from([root.clone()]);
-		while let Some(task) = stack.pop() {
+		while let Some(task) = queue.pop_front() {
 			match task {
 				AncestorTask::Node { depth, key } => {
 					if let Some(authorized) = authorization.value(&key) {
@@ -740,7 +740,7 @@ impl Index {
 						)
 						.await
 					);
-					for key in dependencies.into_iter().rev() {
+					for key in dependencies {
 						let depth = depth + 1;
 						if !budget.add_edge() {
 							return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
@@ -758,13 +758,13 @@ impl Index {
 							return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 						}
 						visited.insert(key.clone());
-						stack.push(AncestorTask::Node { depth, key });
+						queue.push_back(AncestorTask::Node { depth, key });
 					}
 
 					match permission {
 						tg::authorization::Permission::Object(_) => {
 							let object = tg::object::Id::try_from(resource)?;
-							stack.push(AncestorTask::ObjectParents {
+							queue.push_back(AncestorTask::ObjectParents {
 								after: None,
 								depth,
 								object,
@@ -772,7 +772,7 @@ impl Index {
 						},
 						tg::authorization::Permission::Process(permission) => {
 							let process = tg::process::Id::try_from(resource)?;
-							stack.push(AncestorTask::ProcessParents {
+							queue.push_back(AncestorTask::ProcessParents {
 								after: None,
 								depth,
 								permission,
@@ -810,13 +810,13 @@ impl Index {
 						.await
 					);
 					if let Some(after) = after {
-						stack.push(AncestorTask::ObjectParents {
+						queue.push_back(AncestorTask::ObjectParents {
 							after: Some(after),
 							depth,
 							object,
 						});
 					}
-					for key in keys.into_iter().rev() {
+					for key in keys {
 						let crate::fdb::Key::Object(crate::fdb::object::Key::ChildObject {
 							object,
 							..
@@ -847,7 +847,7 @@ impl Index {
 							return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 						}
 						visited.insert(key.clone());
-						stack.push(AncestorTask::Node { depth, key });
+						queue.push_back(AncestorTask::Node { depth, key });
 					}
 				},
 				AncestorTask::ProcessParents {
@@ -875,14 +875,14 @@ impl Index {
 						.await
 					);
 					if let Some(after) = after {
-						stack.push(AncestorTask::ProcessParents {
+						queue.push_back(AncestorTask::ProcessParents {
 							after: Some(after),
 							depth,
 							permission,
 							process,
 						});
 					}
-					for key in keys.into_iter().rev() {
+					for key in keys {
 						let crate::fdb::Key::Process(crate::fdb::process::Key::ChildProcess {
 							parent,
 							..
@@ -911,7 +911,7 @@ impl Index {
 							return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 						}
 						visited.insert(key.clone());
-						stack.push(AncestorTask::Node { depth, key });
+						queue.push_back(AncestorTask::Node { depth, key });
 					}
 				},
 			}
@@ -946,16 +946,16 @@ impl Index {
 
 		let mut budget = SearchBudget::new(context.config.descendant);
 		let mut complete = matches!(context.requester.principal, tg::Principal::Anonymous);
-		let mut stack = Vec::new();
+		let mut queue = VecDeque::new();
 		let mut visited = HashSet::new();
 
 		let public = tg::authorization::Subject::Public;
-		stack.push(DescendantTask::SubjectGrants {
+		queue.push_back(DescendantTask::SubjectGrants {
 			after: None,
 			subject: public.clone(),
 		});
 		if context.requester.subject != public {
-			stack.push(DescendantTask::SubjectGrants {
+			queue.push_back(DescendantTask::SubjectGrants {
 				after: None,
 				subject: context.requester.subject.clone(),
 			});
@@ -979,10 +979,10 @@ impl Index {
 			if !budget.add_node(0) {
 				return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 			}
-			stack.push(DescendantTask::Node { depth: 0, key });
+			queue.push_back(DescendantTask::Node { depth: 0, key });
 		}
 
-		while let Some(task) = stack.pop() {
+		while let Some(task) = queue.pop_front() {
 			match task {
 				DescendantTask::Node { depth, key } => {
 					if key.0 == target.0 && key.1.implies(target.1) {
@@ -995,7 +995,7 @@ impl Index {
 					} else {
 						crate::authorize::permissions_implied_by(permission)
 					};
-					for implied_permission in implied.into_iter().rev() {
+					for implied_permission in implied {
 						if implied_permission == permission {
 							continue;
 						}
@@ -1011,7 +1011,7 @@ impl Index {
 							return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 						}
 						visited.insert(key.clone());
-						stack.push(DescendantTask::Node { depth, key });
+						queue.push_back(DescendantTask::Node { depth, key });
 					}
 
 					match permission {
@@ -1019,7 +1019,7 @@ impl Index {
 							tg::authorization::permission::object::Permission::Subtree,
 						) => {
 							let object = tg::object::Id::try_from(resource)?;
-							stack.push(DescendantTask::ObjectChildren {
+							queue.push_back(DescendantTask::ObjectChildren {
 								after: None,
 								depth,
 								object,
@@ -1060,13 +1060,13 @@ impl Index {
 						.await
 					);
 					if let Some(after) = after {
-						stack.push(DescendantTask::ObjectChildren {
+						queue.push_back(DescendantTask::ObjectChildren {
 							after: Some(after),
 							depth,
 							object,
 						});
 					}
-					for key in keys.into_iter().rev() {
+					for key in keys {
 						let crate::fdb::Key::Object(crate::fdb::object::Key::ObjectChild {
 							child,
 							..
@@ -1094,7 +1094,7 @@ impl Index {
 								return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 							}
 							visited.insert(key.clone());
-							stack.push(DescendantTask::Node { depth, key });
+							queue.push_back(DescendantTask::Node { depth, key });
 						}
 					}
 				},
@@ -1117,12 +1117,12 @@ impl Index {
 						.await
 					);
 					if let Some(after) = after {
-						stack.push(DescendantTask::SubjectGrants {
+						queue.push_back(DescendantTask::SubjectGrants {
 							after: Some(after),
 							subject,
 						});
 					}
-					for key in keys.into_iter().rev() {
+					for key in keys {
 						let crate::fdb::Key::Grant(crate::fdb::grant::Key::SubjectGrant {
 							permission,
 							resource,
@@ -1141,7 +1141,7 @@ impl Index {
 						if !budget.add_node(0) {
 							return Ok(ControlFlow::Break(SearchOutcome::Exhausted));
 						}
-						stack.push(DescendantTask::Node { depth: 0, key });
+						queue.push_back(DescendantTask::Node { depth: 0, key });
 					}
 				},
 			}

--- a/packages/index/src/lmdb/authorize.rs
+++ b/packages/index/src/lmdb/authorize.rs
@@ -108,7 +108,7 @@ enum SearchOutcome {
 struct AncestorSearch {
 	budget: SearchBudget,
 	outcome: Option<SearchOutcome>,
-	stack: Vec<AncestorTask>,
+	queue: VecDeque<AncestorTask>,
 	visited: HashSet<(tg::Id, tg::authorization::Permission)>,
 }
 
@@ -116,7 +116,7 @@ struct DescendantSearch {
 	budget: SearchBudget,
 	complete: bool,
 	outcome: Option<SearchOutcome>,
-	stack: Vec<DescendantTask>,
+	queue: VecDeque<DescendantTask>,
 	visited: HashSet<(tg::Id, tg::authorization::Permission)>,
 }
 
@@ -177,16 +177,16 @@ impl AncestorSearch {
 	) -> Self {
 		let mut budget = SearchBudget::new(config);
 		let outcome = (!budget.add_node(0)).then_some(SearchOutcome::Exhausted);
-		let stack = vec![AncestorTask::Node {
+		let queue = VecDeque::from([AncestorTask::Node {
 			depth: 0,
 			key: root.clone(),
-		}];
+		}]);
 		let visited = HashSet::from([root.clone()]);
 
 		Self {
 			budget,
 			outcome,
-			stack,
+			queue,
 			visited,
 		}
 	}
@@ -200,16 +200,16 @@ impl DescendantSearch {
 			requester.principal,
 			tg::Principal::Group(_) | tg::Principal::User(_)
 		);
-		let mut stack = Vec::new();
+		let mut queue = VecDeque::new();
 		let mut visited = HashSet::new();
 
 		let public = tg::authorization::Subject::Public;
-		stack.push(DescendantTask::SubjectGrants {
+		queue.push_back(DescendantTask::SubjectGrants {
 			after: None,
 			subject: public.clone(),
 		});
 		if requester.subject != public {
-			stack.push(DescendantTask::SubjectGrants {
+			queue.push_back(DescendantTask::SubjectGrants {
 				after: None,
 				subject: requester.subject.clone(),
 			});
@@ -261,14 +261,14 @@ impl DescendantSearch {
 				outcome = Some(SearchOutcome::Exhausted);
 				break;
 			}
-			stack.push(DescendantTask::Node { depth: 0, key });
+			queue.push_back(DescendantTask::Node { depth: 0, key });
 		}
 
 		Self {
 			budget,
 			complete,
 			outcome,
-			stack,
+			queue,
 			visited,
 		}
 	}
@@ -609,9 +609,9 @@ impl Index {
 			return Ok(outcome);
 		}
 		let budget = &mut search.budget;
-		let stack = &mut search.stack;
+		let queue = &mut search.queue;
 		let visited = &mut search.visited;
-		let Some(task) = stack.pop() else {
+		let Some(task) = queue.pop_front() else {
 			for key in visited.iter().cloned() {
 				context.authorization.entry(key).or_insert(false);
 			}
@@ -643,7 +643,7 @@ impl Index {
 					permission,
 					context.cache,
 				)?;
-				for key in dependencies.into_iter().rev() {
+				for key in dependencies {
 					let depth = depth + 1;
 					if !budget.add_edge() {
 						return Ok(SearchOutcome::Exhausted);
@@ -663,13 +663,13 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					visited.insert(key.clone());
-					stack.push(AncestorTask::Node { depth, key });
+					queue.push_back(AncestorTask::Node { depth, key });
 				}
 
 				match permission {
 					tg::authorization::Permission::Object(_) => {
 						let object = tg::object::Id::try_from(resource)?;
-						stack.push(AncestorTask::ObjectParents {
+						queue.push_back(AncestorTask::ObjectParents {
 							after: None,
 							depth,
 							object,
@@ -677,7 +677,7 @@ impl Index {
 					},
 					tg::authorization::Permission::Process(permission) => {
 						let process = tg::process::Id::try_from(resource)?;
-						stack.push(AncestorTask::ProcessParents {
+						queue.push_back(AncestorTask::ProcessParents {
 							after: None,
 							depth,
 							permission,
@@ -713,13 +713,13 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(AncestorTask::ObjectParents {
+					queue.push_back(AncestorTask::ObjectParents {
 						after: Some(after),
 						depth,
 						object,
 					});
 				}
-				for key in keys.into_iter().rev() {
+				for key in keys {
 					let crate::lmdb::Key::Object(crate::lmdb::object::Key::ChildObject {
 						object,
 						..
@@ -752,7 +752,7 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					visited.insert(key.clone());
-					stack.push(AncestorTask::Node { depth, key });
+					queue.push_back(AncestorTask::Node { depth, key });
 				}
 			},
 			AncestorTask::ProcessParents {
@@ -778,14 +778,14 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(AncestorTask::ProcessParents {
+					queue.push_back(AncestorTask::ProcessParents {
 						after: Some(after),
 						depth,
 						permission,
 						process,
 					});
 				}
-				for key in keys.into_iter().rev() {
+				for key in keys {
 					let crate::lmdb::Key::Process(crate::lmdb::process::Key::ChildProcess {
 						parent,
 						..
@@ -816,7 +816,7 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					visited.insert(key.clone());
-					stack.push(AncestorTask::Node { depth, key });
+					queue.push_back(AncestorTask::Node { depth, key });
 				}
 			},
 		}
@@ -833,9 +833,9 @@ impl Index {
 			return Ok(outcome);
 		}
 		let budget = &mut search.budget;
-		let stack = &mut search.stack;
+		let queue = &mut search.queue;
 		let visited = &mut search.visited;
-		let Some(task) = stack.pop() else {
+		let Some(task) = queue.pop_front() else {
 			let outcome = if search.complete {
 				SearchOutcome::Denied
 			} else {
@@ -855,7 +855,7 @@ impl Index {
 				} else {
 					crate::authorize::permissions_implied_by(permission)
 				};
-				for implied_permission in implied.into_iter().rev() {
+				for implied_permission in implied {
 					if implied_permission == permission {
 						continue;
 					}
@@ -874,13 +874,13 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					visited.insert(key.clone());
-					stack.push(DescendantTask::Node { depth, key });
+					queue.push_back(DescendantTask::Node { depth, key });
 				}
 				if crate::authorize::write_permission_for_resource(&resource).ok()
 					== Some(permission)
 					&& let Some(owner) = Self::principal_for_resource(&resource)?
 				{
-					stack.push(DescendantTask::OwnerSandboxes {
+					queue.push_back(DescendantTask::OwnerSandboxes {
 						after: None,
 						depth,
 						owner,
@@ -892,7 +892,7 @@ impl Index {
 						tg::authorization::permission::object::Permission::Subtree,
 					) => {
 						let object = tg::object::Id::try_from(resource)?;
-						stack.push(DescendantTask::ObjectChildren {
+						queue.push_back(DescendantTask::ObjectChildren {
 							after: None,
 							depth,
 							object,
@@ -921,7 +921,7 @@ impl Index {
 								| tg::authorization::permission::process::Permission::SubtreeOutput
 						);
 						if traverses_children {
-							stack.push(DescendantTask::ProcessChildren {
+							queue.push_back(DescendantTask::ProcessChildren {
 								after: None,
 								depth,
 								permission,
@@ -930,7 +930,7 @@ impl Index {
 						}
 						if permission == tg::authorization::permission::process::Permission::Parent
 						{
-							stack.push(DescendantTask::ProcessGrants {
+							queue.push_back(DescendantTask::ProcessGrants {
 								after: None,
 								depth,
 								process,
@@ -939,7 +939,7 @@ impl Index {
 					},
 					tg::authorization::Permission::Sandbox(permission) => {
 						let sandbox = tg::sandbox::Id::try_from(resource)?;
-						stack.push(DescendantTask::SandboxProcesses {
+						queue.push_back(DescendantTask::SandboxProcesses {
 							after: None,
 							depth,
 							permission,
@@ -977,13 +977,13 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(DescendantTask::ObjectChildren {
+					queue.push_back(DescendantTask::ObjectChildren {
 						after: Some(after),
 						depth,
 						object,
 					});
 				}
-				for key in keys.into_iter().rev() {
+				for key in keys {
 					let crate::lmdb::Key::Object(crate::lmdb::object::Key::ObjectChild {
 						child,
 						..
@@ -1014,7 +1014,7 @@ impl Index {
 							return Ok(SearchOutcome::Exhausted);
 						}
 						visited.insert(key.clone());
-						stack.push(DescendantTask::Node { depth, key });
+						queue.push_back(DescendantTask::Node { depth, key });
 					}
 				}
 			},
@@ -1039,13 +1039,13 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(DescendantTask::OwnerSandboxes {
+					queue.push_back(DescendantTask::OwnerSandboxes {
 						after: Some(after),
 						depth,
 						owner,
 					});
 				}
-				for key in keys.into_iter().rev() {
+				for key in keys {
 					let crate::lmdb::Key::Sandbox(crate::lmdb::sandbox::Key::OwnerSandbox {
 						sandbox,
 						..
@@ -1075,7 +1075,7 @@ impl Index {
 							return Ok(SearchOutcome::Exhausted);
 						}
 						visited.insert(key.clone());
-						stack.push(DescendantTask::Node { depth, key });
+						queue.push_back(DescendantTask::Node { depth, key });
 					}
 				}
 			},
@@ -1102,14 +1102,14 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(DescendantTask::ProcessChildren {
+					queue.push_back(DescendantTask::ProcessChildren {
 						after: Some(after),
 						depth,
 						permission,
 						process,
 					});
 				}
-				for key in keys.into_iter().rev() {
+				for key in keys {
 					let crate::lmdb::Key::Process(crate::lmdb::process::Key::ProcessChild {
 						child,
 						..
@@ -1144,7 +1144,7 @@ impl Index {
 							return Ok(SearchOutcome::Exhausted);
 						}
 						visited.insert(key.clone());
-						stack.push(DescendantTask::Node { depth, key });
+						queue.push_back(DescendantTask::Node { depth, key });
 					}
 				}
 			},
@@ -1170,13 +1170,13 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(DescendantTask::ProcessGrants {
+					queue.push_back(DescendantTask::ProcessGrants {
 						after: Some(after),
 						depth,
 						process,
 					});
 				}
-				for (key, value) in entries.into_iter().rev() {
+				for (key, value) in entries {
 					let crate::lmdb::Key::Grant(crate::lmdb::grant::Key::SubjectGrant {
 						creator,
 						permission,
@@ -1210,7 +1210,7 @@ impl Index {
 							return Ok(SearchOutcome::Exhausted);
 						}
 						visited.insert(key.clone());
-						stack.push(DescendantTask::Node { depth, key });
+						queue.push_back(DescendantTask::Node { depth, key });
 					}
 				}
 			},
@@ -1237,14 +1237,14 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(DescendantTask::SandboxProcesses {
+					queue.push_back(DescendantTask::SandboxProcesses {
 						after: Some(after),
 						depth,
 						permission,
 						sandbox,
 					});
 				}
-				for key in keys.into_iter().rev() {
+				for key in keys {
 					let crate::lmdb::Key::Sandbox(crate::lmdb::sandbox::Key::SandboxProcess {
 						process,
 						..
@@ -1288,7 +1288,7 @@ impl Index {
 							return Ok(SearchOutcome::Exhausted);
 						}
 						visited.insert(key.clone());
-						stack.push(DescendantTask::Node { depth, key });
+						queue.push_back(DescendantTask::Node { depth, key });
 					}
 				}
 			},
@@ -1309,12 +1309,12 @@ impl Index {
 					budget.config.page_size,
 				)?;
 				if let Some(after) = after {
-					stack.push(DescendantTask::SubjectGrants {
+					queue.push_back(DescendantTask::SubjectGrants {
 						after: Some(after),
 						subject,
 					});
 				}
-				for (key, _) in entries.into_iter().rev() {
+				for (key, _) in entries {
 					let crate::lmdb::Key::Grant(crate::lmdb::grant::Key::SubjectGrant {
 						permission,
 						resource,
@@ -1333,7 +1333,7 @@ impl Index {
 					if !budget.add_node(0) {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					stack.push(DescendantTask::Node { depth: 0, key });
+					queue.push_back(DescendantTask::Node { depth: 0, key });
 				}
 			},
 		}


### PR DESCRIPTION
Both searches walked depth-first, so the bound went to whichever branch happened to be entered first, and a single over-deep branch abandoned the entire search — while the proof sat one step away in the queue, never examined. When both directions gave up, the result was an error rather than a verdict.

A from-scratch std build hits this on the `cargo build` of tgcc/tgld/tgstrip/wrap, whose command invokes the loader as `${loader} --library-path ${libdir} ${toolchain}/bin/cargo` — six directories and one file, where the file is the loader and also lives inside `libdir`. Since ids sort by kind, directories are always visited before files and before commands. Climbing up, the search entered `libdir` rather than stepping to the granting command beside it, and ran 18 deep against a limit of 16. Walking down, it entered sibling directories of 8353 and 10090 objects rather than stepping to the loader, needing 65536 nodes against a limit of 1024. The loader had exactly two parents: `libdir` and the command that grants the process.

This visits tasks in queue order rather than stack order, in both the LMDB and FoundationDB searches. Every task enqueues work at its own depth or deeper, so a FIFO walks the frontier by increasing depth and examines the one-hop proof before anything further out. No limits change, and a genuinely distant proof can still exhaust the budget. The regression test builds the same shape — a file 18 directories deep, and a 600-entry sibling directory on one command — and fails without the change with the same error.
