### PR TITLE
fix(authz): propagate checkout tokens to xattrs

### DIFF
--- a/packages/cli/test.nu
+++ b/packages/cli/test.nu
@@ -1832,7 +1832,10 @@ def snapshot_path [path: string] {
 		let contents = open $path
 		let executable = ls -l $path | first | get mode | str contains 'x'
 		let names = xattr_list $path | where { |name| $name starts-with 'user.tangram' }
-		let xattrs = $names | reduce -f {} { |name, acc| $acc | insert $name (xattr_read $name $path) }
+		let xattrs = $names | reduce -f {} { |name, acc|
+			let value = xattr_read $name $path | normalize
+			$acc | insert $name $value
+		}
 		mut output = { kind: 'file', contents: $contents }
 		if $executable {
 			$output.executable = true

--- a/packages/cli/tests/checkout/directory_with_file_with_dependency.snapshot
+++ b/packages/cli/tests/checkout/directory_with_file_with_dependency.snapshot
@@ -19,7 +19,7 @@
       "kind": "file",
       "contents": "foo",
       "xattrs": {
-        "user.tangram.dependencies": "[\"bar\"]"
+        "user.tangram.dependencies": "[\"bar?tokens[local]=<token>\"]"
       }
     },
     "tangram.lock": {

--- a/packages/cli/tests/checkout/directory_with_file_with_id_dependency.snapshot
+++ b/packages/cli/tests/checkout/directory_with_file_with_id_dependency.snapshot
@@ -19,7 +19,7 @@
       "kind": "file",
       "contents": "foo",
       "xattrs": {
-        "user.tangram.dependencies": "[\"fil_01drxezv07bnpqt9w6jw4hqrc73b1n66y19krh1krscbc307124z2g\"]"
+        "user.tangram.dependencies": "[\"fil_01drxezv07bnpqt9w6jw4hqrc73b1n66y19krh1krscbc307124z2g?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/checkout/directory_with_file_with_id_dependency_with_tag_dependency.snapshot
+++ b/packages/cli/tests/checkout/directory_with_file_with_id_dependency_with_tag_dependency.snapshot
@@ -15,7 +15,7 @@
               "kind": "file",
               "contents": "bar",
               "xattrs": {
-                "user.tangram.dependencies": "[\"baz\"]"
+                "user.tangram.dependencies": "[\"baz?tokens[local]=<token>\"]"
               }
             }
           }
@@ -26,7 +26,7 @@
       "kind": "file",
       "contents": "foo",
       "xattrs": {
-        "user.tangram.dependencies": "[\"fil_01ggn2me3j21vbjc2fetv113qcksrj4ybh3np5wtqe63f97tyqprf0\"]"
+        "user.tangram.dependencies": "[\"fil_01ggn2me3j21vbjc2fetv113qcksrj4ybh3np5wtqe63f97tyqprf0?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/checkout/directory_with_two_entries_in_same_graph.snapshot
+++ b/packages/cli/tests/checkout/directory_with_two_entries_in_same_graph.snapshot
@@ -14,7 +14,7 @@
                   "kind": "file",
                   "contents": "",
                   "xattrs": {
-                    "user.tangram.dependencies": "[\"../bar\",\"baz\"]"
+                    "user.tangram.dependencies": "[\"../bar?tokens[local]=<token>\",\"baz?tokens[local]=<token>\"]"
                   }
                 }
               }
@@ -26,7 +26,7 @@
                   "kind": "file",
                   "contents": "",
                   "xattrs": {
-                    "user.tangram.dependencies": "[\"../foo\"]"
+                    "user.tangram.dependencies": "[\"../foo?tokens[local]=<token>\"]"
                   }
                 }
               }
@@ -46,7 +46,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\"../foo\"]"
+            "user.tangram.dependencies": "[\"../foo?tokens[local]=<token>\"]"
           }
         }
       }
@@ -58,7 +58,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\"../bar\",\"baz\"]"
+            "user.tangram.dependencies": "[\"../bar?tokens[local]=<token>\",\"baz?tokens[local]=<token>\"]"
           }
         }
       }

--- a/packages/cli/tests/checkout/file_with_id_dependency.snapshot
+++ b/packages/cli/tests/checkout/file_with_id_dependency.snapshot
@@ -2,6 +2,6 @@
   "kind": "file",
   "contents": "foo",
   "xattrs": {
-    "user.tangram.dependencies": "[\"fil_01drxezv07bnpqt9w6jw4hqrc73b1n66y19krh1krscbc307124z2g\"]"
+    "user.tangram.dependencies": "[\"fil_01drxezv07bnpqt9w6jw4hqrc73b1n66y19krh1krscbc307124z2g?tokens[local]=<token>\"]"
   }
 }

