### PR TITLE
fix(server): authorize object children from parent tokens

### DIFF
--- a/packages/cli/tests/grants/object_get_child_with_parent_token.nu
+++ b/packages/cli/tests/grants/object_get_child_with_parent_token.nu
@@ -1,0 +1,33 @@
+use ../../test.nu *
+
+# A signed subtree token and an indexed direct edge authorize a child without a graph search.
+
+let root_token = random chars
+let server = server spawn --config {
+	authentication: {
+		root: { token: $root_token }
+		users: { providers: { insecure: true } }
+	}
+	authorization: { initial: false, final: false }
+}
+let bob = tg login --verbose --name bob | from json
+
+let child = tg --token $root_token put 'tg.file("child")' | str trim
+let parent = tg --token $root_token put 'tg.directory({ "child": tg.file("child") })' | str trim
+tg --token $root_token index
+
+failure (tg --token $bob.token object get --bytes $child | complete) 'the child should require proof'
+
+let socket = $server.url | str replace 'http+unix://' '' | url decode
+let response = http get --full --headers { Authorization: $'Bearer ($root_token)' } --unix-socket $socket $'http://localhost/objects/($parent)'
+let token = (
+	$response.headers.response
+	| where name == 'x-tg-object-tokens'
+	| first
+	| get value
+	| from json
+	| get local
+	| url encode --all
+)
+
+http get --headers { Authorization: $'Bearer ($bob.token)' } --unix-socket $socket $'http://localhost/objects/($child)?tokens[local]=($token)' | ignore

--- a/packages/cli/tests/grants/process_object_get_authorized_despite_search_exhaustion.nu
+++ b/packages/cli/tests/grants/process_object_get_authorized_despite_search_exhaustion.nu
@@ -1,0 +1,148 @@
+use ../../test.nu *
+
+const js_path = path self '../../../js'
+
+# The subtree proof is command -> source -> proof parent -> target.
+# Either search succeeds when only the opposite frontier is wide; both exhaust when both are wide.
+#
+#     Search       Start    Irrelevant frontier before the proof parent
+#     ancestor     target   2,499 other parents
+#     descendant   source   2,500 decoy children
+
+let root_token = random chars
+let server = server spawn --config {
+	authentication: { root: { token: $root_token } }
+	index: { kind: 'lmdb', map_size: 1_073_741_824 }
+}
+
+let setup_program = '
+	import * as tg from "@tangramdotdev/client";
+
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	tg.setEncoding({
+		json: { decode: JSON.parse, encode: JSON.stringify },
+		utf8: {
+			decode: (value) => decoder.decode(value),
+			encode: (value) => encoder.encode(value),
+		},
+	});
+	const env = Object.fromEntries(
+		Object.entries(process.env).filter(([, value]) => value !== undefined),
+	);
+	tg.setProcess({
+		args: process.argv.slice(2),
+		cwd: process.cwd(),
+		env,
+		executable: process.execPath,
+	});
+
+	function directory(entries) {
+		const data = { kind: "directory", value: { entries } };
+		return { data, id: tg.client.objectId(data) };
+	}
+
+	function batchObject(object, children) {
+		return {
+			children: children.map((child) => tg.Object.toReferent(child)),
+			data: object.data,
+			id: object.id,
+		};
+	}
+
+	const target = tg.File.withId(env.TARGET);
+	const leaf = tg.File.withId(env.LEAF);
+	const parents = Array.from({ length: 2_500 }, (_, index) =>
+		directory({ [`target${index}`]: target.id }),
+	).sort((a, b) => a.id.localeCompare(b.id));
+	const proofParent = parents.pop();
+	const targetParents = env.MANY_PARENTS === "true"
+		? [...parents, proofParent]
+		: [proofParent];
+	await tg.client.postObjectBatch({
+		objects: targetParents.map((parent) => batchObject(parent, [target])),
+	});
+
+	const decoys = [];
+	if (env.MANY_CHILDREN === "true") {
+		for (let index = 0; decoys.length < 2_500; index++) {
+			const decoy = directory({ [`decoy${index}`]: leaf.id });
+			if (decoy.id < proofParent.id) decoys.push(decoy);
+		}
+		await tg.client.postObjectBatch({
+			objects: decoys.map((decoy) => batchObject(decoy, [leaf])),
+		});
+	}
+	const entries = Object.fromEntries(
+		decoys.map((decoy, index) => [`decoy${index}`, decoy.id]),
+	);
+	entries.proof = proofParent.id;
+	const sourceData = {
+		kind: "graph",
+		value: { nodes: [{ kind: "directory", entries }] },
+	};
+	const source = { data: sourceData, id: tg.client.objectId(sourceData) };
+	const children = decoys.map((decoy) => tg.Directory.withId(decoy.id));
+	children.push(tg.Directory.withId(proofParent.id));
+	await tg.client.postObjectBatch({
+		objects: [batchObject(source, children)],
+	});
+
+	process.stdout.write(source.id);
+	process.exit(0);
+'
+
+let build_program = '
+	export default async (_source: tg.Graph, target: string) => {
+		await tg.File.withId(target).state.load();
+		return "ok";
+	}
+'
+
+def run_case [
+	setup_program: string
+	build_program: string
+	root_token: string
+	target: string
+	leaf: string
+	--many-parents
+	--many-children
+] {
+	let setup = with-env {
+		LEAF: $leaf
+		MANY_CHILDREN: ($many_children | into string)
+		MANY_PARENTS: ($many_parents | into string)
+		TANGRAM_TOKEN: $root_token
+		TARGET: $target
+	} {
+		node --input-type=module -e $setup_program | complete
+	}
+	success $setup 'the authorization graph should be created'
+	tg --token $root_token index
+	let source = $setup.stdout | str trim
+	let module = artifact { tangram.ts: $build_program }
+
+	tg --token $root_token build $module --arg-value $source --arg-string $target | complete
+}
+
+let parent_target = tg --token $root_token put 'tg.file("many parent target")' | str trim
+let source_target = tg --token $root_token put 'tg.file("wide source target")' | str trim
+let combined_target = tg --token $root_token put 'tg.file("combined target")' | str trim
+let leaf = tg --token $root_token put 'tg.file("wide leaf")' | str trim
+
+cd $js_path
+
+# Many target parents alone succeed because the descendant search reaches the proof.
+let output = run_case $setup_program $build_program $root_token $parent_target $leaf --many-parents
+success $output 'many target parents alone should not prevent the process from reading the target'
+
+# Many source children alone succeed because the ancestor search reaches the proof.
+let output = run_case $setup_program $build_program $root_token $source_target $leaf --many-children
+success $output 'a wide command subtree alone should not prevent the process from reading the target'
+
+# Combining both frontiers exhausts both bounded searches during the process object read.
+let output = run_case $setup_program $build_program $root_token $combined_target $leaf --many-children --many-parents
+server stop $server
+assert ($output.stderr | str contains 'failed to get the object') 'the combined case should reach the process object read'
+assert ($output.stderr | str contains 'the authorization search exhausted') 'the combined case should exhaust both authorization searches'
+failure $output 'a tokenless read should remain bounded when both authorization searches exhaust'

