### PR TITLE
test: reproduce module token refresh cycle

### DIFF
--- a/packages/cli/tests/build/module_token_refresh_cycle.nu
+++ b/packages/cli/tests/build/module_token_refresh_cycle.nu
@@ -1,0 +1,23 @@
+use ../../test.nu *
+
+# A broad cyclic module graph builds successfully when module resolution
+# refreshes authorization tokens.
+#
+# Regression introduced by 0d0b55d28.
+
+let server = server spawn
+
+let path = mktemp -d
+let modules = 0..<55
+let imports = $modules
+	| each { |index| $'import "./module_($index).tg.ts";' }
+	| str join (char newline)
+[$imports 'export default function () { return "Hello, World!"; }']
+	| str join (char newline)
+	| save ($path | path join 'tangram.ts')
+for index in $modules {
+	'import "./tangram.ts";' | save ($path | path join $'module_($index).tg.ts')
+}
+
+let output = timeout 15s tg build $path | complete
+success $output


### PR DESCRIPTION
Adds a minimal CLI reproduction for the module-resolution regression introduced by 0d0b55d28. The 55-spoke cyclic graph completes in 2.63 seconds on 3c22372e4 but exceeds the 15-second timeout on 0d0b55d28. The regression does not require VFS and appears to result from refreshed authorization tokens participating in V8 module-cache identity. This PR is intentionally red until the underlying cache behavior is fixed.