--- a/packages/cli/tests/checkout/file_with_tag_dependency.nu
+++ b/packages/cli/tests/checkout/file_with_tag_dependency.nu
@@ -34,7 +34,7 @@ snapshot --path $path '
 	  "kind": "file",
 	  "contents": "foo",
 	  "xattrs": {
-	    "user.tangram.dependencies": "[\"bar\"]",
+	    "user.tangram.dependencies": "[\"bar?tokens[local]=<token>\"]",
 	    "user.tangram.lock": "{\"nodes\":[{\"kind\":\"file\",\"dependencies\":{\"bar\":{\"node\":null,\"options\":{\"id\":\"fil_01drxezv07bnpqt9w6jw4hqrc73b1n66y19krh1krscbc307124z2g\",\"tag\":\"bar\"}}}}]}"
 	  }
 	}

--- a/packages/cli/tests/checkout/file_with_tag_dependency.nu
+++ b/packages/cli/tests/checkout/file_with_tag_dependency.nu
@@ -29,6 +29,27 @@ let id = tg build $artifact
 
 let path = $tmp | path join "checkout"
 tg checkout --dependencies=false $id --path $path
+
+let reference = xattr_read 'user.tangram.dependencies' $path | from json | first
+let token = (
+	$"http://localhost/($reference)"
+	| url parse
+	| get params
+	| where key == 'tokens[local]'
+	| first
+	| get value
+)
+let expires_at = (
+	$token
+	| split row '.'
+	| get 1
+	| decode base64
+	| decode utf-8
+	| from json
+	| get expires_at
+)
+assert equal $expires_at 9223372036854775807
+
 snapshot --path $path '
 	{
 	  "kind": "file",

--- a/packages/cli/tests/checkout/internal/directory_containing_file_cycle.snapshot
+++ b/packages/cli/tests/checkout/internal/directory_containing_file_cycle.snapshot
@@ -8,7 +8,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\"./bar.tg.ts\"]"
+            "user.tangram.dependencies": "[\"./bar.tg.ts?tokens[local]=<token>\"]"
           }
         }
       }
@@ -17,14 +17,14 @@
       "kind": "file",
       "contents": "",
       "xattrs": {
-        "user.tangram.dependencies": "[\"./bar.tg.ts\"]"
+        "user.tangram.dependencies": "[\"./bar.tg.ts?tokens[local]=<token>\"]"
       }
     },
     "fil_01t01smnant87zs0e8pq1z305js3gjh1yw600977k1at3ztdspb720": {
       "kind": "file",
       "contents": "",
       "xattrs": {
-        "user.tangram.dependencies": "[\"./foo.tg.ts\"]"
+        "user.tangram.dependencies": "[\"./foo.tg.ts?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/checkout/internal/directory_with_file_that_depends_on_directory.snapshot
+++ b/packages/cli/tests/checkout/internal/directory_with_file_that_depends_on_directory.snapshot
@@ -8,7 +8,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\".\"]"
+            "user.tangram.dependencies": "[\".?tokens[local]=<token>\"]"
           }
         }
       }

--- a/packages/cli/tests/checkout/internal/directory_with_file_with_dependency.snapshot
+++ b/packages/cli/tests/checkout/internal/directory_with_file_with_dependency.snapshot
@@ -8,7 +8,7 @@
           "kind": "file",
           "contents": "foo",
           "xattrs": {
-            "user.tangram.dependencies": "[\"bar\"]"
+            "user.tangram.dependencies": "[\"bar?tokens[local]=<token>\"]"
           }
         }
       }

--- a/packages/cli/tests/checkout/internal/directory_with_two_entries_in_same_graph.snapshot
+++ b/packages/cli/tests/checkout/internal/directory_with_two_entries_in_same_graph.snapshot
@@ -11,7 +11,7 @@
               "kind": "file",
               "contents": "",
               "xattrs": {
-                "user.tangram.dependencies": "[\"../foo\"]"
+                "user.tangram.dependencies": "[\"../foo?tokens[local]=<token>\"]"
               }
             }
           }
@@ -23,7 +23,7 @@
               "kind": "file",
               "contents": "",
               "xattrs": {
-                "user.tangram.dependencies": "[\"../bar\",\"baz\"]"
+                "user.tangram.dependencies": "[\"../bar?tokens[local]=<token>\",\"baz?tokens[local]=<token>\"]"
               }
             }
           }
@@ -37,7 +37,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\"../bar\",\"baz\"]"
+            "user.tangram.dependencies": "[\"../bar?tokens[local]=<token>\",\"baz?tokens[local]=<token>\"]"
           }
         }
       }
