### PR TITLE
fix(server): get process children of running process

### DIFF
--- a/packages/cli/tests/children/process_running_remote.nu
+++ b/packages/cli/tests/children/process_running_remote.nu
@@ -1,6 +1,6 @@
 use ../../test.nu *
 
-# The children of a process running on a remote runner are readable through the remote API server before the process finishes and its children are indexed.
+# The children of a process running on a remote runner are readable through the remote API server while its indexed children list is incomplete.
 
 let root_token = random chars
 
@@ -28,10 +28,14 @@ let local = server spawn --name local --config {
 let path = artifact {
 	tangram.ts: '
 		export default async function () {
-			await tg.build(child);
+			await tg.build(a);
+			await tg.build(b);
+			await tg.build(c);
 			return "parent";
 		}
-		export function child() { return "child"; }
+		export function a() { return "a"; }
+		export function b() { return "b"; }
+		export function c() { return "c"; }
 	',
 }
 
@@ -43,24 +47,60 @@ let finish_watch = (
 )
 let process = tg --url $local.url build --detach --remote $path | str trim
 
-# Hold the child's finish so that the parent keeps running and its children are not indexed on the remote.
-let child_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 0 | from json
-let child = $child_hit.params.id
-assert ($child != $process) "the first finish should belong to the child"
+# Hold the first child's finish so that the parent keeps running while its indexed children list is incomplete.
+let first_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 0 | from json
+let first = $first_hit.params.id
+assert ($first != $process) "the first finish should belong to a child"
 
-# The parent's children must be served from the runner while the parent is running.
-let output = tg --url $local.url process children $process | complete
-success $output "the children of a running remote process should be readable"
-let children = $output.stdout | from json
-assert equal ($children | length) 1 "the parent should have one child"
-let listed = $children | first | get process | split row '?' | first
-assert equal $listed $child "the listed child should be the running child process"
+# Start a paginated stream that must receive the later children from the runner.
+let response_watch = (
+	tg --url $remote.url --token $root_token checkpoint watch process.control.response.publish --params '{"kind":"get_children"}'
+	| from json
+	| get watch
+)
+let stream_job = job spawn {
+	let job_id = job id
+	let output = tg --url $local.url process children --length 3 --no-timeout --size 1 $process | complete
+	$output | job send --tag $job_id 0
+}
 
-# Release the finishes and confirm the build completes.
+# Let the stream read the first child and reach the current end of the list.
+tg --url $remote.url --token $root_token checkpoint wait process.control.response.publish $response_watch 0 | ignore
+tg --url $remote.url --token $root_token checkpoint continue process.control.response.publish $response_watch 0
+tg --url $remote.url --token $root_token checkpoint wait process.control.response.publish $response_watch 1 | ignore
+tg --url $remote.url --token $root_token checkpoint continue process.control.response.publish $response_watch 1
+tg --url $remote.url --token $root_token checkpoint unwatch process.control.response.publish $response_watch
+
+# Let the parent spawn the remaining children, holding each finish in turn.
 tg --url $remote.url --token $root_token checkpoint continue process.control.finish $finish_watch 0
-let parent_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 1 | from json
-assert equal $parent_hit.params.id $process "the second finish should belong to the parent"
+let second_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 1 | from json
+let second = $second_hit.params.id
+assert ($second != $process) "the second finish should belong to a child"
 tg --url $remote.url --token $root_token checkpoint continue process.control.finish $finish_watch 1
+let third_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 2 | from json
+let third = $third_hit.params.id
+assert ($third != $process) "the third finish should belong to a child"
+
+# The stream must wake for each child and preserve their spawn order across pages.
+let output = job recv --tag $stream_job --timeout 30sec
+success $output "the children stream should receive all running remote children"
+let children = $output.stdout | from json
+let listed = $children | each { get process | split row '?' | first }
+assert equal $listed [$first $second $third] "the stream should preserve the child spawn order"
+
+# Snapshot pagination and end-relative positions must also be served by the runner.
+let middle = tg --url $local.url process children --length 1 --position 1 $process | from json
+let middle = $middle | first | get process | split row '?' | first
+assert equal $middle $second "the middle child should be readable by position"
+let tail = tg --url $local.url process children --position=end.-2 --size 1 $process | from json
+let tail = $tail | each { get process | split row '?' | first }
+assert equal $tail [$second $third] "the tail should be readable relative to the end"
+
+# Release the remaining finishes and confirm the build completes.
+tg --url $remote.url --token $root_token checkpoint continue process.control.finish $finish_watch 2
+let parent_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 3 | from json
+assert equal $parent_hit.params.id $process "the fourth finish should belong to the parent"
+tg --url $remote.url --token $root_token checkpoint continue process.control.finish $finish_watch 3
 tg --url $remote.url --token $root_token checkpoint unwatch process.control.finish $finish_watch
 let output = tg --url $local.url wait $process | complete
 success $output "the parent should finish after its finish checkpoint continues"

--- a/packages/cli/tests/children/process_running_remote.nu
+++ b/packages/cli/tests/children/process_running_remote.nu
@@ -1,0 +1,66 @@
+use ../../test.nu *
+
+# The children of a process running on a remote runner are readable through the remote API server before the process finishes and its children are indexed.
+
+let root_token = random chars
+
+# Spawn the remote with checkpoints enabled and create the runner.
+let remote = server spawn --preserve-keys --name remote --config {
+	advanced: { checkpoints: true, single_process: false },
+	authentication: { root: { token: $root_token }, users: { providers: { insecure: true } } },
+	roles: [api indexer scheduler],
+}
+let created = tg --url $remote.url --token $root_token runner create | from json
+
+# Spawn the runner as a separate server so that the remote's runner state is empty.
+let runner = server spawn --name runner --config {
+	remotes: { default: { token: $created.token.token, url: $remote.url } },
+	roles: [api indexer runner],
+	runner: { id: $created.data.id, remote: 'default', token: $created.token.token },
+}
+
+# Create user credentials and spawn the local server.
+let alice = tg --url $remote.url login --verbose --name alice | from json
+let local = server spawn --name local --config {
+	remotes: { default: { token: $alice.token, url: $remote.url } },
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			await tg.build(child);
+			return "parent";
+		}
+		export function child() { return "child"; }
+	',
+}
+
+# Hold every process finish on the remote.
+let finish_watch = (
+	tg --url $remote.url --token $root_token checkpoint watch process.control.finish
+	| from json
+	| get watch
+)
+let process = tg --url $local.url build --detach --remote $path | str trim
+
+# Hold the child's finish so that the parent keeps running and its children are not indexed on the remote.
+let child_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 0 | from json
+let child = $child_hit.params.id
+assert ($child != $process) "the first finish should belong to the child"
+
+# The parent's children must be served from the runner while the parent is running.
+let output = tg --url $local.url process children $process | complete
+success $output "the children of a running remote process should be readable"
+let children = $output.stdout | from json
+assert equal ($children | length) 1 "the parent should have one child"
+let listed = $children | first | get process | split row '?' | first
+assert equal $listed $child "the listed child should be the running child process"
+
+# Release the finishes and confirm the build completes.
+tg --url $remote.url --token $root_token checkpoint continue process.control.finish $finish_watch 0
+let parent_hit = timeout 30s tg --url $remote.url --token $root_token checkpoint wait process.control.finish $finish_watch 1 | from json
+assert equal $parent_hit.params.id $process "the second finish should belong to the parent"
+tg --url $remote.url --token $root_token checkpoint continue process.control.finish $finish_watch 1
+tg --url $remote.url --token $root_token checkpoint unwatch process.control.finish $finish_watch
+let output = tg --url $local.url wait $process | complete
+success $output "the parent should finish after its finish checkpoint continues"

