### PR TITLE
test(index/authorize): demonstrate that the ancestor search aborts with the proof enqueued

### DIFF
--- a/packages/index/src/lmdb/authorize.rs
+++ b/packages/index/src/lmdb/authorize.rs
@@ -6,6 +6,9 @@ use {
 	tangram_client::prelude::*,
 };
 
+#[cfg(test)]
+mod tests;
+
 const PRECOMPUTE_REQUESTER_PRINCIPALS: bool = false;
 
 #[derive(Default)]

--- a/packages/index/src/lmdb/authorize/tests.rs
+++ b/packages/index/src/lmdb/authorize/tests.rs
@@ -1,0 +1,184 @@
+use {
+	super::{AncestorSearch, AncestorTask, AuthorizationContext, Cache, Requester, SearchOutcome},
+	crate::lmdb::{Config, Index, Key, grant::Key as GrantKey, object::Key as ObjectKey},
+	heed as lmdb,
+	std::collections::HashMap,
+	tangram_client::prelude::*,
+};
+
+// The ancestor search visits parents in key order, so the identifiers must sort in the order the
+// search is expected to visit them.
+fn ordered_object_id(n: usize) -> tg::object::Id {
+	let mut body = [0; 32];
+	body[..size_of::<usize>()].copy_from_slice(&n.to_be_bytes());
+	let id = tg::Id::new(tg::id::Kind::Blob, tg::id::Body::Blake3(body));
+	tg::object::Id::try_from(id).unwrap()
+}
+
+fn new_index() -> (tempfile::TempDir, Index) {
+	let dir = tempfile::TempDir::new().unwrap();
+	let config = Config {
+		map_size: 1 << 30,
+		max_process_depth: None,
+		path: dir.path().join("index"),
+		read_request_batch_size: 64,
+		read_transaction_concurrency: 4,
+		usage_partition_total: 1,
+		write_operation_batch_size: 100_000,
+	};
+	let index = Index::new(&config).unwrap();
+	(dir, index)
+}
+
+fn put(index: &Index, txn: &mut lmdb::RwTxn<'_>, key: &Key, value: &[u8]) {
+	let key = Index::pack(&index.subspace, key);
+	index.db.put(txn, &key, value).unwrap();
+}
+
+fn put_object(index: &Index, txn: &mut lmdb::RwTxn<'_>, object: &tg::object::Id) {
+	let key = Key::Object(ObjectKey::Object(object.clone()));
+	put(index, txn, &key, &[]);
+}
+
+fn put_child(
+	index: &Index,
+	txn: &mut lmdb::RwTxn<'_>,
+	parent: &tg::object::Id,
+	child: &tg::object::Id,
+) {
+	let key = Key::Object(ObjectKey::ObjectChild {
+		child: child.clone(),
+		object: parent.clone(),
+	});
+	put(index, txn, &key, &[]);
+	let key = Key::Object(ObjectKey::ChildObject {
+		child: child.clone(),
+		object: parent.clone(),
+	});
+	put(index, txn, &key, &[]);
+}
+
+fn put_grant(
+	index: &Index,
+	txn: &mut lmdb::RwTxn<'_>,
+	resource: &tg::object::Id,
+	user: &tg::user::Id,
+	permission: tg::authorization::permission::object::Permission,
+) {
+	let value = crate::lmdb::grant::GrantValue {
+		explicit: true,
+		..Default::default()
+	}
+	.serialize()
+	.unwrap();
+	let key = Key::Grant(GrantKey::ResourceGrant {
+		creator: None,
+		permission: tg::authorization::Permission::Object(permission),
+		resource: resource.clone().into(),
+		subject: tg::authorization::Subject::User(user.clone()),
+	});
+	put(index, txn, &key, &value);
+}
+
+// The ancestor search abandons a frontier that already holds the proof.
+//
+//     p1 ... p1088        the decoy's parents, more numerous than the edge budget
+//        \   |   /
+//         decoy   proof   the proof carries a grant for the requester
+//             \   /
+//             target      the resource being authorized
+//
+// Object ids are constructed to sort in visit order, so the decoy is the first of the target's two
+// parents the search reaches. Reading the target's parents enqueues both at depth one and costs two
+// edges. The decoy pops first, and paging through its parents charges one edge each until the
+// budget runs out, at which point the walk returns Exhausted as a whole. The proof has been queued
+// one hop from the target since the second edge and is never examined; the abandoned stack holds
+// it, the decoy's unfinished pagination, and 61 of the decoy's parents at depth two.
+#[tokio::test]
+async fn ancestor_search_must_not_abort_with_the_proof_enqueued() {
+	// Use the default budgets, and size the decoy's fan-in against the edge budget rather than
+	// hardcoding it, so raising the budget cannot make this test pass.
+	let authorize = crate::authorize::Config::default();
+	let ancestor = authorize.ancestor;
+	let fanin = ancestor.max_edges + ancestor.page_size;
+
+	// Create the graph.
+	let (_dir, index) = new_index();
+	let user = tg::user::Id::new();
+	let decoy = ordered_object_id(0);
+	let proof = ordered_object_id(fanin + 1);
+	let target = ordered_object_id(fanin + 2);
+	let mut txn = index.env.write_txn().unwrap();
+	put_object(&index, &mut txn, &decoy);
+	put_object(&index, &mut txn, &proof);
+	put_object(&index, &mut txn, &target);
+	put_child(&index, &mut txn, &decoy, &target);
+	put_child(&index, &mut txn, &proof, &target);
+	for i in 1..=fanin {
+		let object = ordered_object_id(i);
+		put_object(&index, &mut txn, &object);
+		put_child(&index, &mut txn, &object, &decoy);
+	}
+	let subtree = tg::authorization::permission::object::Permission::Subtree;
+	put_grant(&index, &mut txn, &proof, &user, subtree);
+	txn.commit().unwrap();
+
+	// Create the search.
+	let permission = tg::authorization::Permission::Object(
+		tg::authorization::permission::object::Permission::Node,
+	);
+	let root = (tg::Id::from(target.clone()), permission);
+	let mut search = AncestorSearch::new(ancestor, &root);
+	let principal = tg::Principal::User(user);
+	let requester = Requester::new(&principal);
+	let transaction = index.env.read_txn().unwrap();
+	let mut authorization = HashMap::new();
+	let mut cache = Cache::default();
+	let mut context = AuthorizationContext {
+		authorization: &mut authorization,
+		authorize,
+		cache: &mut cache,
+		db: &index.db,
+		requester: &requester,
+		subspace: &index.subspace,
+		token: None,
+		transaction: &transaction,
+	};
+
+	// Advance the search until it settles.
+	let outcome = loop {
+		let outcome =
+			Index::advance_ancestor_search_with_transaction(&mut context, &mut search).unwrap();
+		if outcome != SearchOutcome::Pending {
+			break outcome;
+		}
+	};
+
+	// Describe the frontier the search was holding when it settled.
+	let proof = tg::Id::from(proof);
+	let pending = search
+		.stack
+		.iter()
+		.map(|task| match task {
+			AncestorTask::Node { depth, key } => (*depth, key.0.clone()),
+			AncestorTask::ObjectParents { depth, object, .. } => {
+				(*depth, tg::Id::from(object.clone()))
+			},
+			AncestorTask::ProcessParents { depth, process, .. } => {
+				(*depth, tg::Id::from(process.clone()))
+			},
+		})
+		.collect::<Vec<_>>();
+	let nearest = pending.iter().map(|(depth, _)| *depth).min().unwrap_or(0);
+	let enqueued = pending.contains(&(1, proof.clone()));
+
+	assert_eq!(
+		outcome,
+		SearchOutcome::Authorized,
+		"the search spent {} of its {} edges and gave up holding {} queued tasks, the nearest {} hop from the target, with the proof enqueued at depth one: {enqueued}",
+		search.budget.edges,
+		ancestor.max_edges,
+		pending.len(),
+		nearest,
+	);
+}


### PR DESCRIPTION
`advance_ancestor_search_with_transaction` returns `Exhausted` for the whole walk when the edge budget runs out, discarding everything still on the stack. The stack can hold the proof.

The test gives the target two parents: a decoy whose fan-in exceeds the edge budget, and an object carrying a grant. Reading the target's parents enqueues both at depth one, on the second of 1024 edges. The decoy pops first, paging its parents spends the rest, and the search gives up, holding 63 tasks with the proof still queued one hop away, never examined.