@@ -49,7 +49,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\"../foo\"]"
+            "user.tangram.dependencies": "[\"../foo?tokens[local]=<token>\"]"
           }
         }
       }

--- a/packages/cli/tests/checkout/internal/file_cycle.snapshot
+++ b/packages/cli/tests/checkout/internal/file_cycle.snapshot
@@ -5,14 +5,14 @@
       "kind": "file",
       "contents": "",
       "xattrs": {
-        "user.tangram.dependencies": "[\"./bar.tg.ts\"]"
+        "user.tangram.dependencies": "[\"./bar.tg.ts?tokens[local]=<token>\"]"
       }
     },
     "fil_01t01smnant87zs0e8pq1z305js3gjh1yw600977k1at3ztdspb720": {
       "kind": "file",
       "contents": "",
       "xattrs": {
-        "user.tangram.dependencies": "[\"./foo.tg.ts\"]"
+        "user.tangram.dependencies": "[\"./foo.tg.ts?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/checkout/internal/file_with_dependency.snapshot
+++ b/packages/cli/tests/checkout/internal/file_with_dependency.snapshot
@@ -9,7 +9,7 @@
       "kind": "file",
       "contents": "foo",
       "xattrs": {
-        "user.tangram.dependencies": "[\"bar\"]"
+        "user.tangram.dependencies": "[\"bar?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/checkout/internal/reference_to_cycle.snapshot
+++ b/packages/cli/tests/checkout/internal/reference_to_cycle.snapshot
@@ -11,7 +11,7 @@
               "kind": "file",
               "contents": "",
               "xattrs": {
-                "user.tangram.dependencies": "[\"a\"]"
+                "user.tangram.dependencies": "[\"a?tokens[local]=<token>\"]"
               }
             }
           }
@@ -25,7 +25,7 @@
           "kind": "file",
           "contents": "",
           "xattrs": {
-            "user.tangram.dependencies": "[\"a\"]"
+            "user.tangram.dependencies": "[\"a?tokens[local]=<token>\"]"
           }
         }
       }

--- a/packages/cli/tests/checkout/reference_to_cycle.snapshot
+++ b/packages/cli/tests/checkout/reference_to_cycle.snapshot
@@ -17,7 +17,7 @@
                       "kind": "file",
                       "contents": "",
                       "xattrs": {
-                        "user.tangram.dependencies": "[\"a\"]"
+                        "user.tangram.dependencies": "[\"a?tokens[local]=<token>\"]"
                       }
                     }
                   }
@@ -32,7 +32,7 @@
       "kind": "file",
       "contents": "",
       "xattrs": {
-        "user.tangram.dependencies": "[\"a\"]"
+        "user.tangram.dependencies": "[\"a?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/checkout/shared_dependency_on_symlink.snapshot
+++ b/packages/cli/tests/checkout/shared_dependency_on_symlink.snapshot
@@ -28,14 +28,14 @@
       "kind": "file",
       "contents": "bar",
       "xattrs": {
-        "user.tangram.dependencies": "[\"dir_01adw2800e84an26zs18h1h7q1swfv7hvdvsb3g0zxz59c91rkh51g\"]"
+        "user.tangram.dependencies": "[\"dir_01adw2800e84an26zs18h1h7q1swfv7hvdvsb3g0zxz59c91rkh51g?tokens[local]=<token>\"]"
       }
     },
     "foo.txt": {
       "kind": "file",
       "contents": "foo",
       "xattrs": {
-        "user.tangram.dependencies": "[\"dir_01adw2800e84an26zs18h1h7q1swfv7hvdvsb3g0zxz59c91rkh51g\"]"
+        "user.tangram.dependencies": "[\"dir_01adw2800e84an26zs18h1h7q1swfv7hvdvsb3g0zxz59c91rkh51g?tokens[local]=<token>\"]"
       }
     }
   }

--- a/packages/cli/tests/grants/process_output_checkin_authorization_search_exhaustion.nu
+++ b/packages/cli/tests/grants/process_output_checkin_authorization_search_exhaustion.nu
@@ -1,0 +1,41 @@
+use ../../test.nu *
+
+# Checking in a process output preserves authorization for dependencies inherited from an input file.
+
+let server = server spawn --config {
+	authorization: {
+		initial: { ancestor: { max_edges: 3 }, descendant: { max_edges: 3 } }
+		final: { ancestor: { max_edges: 3 }, descendant: { max_edges: 3 } }
+	}
+}
+
+let program = '
+	export default async function () {
+		const dependency = await tg.file("dependency");
+		const input = await tg.file({
+			contents: tg.blob("input"),
+			dependencies: { [dependency.id]: dependency },
+		});
+		// Give checkout the input token directly so only output checkin must resolve the dependency.
+		await input.store();
+		const reference = tg.Referent.toDataString(
+			tg.Object.toReferent(input),
+			id => id,
+		);
+		return tg.command({
+			args: ["checkout", "--dependencies=false", "--path", tg.output, reference],
+			env: { INPUT: input },
+			executable: "tg",
+			host: tg.host.current,
+		});
+	}
+'
+let path = artifact {
+	tangram.ts: $program
+}
+
+let command = tg build $path | str trim
+let output = tg build $command | complete
+success $output "the process should check in its authorized materialized dependency"
+let object = tg get --pretty ($output.stdout | str trim)
+assert ($object | str contains 'dependencies') "the output should preserve the dependency xattr"

