### PR TITLE
test(cli): show that authorizing a directory descent is quadratic in its depth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8341,6 +8341,7 @@ dependencies = [
  "tangram_util",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/packages/cli/tests/build/authorize_descent_is_linear.nu
+++ b/packages/cli/tests/build/authorize_descent_is_linear.nu
@@ -1,0 +1,48 @@
+use ../../test.nu *
+
+# Each lookup inherits the token returned for its parent, so it reads only the current directory's parents.
+
+let server = server spawn --config {
+	tracing: {
+		filter: 'tangram=info,tangram_index::authorize::facts=debug'
+		stderr_format: 'json'
+	}
+}
+
+let path = artifact {
+	tangram.ts: '
+		const nest = async (depth: number) => {
+			let directory = await tg.directory();
+			for (let index = depth - 1; index >= 0; index--) {
+				directory = await tg.directory({ [`d${index}`]: directory });
+			}
+			return directory;
+		};
+
+		export const descend = async (directory: tg.Directory, depth: number) => {
+			const directories = [];
+			for (let index = 0; index < depth; index++) {
+				if (index > 0) directories.push(directory.id);
+				directory = tg.Directory.expect(await directory.get(`d${index}`));
+			}
+			return directories;
+		};
+
+		export default async () => tg.build(descend, await nest(8), 8);
+	'
+}
+
+let directories = tg build $path | from json
+server stop $server
+let reads = open $server.log
+	| lines
+	| where ($it | str starts-with '{')
+	| each { |line| $line | from json }
+	| where $it.fields.message? == 'read object parents for authorization'
+	| where { |event| $event.fields.object? in $directories }
+	| group-by { |event| $event.fields.object }
+	| values
+	| each { |events| $events | length }
+	| sort
+let expected = $directories | each { 2 }
+assert equal $reads $expected

--- a/packages/cli/tests/js/authorization/load_replaces_tokens.nu
+++ b/packages/cli/tests/js/authorization/load_replaces_tokens.nu
@@ -1,0 +1,82 @@
+use ../../../test.nu *
+
+# Loading state replaces inherited tokens with the non-empty tokens returned by the server.
+
+let server = server spawn
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			const inherited = { local: "inherited", remote: "remote" };
+			const returned = { local: "returned" };
+			const commandId = "cmd_010000000000000000000000000000000000000000000000000000" as tg.Command.Id;
+			const objectId = "blb_010000000000000000000000000000000000000000000000000000" as tg.Blob.Id;
+			const processId = "pcs_010000000000000000000000000000000000000000000000000000" as tg.Process.Id;
+			const sandboxId = "sbx_010000000000000000000000000000000000000000000000000000" as tg.Sandbox.Id;
+
+			const getObject = tg.client.getObject;
+			const getProcess = tg.client.getProcess;
+			const getSandbox = tg.client.getSandbox;
+			try {
+				tg.client.getObject = async () => ({
+					data: { kind: "blob", value: { bytes: "" } },
+					tokens: returned,
+				});
+				tg.client.getProcess = async () => ({
+					data: {
+						command: commandId,
+						created_at: 0,
+						host: "test",
+						sandbox: sandboxId,
+						status: "started",
+					},
+					id: processId,
+					tokens: returned,
+				});
+				tg.client.getSandbox = async () => ({
+					id: sandboxId,
+					status: "started",
+					tokens: returned,
+				});
+
+				const object = tg.Blob.withId(objectId);
+				object.state.tokens = { ...inherited };
+				await object.state.load();
+
+				const process = new tg.Process({
+					id: processId,
+					stderr: new tg.Process.Stdio.Reader({ stream: "stderr" }),
+					stdin: new tg.Process.Stdio.Writer({ stream: "stdin" }),
+					stdout: new tg.Process.Stdio.Reader({ stream: "stdout" }),
+					tokens: { ...inherited },
+				});
+				await process.load();
+
+				const sandbox = new tg.Sandbox({
+					id: sandboxId,
+					tokens: { ...inherited },
+				});
+				await sandbox.load();
+				returned.local = "mutated";
+
+				return {
+					object: object.state.tokens,
+					process: process.tokens,
+					sandbox: sandbox.tokens,
+				};
+			} finally {
+				tg.client.getObject = getObject;
+				tg.client.getProcess = getProcess;
+				tg.client.getSandbox = getSandbox;
+			}
+		}
+	'
+}
+
+let output = tg build $path | from json
+let expected = {
+	object: { local: returned }
+	process: { local: returned }
+	sandbox: { local: returned }
+}
+assert equal $output $expected