--- a/packages/index/src/lmdb/tests/authorize.rs
+++ b/packages/index/src/lmdb/tests/authorize.rs
@@ -2924,3 +2924,198 @@ async fn authorize_batch_propagates_a_converging_positive_proof() {
 			.all(|outcome| matches!(outcome, crate::authorize::Outcome::Authorized(_)))
 	);
 }
+
+fn put_wide_two_hop_frontiers(index: &Index, width: usize) -> (tg::object::Id, tg::user::Id) {
+	assert!(width > 0);
+	let target = object_id(2 * width - 1);
+	let holder = object_id(2 * width);
+	let user = tg::user::Id::new();
+	let mut objects = (0..2 * width - 1).map(object_id).collect::<Vec<_>>();
+	let proof = objects.remove(0);
+	let (parents, siblings) = objects.split_at(width - 1);
+
+	// Build one proof path beyond a wide irrelevant frontier in each direction.
+	let mut transaction = index.env.write_txn().unwrap();
+	for object in parents
+		.iter()
+		.chain(siblings)
+		.chain([&holder, &proof, &target])
+	{
+		put_object(index, &mut transaction, object);
+	}
+	put_child(index, &mut transaction, &proof, &target);
+	for parent in parents {
+		put_child(index, &mut transaction, parent, &target);
+	}
+	put_child(index, &mut transaction, &holder, &proof);
+	for sibling in siblings {
+		put_child(index, &mut transaction, &holder, sibling);
+	}
+	put_grant(
+		index,
+		&mut transaction,
+		&holder,
+		&user,
+		tg::authorization::permission::object::Permission::Subtree,
+	);
+	transaction.commit().unwrap();
+
+	(target, user)
+}
+
+fn put_order_sensitive_frontiers(
+	index: &Index,
+	width: usize,
+) -> (tg::object::Id, Vec<tg::object::Id>) {
+	assert!(width > 1);
+	let mut parents = (0..width).map(object_id).collect::<Vec<_>>();
+	let mut children = (width..2 * width).map(object_id).collect::<Vec<_>>();
+
+	// Put the target last in the child enumeration for every parent.
+	children.sort_by_cached_key(|child| {
+		Index::pack(
+			&index.subspace,
+			&Key::Object(ObjectKey::ObjectChild {
+				child: child.clone(),
+				object: parents[0].clone(),
+			}),
+		)
+	});
+	let target = children.pop().unwrap();
+
+	// Identify the first and last parents in the index's enumeration order.
+	parents.sort_by_cached_key(|parent| {
+		Index::pack(
+			&index.subspace,
+			&Key::Object(ObjectKey::ChildObject {
+				child: target.clone(),
+				object: parent.clone(),
+			}),
+		)
+	});
+	let mut transaction = index.env.write_txn().unwrap();
+	for object in parents.iter().chain(&children).chain([&target]) {
+		put_object(index, &mut transaction, object);
+	}
+	for parent in &parents {
+		put_child(index, &mut transaction, parent, &target);
+	}
+	for parent in [&parents[0], &parents[width - 1]] {
+		for child in &children {
+			put_child(index, &mut transaction, parent, child);
+		}
+	}
+	transaction.commit().unwrap();
+
+	(target, parents)
+}
+
+fn wide_frontier_config(edge_budget: usize) -> crate::authorize::Config {
+	// Leave enough node budget to isolate the edge-budget boundary.
+	let search = crate::authorize::SearchConfig {
+		max_edges: edge_budget,
+		max_nodes: edge_budget + 2,
+		..Default::default()
+	};
+
+	crate::authorize::Config {
+		ancestor: search,
+		descendant: search,
+		..Default::default()
+	}
+}
+
+async fn authorize_object_with_config(
+	index: &Index,
+	config: crate::authorize::Config,
+	object: tg::object::Id,
+	user: tg::user::Id,
+) -> crate::authorize::Outcome {
+	let permissions = object_permissions([tg::authorization::permission::object::Permission::Node]);
+	let arg = crate::authorize::Arg {
+		requested: permissions,
+		required: permissions,
+		resource: tg::Selector::Id(object.into()),
+		token: None,
+	};
+	let outcomes = index
+		.authorize_batch(&[arg], config, &tg::Principal::User(user))
+		.await
+		.unwrap();
+
+	outcomes.into_iter().next().unwrap()
+}
+
+async fn authorize_two_hop_wide_frontier(
+	edge_budget: usize,
+	width: usize,
+) -> crate::authorize::Outcome {
+	let (_directory, index) = new_index();
+	let (target, user) = put_wide_two_hop_frontiers(&index, width);
+	let config = wide_frontier_config(edge_budget);
+
+	authorize_object_with_config(&index, config, target, user).await
+}
+
+#[tokio::test]
+async fn authorize_shallow_proof_exhaustion_tracks_irrelevant_frontier_width() {
+	// Keep the proof two hops away while moving the frontier across each edge budget.
+	let mut cases = Vec::new();
+	for edge_budget in [64, 256, 1024] {
+		let below = authorize_two_hop_wide_frontier(edge_budget, edge_budget - 1).await;
+		let at = authorize_two_hop_wide_frontier(edge_budget, edge_budget).await;
+		cases.push((edge_budget, below, at));
+	}
+	assert!(
+		cases
+			.iter()
+			.all(|(_, below, _)| matches!(below, crate::authorize::Outcome::Authorized(_))),
+		"the control cases below the edge budget must be authorized: {cases:#?}"
+	);
+	assert!(
+		cases
+			.iter()
+			.all(|(_, _, at)| matches!(at, crate::authorize::Outcome::Exhausted)),
+		"the cases at the edge budget must exhaust: {cases:#?}"
+	);
+}
+
+#[tokio::test]
+async fn authorize_shallow_proof_exhaustion_depends_on_parent_order() {
+	const EDGE_BUDGET: usize = 64;
+	const WIDTH: usize = EDGE_BUDGET + 1;
+
+	let (_directory, index) = new_index();
+	let (target, parents) = put_order_sensitive_frontiers(&index, WIDTH);
+
+	// Put equivalent one-hop proofs at opposite ends of the same ordered frontier.
+	let first_user = tg::user::Id::new();
+	let last_user = tg::user::Id::new();
+	let mut transaction = index.env.write_txn().unwrap();
+	put_grant(
+		&index,
+		&mut transaction,
+		&parents[0],
+		&first_user,
+		tg::authorization::permission::object::Permission::Subtree,
+	);
+	put_grant(
+		&index,
+		&mut transaction,
+		&parents[WIDTH - 1],
+		&last_user,
+		tg::authorization::permission::object::Permission::Subtree,
+	);
+	transaction.commit().unwrap();
+	let config = wide_frontier_config(EDGE_BUDGET);
+	let first = authorize_object_with_config(&index, config, target.clone(), first_user).await;
+	let last = authorize_object_with_config(&index, config, target, last_user).await;
+	assert!(
+		matches!(first, crate::authorize::Outcome::Authorized(_)),
+		"the first grant in the parent enumeration must be authorized: {first:#?}"
+	);
+	assert!(
+		matches!(last, crate::authorize::Outcome::Exhausted),
+		"the same one-hop proof must exhaust when its parent is enumerated last: {last:#?}"
+	);
+}

