### PR TITLE
test(cli): reproduce the undeduplicated object load

### DIFF
--- a/packages/cli/tests/build/object_load_is_not_deduplicated.nu
+++ b/packages/cli/tests/build/object_load_is_not_deduplicated.nu
@@ -1,0 +1,39 @@
+use ../../test.nu *
+
+# Concurrent loads through one handle should share an in-flight object GET.
+
+let server = server spawn --config {
+	tracing: {
+		filter: 'tangram=info,tangram_http::layer::tracing=trace'
+		stderr_format: 'json'
+	}
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default async () => {
+			const concurrency = 8;
+			const directory = await tg.directory({ file: "contents" });
+			const id = await directory.store();
+			const handle = tg.Directory.withId(id);
+			await Promise.all(Array.from({ length: concurrency }, () => handle.load()));
+			return id;
+		};
+	'
+}
+
+let id = tg build $path | from json
+server stop $server
+
+# The tracing layer debug formats the path, so the recorded value carries literal quotes.
+let gets = open $server.log
+	| lines
+	| where ($it | str starts-with '{')
+	| each { from json }
+	| where $it.fields.message? == 'request'
+	| where ($it.fields.method? | default '') == 'GET'
+	| each { |event| $event.fields.path? | default '' | str trim --char '"' }
+	| where $it == $'/objects/($id)'
+	| length
+
+assert equal $gets 1 'concurrent loads through one handle should share one object GET'

--- a/packages/clients/rust/src/object/state.rs
+++ b/packages/clients/rust/src/object/state.rs
@@ -3,6 +3,9 @@ use {
 	std::sync::{Arc, RwLock},
 };
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Clone, Debug)]
 pub struct State(Arc<RwLock<Inner>>);
 

--- a/packages/clients/rust/src/object/state/tests.rs
+++ b/packages/clients/rust/src/object/state/tests.rs
@@ -1,0 +1,76 @@
+use {
+	super::*,
+	futures::future,
+	hyper::service::service_fn,
+	hyper_util::rt::{TokioExecutor, TokioIo},
+	std::{
+		collections::BTreeMap,
+		convert::Infallible,
+		sync::{
+			Arc,
+			atomic::{AtomicUsize, Ordering},
+		},
+	},
+	tangram_http::body::Boxed,
+};
+
+#[tokio::test]
+async fn concurrent_loads_share_an_in_flight_get() {
+	// Create an object response.
+	let directory = tg::Directory::with_entries(BTreeMap::new());
+	let id = directory.id();
+	let bytes = directory
+		.state()
+		.object()
+		.unwrap()
+		.to_data()
+		.serialize()
+		.unwrap();
+
+	// Serve object GETs over an in-memory connection.
+	let requests = Arc::new(AtomicUsize::new(0));
+	let (client_stream, server_stream) = tokio::io::duplex(64 * 1024);
+	let server = tokio::spawn({
+		let id = id.clone();
+		let requests = requests.clone();
+		async move {
+			let service = service_fn(move |request| {
+				let bytes = bytes.clone();
+				let id = id.clone();
+				let requests = requests.clone();
+				async move {
+					assert_eq!(request.method(), http::Method::GET);
+					assert_eq!(request.uri().path(), format!("/objects/{id}"));
+					requests.fetch_add(1, Ordering::SeqCst);
+					let response = http::Response::builder()
+						.body(Boxed::with_bytes(bytes))
+						.unwrap();
+
+					Ok::<_, Infallible>(response)
+				}
+			});
+			let executor = TokioExecutor::new();
+			let stream = TokioIo::new(server_stream);
+			hyper::server::conn::http2::Builder::new(executor)
+				.serve_connection(stream, service)
+				.await
+				.unwrap();
+		}
+	});
+
+	// Load the object concurrently through one state.
+	let client = tg::Client::with_stream(tg::Arg::default(), client_stream)
+		.await
+		.unwrap();
+	let state = State::with_id(id);
+	let loads = (0..8).map(|_| state.load_with_handle(&client));
+	let objects = future::try_join_all(loads).await.unwrap();
+	assert_eq!(objects.len(), 8);
+
+	// Stop the server and check the request count.
+	let requests = requests.load(Ordering::SeqCst);
+	drop(client);
+	server.await.unwrap();
+
+	assert_eq!(requests, 1);
+}


### PR DESCRIPTION
An object handle caches its object but nothing guards the load, so concurrent readers each start their own fetch, and the cache lives on the handle rather than beside the id, so handles for the same object never share it. Both the Rust and JS clients have this shape.

Pin both costs: eight concurrent reads through one handle, and eight handles read once each, against a control that reads once.