### PR TITLE
fix(sandbox): concurrent sandbox user resolution

### DIFF
--- a/packages/sandbox/Cargo.toml
+++ b/packages/sandbox/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 
 [lib]
 doctest = false
-test = false
 
 [lints]
 workspace = true

--- a/packages/sandbox/src/container/spawn.rs
+++ b/packages/sandbox/src/container/spawn.rs
@@ -11,11 +11,17 @@ use {
 	tangram_client::prelude::*,
 };
 
+#[derive(Debug, Eq, PartialEq)]
 struct User {
 	gid: libc::gid_t,
 	home: PathBuf,
 	name: String,
 	uid: libc::uid_t,
+}
+
+enum UserQuery {
+	Name(CString),
+	Uid(libc::uid_t),
 }
 
 pub(crate) async fn spawn(
@@ -366,30 +372,74 @@ fn render_passwd(user: &User) -> String {
 }
 
 fn resolve_user(name: Option<&str>) -> tg::Result<User> {
+	let query = if let Some(name) = name {
+		let name = CString::new(OsStr::new(name).as_bytes())
+			.map_err(|error| tg::error!(!error, "failed to encode the user name"))?;
+		UserQuery::Name(name)
+	} else {
+		// SAFETY: This function has no preconditions.
+		let uid = unsafe { libc::getuid() };
+		UserQuery::Uid(uid)
+	};
+
+	resolve_user_with_checkpoint(&query, || {})
+}
+
+fn resolve_user_with_checkpoint(query: &UserQuery, checkpoint: impl FnOnce()) -> tg::Result<User> {
+	// SAFETY: The name pointer is valid and both lookup functions have no other preconditions.
 	let ptr = unsafe {
-		if let Some(name) = name {
-			let name = CString::new(OsStr::new(name).as_bytes())
-				.map_err(|error| tg::error!(!error, "failed to encode the user name"))?;
-			libc::getpwnam(name.as_ptr())
-		} else {
-			libc::getpwuid(libc::getuid())
+		match query {
+			UserQuery::Name(name) => libc::getpwnam(name.as_ptr()),
+			UserQuery::Uid(uid) => libc::getpwuid(*uid),
 		}
 	};
 	if ptr.is_null() {
 		return Err(tg::error!("failed to resolve the user"));
 	}
+	// SAFETY: The lookup returned a non-null passwd record.
 	let passwd = unsafe { &*ptr };
+	// SAFETY: The lookup returned a NUL-terminated string.
 	let name = unsafe { CStr::from_ptr(passwd.pw_name) }
 		.to_string_lossy()
 		.into_owned();
-	let home = unsafe { CStr::from_ptr(passwd.pw_dir) }
-		.to_string_lossy()
-		.into_owned();
+	// SAFETY: The lookup returned a NUL-terminated string.
+	let home = unsafe { CStr::from_ptr(passwd.pw_dir) };
+	checkpoint();
+	let home = home.to_string_lossy().into_owned();
 	let user = User {
 		gid: passwd.pw_gid,
 		home: PathBuf::from(home),
 		name,
 		uid: passwd.pw_uid,
 	};
+
 	Ok(user)
+}
+
+#[cfg(test)]
+mod tests {
+	use {super::*, std::sync::Arc};
+
+	#[test]
+	fn concurrent_user_resolution_owns_the_passwd_record() {
+		let root = UserQuery::Uid(0);
+		let expected = resolve_user_with_checkpoint(&root, || {}).unwrap();
+		let checkpoint = Arc::new(std::sync::Barrier::new(2));
+		let task = {
+			let checkpoint = checkpoint.clone();
+			std::thread::spawn(move || {
+				resolve_user_with_checkpoint(&root, || {
+					checkpoint.wait();
+					checkpoint.wait();
+				})
+				.unwrap()
+			})
+		};
+		checkpoint.wait();
+		resolve_user_with_checkpoint(&UserQuery::Uid(2), || {}).unwrap();
+		checkpoint.wait();
+		let user = task.join().unwrap();
+
+		assert_eq!(user, expected);
+	}
 }

--- a/packages/sandbox/src/container/spawn.rs
+++ b/packages/sandbox/src/container/spawn.rs
@@ -4,12 +4,15 @@ use {
 	std::{
 		ffi::{CStr, CString, OsStr},
 		fmt::Write as _,
+		mem::MaybeUninit,
 		net::Ipv4Addr,
 		os::{fd::AsRawFd as _, unix::ffi::OsStrExt as _},
 		path::{Path, PathBuf},
 	},
 	tangram_client::prelude::*,
 };
+
+const DEFAULT_USER_BUFFER_SIZE: usize = 16 * 1024;
 
 #[derive(Debug, Eq, PartialEq)]
 struct User {
@@ -386,34 +389,72 @@ fn resolve_user(name: Option<&str>) -> tg::Result<User> {
 }
 
 fn resolve_user_with_checkpoint(query: &UserQuery, checkpoint: impl FnOnce()) -> tg::Result<User> {
-	// SAFETY: The name pointer is valid and both lookup functions have no other preconditions.
-	let ptr = unsafe {
-		match query {
-			UserQuery::Name(name) => libc::getpwnam(name.as_ptr()),
-			UserQuery::Uid(uid) => libc::getpwuid(*uid),
-		}
-	};
-	if ptr.is_null() {
-		return Err(tg::error!("failed to resolve the user"));
-	}
-	// SAFETY: The lookup returned a non-null passwd record.
-	let passwd = unsafe { &*ptr };
-	// SAFETY: The lookup returned a NUL-terminated string.
-	let name = unsafe { CStr::from_ptr(passwd.pw_name) }
-		.to_string_lossy()
-		.into_owned();
-	// SAFETY: The lookup returned a NUL-terminated string.
-	let home = unsafe { CStr::from_ptr(passwd.pw_dir) };
-	checkpoint();
-	let home = home.to_string_lossy().into_owned();
-	let user = User {
-		gid: passwd.pw_gid,
-		home: PathBuf::from(home),
-		name,
-		uid: passwd.pw_uid,
-	};
+	// Determine the initial buffer size.
+	// SAFETY: This function has no preconditions.
+	let configured_buffer_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+	let mut buffer_size = usize::try_from(configured_buffer_size)
+		.ok()
+		.filter(|size| *size > 0)
+		.unwrap_or(DEFAULT_USER_BUFFER_SIZE);
+	loop {
+		let mut buffer = vec![0u8; buffer_size];
+		let mut passwd = MaybeUninit::<libc::passwd>::uninit();
+		let mut result = std::ptr::null_mut();
 
-	Ok(user)
+		// Resolve the record.
+		// SAFETY: The name pointer, output pointers, and buffer are valid for the call.
+		let status = unsafe {
+			match query {
+				UserQuery::Name(name) => libc::getpwnam_r(
+					name.as_ptr(),
+					passwd.as_mut_ptr(),
+					buffer.as_mut_ptr().cast(),
+					buffer.len(),
+					&raw mut result,
+				),
+				UserQuery::Uid(uid) => libc::getpwuid_r(
+					*uid,
+					passwd.as_mut_ptr(),
+					buffer.as_mut_ptr().cast(),
+					buffer.len(),
+					&raw mut result,
+				),
+			}
+		};
+		if status == libc::ERANGE {
+			buffer_size = buffer_size
+				.checked_mul(2)
+				.ok_or_else(|| tg::error!("the user record is too large"))?;
+			continue;
+		}
+		if status != 0 {
+			let error = std::io::Error::from_raw_os_error(status);
+			return Err(tg::error!(!error, "failed to resolve the user"));
+		}
+		if result.is_null() {
+			return Err(tg::error!("failed to resolve the user"));
+		}
+
+		// Copy the record while its buffer is live.
+		// SAFETY: A successful lookup with a non-null result initialized the passwd record.
+		let passwd = unsafe { passwd.assume_init() };
+		// SAFETY: A successful lookup returned a NUL-terminated string backed by the live buffer.
+		let name = unsafe { CStr::from_ptr(passwd.pw_name) }
+			.to_string_lossy()
+			.into_owned();
+		// SAFETY: A successful lookup returned a NUL-terminated string backed by the live buffer.
+		let home = unsafe { CStr::from_ptr(passwd.pw_dir) };
+		checkpoint();
+		let home = home.to_string_lossy().into_owned();
+		let user = User {
+			gid: passwd.pw_gid,
+			home: PathBuf::from(home),
+			name,
+			uid: passwd.pw_uid,
+		};
+
+		return Ok(user);
+	}
 }
 
 #[cfg(test)]

--- a/packages/sandbox/src/container/spawn.rs
+++ b/packages/sandbox/src/container/spawn.rs
@@ -24,6 +24,8 @@ struct User {
 
 enum UserQuery {
 	Name(CString),
+	#[cfg(test)]
+	Record(User),
 	Uid(libc::uid_t),
 }
 
@@ -412,6 +414,8 @@ fn resolve_user_with_checkpoint(query: &UserQuery, checkpoint: impl FnOnce()) ->
 					buffer.len(),
 					&raw mut result,
 				),
+				#[cfg(test)]
+				UserQuery::Record(user) => tests::resolve_record(user, &mut passwd, &mut buffer, &mut result),
 				UserQuery::Uid(uid) => libc::getpwuid_r(
 					*uid,
 					passwd.as_mut_ptr(),
@@ -463,8 +467,24 @@ mod tests {
 
 	#[test]
 	fn concurrent_user_resolution_owns_the_passwd_record() {
-		let root = UserQuery::Uid(0);
-		let expected = resolve_user_with_checkpoint(&root, || {}).unwrap();
+		let expected = User {
+			gid: 0,
+			home: PathBuf::from("/root"),
+			name: "root".to_owned(),
+			uid: 0,
+		};
+		let root = UserQuery::Record(User {
+			gid: expected.gid,
+			home: expected.home.clone(),
+			name: expected.name.clone(),
+			uid: expected.uid,
+		});
+		let bin = UserQuery::Record(User {
+			gid: 2,
+			home: PathBuf::from("/bin"),
+			name: "bin".to_owned(),
+			uid: 2,
+		});
 		let checkpoint = Arc::new(std::sync::Barrier::new(2));
 		let task = {
 			let checkpoint = checkpoint.clone();
@@ -477,10 +497,40 @@ mod tests {
 			})
 		};
 		checkpoint.wait();
-		resolve_user_with_checkpoint(&UserQuery::Uid(2), || {}).unwrap();
+		resolve_user_with_checkpoint(&bin, || {}).unwrap();
 		checkpoint.wait();
 		let user = task.join().unwrap();
 
 		assert_eq!(user, expected);
+	}
+
+	pub(super) fn resolve_record(
+		user: &User,
+		passwd: &mut MaybeUninit<libc::passwd>,
+		buffer: &mut [u8],
+		result: &mut *mut libc::passwd,
+	) -> libc::c_int {
+		let name = CString::new(user.name.as_bytes()).unwrap();
+		let home = CString::new(user.home.as_os_str().as_bytes()).unwrap();
+		let name = name.as_bytes_with_nul();
+		let home = home.as_bytes_with_nul();
+		if buffer.len() < name.len() + home.len() {
+			*result = std::ptr::null_mut();
+			return libc::ERANGE;
+		}
+		let (name_buffer, home_buffer) = buffer.split_at_mut(name.len());
+		name_buffer.copy_from_slice(name);
+		home_buffer[..home.len()].copy_from_slice(home);
+		let record = libc::passwd {
+			pw_dir: home_buffer.as_mut_ptr().cast(),
+			pw_gecos: std::ptr::null_mut(),
+			pw_gid: user.gid,
+			pw_name: name_buffer.as_mut_ptr().cast(),
+			pw_passwd: std::ptr::null_mut(),
+			pw_shell: std::ptr::null_mut(),
+			pw_uid: user.uid,
+		};
+		*result = passwd.write(record);
+		0
 	}
 }


### PR DESCRIPTION
## Problem

Sandbox container creation used the non-reentrant `getpwuid` and `getpwnam` functions. They return pointers to shared storage, so concurrent lookups could overwrite a `passwd` record while another thread was copying it. The deterministic regression reproduces the observed failure by turning the root home directory into `"bin\0/"`, which is later passed to the sandbox command as `HOME`, which cannot contain a `NUL` byte.

This manifested in practice as a sandbox creation failure when starting many concurrent sandboxes:

```
  failed to claim a sandbox from the pool; falling back to cold creation
  -> failed to warm a sandbox
  -> failed to create the sandbox
  -> failed to spawn sandbox container
  -> nul byte found in provided data
  ```

## Fix

Use `getpwuid_r` and `getpwnam_r` with a caller-owned buffer, growing it on `ERANGE`. Each lookup now owns its record storage until all fields have been copied, so another thread cannot mutate the data. The existing optional name lookup behavior is preserved.