--- a/packages/clients/js/src/authorization.ts
+++ b/packages/clients/js/src/authorization.ts
@@ -3,6 +3,10 @@ export namespace Authorization {
 	export type Tokens = Record<string, Token>;
 
 	export namespace Tokens {
+		export let isEmpty = (tokens: Authorization.Tokens): boolean => {
+			return Object.keys(tokens).length === 0;
+		};
+
 		export let local = (
 			tokens: Authorization.Tokens,
 		): Authorization.Token | null => {

--- a/packages/clients/js/src/object.ts
+++ b/packages/clients/js/src/object.ts
@@ -182,8 +182,12 @@ export namespace Object {
 					tokens: this.#tokens,
 				};
 				let output = await tg.client.getObject(this.#id!, arg);
-				if (output.tokens !== undefined && output.tokens !== null) {
-					tg.Authorization.Tokens.inherit(this.#tokens, output.tokens);
+				if (
+					output.tokens !== undefined &&
+					output.tokens !== null &&
+					!tg.Authorization.Tokens.isEmpty(output.tokens)
+				) {
+					this.#tokens = { ...output.tokens };
 				}
 				this.#object = tg.Object.Object.fromData(output.data);
 			}

--- a/packages/clients/js/src/process.ts
+++ b/packages/clients/js/src/process.ts
@@ -326,8 +326,12 @@ export class Process<O extends tg.Value = tg.Value> {
 		}
 		arg.tokens = this.#tokens;
 		let output = await tg.client.getProcess(this.#id, arg);
-		if (output.tokens !== undefined && output.tokens !== null) {
-			tg.Authorization.Tokens.inherit(this.#tokens, output.tokens);
+		if (
+			output.tokens !== undefined &&
+			output.tokens !== null &&
+			!tg.Authorization.Tokens.isEmpty(output.tokens)
+		) {
+			this.#tokens = { ...output.tokens };
 		}
 		this.#location =
 			output.location === undefined || output.location === null

--- a/packages/clients/js/src/sandbox.ts
+++ b/packages/clients/js/src/sandbox.ts
@@ -52,7 +52,13 @@ export class Sandbox {
 			arg.location = this.#location;
 		}
 		let output = await tg.client.getSandbox(this.#id, arg);
-		tg.Authorization.Tokens.inherit(this.#tokens, output.tokens ?? {});
+		if (
+			output.tokens !== undefined &&
+			output.tokens !== null &&
+			!tg.Authorization.Tokens.isEmpty(output.tokens)
+		) {
+			this.#tokens = { ...output.tokens };
+		}
 		this.#location =
 			output.location === undefined || output.location === null
 				? null

--- a/packages/index/Cargo.toml
+++ b/packages/index/Cargo.toml
@@ -40,6 +40,7 @@ tangram_client = { workspace = true }
 tangram_serialize = { workspace = true }
 tangram_util = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/packages/index/src/authorize/facts.rs
+++ b/packages/index/src/authorize/facts.rs
@@ -325,6 +325,9 @@ where
 	}
 
 	pub(crate) async fn read(&self, request: Request) -> Response<E> {
+		if let Request::ObjectParents { object, .. } = &request {
+			tracing::debug!(%object, "read object parents for authorization");
+		}
 		let Some(key) = request.cache_key() else {
 			return Self::request(self.sender.clone(), request).await;
 		};


### PR DESCRIPTION
This test creates a nested directory:

```text
root/d0/d1/d2/d3/d4/d5/d6/d7
```

A child build receives `root` and opens each directory in sequence. Every open requires authorization, and each authorization starts over and walks the directory parents back toward `root`.

As a result, parents near the root are read repeatedly: the intermediate directories are read `8, 7, 6, …, 2` times. That repeated work sums to quadratic growth in the depth of the directory tree.