--- a/packages/server/src/authorization.rs
+++ b/packages/server/src/authorization.rs
@@ -123,7 +123,18 @@ impl Session {
 					outputs.push(Some(permissions));
 					continue;
 				}
-				self.verify_token(&token).then_some(token.body)
+				if self.verify_token(&token) {
+					if self
+						.authorize_object_child_token(&resource, permissions, &token.body)
+						.await?
+					{
+						outputs.push(Some(permissions));
+						continue;
+					}
+					Some(token.body)
+				} else {
+					None
+				}
 			} else {
 				None
 			};
@@ -272,6 +283,39 @@ impl Session {
 		}
 
 		Ok(outputs)
+	}
+
+	async fn authorize_object_child_token(
+		&self,
+		resource: &tg::Selector<tg::Id>,
+		permissions: tg::authorization::permission::Set,
+		token: &tg::authorization::Body,
+	) -> tg::Result<bool> {
+		let subtree = tg::authorization::Permission::Object(
+			tg::authorization::permission::object::Permission::Subtree,
+		);
+		if !permissions
+			.iter()
+			.all(|permission| subtree.implies(permission))
+			|| !token.grants(subtree)
+		{
+			return Ok(false);
+		}
+		let Ok(parent) = tg::object::Id::try_from(token.resource.clone()) else {
+			return Ok(false);
+		};
+		let tg::Selector::Id(resource) = resource else {
+			return Ok(false);
+		};
+		let Ok(child) = tg::object::Id::try_from(resource.clone()) else {
+			return Ok(false);
+		};
+		let Some(children) = self.server.index.try_get_object_children(&parent).await? else {
+			return Ok(false);
+		};
+		let authorized = children.contains(&child);
+
+		Ok(authorized)
 	}
 
 	pub(crate) async fn authorize_owner(&self, owner: Option<&tg::Principal>) -> tg::Result<()> {


### PR DESCRIPTION
## Summary

- Reproduce authorization exhaustion when the requested object has many parents and the command source has many children.
- Authorize a direct object child from its parent's signed subtree token and indexed parent-child edge.
- Add a focused test that disables graph searches and proves the local parent-token path is sufficient.

## Problem

Both graph searches can spend their budgets on irrelevant frontiers before reaching a valid shallow proof. In the production check-in path, this happened even though each fetched parent already passed its signed subtree token to its children.

## Fix and soundness

When an exact-token check does not apply, the server now recognizes the immediate-child proof directly. It verifies that:

- the token is valid and grants object subtree permission on parent `P`;
- every requested permission is implied by object subtree permission;
- the requested resource is an exact object ID `C`; and
- the trusted index records the direct edge `P -> C`.

The signed token proves access to `P`'s subtree, and the indexed edge proves that `C` belongs to that subtree, so the same subtree access is valid for `C`. The relationship is read from the index rather than trusted from the request. Invalid tokens, non-object resources, insufficient permissions, specifiers, and missing edges continue through the existing authorization search. Search budgets and exhaustion behavior are unchanged.

## Verification

- `bun run format`
- `bun run check`
- `cargo test --package tangram_index --features lmdb authorize_shallow_proof -- --nocapture`
- `nu packages/cli/test.nu --no-cloud --no-capture --tangram-path ./target/debug/tangram '(object_get_child_with_parent_token|process_object_get_authorized_despite_search_exhaustion|process_output_reused_directory_entry)'`