--- a/packages/cli/tests/vfs/dependency_xattr_token.nu
+++ b/packages/cli/tests/vfs/dependency_xattr_token.nu
@@ -13,15 +13,39 @@ let module = artifact {
 	tangram.ts: '
 		export default () => {
 			const dependency = tg.file("dependency");
-			return tg.file({
+			const file = tg.file({
 				contents: "input",
 				dependencies: { dependency },
 			});
+			return { dependency: dependency.id, file: file.id };
 		}
 	'
 }
-let id = tg build $module | str trim
+let artifacts = tg build $module | from json
 
-let path = vfs root $server_path $id
-let dependencies = xattr_read 'user.tangram.dependencies' $path | normalize
-assert equal $dependencies '["dependency?tokens[local]=<token>"]'
+let path = vfs root $server_path $artifacts.file
+let dependencies = xattr_read 'user.tangram.dependencies' $path
+assert equal ($dependencies | normalize) '["dependency?tokens[local]=<token>"]'
+
+# The in-server VFS provider issues an exact token for the dependency.
+if $nu.os-info.name == 'linux' {
+	let reference = $dependencies | from json | first
+	let token = (
+		$"http://localhost/($reference)"
+		| url parse
+		| get params
+		| where key == 'tokens[local]'
+		| first
+		| get value
+	)
+	let resource = (
+		$token
+		| split row '.'
+		| get 1
+		| decode base64
+		| decode utf-8
+		| from json
+		| get resource
+	)
+	assert equal $resource $artifacts.dependency
+}

--- a/packages/cli/tests/vfs/dependency_xattr_token.nu
+++ b/packages/cli/tests/vfs/dependency_xattr_token.nu
@@ -27,7 +27,7 @@ let path = vfs root $server_path $artifacts.file
 let dependencies = xattr_read 'user.tangram.dependencies' $path
 assert equal ($dependencies | normalize) '["dependency?tokens[local]=<token>"]'
 
-# The in-server VFS provider issues an exact token for the dependency.
+# The in-server VFS provider issues a permanent, exact token for the dependency.
 if $nu.os-info.name == 'linux' {
 	let reference = $dependencies | from json | first
 	let token = (
@@ -38,14 +38,14 @@ if $nu.os-info.name == 'linux' {
 		| first
 		| get value
 	)
-	let resource = (
+	let body = (
 		$token
 		| split row '.'
 		| get 1
 		| decode base64
 		| decode utf-8
 		| from json
-		| get resource
 	)
-	assert equal $resource $artifacts.dependency
+	assert equal $body.expires_at 9223372036854775807
+	assert equal $body.resource $artifacts.dependency
 }

--- a/packages/cli/tests/vfs/dependency_xattr_token.nu
+++ b/packages/cli/tests/vfs/dependency_xattr_token.nu
@@ -1,0 +1,27 @@
+use ../../test.nu *
+use ../lib/vfs.nu
+
+# A dependency reference read through the VFS includes a token so a later checkin does not need an authorization graph search.
+
+vfs skip_unless_supported
+
+let server_path = mktemp --directory
+let server = server spawn --directory $server_path --config { vfs: true }
+vfs assert_mounted $server_path
+
+let module = artifact {
+	tangram.ts: '
+		export default () => {
+			const dependency = tg.file("dependency");
+			return tg.file({
+				contents: "input",
+				dependencies: { dependency },
+			});
+		}
+	'
+}
+let id = tg build $module | str trim
+
+let path = vfs root $server_path $id
+let dependencies = xattr_read 'user.tangram.dependencies' $path | normalize
+assert equal $dependencies '["dependency?tokens[local]=<token>"]'

--- a/packages/cli/tests/vfs/xattrs.nu
+++ b/packages/cli/tests/vfs/xattrs.nu
@@ -27,5 +27,6 @@ let id = tg build (artifact {
 let path = vfs root $server_path $id | path join 'file.txt'
 let names = xattr_list $path | sort
 assert ($names == ['user.tangram.dependencies', 'user.tangram.module']) 'unexpected xattr names'
-assert ((xattr_read 'user.tangram.dependencies' $path | from json) == ['dependency']) 'unexpected dependency xattr'
+let dependency = xattr_read 'user.tangram.dependencies' $path | from json | first
+assert equal ($dependency | split row '?' | first) 'dependency' 'unexpected dependency xattr'
 assert ((xattr_read 'user.tangram.module' $path) == 'ts') 'unexpected module xattr'

--- a/packages/server/src/authorization/token.rs
+++ b/packages/server/src/authorization/token.rs
@@ -61,6 +61,36 @@ impl Session {
 		Ok(())
 	}
 
+	pub(crate) fn add_token_to_object_reference(
+		&self,
+		reference: &mut tg::Reference,
+		resource: &tg::artifact::Id,
+	) -> tg::Result<()> {
+		let expires_at = self.server.clock.unix_timestamp()?
+			+ self
+				.server
+				.config
+				.object
+				.grant_time_to_live
+				.as_secs()
+				.to_i64()
+				.unwrap();
+		let token = self.create_token(
+			resource.clone().into(),
+			vec![tg::authorization::Permission::Object(
+				tg::authorization::permission::object::Permission::Subtree,
+			)],
+			expires_at,
+		)?;
+		if let Some(token) = token {
+			let mut options = reference.options().clone();
+			options.tokens.set_local(token);
+			reference.set_options(options);
+		}
+
+		Ok(())
+	}
+
 	pub(crate) fn update_tokens_and_location(
 		&self,
 		tokens: &mut tg::authorization::Tokens,

--- a/packages/server/src/authorization/token.rs
+++ b/packages/server/src/authorization/token.rs
@@ -61,20 +61,12 @@ impl Session {
 		Ok(())
 	}
 
-	pub(crate) fn add_token_to_object_reference(
+	pub(crate) fn add_permanent_token_to_object_reference(
 		&self,
 		reference: &mut tg::Reference,
 		resource: &tg::artifact::Id,
 	) -> tg::Result<()> {
-		let expires_at = self.server.clock.unix_timestamp()?
-			+ self
-				.server
-				.config
-				.object
-				.grant_time_to_live
-				.as_secs()
-				.to_i64()
-				.unwrap();
+		let expires_at = i64::MAX;
 		let token = self.create_token(
 			resource.clone().into(),
 			vec![tg::authorization::Permission::Object(

--- a/packages/server/src/checkin/checkout.rs
+++ b/packages/server/src/checkin/checkout.rs
@@ -484,7 +484,19 @@ impl Session {
 		}
 
 		progress.spinner("dependencies", "checking out dependencies");
-		let artifacts = artifacts.into_iter().map(tg::Referent::with_node).collect();
+		let artifacts = artifacts
+			.into_iter()
+			.map(|artifact| {
+				let id = tg::object::Id::from(artifact.clone());
+				let permissions = graph.object_permissions(&id);
+				let mut artifact = tg::Referent::with_node(artifact);
+				if permissions.contains(tg::authorization::permission::object::Set::SUBTREE) {
+					self.add_token_to_object_referent(&mut artifact)?;
+				}
+
+				Ok::<_, tg::Error>(artifact)
+			})
+			.collect::<tg::Result<Vec<_>>>()?;
 		let stream = self
 			.checkout_internal(artifacts)
 			.await

--- a/packages/server/src/checkout/external.rs
+++ b/packages/server/src/checkout/external.rs
@@ -586,19 +586,28 @@ impl Session {
 		let Item { graph, id, .. } = item;
 
 		// Check out the dependencies.
-		for dependency in node.dependencies.values() {
+		let mut references = Vec::with_capacity(node.dependencies.len());
+		for (reference, dependency) in &node.dependencies {
+			let mut reference = reference.clone();
 			let Some(dependency) = dependency else {
+				references.push(reference);
 				continue;
 			};
 			let mut edge = match dependency.node.clone() {
 				Some(tg::graph::data::Edge::Pointer(graph)) => {
 					tg::graph::data::Edge::Pointer(graph)
 				},
-				Some(tg::graph::data::Edge::Object(id)) => match id.try_into() {
-					Ok(id) => tg::graph::data::Edge::Object(id),
-					Err(_) => continue,
+				Some(tg::graph::data::Edge::Object(id)) => {
+					let Ok(id) = id.try_into() else {
+						references.push(reference);
+						continue;
+					};
+					tg::graph::data::Edge::Object(id)
 				},
-				None => continue,
+				None => {
+					references.push(reference);
+					continue;
+				},
 			};
 			if let tg::graph::data::Edge::Pointer(pointer) = &mut edge
 				&& pointer.graph.is_none()
@@ -608,6 +617,8 @@ impl Session {
 			let item = self
 				.checkout_get_item(edge)
 				.map_err(|error| tg::error!(!error, "failed to get the item"))?;
+			self.add_token_to_object_reference(&mut reference, &item.id)?;
+			references.push(reference);
 			if item.id != state.artifact {
 				self.checkout_dependency(state, &item)
 					.map_err(|error| tg::error!(!error, "failed to check out the dependency"))?;
@@ -637,17 +648,6 @@ impl Session {
 				.map_err(|error| tg::error!(!error, "failed to set the permissions"))?;
 
 			if cfg!(target_os = "linux") {
-				// Set the dependencies attr.
-				let dependencies = node.dependencies.keys().cloned().collect::<Vec<_>>();
-				if !dependencies.is_empty() {
-					let dependencies = serde_json::to_vec(&dependencies).map_err(|error| {
-						tg::error!(!error, "failed to serialize the dependencies")
-					})?;
-					xattr::set(dst, tg::file::DEPENDENCIES_XATTR_NAME, &dependencies).map_err(
-						|error| tg::error!(!error, "failed to write the dependencies attr"),
-					)?;
-				}
-
 				// Set the module xattr.
 				if let Some(module) = &node.module {
 					let module = module.to_string();
@@ -682,15 +682,6 @@ impl Session {
 			std::io::copy(&mut reader, &mut file)
 				.map_err(|error| tg::error!(!error, ?path, "failed to write to the file"))?;
 
-			// Set the dependencies attr.
-			let dependencies = node.dependencies.keys().cloned().collect::<Vec<_>>();
-			if !dependencies.is_empty() {
-				let dependencies = serde_json::to_vec(&dependencies)
-					.map_err(|error| tg::error!(!error, "failed to serialize the dependencies"))?;
-				xattr::set(path, tg::file::DEPENDENCIES_XATTR_NAME, &dependencies)
-					.map_err(|error| tg::error!(!error, "failed to write the dependencies attr"))?;
-			}
-
 			// Set the module xattr.
 			if let Some(module) = &node.module {
 				let module = module.to_string();
@@ -704,6 +695,14 @@ impl Session {
 				std::fs::set_permissions(path, permissions)
 					.map_err(|error| tg::error!(!error, "failed to set the permissions"))?;
 			}
+		}
+
+		// Set the dependencies attr with authorization for each resolved dependency.
+		if !references.is_empty() {
+			let references = serde_json::to_vec(&references)
+				.map_err(|error| tg::error!(!error, "failed to serialize the dependencies"))?;
+			xattr::set(path, tg::file::DEPENDENCIES_XATTR_NAME, &references)
+				.map_err(|error| tg::error!(!error, "failed to write the dependencies attr"))?;
 		}
 
 		// Increment the progress.

--- a/packages/server/src/checkout/external.rs
+++ b/packages/server/src/checkout/external.rs
@@ -617,7 +617,7 @@ impl Session {
 			let item = self
 				.checkout_get_item(edge)
 				.map_err(|error| tg::error!(!error, "failed to get the item"))?;
-			self.add_token_to_object_reference(&mut reference, &item.id)?;
+			self.add_permanent_token_to_object_reference(&mut reference, &item.id)?;
 			references.push(reference);
 			if item.id != state.artifact {
 				self.checkout_dependency(state, &item)

--- a/packages/server/src/checkout/internal.rs
+++ b/packages/server/src/checkout/internal.rs
@@ -1177,9 +1177,12 @@ impl Session {
 		let Item { graph, id, .. } = item;
 
 		let mut dependencies = Vec::new();
+		let mut references = Vec::with_capacity(node.dependencies.len());
 		let mut visited = HashSet::<tg::artifact::Id, tg::id::BuildHasher>::default();
-		for dependency in node.dependencies.values() {
+		for (reference, dependency) in &node.dependencies {
+			let mut reference = reference.clone();
 			let Some(dependency) = dependency else {
+				references.push(reference);
 				continue;
 			};
 
@@ -1188,11 +1191,17 @@ impl Session {
 				Some(tg::graph::data::Edge::Pointer(graph)) => {
 					tg::graph::data::Edge::Pointer(graph)
 				},
-				Some(tg::graph::data::Edge::Object(id)) => match id.try_into() {
-					Ok(id) => tg::graph::data::Edge::Object(id),
-					Err(_) => continue,
+				Some(tg::graph::data::Edge::Object(id)) => {
+					let Ok(id) = id.try_into() else {
+						references.push(reference);
+						continue;
+					};
+					tg::graph::data::Edge::Object(id)
 				},
-				None => continue,
+				None => {
+					references.push(reference);
+					continue;
+				},
 			};
 
 			// Update the graph if necessary.
@@ -1206,6 +1215,8 @@ impl Session {
 			let item = self
 				.checkout_internal_get_item(edge)
 				.map_err(|error| tg::error!(!error, "failed to get the item"))?;
+			self.add_token_to_object_reference(&mut reference, &item.id)?;
+			references.push(reference);
 
 			// Collect the dependency if it is not the root artifact.
 			if item.id != state.artifact && visited.insert(item.id.clone()) {
@@ -1260,12 +1271,11 @@ impl Session {
 			std::io::copy(&mut reader, &mut file)
 				.map_err(|error| tg::error!(!error, ?path, "failed to write to the file"))?;
 
-			// Set the dependencies attr.
-			let dependencies_ = node.dependencies.keys().cloned().collect::<Vec<_>>();
-			if !dependencies_.is_empty() {
-				let dependencies = serde_json::to_vec(&dependencies_)
+			// Set the dependencies attr with authorization for each resolved dependency.
+			if !references.is_empty() {
+				let references = serde_json::to_vec(&references)
 					.map_err(|error| tg::error!(!error, "failed to serialize the dependencies"))?;
-				xattr::set(path, tg::file::DEPENDENCIES_XATTR_NAME, &dependencies)
+				xattr::set(path, tg::file::DEPENDENCIES_XATTR_NAME, &references)
 					.map_err(|error| tg::error!(!error, "failed to write the dependencies attr"))?;
 			}
 

--- a/packages/server/src/checkout/internal.rs
+++ b/packages/server/src/checkout/internal.rs
@@ -1215,7 +1215,7 @@ impl Session {
 			let item = self
 				.checkout_internal_get_item(edge)
 				.map_err(|error| tg::error!(!error, "failed to get the item"))?;
-			self.add_token_to_object_reference(&mut reference, &item.id)?;
+			self.add_permanent_token_to_object_reference(&mut reference, &item.id)?;
 			references.push(reference);
 
 			// Collect the dependency if it is not the root artifact.

--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -551,7 +551,7 @@ impl Provider {
 			};
 			let dependency = Self::artifact_from_edge_inner(edge, graph)?;
 			session
-				.add_token_to_object_reference(&mut reference, &dependency.id)
+				.add_permanent_token_to_object_reference(&mut reference, &dependency.id)
 				.map_err(|error| {
 					tracing::error!(
 						error = %error.trace(),

--- a/packages/server/src/vfs/provider.rs
+++ b/packages/server/src/vfs/provider.rs
@@ -475,12 +475,12 @@ impl Provider {
 		if !matches!(artifact.id.kind(), tg::artifact::Kind::File) {
 			return Ok(None);
 		}
-		let (file, _) = self.file_node_inner(&artifact).await?;
+		let (file, graph) = self.file_node_inner(&artifact).await?;
 		if name == tg::file::DEPENDENCIES_XATTR_NAME {
 			if file.dependencies.is_empty() {
 				return Ok(None);
 			}
-			let references = file.dependencies.keys().cloned().collect::<Vec<_>>();
+			let references = self.file_dependency_references(&file, graph.as_ref())?;
 			let data = serde_json::to_vec(&references).unwrap();
 			return Ok(Some(data.into()));
 		}
@@ -511,12 +511,12 @@ impl Provider {
 		if !matches!(artifact.id.kind(), tg::artifact::Kind::File) {
 			return Ok(None);
 		}
-		let (file, _) = self.file_node_sync_inner(&artifact, transaction)?;
+		let (file, graph) = self.file_node_sync_inner(&artifact, transaction)?;
 		if name == tg::file::DEPENDENCIES_XATTR_NAME {
 			if file.dependencies.is_empty() {
 				return Ok(None);
 			}
-			let references = file.dependencies.keys().cloned().collect::<Vec<_>>();
+			let references = self.file_dependency_references(&file, graph.as_ref())?;
 			let data = serde_json::to_vec(&references).unwrap();
 			return Ok(Some(data.into()));
 		}
@@ -527,6 +527,42 @@ impl Provider {
 			return Ok(Some(module.to_string().as_bytes().to_vec().into()));
 		}
 		Ok(None)
+	}
+
+	fn file_dependency_references(
+		&self,
+		file: &tg::graph::data::File,
+		graph: Option<&tg::graph::Id>,
+	) -> std::io::Result<Vec<tg::Reference>> {
+		let session = self.session();
+		let mut references = Vec::with_capacity(file.dependencies.len());
+		for (reference, dependency) in &file.dependencies {
+			let mut reference = reference.clone();
+			let Some(edge) = dependency
+				.as_ref()
+				.and_then(|dependency| dependency.0.node.as_ref())
+			else {
+				references.push(reference);
+				continue;
+			};
+			let Ok(edge) = tg::graph::data::Edge::<tg::artifact::Id>::try_from(edge.clone()) else {
+				references.push(reference);
+				continue;
+			};
+			let dependency = Self::artifact_from_edge_inner(edge, graph)?;
+			session
+				.add_token_to_object_reference(&mut reference, &dependency.id)
+				.map_err(|error| {
+					tracing::error!(
+						error = %error.trace(),
+						"failed to add an authorization token to a dependency reference"
+					);
+					std::io::Error::from_raw_os_error(libc::EIO)
+				})?;
+			references.push(reference);
+		}
+
+		Ok(references)
 	}
 
 	pub async fn listxattrs(&self, id: u64) -> std::io::Result<Vec<String>> {

--- a/packages/vfs/provider/src/provider.rs
+++ b/packages/vfs/provider/src/provider.rs
@@ -1176,14 +1176,10 @@ impl Inner {
 			return Ok(None);
 		};
 		if name == tg::file::DEPENDENCIES_XATTR_NAME {
-			let dependencies = file
-				.dependencies_with_handle(&self.client)
-				.await
-				.map_err(eio)?;
-			if dependencies.is_empty() {
+			let references = self.file_dependency_references(&file).await?;
+			if references.is_empty() {
 				return Ok(None);
 			}
-			let references = dependencies.into_keys().collect::<Vec<_>>();
 			let data = serde_json::to_vec(&references).map_err(eio)?;
 			return Ok(Some(data.into()));
 		}
@@ -1194,6 +1190,31 @@ impl Inner {
 			return Ok(Some(module.to_string().as_bytes().to_vec().into()));
 		}
 		Ok(None)
+	}
+
+	async fn file_dependency_references(
+		&self,
+		file: &tg::File,
+	) -> std::io::Result<Vec<tg::Reference>> {
+		let dependencies = file
+			.dependencies_with_handle(&self.client)
+			.await
+			.map_err(eio)?;
+		let tokens = file.state().tokens();
+		let mut references = Vec::with_capacity(dependencies.len());
+		for (mut reference, dependency) in dependencies {
+			let resolved = dependency
+				.and_then(|dependency| dependency.0.node)
+				.is_some_and(|object| tg::Artifact::try_from(object).is_ok());
+			if resolved {
+				let mut options = reference.options().clone();
+				options.tokens.inherit(&tokens);
+				reference.set_options(options);
+			}
+			references.push(reference);
+		}
+
+		Ok(references)
 	}
 
 	fn close(&self, handle: u64) {
@@ -1356,16 +1377,12 @@ impl Fast {
 		if !matches!(artifact.kind(), tg::artifact::Kind::File) {
 			return Ok(None);
 		}
+		if name == tg::file::DEPENDENCIES_XATTR_NAME {
+			// Use the token-aware client path for dependency references.
+			return Err(fallback());
+		}
 		let transaction = self.transaction()?;
 		let (file, _) = self.file_node_with_transaction(&transaction, artifact)?;
-		if name == tg::file::DEPENDENCIES_XATTR_NAME {
-			if file.dependencies.is_empty() {
-				return Ok(None);
-			}
-			let references = file.dependencies.keys().cloned().collect::<Vec<_>>();
-			let data = serde_json::to_vec(&references).map_err(eio)?;
-			return Ok(Some(data.into()));
-		}
 		if name == tg::file::MODULE_XATTR_NAME {
 			let Some(module) = file.module else {
 				return Ok(None);


### PR DESCRIPTION
Files materialized by checkout or the VFS record their dependencies in `user.tangram.dependencies`. Those references previously omitted authorization tokens. When a process copied such a file into its output, checkin had to prove access again with a bounded graph search, which could exhaust even though the input was authorized.

This change adds tokens to resolved dependency references emitted by checkout and both VFS providers, and preserves verified authorization during destructive checkin. FSKit routes dependency xattr reads through its token-aware client path because the local fast path cannot issue tokens.

For VFS, each dependency reference receives authorization inherited from its source file. This is scoped to dependencies recorded directly by that file, and #1099 validates that direct parent-child relationship without a graph search.

## Tests

- `nu packages/cli/test.nu process_output_checkin_authorization_search_exhaustion --no-cloud`
- `nu packages/cli/test.nu 'vfs/(dependency_xattr_token|xattrs)' --no-cloud --vfs`
- `bun run check`

Stacked on #1099.