### PR TITLE
fix(server): avoid exhausted subtree searches for node-authorized object reads

### DIFF
--- a/packages/cli/tests/grants/object_get_node_authorization_search_exhaustion.nu
+++ b/packages/cli/tests/grants/object_get_node_authorization_search_exhaustion.nu
@@ -22,9 +22,14 @@ tg --token $alice.token index
 
 let output = tg --token $bob.token object get --availability --bytes --metadata $directory | complete
 success $output "Bob should read the directory node even when its optional subtree authorization is indeterminate."
+assert not ($output.stderr | str contains '"subtree"') "Bob should not see the directory subtree metadata or availability."
 
 let metadata = tg --token $bob.token metadata $directory | complete
 success $metadata "Bob should read the directory metadata even when its optional subtree authorization is indeterminate."
+let metadata = $metadata.stdout | from json
+assert equal ($metadata | columns) [] "Bob should not see the directory subtree metadata."
 
 let availability = tg --token $bob.token availability $directory | complete
 success $availability "Bob should read the directory availability even when its optional subtree authorization is indeterminate."
+let availability = $availability.stdout | from json
+assert equal ($availability | columns) [] "Bob should not see the directory subtree availability."

--- a/packages/cli/tests/grants/object_get_node_authorization_search_exhaustion.nu
+++ b/packages/cli/tests/grants/object_get_node_authorization_search_exhaustion.nu
@@ -1,0 +1,30 @@
+use ../../test.nu *
+
+# Getting an object succeeds when its required node permission is authorized but its optional subtree permission exhausts the authorization search.
+
+let server = server spawn --config {
+	authentication: { users: { providers: { insecure: true } } }
+	authorization: {
+		final: {
+			descendant: { max_depth: 0, max_edges: 0, max_nodes: 0 }
+			subtree: { max_objects: 0 }
+		}
+	}
+}
+
+let alice = tg login --verbose --name alice | from json
+let bob = tg login --verbose --name bob | from json
+
+let directory = tg --token $alice.token put 'tg.directory({ "child": tg.directory({}) })' | str trim
+tg --token $alice.token index
+tg --token $alice.token grant $bob.user.id object_node $directory | ignore
+tg --token $alice.token index
+
+let output = tg --token $bob.token object get --availability --bytes --metadata $directory | complete
+success $output "Bob should read the directory node even when its optional subtree authorization is indeterminate."
+
+let metadata = tg --token $bob.token metadata $directory | complete
+success $metadata "Bob should read the directory metadata even when its optional subtree authorization is indeterminate."
+
+let availability = tg --token $bob.token availability $directory | complete
+success $availability "Bob should read the directory availability even when its optional subtree authorization is indeterminate."

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -35,6 +35,41 @@ impl Session {
 		Ok(outputs.pop().unwrap())
 	}
 
