### PR TITLE
fix(index, lmdb): memoize authz searches on the success path

### DIFF
--- a/packages/index/src/lmdb/authorize.rs
+++ b/packages/index/src/lmdb/authorize.rs
@@ -50,6 +50,7 @@ enum AncestorTask {
 		after: Option<Vec<u8>>,
 		depth: usize,
 		object: tg::object::Id,
+		permission: tg::authorization::permission::object::Permission,
 	},
 	ProcessParents {
 		after: Option<Vec<u8>>,
@@ -108,8 +109,11 @@ enum SearchOutcome {
 struct AncestorSearch {
 	budget: SearchBudget,
 	outcome: Option<SearchOutcome>,
+	predecessors: HashMap<
+		(tg::Id, tg::authorization::Permission),
+		Option<(tg::Id, tg::authorization::Permission)>,
+	>,
 	stack: Vec<AncestorTask>,
-	visited: HashSet<(tg::Id, tg::authorization::Permission)>,
 }
 
 struct DescendantSearch {
@@ -177,17 +181,17 @@ impl AncestorSearch {
 	) -> Self {
 		let mut budget = SearchBudget::new(config);
 		let outcome = (!budget.add_node(0)).then_some(SearchOutcome::Exhausted);
+		let predecessors = HashMap::from([(root.clone(), None)]);
 		let stack = vec![AncestorTask::Node {
 			depth: 0,
 			key: root.clone(),
 		}];
-		let visited = HashSet::from([root.clone()]);
 
 		Self {
 			budget,
 			outcome,
+			predecessors,
 			stack,
-			visited,
 		}
 	}
 }
@@ -642,9 +646,9 @@ impl Index {
 		}
 		let budget = &mut search.budget;
 		let stack = &mut search.stack;
-		let visited = &mut search.visited;
+		let predecessors = &mut search.predecessors;
 		let Some(task) = stack.pop() else {
-			for key in visited.iter().cloned() {
+			for key in predecessors.keys().cloned() {
 				context.authorization.entry(key).or_insert(false);
 			}
 
@@ -652,8 +656,13 @@ impl Index {
 		};
 		match task {
 			AncestorTask::Node { depth, key } => {
-				if let Some(authorized) = context.authorization.get(&key) {
-					if *authorized {
+				if let Some(authorized) = context.authorization.get(&key).copied() {
+					if authorized {
+						Self::memoize_authorized_ancestor_path(
+							context.authorization,
+							predecessors,
+							&key,
+						);
 						return Ok(SearchOutcome::Authorized);
 					}
 					return Ok(SearchOutcome::Pending);
@@ -663,7 +672,11 @@ impl Index {
 					|| Self::is_directly_authorized_with_transaction(
 						context, &resource, permission,
 					)? {
-					context.authorization.insert(key, true);
+					Self::memoize_authorized_ancestor_path(
+						context.authorization,
+						predecessors,
+						&key,
+					);
 					return Ok(SearchOutcome::Authorized);
 				}
 
@@ -680,7 +693,7 @@ impl Index {
 					if !budget.add_edge() {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					if visited.contains(&key)
+					if predecessors.contains_key(&key)
 						|| context.authorization.get(&key).copied() == Some(false)
 					{
 						continue;
@@ -689,22 +702,28 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					if context.authorization.get(&key).copied() == Some(true) {
+						Self::memoize_authorized_ancestor_path(
+							context.authorization,
+							predecessors,
+							&(resource.clone(), permission),
+						);
 						return Ok(SearchOutcome::Authorized);
 					}
 					if !budget.add_node(depth) {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					visited.insert(key.clone());
+					predecessors.insert(key.clone(), Some((resource.clone(), permission)));
 					stack.push(AncestorTask::Node { depth, key });
 				}
 
 				match permission {
-					tg::authorization::Permission::Object(_) => {
+					tg::authorization::Permission::Object(permission) => {
 						let object = tg::object::Id::try_from(resource)?;
 						stack.push(AncestorTask::ObjectParents {
 							after: None,
 							depth,
 							object,
+							permission,
 						});
 					},
 					tg::authorization::Permission::Process(permission) => {
@@ -727,7 +746,12 @@ impl Index {
 				after,
 				depth,
 				object,
+				permission,
 			} => {
+				let node = (
+					tg::Id::from(object.clone()),
+					tg::authorization::Permission::Object(permission),
+				);
 				let object_bytes = object.to_bytes();
 				let prefix = Self::pack(
 					context.subspace,
@@ -749,6 +773,7 @@ impl Index {
 						after: Some(after),
 						depth,
 						object,
+						permission,
 					});
 				}
 				for key in keys.into_iter().rev() {
@@ -769,7 +794,7 @@ impl Index {
 					if !budget.add_edge() {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					if visited.contains(&key)
+					if predecessors.contains_key(&key)
 						|| context.authorization.get(&key).copied() == Some(false)
 					{
 						continue;
@@ -778,12 +803,17 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					if context.authorization.get(&key).copied() == Some(true) {
+						Self::memoize_authorized_ancestor_path(
+							context.authorization,
+							predecessors,
+							&node,
+						);
 						return Ok(SearchOutcome::Authorized);
 					}
 					if !budget.add_node(depth) {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					visited.insert(key.clone());
+					predecessors.insert(key.clone(), Some(node.clone()));
 					stack.push(AncestorTask::Node { depth, key });
 				}
 			},
@@ -793,6 +823,10 @@ impl Index {
 				permission,
 				process,
 			} => {
+				let node = (
+					tg::Id::from(process.clone()),
+					tg::authorization::Permission::Process(permission),
+				);
 				let process_bytes = process.to_bytes();
 				let prefix = Self::pack(
 					context.subspace,
@@ -833,7 +867,7 @@ impl Index {
 					if !budget.add_edge() {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					if visited.contains(&key)
+					if predecessors.contains_key(&key)
 						|| context.authorization.get(&key).copied() == Some(false)
 					{
 						continue;
@@ -842,12 +876,17 @@ impl Index {
 						return Ok(SearchOutcome::Exhausted);
 					}
 					if context.authorization.get(&key).copied() == Some(true) {
+						Self::memoize_authorized_ancestor_path(
+							context.authorization,
+							predecessors,
+							&node,
+						);
 						return Ok(SearchOutcome::Authorized);
 					}
 					if !budget.add_node(depth) {
 						return Ok(SearchOutcome::Exhausted);
 					}
-					visited.insert(key.clone());
+					predecessors.insert(key.clone(), Some(node.clone()));
 					stack.push(AncestorTask::Node { depth, key });
 				}
 			},
@@ -1371,6 +1410,22 @@ impl Index {
 		}
 
 		Ok(SearchOutcome::Pending)
+	}
+
+	// Mark the key and its discovery path back to the search root as authorized, because every ancestor search edge implies the pushing key's authorization from the pushed key's authorization.
+	fn memoize_authorized_ancestor_path(
+		authorization: &mut HashMap<(tg::Id, tg::authorization::Permission), bool>,
+		predecessors: &HashMap<
+			(tg::Id, tg::authorization::Permission),
+			Option<(tg::Id, tg::authorization::Permission)>,
+		>,
+		key: &(tg::Id, tg::authorization::Permission),
+	) {
+		let mut current = Some(key);
+		while let Some(key) = current {
+			authorization.insert(key.clone(), true);
+			current = predecessors.get(key).and_then(Option::as_ref);
+		}
 	}
 
 	#[must_use]

--- a/packages/index/src/lmdb/tests/authorize.rs
+++ b/packages/index/src/lmdb/tests/authorize.rs
@@ -1845,3 +1845,74 @@ async fn authorize_uses_cached_subject_membership() {
 	.await;
 	assert!(output[0].output().unwrap().permissions.contains(node));
 }
+
+// Authorizing `near` proves near -> shared -> root within the depth budget. That
+// proof must memoize `shared`, so authorizing `far` (far -> middle -> shared) can
+// stop at `shared` at depth two instead of re-walking to `root` at depth three.
+#[tokio::test]
+async fn authorize_batch_memoizes_intermediate_nodes_on_an_authorized_path() {
+	let ancestor = crate::authorize::SearchConfig {
+		max_depth: 2,
+		..Default::default()
+	};
+	let descendant = crate::authorize::SearchConfig {
+		max_depth: 0,
+		max_edges: 0,
+		max_nodes: 0,
+		..Default::default()
+	};
+	let config = crate::authorize::Config {
+		ancestor,
+		descendant,
+		subtree: crate::authorize::SubtreeConfig::default(),
+	};
+	let (_dir, index) = new_index();
+	let bystander = object_id(0);
+	let far = object_id(1);
+	let middle = object_id(2);
+	let near = object_id(3);
+	let root = object_id(4);
+	let shared = object_id(5);
+	let user = tg::user::Id::new();
+	let mut txn = index.env.write_txn().unwrap();
+	for object in [&bystander, &far, &middle, &near, &root, &shared] {
+		put_object(&index, &mut txn, object);
+	}
+	put_child(&index, &mut txn, &root, &shared);
+	put_child(&index, &mut txn, &bystander, &shared);
+	put_child(&index, &mut txn, &shared, &near);
+	put_child(&index, &mut txn, &shared, &middle);
+	put_child(&index, &mut txn, &middle, &far);
+	put_grant(
+		&index,
+		&mut txn,
+		&root,
+		&user,
+		tg::authorization::permission::object::Permission::Subtree,
+	);
+	txn.commit().unwrap();
+
+	let subtree = object_permissions([tg::authorization::permission::object::Permission::Subtree]);
+	let args = [&root, &bystander, &near, &far].map(|object| crate::authorize::Arg {
+		permissions: subtree,
+		resource: tg::Selector::Id(object.clone().into()),
+		token: None,
+	});
+	let outcomes = index
+		.authorize_batch(&args, config, &tg::Principal::User(user))
+		.await
+		.unwrap();
+	assert!(matches!(
+		outcomes[0],
+		crate::authorize::Outcome::Authorized(_)
+	));
+	assert!(matches!(outcomes[1], crate::authorize::Outcome::Denied(_)));
+	assert!(matches!(
+		outcomes[2],
+		crate::authorize::Outcome::Authorized(_)
+	));
+	assert!(matches!(
+		outcomes[3],
+		crate::authorize::Outcome::Authorized(_)
+	));
+}


### PR DESCRIPTION
- Adds a test that requires intermediate node authz to be memoized to avoid exhausting the search budget
- Implement memoization of intermediate nodes