--- a/packages/server/src/process/children/get.rs
+++ b/packages/server/src/process/children/get.rs
@@ -295,18 +295,33 @@ impl Session {
 			.try_get_process_from_index(id)
 			.await?
 			.ok_or_else(|| tg::error!(%id, "failed to find the process"))?;
-		if !process.set.children {
-			return Err(tg::error!(%id, "the process children are incomplete"));
+		if process.set.children {
+			return Ok(position);
 		}
 		if process
 			.data
 			.as_ref()
 			.is_some_and(|data| data.status.is_finished())
 		{
-			return Ok(position);
+			return Err(tg::error!(%id, "the process children are incomplete"));
 		}
 
-		Err(tg::error!(%id, "failed to read the process children"))
+		// The process is running on a runner, so ask it for the length.
+		let output = self
+			.get_process_children_from_control(id, 0, 0)
+			.await
+			.map_err(|error| {
+				tg::error!(!error, %id, "failed to get the process children from the runner")
+			})?;
+		let position = output
+			.length
+			.to_i64()
+			.unwrap()
+			.checked_add(seek)
+			.and_then(|position| position.to_u64())
+			.ok_or_else(|| tg::error!("invalid position"))?;
+
+		Ok(std::io::SeekFrom::Start(position))
 	}
 
 	async fn get_process_children_local(
@@ -337,13 +352,36 @@ impl Session {
 			.try_get_process_from_index(id)
 			.await?
 			.ok_or_else(|| tg::error!(%id, "failed to find the process"))?;
-		if !process.set.children {
-			return Err(tg::error!(%id, "the process children are incomplete"));
-		}
 		let status = process
 			.data
 			.ok_or_else(|| tg::error!(%id, "missing the process data"))?
 			.status;
+		if !process.set.children {
+			if status.is_finished() {
+				return Err(tg::error!(%id, "the process children are incomplete"));
+			}
+
+			// The process is running on a runner, so ask it for the children.
+			let std::io::SeekFrom::Start(position) = position else {
+				return Err(tg::error!(%id, "invalid position"));
+			};
+			let output = self
+				.get_process_children_from_control(id, position, length)
+				.await
+				.map_err(|error| {
+					tg::error!(!error, %id, "failed to get the process children from the runner")
+				})?;
+			let output = LocalChildren {
+				children: output
+					.children
+					.into_iter()
+					.map(tg::process::data::Child::without_location_and_tokens)
+					.collect(),
+				status: output.status,
+			};
+
+			return Ok(output);
+		}
 		let children = self
 			.server
 			.index
@@ -386,9 +424,44 @@ impl Session {
 		let Some(process) = self.try_get_process_from_index(id).await? else {
 			return Ok(false);
 		};
-		let readable = process.set.children;
+		if process.set.children {
+			return Ok(true);
+		}
 
-		Ok(readable)
+		// A running process's children are readable from its runner over the control stream.
+		let running = process
+			.data
+			.as_ref()
+			.is_some_and(|data| !data.status.is_finished());
+
+		Ok(running)
+	}
+
+	async fn get_process_children_from_control(
+		&self,
+		id: &tg::process::Id,
+		position: u64,
+		length: u64,
+	) -> tg::Result<tg::process::control::GetChildrenClientResponseOutput> {
+		let request = tg::process::control::ServerRequestArg::GetChildren(
+			tg::process::control::GetChildrenServerRequestArg { length, position },
+		);
+		let options = crate::control::Options {
+			retry: tangram_futures::retry::Options::default(),
+			timeout: Duration::from_secs(10),
+		};
+		let response = self
+			.send_process_control_request(id, request, options)
+			.await
+			.map_err(|error| {
+				tg::error!(!error, %id, "failed to send the get children control request")
+			})?
+			.map_err(|error| tg::error!(!error, %id, "the get children control request failed"))?;
+		let output = response
+			.try_unwrap_get_children()
+			.map_err(|_| tg::error!("expected a get children response"))?;
+
+		Ok(output)
 	}
 
 	async fn try_get_process_children_regions(

--- a/packages/server/src/process/children/get.rs
+++ b/packages/server/src/process/children/get.rs
@@ -310,9 +310,9 @@ impl Session {
 		let output = self
 			.get_process_children_from_control(id, 0, 0)
 			.await
-			.map_err(|error| {
-				tg::error!(!error, %id, "failed to get the process children from the runner")
-			})?;
+			.map_err(
+				|error| tg::error!(!error, %id, "failed to get the process children from the runner"),
+			)?;
 		let position = output
 			.length
 			.to_i64()
@@ -368,9 +368,9 @@ impl Session {
 			let output = self
 				.get_process_children_from_control(id, position, length)
 				.await
-				.map_err(|error| {
-					tg::error!(!error, %id, "failed to get the process children from the runner")
-				})?;
+				.map_err(
+					|error| tg::error!(!error, %id, "failed to get the process children from the runner"),
+				)?;
 			let output = LocalChildren {
 				children: output
 					.children
@@ -453,9 +453,9 @@ impl Session {
 		let response = self
 			.send_process_control_request(id, request, options)
 			.await
-			.map_err(|error| {
-				tg::error!(!error, %id, "failed to send the get children control request")
-			})?
+			.map_err(
+				|error| tg::error!(!error, %id, "failed to send the get children control request"),
+			)?
 			.map_err(|error| tg::error!(!error, %id, "the get children control request failed"))?;
 		let output = response
 			.try_unwrap_get_children()

--- a/packages/server/src/process/children/get.rs
+++ b/packages/server/src/process/children/get.rs
@@ -306,7 +306,6 @@ impl Session {
 			return Err(tg::error!(%id, "the process children are incomplete"));
 		}
 
-		// The process is running on a runner, so ask it for the length.
 		let output = self
 			.get_process_children_from_control(id, 0, 0)
 			.await
@@ -361,7 +360,6 @@ impl Session {
 				return Err(tg::error!(%id, "the process children are incomplete"));
 			}
 
-			// The process is running on a runner, so ask it for the children.
 			let std::io::SeekFrom::Start(position) = position else {
 				return Err(tg::error!(%id, "invalid position"));
 			};
@@ -428,7 +426,6 @@ impl Session {
 			return Ok(true);
 		}
 
-		// A running process's children are readable from its runner over the control stream.
 		let running = process
 			.data
 			.as_ref()

--- a/packages/server/src/process/control.rs
+++ b/packages/server/src/process/control.rs
@@ -259,6 +259,7 @@ impl Session {
 							let result = match request.arg {
 								tg::process::control::ClientRequestArg::Finish(arg) => session
 									.finish_process_control_request(&id, arg)
+									.boxed()
 									.await
 									.map(tg::process::control::ServerResponseOutput::Finish),
 							};

--- a/packages/server/src/process/control/finish.rs
+++ b/packages/server/src/process/control/finish.rs
@@ -6,6 +6,7 @@ impl Session {
 		id: &tg::process::Id,
 		arg: tg::process::control::FinishClientRequestArg,
 	) -> tg::Result<tg::process::control::FinishServerResponseOutput> {
+		crate::checkpoint!(self.server, "process.control.finish", id = %id).await;
 		self.put_finished_process_local(id, arg.data).await?;
 		self.spawn_process_finish_tasks(id);
 


### PR DESCRIPTION
Demonstrates and resolves a bug where process children could not be retrieved in remote running processes. 