### PR TITLE
test(authz): reproduce increasing directory authorization cost

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -4256,9 +4256,10 @@ mod tests {
 		assert_eq!(authorization.final_.descendant.max_edges, 3);
 		assert_eq!(authorization.final_.subtree.max_objects, 4);
 		assert_eq!(authorization.initial.ancestor.max_edges, 1);
-		assert_eq!(authorization.initial.descendant.max_depth, 0);
-		assert_eq!(authorization.initial.descendant.max_edges, 0);
-		assert_eq!(authorization.initial.descendant.max_nodes, 0);
+		assert_eq!(
+			authorization.initial.descendant,
+			server::AuthorizationSearch::default()
+		);
 		assert_eq!(authorization.initial.subtree.max_depth, 0);
 		assert_eq!(authorization.initial.subtree.max_objects, 0);
 		assert_eq!(authorization.initial.subtree.max_processes, 0);

--- a/packages/cli/tests/build/authorize_cost_grows_with_process_count.nu
+++ b/packages/cli/tests/build/authorize_cost_grows_with_process_count.nu
@@ -1,0 +1,42 @@
+use ../../test.nu *
+
+# Authorizing a shared directory should not get more expensive as more processes reference it.
+
+let server = server spawn --config {
+	tracing: {
+		filter: 'tangram=info,tangram_index::authorize=debug'
+		stderr_format: 'json'
+	}
+}
+
+let path = artifact {
+	tangram.ts: '
+		export const touch = async (directory: tg.Directory, i: number) => {
+			await directory.entries;
+			return i;
+		};
+
+		export default async () => {
+			const directory = await tg.directory({ file: "contents" });
+			for (let i = 0; i < 32; i++) {
+				await tg.build(touch, directory, i);
+			}
+			return directory.id;
+		};
+	'
+}
+
+let id = tg build $path | from json
+let reads = open $server.log
+	| lines
+	| where ($it | str starts-with '{')
+	| each { from json }
+	| where $it.fields.message? == 'authorize batch'
+	| where $it.fields.args? == 1
+	| where $it.fields.resource? == $id
+	| get fields.reads
+
+let first = $reads | first 8 | math avg
+let last = $reads | last 8 | math avg
+print $'authorization reads grew from an average of ($first) to ($last)'
+assert ($last < ($first * 1.5)) 'authorizing the same directory got more expensive as more processes referenced it'

--- a/packages/index/src/authorize/engine.rs
+++ b/packages/index/src/authorize/engine.rs
@@ -121,6 +121,30 @@ impl Batch {
 	where
 		E: Clone + Send + Sync + 'static,
 	{
+		let client_for_reads = client.clone();
+		let result = Self::authorize_inner(args, client, config, principal).await;
+		let reads = client_for_reads.reads();
+		for arg in args {
+			tracing::debug!(
+				args = args.len(),
+				reads,
+				resource = %arg.resource,
+				"authorize batch"
+			);
+		}
+
+		result
+	}
+
+	async fn authorize_inner<E>(
+		args: &[super::Arg],
+		client: facts::Client<E>,
+		config: super::Config,
+		principal: &tg::Principal,
+	) -> Result<ControlFlow<Vec<super::Outcome>, E>, tg::Error>
+	where
+		E: Clone + Send + Sync + 'static,
+	{
 		let mut batch = Self::new(args, config, principal)?;
 
 		// Resolve the resources and expand the principal's memberships.
@@ -441,7 +465,7 @@ impl TokenSearch {
 		subjects: &[tg::authorization::Subject],
 		token: Option<tg::authorization::Body>,
 	) -> Self {
-		let state = State::default();
+		let mut state = State::default();
 		let token = token.map(|body| {
 			let resource = body.resource.clone();
 			(body, resource)
@@ -451,8 +475,8 @@ impl TokenSearch {
 			principal,
 			&roots,
 			subjects,
-			token.clone(),
-			&state,
+			token.as_ref(),
+			&mut state,
 		);
 		let final_search = FinalSearch::new(roots.iter().cloned());
 
@@ -721,12 +745,7 @@ impl SubtreeEvaluation {
 					{
 						SubtreeAction::AuthorizeAncestorOrDescendant { roots } => {
 							let search = AncestorOrDescendantSearch::new(
-								config,
-								principal,
-								&roots,
-								subjects,
-								token.cloned(),
-								state,
+								config, principal, &roots, subjects, token, state,
 							);
 							self.phase = SubtreePhase::AncestorOrDescendant { roots, search };
 						},
@@ -977,14 +996,8 @@ impl ProcessSearch {
 
 			return;
 		}
-		let search = AncestorOrDescendantSearch::new(
-			config,
-			principal,
-			&roots,
-			subjects,
-			token.cloned(),
-			state,
-		);
+		let search =
+			AncestorOrDescendantSearch::new(config, principal, &roots, subjects, token, state);
 		self.phase = ProcessPhase::ObjectInitial { roots, search };
 	}
 }
@@ -1607,6 +1620,10 @@ mod tests {
 								after: None,
 								grants: Vec::new(),
 							}
+						},
+						facts::Request::SubjectGrants { .. } => facts::Output::Grants {
+							after: None,
+							grants: Vec::new(),
 						},
 						facts::Request::TargetTags { .. } => facts::Output::Tags(Vec::new()),
 						request => panic!("received an unexpected fact request: {request:?}"),

--- a/packages/index/src/authorize/facts.rs
+++ b/packages/index/src/authorize/facts.rs
@@ -6,7 +6,10 @@ use {
 		future::Future,
 		hash::Hash,
 		ops::ControlFlow,
-		sync::{Arc, Mutex},
+		sync::{
+			Arc, Mutex,
+			atomic::{AtomicUsize, Ordering},
+		},
 	},
 	tangram_client::prelude::*,
 };
@@ -142,6 +145,7 @@ enum CacheKey {
 pub(crate) struct Client<E> {
 	cache: Arc<Mutex<HashMap<CacheKey, ResponseFuture<E>>>>,
 	concurrency: usize,
+	reads: Arc<AtomicUsize>,
 	sender: mpsc::Sender<Message<E>>,
 }
 
@@ -152,6 +156,7 @@ pub(crate) fn channel<E>(concurrency: usize) -> (Client<E>, Receiver<E>) {
 	let client = Client {
 		cache: Arc::new(Mutex::new(HashMap::new())),
 		concurrency,
+		reads: Arc::new(AtomicUsize::new(0)),
 		sender,
 	};
 
@@ -324,7 +329,13 @@ where
 		self.concurrency
 	}
 
+	#[must_use]
+	pub(crate) fn reads(&self) -> usize {
+		self.reads.load(Ordering::Relaxed)
+	}
+
 	pub(crate) async fn read(&self, request: Request) -> Response<E> {
+		self.reads.fetch_add(1, Ordering::Relaxed);
 		if let Request::ObjectParents { object, .. } = &request {
 			tracing::debug!(%object, "read object parents for authorization");
 		}
@@ -371,6 +382,7 @@ impl<E> Clone for Client<E> {
 		Self {
 			cache: self.cache.clone(),
 			concurrency: self.concurrency,
+			reads: self.reads.clone(),
 			sender: self.sender.clone(),
 		}
 	}

--- a/packages/index/src/authorize/search.rs
+++ b/packages/index/src/authorize/search.rs
@@ -152,20 +152,20 @@ struct Budget {
 	nodes: usize,
 }
 
-enum Phase {
-	Ancestor(AncestorSearch),
-	Complete,
-	Descendant { search: DescendantSearch },
+pub(crate) struct AncestorOrDescendantSearch {
+	ancestor: Option<AncestorSearch>,
+	ancestor_exhausted: HashSet<Key>,
+	complete: bool,
+	descendant: Option<DescendantSearch>,
+	descendant_exhausted: HashSet<Key>,
+	next: Direction,
+	roots: Vec<Key>,
 }
 
-pub(crate) struct AncestorOrDescendantSearch {
-	config: crate::authorize::Config,
-	exhausted: HashSet<Key>,
-	phase: Phase,
-	principal: tg::Principal,
-	roots: Vec<Key>,
-	subjects: Vec<tg::authorization::Subject>,
-	token: Option<(tg::authorization::Body, tg::Id)>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Direction {
+	Ancestor,
+	Descendant,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -347,8 +347,8 @@ impl AncestorOrDescendantSearch {
 		principal: &tg::Principal,
 		roots: &[Key],
 		subjects: &[tg::authorization::Subject],
-		token: Option<(tg::authorization::Body, tg::Id)>,
-		state: &State,
+		token: Option<&(tg::authorization::Body, tg::Id)>,
+		state: &mut State,
 	) -> Self {
 		let mut seen = HashSet::new();
 		let roots = roots
@@ -359,39 +359,61 @@ impl AncestorOrDescendantSearch {
 			})
 			.cloned()
 			.collect::<Vec<_>>();
-		let phase = if roots.is_empty() {
-			Phase::Complete
+		let complete = roots.is_empty();
+		let (ancestor, descendant) = if complete {
+			(None, None)
 		} else {
-			Phase::Ancestor(AncestorSearch::new(
+			let ancestor = AncestorSearch::new(
 				config.ancestor,
 				principal,
 				&roots,
 				subjects,
-				token.clone(),
+				token.cloned(),
 				state,
-			))
+			);
+			let descendant = if let Some(mut descendant) = state.take_descendant() {
+				descendant.add_targets(config.descendant, roots.clone());
+				descendant
+			} else {
+				let token = token.map(|(body, resource)| (body, resource));
+				DescendantSearch::new(
+					config.descendant,
+					principal,
+					state,
+					subjects,
+					roots.clone(),
+					token,
+				)
+			};
+
+			(Some(ancestor), Some(descendant))
 		};
 
 		Self {
-			config,
-			exhausted: HashSet::new(),
-			phase,
-			principal: principal.clone(),
+			ancestor,
+			ancestor_exhausted: HashSet::new(),
+			complete,
+			descendant,
+			descendant_exhausted: HashSet::new(),
+			next: Direction::Descendant,
 			roots,
-			subjects: subjects.to_vec(),
-			token,
 		}
 	}
 
 	#[must_use]
 	pub(crate) fn complete(&self) -> bool {
-		matches!(self.phase, Phase::Complete)
+		self.complete
 	}
 
 	#[must_use]
 	pub(crate) fn outcome(&self, state: &State, root: &Key) -> Outcome {
 		match state.ancestor_or_descendant(root) {
-			Outcome::Pending if self.exhausted.contains(root) => Outcome::Exhausted,
+			Outcome::Pending
+				if self.ancestor_exhausted.contains(root)
+					&& self.descendant_exhausted.contains(root) =>
+			{
+				Outcome::Exhausted
+			},
 			outcome => outcome,
 		}
 	}
@@ -399,62 +421,81 @@ impl AncestorOrDescendantSearch {
 	pub(crate) fn take_reads(&mut self, state: &mut State, limit: usize) -> tg::Result<Vec<Read>> {
 		assert!(limit > 0);
 		loop {
-			let reads = match &mut self.phase {
-				Phase::Ancestor(search) => search.take_reads(state, limit)?,
-				Phase::Complete => return Ok(Vec::new()),
-				Phase::Descendant { search } => search.take_reads(state, limit),
-			};
-			if !reads.is_empty() {
-				return Ok(reads);
+			if self.complete {
+				return Ok(Vec::new());
 			}
 
-			let phase = std::mem::replace(&mut self.phase, Phase::Complete);
-			match phase {
-				Phase::Ancestor(mut search) => {
+			if self.roots.iter().all(|root| {
+				state.ancestor_or_descendant(root) != Outcome::Pending
+					|| (self.ancestor_exhausted.contains(root)
+						&& self.descendant_exhausted.contains(root))
+			}) {
+				self.finish(state);
+
+				return Ok(Vec::new());
+			}
+
+			// Give both directions part of the batch so their reads execute concurrently.
+			let mut reads = Vec::new();
+			let both = self.ancestor.is_some() && self.descendant.is_some();
+			let direction = self.next;
+			if both && limit == 1 {
+				self.next = match direction {
+					Direction::Ancestor => Direction::Descendant,
+					Direction::Descendant => Direction::Ancestor,
+				};
+			}
+			let descendant_limit = if both && limit == 1 {
+				usize::from(direction == Direction::Descendant)
+			} else if both {
+				limit.div_ceil(2)
+			} else if self.descendant.is_some() {
+				limit
+			} else {
+				0
+			};
+			if descendant_limit > 0
+				&& let Some(search) = &mut self.descendant
+			{
+				let descendant_reads = search.take_reads(state, descendant_limit);
+				if descendant_reads.is_empty() {
+					let mut search = self.descendant.take().unwrap();
+					if search.finish(state) == Outcome::Exhausted {
+						self.descendant_exhausted
+							.extend(search.unresolved.iter().cloned());
+					}
+					search.reset_visited_if_complete();
+					state.set_descendant(search);
+				} else {
+					reads.extend(descendant_reads);
+				}
+			}
+
+			let remaining = limit - reads.len();
+			if remaining > 0
+				&& let Some(search) = &mut self.ancestor
+			{
+				let ancestor_reads = search.take_reads(state, remaining)?;
+				if ancestor_reads.is_empty() {
+					let mut search = self.ancestor.take().unwrap();
 					search.finish(state);
-					let mut roots = Vec::new();
 					for root in &self.roots {
 						if state.is_authorized(root) {
 							continue;
 						}
 						if search.incomplete.contains(root) {
-							roots.push(root.clone());
+							self.ancestor_exhausted.insert(root.clone());
 						} else {
 							state.deny_ancestor_or_descendant(root);
 						}
 					}
-					if roots.is_empty() {
-						continue;
-					}
-					let descendant = if let Some(mut descendant) = state.take_descendant() {
-						descendant.add_targets(self.config.descendant, roots.clone());
-						descendant
-					} else {
-						let token = self.token.as_ref().map(|(body, resource)| (body, resource));
-						DescendantSearch::new(
-							self.config.descendant,
-							&self.principal,
-							state,
-							&self.subjects,
-							roots.clone(),
-							token,
-						)
-					};
-					self.phase = Phase::Descendant { search: descendant };
-				},
-				Phase::Complete => {},
-				Phase::Descendant { mut search } => {
-					let outcome = search.finish(state);
-					match outcome {
-						Outcome::Authorized | Outcome::Denied => {},
-						Outcome::Exhausted => {
-							self.exhausted.extend(search.unresolved.iter().cloned());
-						},
-						Outcome::Pending => unreachable!(),
-					}
-					search.reset_visited_if_complete();
-					state.set_descendant(search);
-				},
+				} else {
+					reads.extend(ancestor_reads);
+				}
+			}
+
+			if !reads.is_empty() {
+				return Ok(reads);
 			}
 		}
 	}
@@ -465,13 +506,41 @@ impl AncestorOrDescendantSearch {
 		read: Read,
 		output: ReadOutput,
 	) -> tg::Result<()> {
-		match &mut self.phase {
-			Phase::Ancestor(search) => search.apply(state, read, output),
-			Phase::Complete => Err(tg::error!(
-				"received a read after the ancestor or descendant search completed"
+		match read {
+			read @ (Read::AncestorNode { .. }
+			| Read::ObjectParents { .. }
+			| Read::ProcessParents { .. }) => self
+				.ancestor
+				.as_mut()
+				.ok_or_else(|| tg::error!("received a read after the ancestor search completed"))?
+				.apply(state, read, output),
+			read @ (Read::ObjectChildren { .. }
+			| Read::OwnerSandboxes { .. }
+			| Read::ProcessChildren { .. }
+			| Read::ProcessGrants { .. }
+			| Read::SandboxProcesses { .. }
+			| Read::SubjectGrants { .. }) => self
+				.descendant
+				.as_mut()
+				.ok_or_else(|| tg::error!("received a read after the descendant search completed"))?
+				.apply(state, read, output),
+			Read::Member { .. }
+			| Read::Process { .. }
+			| Read::Resolve { .. }
+			| Read::SubtreeObjectChildren { .. }
+			| Read::SubtreeProcessChildren { .. } => Err(tg::error!(
+				"received an invalid read for an ancestor or descendant search"
 			)),
-			Phase::Descendant { search } => search.apply(state, read, output),
 		}
+	}
+
+	fn finish(&mut self, state: &mut State) {
+		self.ancestor = None;
+		if let Some(mut descendant) = self.descendant.take() {
+			descendant.reset_visited_if_complete();
+			state.set_descendant(descendant);
+		}
+		self.complete = true;
 	}
 }
 
@@ -992,6 +1061,59 @@ fn has_derived_proof(permission: tg::authorization::Permission) -> bool {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn ancestor_and_descendant_searches_share_a_read_batch() {
+		let root = key();
+		let mut state = State::default();
+		let mut search = AncestorOrDescendantSearch::new(
+			crate::authorize::Config::default(),
+			&tg::Principal::Anonymous,
+			std::slice::from_ref(&root),
+			&[tg::authorization::Subject::Public],
+			None,
+			&mut state,
+		);
+
+		let reads = search.take_reads(&mut state, 2).unwrap();
+
+		assert!(
+			reads
+				.iter()
+				.any(|read| matches!(read, Read::AncestorNode { .. }))
+		);
+		assert!(
+			reads
+				.iter()
+				.any(|read| matches!(read, Read::SubjectGrants { .. }))
+		);
+	}
+
+	#[test]
+	fn ancestor_and_descendant_searches_take_turns_with_one_read() {
+		let root = key();
+		let mut state = State::default();
+		let mut search = AncestorOrDescendantSearch::new(
+			crate::authorize::Config::default(),
+			&tg::Principal::Anonymous,
+			std::slice::from_ref(&root),
+			&[tg::authorization::Subject::Public],
+			None,
+			&mut state,
+		);
+		let mut reads = search.take_reads(&mut state, 1).unwrap();
+		let read = reads.pop().unwrap();
+		assert!(matches!(read, Read::SubjectGrants { .. }));
+		let output = ReadOutput::Grants {
+			after: None,
+			grants: Vec::new(),
+		};
+		search.apply(&mut state, read, output).unwrap();
+
+		let reads = search.take_reads(&mut state, 1).unwrap();
+
+		assert!(matches!(reads.as_slice(), [Read::AncestorNode { .. }]));
+	}
 
 	#[test]
 	fn authorization_propagates_across_an_edge_added_after_the_proof() {

--- a/packages/index/src/authorize/search/descendant.rs
+++ b/packages/index/src/authorize/search/descendant.rs
@@ -129,7 +129,7 @@ impl Search {
 		self.unresolved.extend(targets);
 		let added = self.unresolved.len() - previous;
 		self.budget.add_root_total(config, added);
-		if added > 0 {
+		if added > 0 && (config.max_edges > 0 || config.max_nodes > 0) {
 			self.exhausted = false;
 		}
 	}

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -2144,12 +2144,7 @@ fn default_dns() -> Vec<Ipv4Addr> {
 
 fn authorization_initial_default() -> AuthorizationSearches {
 	let ancestor = AuthorizationSearch::default();
-	let descendant = AuthorizationSearch {
-		max_depth: 0,
-		max_edges: 0,
-		max_nodes: 0,
-		page_size: ancestor.page_size,
-	};
+	let descendant = AuthorizationSearch::default();
 	let subtree = AuthorizationSubtree {
 		max_depth: 0,
 		max_objects: 0,


### PR DESCRIPTION
The std build trace shows frequently reused objects becoming more expensive to authorize as more processes reference them.

This adds a minimal fact-read probe and a CLI regression using one directory shared by 32 processes. The focused test is intentionally red: the first eight authorizations average 19.125 reads and the last eight average 48.375 reads, exceeding the 1.5x ceiling.