+	pub(crate) async fn authorize_object_read(
+		&self,
+		resource: impl IntoAuthorizationResource,
+		search_subtree: bool,
+	) -> tg::Result<Option<tg::authorization::permission::Set>> {
+		let mut outputs = self
+			.authorize_object_read_batch([resource], search_subtree)
+			.await?;
+		let output = outputs.pop().unwrap();
+
+		Ok(output)
+	}
+
+	pub(crate) async fn authorize_object_read_batch<R, I>(
+		&self,
+		resources: I,
+		search_subtree: bool,
+	) -> tg::Result<Vec<Option<tg::authorization::permission::Set>>>
+	where
+		R: IntoAuthorizationResource,
+		I: IntoIterator<Item = R>,
+	{
+		let mut requested = tg::authorization::permission::object::Set::empty();
+		requested.insert(tg::authorization::permission::object::Set::NODE);
+		requested.insert(tg::authorization::permission::object::Set::SUBTREE);
+		let requested = tg::authorization::permission::Set::Object(requested);
+		let required = tg::authorization::Permission::Object(
+			tg::authorization::permission::object::Permission::Node,
+		);
+		let args = resources.into_iter().map(|resource| (resource, requested));
+
+		self.authorize_batch_inner(args, Some(required.into()), search_subtree)
+			.await
+	}
+
 	pub(crate) async fn authorize_batch<R, I>(
 		&self,
 		args: I,
@@ -43,7 +78,7 @@ impl Session {
 		R: IntoAuthorizationResource,
 		I: IntoIterator<Item = (R, tg::authorization::permission::Set)>,
 	{
-		self.authorize_batch_inner(args, None).await
+		self.authorize_batch_inner(args, None, false).await
 	}
 
 	pub(crate) async fn authorize_batch_with_required<R, I>(
@@ -55,13 +90,15 @@ impl Session {
 		R: IntoAuthorizationResource,
 		I: IntoIterator<Item = (R, tg::authorization::permission::Set)>,
 	{
-		self.authorize_batch_inner(args, Some(required)).await
+		self.authorize_batch_inner(args, Some(required), false)
+			.await
 	}
 
 	async fn authorize_batch_inner<R, I>(
 		&self,
 		args: I,
 		required: Option<tg::authorization::permission::Set>,
+		search_requested: bool,
 	) -> tg::Result<Vec<Option<tg::authorization::permission::Set>>>
 	where
 		R: IntoAuthorizationResource,
@@ -132,13 +169,20 @@ impl Session {
 		let authorization = &self.server.config.authorization;
 		let delay = authorization.index.delay;
 		let initial_config = crate::authorization_search_config(&authorization.initial);
-		let grants_required = |outcomes: &[tangram_index::authorize::Outcome]| {
+		let grants_sufficient = |outcomes: &[tangram_index::authorize::Outcome]| {
 			outcomes.len() == index_required.len()
-				&& std::iter::zip(outcomes, &index_required).all(|(outcome, required)| {
-					outcome
-						.output()
-						.is_some_and(|output| output.permissions.contains(*required))
-				})
+				&& std::iter::zip(std::iter::zip(outcomes, &index_args), &index_required).all(
+					|((outcome, arg), required)| {
+						let permissions = if search_requested {
+							arg.requested
+						} else {
+							*required
+						};
+						outcome
+							.output()
+							.is_some_and(|output| output.permissions.contains(permissions))
+					},
+				)
 		};
 		let initial =
 			self.server
@@ -173,7 +217,7 @@ impl Session {
 			ensure_authorization_search_complete(outcomes)
 		};
 		let index_outcomes = match initial_result {
-			Some(Ok(outcomes)) if grants_required(&outcomes) => outcomes,
+			Some(Ok(outcomes)) if grants_sufficient(&outcomes) => outcomes,
 			Some(Ok(_)) => {
 				index_wait.await?;
 				final_authorization().await?
@@ -183,7 +227,7 @@ impl Session {
 				tokio::pin!(index_wait);
 				tokio::select! {
 					result = &mut initial => match result {
-						Ok(outcomes) if grants_required(&outcomes) => outcomes,
+						Ok(outcomes) if grants_sufficient(&outcomes) => outcomes,
 						Ok(_) => {
 							index_wait.await?;
 							final_authorization().await?
@@ -192,11 +236,11 @@ impl Session {
 					},
 					result = &mut index_wait => match result {
 						Ok(()) => match initial.await {
-							Ok(outcomes) if grants_required(&outcomes) => outcomes,
+							Ok(outcomes) if grants_sufficient(&outcomes) => outcomes,
 							Ok(_) | Err(_) => final_authorization().await?,
 						},
 						Err(error) => match initial.await {
-							Ok(outcomes) if grants_required(&outcomes) => outcomes,
+							Ok(outcomes) if grants_sufficient(&outcomes) => outcomes,
 							Ok(_) | Err(_) => return Err(error),
 						},
 					},

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -35,41 +35,6 @@ impl Session {
 		Ok(outputs.pop().unwrap())
 	}
 
-	pub(crate) async fn authorize_object_read(
-		&self,
-		resource: impl IntoAuthorizationResource,
-		search_subtree: bool,
-	) -> tg::Result<Option<tg::authorization::permission::Set>> {
-		let mut outputs = self
-			.authorize_object_read_batch([resource], search_subtree)
-			.await?;
-		let output = outputs.pop().unwrap();
-
-		Ok(output)
-	}
-
-	pub(crate) async fn authorize_object_read_batch<R, I>(
-		&self,
-		resources: I,
-		search_subtree: bool,
-	) -> tg::Result<Vec<Option<tg::authorization::permission::Set>>>
-	where
-		R: IntoAuthorizationResource,
-		I: IntoIterator<Item = R>,
-	{
-		let mut requested = tg::authorization::permission::object::Set::empty();
-		requested.insert(tg::authorization::permission::object::Set::NODE);
-		requested.insert(tg::authorization::permission::object::Set::SUBTREE);
-		let requested = tg::authorization::permission::Set::Object(requested);
-		let required = tg::authorization::Permission::Object(
-			tg::authorization::permission::object::Permission::Node,
-		);
-		let args = resources.into_iter().map(|resource| (resource, requested));
-
-		self.authorize_batch_inner(args, Some(required.into()), search_subtree)
-			.await
-	}
-
 	pub(crate) async fn authorize_batch<R, I>(
 		&self,
 		args: I,
@@ -94,11 +59,47 @@ impl Session {
 			.await
 	}
 
+	pub(crate) async fn authorize_object_read(
+		&self,
+		resource: impl IntoAuthorizationResource,
+		wait_for_subtree: bool,
+	) -> tg::Result<Option<tg::authorization::permission::Set>> {
+		let mut outputs = self
+			.authorize_object_read_batch([resource], wait_for_subtree)
+			.await?;
+		let output = outputs.pop().unwrap();
+
+		Ok(output)
+	}
+
+	pub(crate) async fn authorize_object_read_batch<R, I>(
+		&self,
+		resources: I,
+		wait_for_subtree: bool,
+	) -> tg::Result<Vec<Option<tg::authorization::permission::Set>>>
+	where
+		R: IntoAuthorizationResource,
+		I: IntoIterator<Item = R>,
+	{
+		// Request the optional subtree permission while requiring the node permission.
+		let mut requested = tg::authorization::permission::object::Set::empty();
+		requested.insert(tg::authorization::permission::object::Set::NODE);
+		requested.insert(tg::authorization::permission::object::Set::SUBTREE);
+		let requested = tg::authorization::permission::Set::Object(requested);
+		let required = tg::authorization::Permission::Object(
+			tg::authorization::permission::object::Permission::Node,
+		);
+		let args = resources.into_iter().map(|resource| (resource, requested));
+
+		self.authorize_batch_inner(args, Some(required.into()), wait_for_subtree)
+			.await
+	}
+
 	async fn authorize_batch_inner<R, I>(
 		&self,
 		args: I,
 		required: Option<tg::authorization::permission::Set>,
-		search_requested: bool,
+		wait_for_requested_permissions: bool,
 	) -> tg::Result<Vec<Option<tg::authorization::permission::Set>>>
 	where
 		R: IntoAuthorizationResource,
@@ -107,7 +108,6 @@ impl Session {
 		let mut outputs = Vec::new();
 		let mut index_args = Vec::new();
 		let mut index_positions = Vec::new();
-		let mut index_required = Vec::new();
 
 		for (position, (resource, permissions)) in args.into_iter().enumerate() {
 			let required = required.unwrap_or(permissions);
@@ -152,7 +152,6 @@ impl Session {
 
 			outputs.push(None);
 			index_positions.push(position);
-			index_required.push(required);
 			index_args.push(tangram_index::authorize::Arg {
 				required,
 				requested: permissions,
@@ -169,20 +168,18 @@ impl Session {
 		let authorization = &self.server.config.authorization;
 		let delay = authorization.index.delay;
 		let initial_config = crate::authorization_search_config(&authorization.initial);
-		let grants_sufficient = |outcomes: &[tangram_index::authorize::Outcome]| {
-			outcomes.len() == index_required.len()
-				&& std::iter::zip(std::iter::zip(outcomes, &index_args), &index_required).all(
-					|((outcome, arg), required)| {
-						let permissions = if search_requested {
-							arg.requested
-						} else {
-							*required
-						};
-						outcome
-							.output()
-							.is_some_and(|output| output.permissions.contains(permissions))
-					},
-				)
+		let initial_is_sufficient = |outcomes: &[tangram_index::authorize::Outcome]| {
+			outcomes.len() == index_args.len()
+				&& std::iter::zip(outcomes, &index_args).all(|(outcome, arg)| {
+					let permissions = if wait_for_requested_permissions {
+						arg.requested
+					} else {
+						arg.required
+					};
+					outcome
+						.output()
+						.is_some_and(|output| output.permissions.contains(permissions))
+				})
 		};
 		let initial =
 			self.server
@@ -217,7 +214,7 @@ impl Session {
 			ensure_authorization_search_complete(outcomes)
 		};
 		let index_outcomes = match initial_result {
-			Some(Ok(outcomes)) if grants_sufficient(&outcomes) => outcomes,
+			Some(Ok(outcomes)) if initial_is_sufficient(&outcomes) => outcomes,
 			Some(Ok(_)) => {
 				index_wait.await?;
 				final_authorization().await?
@@ -227,7 +224,7 @@ impl Session {
 				tokio::pin!(index_wait);
 				tokio::select! {
 					result = &mut initial => match result {
-						Ok(outcomes) if grants_sufficient(&outcomes) => outcomes,
+						Ok(outcomes) if initial_is_sufficient(&outcomes) => outcomes,
 						Ok(_) => {
 							index_wait.await?;
 							final_authorization().await?
@@ -236,11 +233,11 @@ impl Session {
 					},
 					result = &mut index_wait => match result {
 						Ok(()) => match initial.await {
-							Ok(outcomes) if grants_sufficient(&outcomes) => outcomes,
+							Ok(outcomes) if initial_is_sufficient(&outcomes) => outcomes,
 							Ok(_) | Err(_) => final_authorization().await?,
 						},
 						Err(error) => match initial.await {
-							Ok(outcomes) if grants_sufficient(&outcomes) => outcomes,
+							Ok(outcomes) if initial_is_sufficient(&outcomes) => outcomes,
 							Ok(_) | Err(_) => return Err(error),
 						},
 					},

--- a/packages/server/src/object/availability.rs
+++ b/packages/server/src/object/availability.rs
@@ -75,33 +75,35 @@ impl Session {
 		token: Option<&tg::authorization::Token>,
 	) -> tg::Result<Option<tg::object::Availability>> {
 		let resource = tg::Referent::with_node_and_token(id.clone(), token.cloned());
+		let Some(permissions) = self.authorize_object_read(resource, true).await? else {
+			return Ok(None);
+		};
+		let output = Self::compute_object_availability_with_permissions(&storage, permissions);
+
+		Ok(output)
+	}
+
+	pub(crate) fn compute_object_availability_with_permissions(
+		storage: &tangram_index::object::Storage,
+		permissions: tg::authorization::permission::Set,
+	) -> Option<tg::object::Availability> {
 		let subtree = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Subtree,
 		);
-		if self
-			.authorize(resource.clone(), subtree)
-			.await?
-			.is_some_and(|permissions| permissions.contains(subtree))
-		{
+		if permissions.contains(subtree) {
 			let availability = tg::object::Availability {
 				subtree: storage.subtree,
 			};
 
-			return Ok(Some(availability));
+			return Some(availability);
 		}
 
 		let node = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Node,
 		);
-		if self
-			.authorize(resource, node)
-			.await?
-			.is_some_and(|permissions| permissions.contains(node))
-		{
-			return Ok(Some(tg::object::Availability::default()));
-		}
-
-		Ok(None)
+		permissions
+			.contains(node)
+			.then(tg::object::Availability::default)
 	}
 
 	async fn try_get_object_availability_regions(

--- a/packages/server/src/object/get.rs
+++ b/packages/server/src/object/get.rs
@@ -104,17 +104,14 @@ impl Session {
 		token: Option<&tg::authorization::Token>,
 	) -> tg::Result<Option<tg::object::get::Output>> {
 		let resource = tg::Referent::with_node_and_token(id.clone(), token.cloned());
-		let mut permissions = tg::authorization::permission::object::Set::empty();
-		permissions.insert(tg::authorization::permission::object::Set::NODE);
-		permissions.insert(tg::authorization::permission::object::Set::SUBTREE);
-		let permissions = tg::authorization::permission::Set::Object(permissions);
-		let Some(permissions) = self.authorize(resource, permissions).await? else {
-			tracing::trace!(%id, principal = ?self.context.principal, "authorization denied");
-			return Ok(None);
-		};
 		let node = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Node,
 		);
+		let search_subtree = metadata || availability;
+		let Some(permissions) = self.authorize_object_read(resource, search_subtree).await? else {
+			tracing::trace!(%id, principal = ?self.context.principal, "authorization denied");
+			return Ok(None);
+		};
 		if !permissions.contains(node) {
 			tracing::trace!(%id, principal = ?self.context.principal, "authorization denied");
 			return Ok(None);
@@ -135,10 +132,11 @@ impl Session {
 			output.tokens.set_local(token);
 		}
 		if let Some(metadata) = output.metadata {
-			output.metadata = self.mask_object_metadata(id, metadata, token).await?;
+			output.metadata = Self::mask_object_metadata_with_permissions(metadata, permissions);
 		}
 		if availability && let Some(storage) = self.server.try_get_object_storage_local(id).await? {
-			output.availability = self.compute_object_availability(id, storage, token).await?;
+			output.availability =
+				Self::compute_object_availability_with_permissions(&storage, permissions);
 		}
 		Ok(Some(output))
 	}
@@ -189,6 +187,7 @@ impl Session {
 		objects: &[tg::Referent<tg::object::Id>],
 		metadata: bool,
 	) -> tg::Result<Vec<Option<tg::object::get::Output>>> {
+		// Get the objects.
 		let ids = objects
 			.iter()
 			.map(|object| object.node.clone())
@@ -197,39 +196,58 @@ impl Session {
 			.server
 			.try_get_object_batch_local(&ids, metadata)
 			.await?;
-		let outputs = std::iter::zip(objects, outputs)
-			.map(|(object, output)| async move {
-				if output.is_none() {
-					return Ok::<_, tg::Error>(None);
-				}
-				let permission = tg::authorization::Permission::Object(
-					tg::authorization::permission::object::Permission::Node,
-				);
-				if !self
-					.authorize(object.clone(), permission)
-					.await?
-					.is_some_and(|permissions| permissions.contains(permission))
-				{
+
+		// Authorize the objects.
+		let required = tg::authorization::Permission::Object(
+			tg::authorization::permission::object::Permission::Node,
+		);
+		let mut resources = Vec::new();
+		let mut positions = Vec::new();
+		for (position, (object, output)) in std::iter::zip(objects, &outputs).enumerate() {
+			if output.is_none() {
+				continue;
+			}
+			resources.push(object.clone());
+			positions.push(position);
+		}
+		let authorizations = self
+			.authorize_object_read_batch(resources, metadata)
+			.await?;
+		let mut permissions = vec![None; objects.len()];
+		for (position, authorization) in std::iter::zip(positions, authorizations) {
+			permissions[position] = authorization;
+		}
+
+		// Mask the outputs.
+		let outputs = std::iter::zip(std::iter::zip(objects, outputs), permissions)
+			.map(|((object, output), permissions)| {
+				let mut output = output?;
+				let Some(permissions) = permissions else {
 					tracing::trace!(
 						id = %object.node,
 						principal = ?self.context.principal,
 						"authorization denied"
 					);
-					return Ok(None);
+
+					return None;
+				};
+				if !permissions.contains(required) {
+					tracing::trace!(
+						id = %object.node,
+						principal = ?self.context.principal,
+						"authorization denied"
+					);
+
+					return None;
 				}
-				let mut output = output;
-				if let Some(output) = &mut output
-					&& let Some(metadata) = output.metadata.take()
-				{
-					output.metadata = self
-						.mask_object_metadata(&object.node, metadata, object.options.tokens.local())
-						.await?;
+				if let Some(metadata) = output.metadata.take() {
+					output.metadata =
+						Self::mask_object_metadata_with_permissions(metadata, permissions);
 				}
-				Ok::<_, tg::Error>(output)
+
+				Some(output)
 			})
-			.collect::<FuturesOrdered<_>>()
-			.try_collect()
-			.await?;
+			.collect();
 
 		Ok(outputs)
 	}

--- a/packages/server/src/object/get.rs
+++ b/packages/server/src/object/get.rs
@@ -107,8 +107,11 @@ impl Session {
 		let node = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Node,
 		);
-		let search_subtree = metadata || availability;
-		let Some(permissions) = self.authorize_object_read(resource, search_subtree).await? else {
+		let wait_for_subtree = metadata || availability;
+		let Some(permissions) = self
+			.authorize_object_read(resource, wait_for_subtree)
+			.await?
+		else {
 			tracing::trace!(%id, principal = ?self.context.principal, "authorization denied");
 			return Ok(None);
 		};
@@ -198,7 +201,7 @@ impl Session {
 			.await?;
 
 		// Authorize the objects.
-		let required = tg::authorization::Permission::Object(
+		let node = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Node,
 		);
 		let mut resources = Vec::new();
@@ -231,7 +234,7 @@ impl Session {
 
 					return None;
 				};
-				if !permissions.contains(required) {
+				if !permissions.contains(node) {
 					tracing::trace!(
 						id = %object.node,
 						principal = ?self.context.principal,

--- a/packages/server/src/object/metadata.rs
+++ b/packages/server/src/object/metadata.rs
@@ -72,29 +72,12 @@ impl Session {
 		token: Option<&tg::authorization::Token>,
 	) -> tg::Result<Option<tg::object::Metadata>> {
 		let resource = tg::Referent::with_node_and_token(id.clone(), token.cloned());
-		let subtree = tg::authorization::Permission::Object(
-			tg::authorization::permission::object::Permission::Subtree,
-		);
-		if self
-			.authorize(resource.clone(), subtree)
-			.await?
-			.is_some_and(|permissions| permissions.contains(subtree))
-		{
-			return Ok(Some(metadata));
-		}
+		let Some(permissions) = self.authorize_object_read(resource, true).await? else {
+			return Ok(None);
+		};
+		let output = Self::mask_object_metadata_with_permissions(metadata, permissions);
 
-		let node = tg::authorization::Permission::Object(
-			tg::authorization::permission::object::Permission::Node,
-		);
-		if self
-			.authorize(resource, node)
-			.await?
-			.is_some_and(|permissions| permissions.contains(node))
-		{
-			return Ok(Some(tg::object::Metadata::default()));
-		}
-
-		Ok(None)
+		Ok(output)
 	}
 
 	pub(crate) fn mask_object_metadata_with_permissions(


### PR DESCRIPTION
Object reads requested both node and subtree permissions, even though only node permission is required. If the optional subtree search exhausted its budget, the entire read failed. These reads could also repeat authorization for metadata and availability, causing index waits and expensive searches that slowed builds.

This change:

- Treats node permission as required and subtree permission as optional.
- Reuses authorization results for metadata and availability.
- Batches authorization for multi-object reads.

The included regression test is red on main and green with the fix.