### PR TITLE
fix(server): preserve authorization proofs for duplicate object children

### DIFF
--- a/packages/cli/tests/grants/process_store_duplicate_child_referents.nu
+++ b/packages/cli/tests/grants/process_store_duplicate_child_referents.nu
@@ -1,0 +1,52 @@
+use ../../test.nu *
+
+# A process that stores an object whose children name the same child twice must receive a token for its subtree, so checking that object out costs no more authorization work than for an object with distinct children.
+
+let server = server spawn --config {
+	tracing: { filter: 'tangram=info,tangram_index::authorize=debug', stderr_format: 'json' }
+}
+
+let path = artifact {
+	tangram.ts: '
+		export default async (mark: string) => {
+			const shared = await tg.file(`shared ${mark}`);
+			const other = await tg.file(`other ${mark}`);
+			// One child under two names serializes to a single child, but to two referents.
+			const output = mark === "duplicate"
+				? await tg.directory({ a: shared, b: shared })
+				: await tg.directory({ a: shared, b: other });
+			await output.store();
+			const reference = tg.Referent.toDataString(
+				tg.Object.toReferent(output),
+				id => id,
+			);
+			return tg.command({
+				args: ["checkout", "--dependencies=false", "--path", tg.output, reference],
+				env: { OUTPUT: output },
+				executable: "tg",
+				host: tg.host.current,
+			});
+		};
+	'
+}
+
+let command = tg build $path -a distinct | str trim
+let output = tg build $command | complete
+success $output "a process should check out a directory with distinct children"
+let distinct = $output.stdout | str trim
+
+let command = tg build $path -a duplicate | str trim
+let output = tg build $command | complete
+success $output "a process should check out a directory whose children name the same child twice"
+let duplicate = $output.stdout | str trim
+
+let searches = open $server.log
+	| lines
+	| where ($it | str starts-with '{')
+	| each { from json }
+	| where ($in.fields.message? | default '') == 'authorize batch'
+	| get fields.resource
+let distinct = $searches | where $it == $distinct | length
+let duplicate = $searches | where $it == $duplicate | length
+print $'authorizing the checkout took ($distinct) searches with distinct children and ($duplicate) with a repeated child'
+assert ($duplicate <= $distinct) 'a repeated child should not cost extra authorization searches'

--- a/packages/cli/tests/grants/process_store_duplicate_child_referents.nu
+++ b/packages/cli/tests/grants/process_store_duplicate_child_referents.nu
@@ -1,15 +1,19 @@
 use ../../test.nu *
 
-# Repeated children retain any available subtree proof, independent of referent order.
+# Two directory entries can name the same child but carry different authorization tokens.
+# The directory should receive subtree permission if every child has at least one valid proof.
 let server = server spawn
 let path = artifact {
 	tangram.ts: '
 		export const source = async (seed: string) => {
+			// Create two separate trees: parent contains child, and unrelated contains other.
 			const child = await tg.file(seed);
 			const other = await tg.file(`other ${seed}`);
 			const parent = await tg.directory({ child });
 			const unrelated = await tg.directory({ other });
 			await tg.Value.store([parent, unrelated]);
+
+			// The exact token names child; the inherited token names its parent.
 			return {
 				child: child.id,
 				exact: child.state.tokens.local,
@@ -21,12 +25,16 @@ let path = artifact {
 
 		export default async (kind: string, order: string, json: string) => {
 			const input = JSON.parse(json);
-			const referent = (token: string, id = input.child) =>
+			const withToken = (id: tg.File.Id, token: string) =>
 				tg.File.withReferent({ node: id, options: { tokens: { local: token } } });
+
+			// These referents name the same stored file and differ only in their tokens.
 			const bare = tg.File.withId(input.child);
-			const exact = referent(input.exact);
-			const inherited = referent(input.inherited);
-			const unrelated = referent(input.unrelated);
+			const exact = withToken(input.child, input.exact);
+			const inherited = withToken(input.child, input.inherited);
+			const unrelated = withToken(input.child, input.unrelated);
+
+			// This file is stored in the same batch as the output, so it needs no existing token.
 			const fresh = await tg.file(`fresh ${order}`);
 			const pairs = {
 				alternatives: [unrelated, inherited],
@@ -37,11 +45,18 @@ let path = artifact {
 				partial: [unrelated, inherited],
 				unrelated: [unrelated, unrelated],
 			};
-			const [a, b] = order === "forward" ? pairs[kind] : pairs[kind].reverse();
-			const output = await tg.directory({
-				a, b,
-				...(kind === "partial" ? { c: referent(input.inherited, input.other) } : {}),
-			});
+			const pair = pairs[kind];
+			if (order === "reverse") {
+				pair.reverse();
+			}
+			const [a, b] = pair;
+			const entries: Record<string, tg.Artifact> = { a, b };
+			if (kind === "partial") {
+				// The proof for child does not authorize the separate file named other.
+				entries.c = withToken(input.other, input.inherited);
+			}
+
+			const output = await tg.directory(entries);
 			await output.store();
 			return { token: output.state.tokens.local };
 		};
@@ -50,20 +65,31 @@ let path = artifact {
 
 for case in [
 	[kind permission];
+	# One of two different ancestor tokens proves access.
 	[alternatives object_subtree]
+	# Repeating a bare ID provides no proof.
 	[bare object_node]
+	# A new child can be authorized within the batch itself.
 	[batch object_subtree]
+	# Either an exact token or an ancestor token can supply the missing proof.
 	[exact object_subtree]
 	[inherited object_subtree]
+	# A proof for one child cannot compensate for another child without a proof.
 	[partial object_node]
+	# Repeating a token for the wrong tree provides no proof.
 	[unrelated object_node]
 ] {
 	for order in [forward reverse] {
 		# Pass tokens as strings between independent processes so grants cannot substitute for the token proofs.
+		# Give each case distinct content so earlier cases cannot authorize later ones.
 		let input = tg build $'($path)#source' -a $'($case.kind)-($order)' | str trim
 		let output = tg build $path -a $case.kind -a $order -a $input | complete
 		success $output $'storing ($case.kind) children in ($order) order should succeed'
-		let permissions = $output.stdout | from json | get token | split row '.' | get 1 | decode base64 | decode utf-8 | from json | get permissions
+
+		# The second token component is its base64-encoded JSON body.
+		let token = $output.stdout | from json | get token
+		let body = $token | split row '.' | get 1 | decode base64 | decode utf-8 | from json
+		let permissions = $body.permissions
 		assert equal $permissions [$case.permission] $'unexpected permissions for ($case.kind) children in ($order) order'
 	}
 }

--- a/packages/cli/tests/grants/process_store_duplicate_child_referents.nu
+++ b/packages/cli/tests/grants/process_store_duplicate_child_referents.nu
@@ -1,52 +1,69 @@
 use ../../test.nu *
 
-# A process that stores an object whose children name the same child twice must receive a token for its subtree, so checking that object out costs no more authorization work than for an object with distinct children.
-
-let server = server spawn --config {
-	tracing: { filter: 'tangram=info,tangram_index::authorize=debug', stderr_format: 'json' }
-}
-
+# Repeated children retain any available subtree proof, independent of referent order.
+let server = server spawn
 let path = artifact {
 	tangram.ts: '
-		export default async (mark: string) => {
-			const shared = await tg.file(`shared ${mark}`);
-			const other = await tg.file(`other ${mark}`);
-			// One child under two names serializes to a single child, but to two referents.
-			const output = mark === "duplicate"
-				? await tg.directory({ a: shared, b: shared })
-				: await tg.directory({ a: shared, b: other });
-			await output.store();
-			const reference = tg.Referent.toDataString(
-				tg.Object.toReferent(output),
-				id => id,
-			);
-			return tg.command({
-				args: ["checkout", "--dependencies=false", "--path", tg.output, reference],
-				env: { OUTPUT: output },
-				executable: "tg",
-				host: tg.host.current,
+		export const source = async (seed: string) => {
+			const child = await tg.file(seed);
+			const other = await tg.file(`other ${seed}`);
+			const parent = await tg.directory({ child });
+			const unrelated = await tg.directory({ other });
+			await tg.Value.store([parent, unrelated]);
+			return {
+				child: child.id,
+				exact: child.state.tokens.local,
+				inherited: parent.state.tokens.local,
+				other: other.id,
+				unrelated: unrelated.state.tokens.local,
+			};
+		};
+
+		export default async (kind: string, order: string, json: string) => {
+			const input = JSON.parse(json);
+			const referent = (token: string, id = input.child) =>
+				tg.File.withReferent({ node: id, options: { tokens: { local: token } } });
+			const bare = tg.File.withId(input.child);
+			const exact = referent(input.exact);
+			const inherited = referent(input.inherited);
+			const unrelated = referent(input.unrelated);
+			const fresh = await tg.file(`fresh ${order}`);
+			const pairs = {
+				alternatives: [unrelated, inherited],
+				bare: [bare, bare],
+				batch: [fresh, fresh],
+				exact: [bare, exact],
+				inherited: [bare, inherited],
+				partial: [unrelated, inherited],
+				unrelated: [unrelated, unrelated],
+			};
+			const [a, b] = order === "forward" ? pairs[kind] : pairs[kind].reverse();
+			const output = await tg.directory({
+				a, b,
+				...(kind === "partial" ? { c: referent(input.inherited, input.other) } : {}),
 			});
+			await output.store();
+			return { token: output.state.tokens.local };
 		};
 	'
 }
 
-let command = tg build $path -a distinct | str trim
-let output = tg build $command | complete
-success $output "a process should check out a directory with distinct children"
-let distinct = $output.stdout | str trim
-
-let command = tg build $path -a duplicate | str trim
-let output = tg build $command | complete
-success $output "a process should check out a directory whose children name the same child twice"
-let duplicate = $output.stdout | str trim
-
-let searches = open $server.log
-	| lines
-	| where ($it | str starts-with '{')
-	| each { from json }
-	| where ($in.fields.message? | default '') == 'authorize batch'
-	| get fields.resource
-let distinct = $searches | where $it == $distinct | length
-let duplicate = $searches | where $it == $duplicate | length
-print $'authorizing the checkout took ($distinct) searches with distinct children and ($duplicate) with a repeated child'
-assert ($duplicate <= $distinct) 'a repeated child should not cost extra authorization searches'
+for case in [
+	[kind permission];
+	[alternatives object_subtree]
+	[bare object_node]
+	[batch object_subtree]
+	[exact object_subtree]
+	[inherited object_subtree]
+	[partial object_node]
+	[unrelated object_node]
+] {
+	for order in [forward reverse] {
+		# Pass tokens as strings between independent processes so grants cannot substitute for the token proofs.
+		let input = tg build $'($path)#source' -a $'($case.kind)-($order)' | str trim
+		let output = tg build $path -a $case.kind -a $order -a $input | complete
+		success $output $'storing ($case.kind) children in ($order) order should succeed'
+		let permissions = $output.stdout | from json | get token | split row '.' | get 1 | decode base64 | decode utf-8 | from json | get permissions
+		assert equal $permissions [$case.permission] $'unexpected permissions for ($case.kind) children in ($order) order'
+	}
+}

--- a/packages/server/src/object/batch.rs
+++ b/packages/server/src/object/batch.rs
@@ -1,7 +1,7 @@
 use {
 	crate::Session,
 	num::ToPrimitive as _,
-	std::collections::{BTreeMap, BTreeSet, btree_map::Entry},
+	std::collections::{BTreeMap, BTreeSet},
 	tangram_client::prelude::*,
 	tangram_http::{
 		body::Boxed as BoxBody, request::Ext as _, response::Ext as _, response::builder::Ext as _,
@@ -232,32 +232,26 @@ impl Session {
 		batch_subtrees: &BTreeSet<tg::object::Id>,
 		batch_objects: &BTreeSet<tg::object::Id>,
 	) -> tg::Result<bool> {
+		// Preserve each child's distinct local tokens for authorization.
+		let mut children_map = BTreeMap::<_, BTreeMap<_, _>>::new();
+		for child in children {
+			if !actual_children.contains(&child.node) {
+				continue;
+			}
+			let Some(token) = child.options.tokens.local() else {
+				continue;
+			};
+			children_map
+				.entry(&child.node)
+				.or_default()
+				.insert(token, child);
+		}
+
 		let permission = tg::authorization::Permission::Object(
 			tg::authorization::permission::object::Permission::Subtree,
 		);
-
-		// Merge the children. An object's children may name the same child more than once, while its serialized children are deduplicated, so prefer a referent whose token authorizes the child's subtree.
-		let mut children_map = BTreeMap::new();
-		for child in children {
-			let id = child.node.clone();
-			if !actual_children.contains(&id) {
-				continue;
-			}
-			match children_map.entry(id) {
-				Entry::Occupied(mut entry) => {
-					if self.post_object_batch_authorize_token(child, permission)
-						&& !self.post_object_batch_authorize_token(entry.get(), permission)
-					{
-						entry.insert(child.clone());
-					}
-				},
-				Entry::Vacant(entry) => {
-					entry.insert(child.clone());
-				},
-			}
-		}
-
 		let mut authorization_args = Vec::new();
+		let mut authorization_ranges = Vec::new();
 		for child in actual_children {
 			if batch_objects.contains(child) {
 				if !batch_subtrees.contains(child) {
@@ -265,35 +259,34 @@ impl Session {
 				}
 				continue;
 			}
-			let Some(child) = children_map.get(child) else {
+			let Some(children) = children_map.get(child) else {
 				return Ok(false);
 			};
-			if child.options.tokens.local().is_none() {
-				return Ok(false);
+			let resource = tg::Selector::Id(child.clone().into());
+			if children
+				.keys()
+				.any(|token| self.authorize_token(&resource, permission.into(), token))
+			{
+				continue;
 			}
-			if !self.post_object_batch_authorize_token(child, permission) {
-				authorization_args.push((child.clone(), permission.into()));
-			}
+			let start = authorization_args.len();
+			authorization_args.extend(
+				children
+					.values()
+					.map(|child| ((*child).clone(), permission.into())),
+			);
+			authorization_ranges.push(start..authorization_args.len());
 		}
 
+		// Require a proof for every child, accepting any of its token candidates.
 		let outputs = self.authorize_batch(authorization_args).await?;
-		let authorized = outputs
-			.into_iter()
-			.all(|output| output.is_some_and(|permissions| permissions.contains(permission)));
+		let authorized = authorization_ranges.into_iter().all(|range| {
+			outputs[range]
+				.iter()
+				.any(|output| output.is_some_and(|permissions| permissions.contains(permission)))
+		});
 
 		Ok(authorized)
-	}
-
-	fn post_object_batch_authorize_token(
-		&self,
-		child: &tg::Referent<tg::object::Id>,
-		permission: tg::authorization::Permission,
-	) -> bool {
-		let Some(token) = child.options.tokens.local() else {
-			return false;
-		};
-		let resource = tg::Selector::Id(child.node.clone().into());
-		self.authorize_token(&resource, permission.into(), token)
 	}
 
 	async fn post_object_batch_region(

--- a/packages/server/src/object/batch.rs
+++ b/packages/server/src/object/batch.rs
@@ -1,7 +1,7 @@
 use {
 	crate::Session,
 	num::ToPrimitive as _,
-	std::collections::{BTreeMap, BTreeSet},
+	std::collections::{BTreeMap, BTreeSet, btree_map::Entry},
 	tangram_client::prelude::*,
 	tangram_http::{
 		body::Boxed as BoxBody, request::Ext as _, response::Ext as _, response::builder::Ext as _,
@@ -232,20 +232,31 @@ impl Session {
 		batch_subtrees: &BTreeSet<tg::object::Id>,
 		batch_objects: &BTreeSet<tg::object::Id>,
 	) -> tg::Result<bool> {
-		let mut children_map = std::collections::BTreeMap::new();
+		let permission = tg::authorization::Permission::Object(
+			tg::authorization::permission::object::Permission::Subtree,
+		);
+
+		// Merge the children. An object's children may name the same child more than once, while its serialized children are deduplicated, so prefer a referent whose token authorizes the child's subtree.
+		let mut children_map = BTreeMap::new();
 		for child in children {
 			let id = child.node.clone();
 			if !actual_children.contains(&id) {
 				continue;
 			}
-			if children_map.insert(id, child.clone()).is_some() {
-				return Ok(false);
+			match children_map.entry(id) {
+				Entry::Occupied(mut entry) => {
+					if self.post_object_batch_authorize_token(child, permission)
+						&& !self.post_object_batch_authorize_token(entry.get(), permission)
+					{
+						entry.insert(child.clone());
+					}
+				},
+				Entry::Vacant(entry) => {
+					entry.insert(child.clone());
+				},
 			}
 		}
 
-		let permission = tg::authorization::Permission::Object(
-			tg::authorization::permission::object::Permission::Subtree,
-		);
 		let mut authorization_args = Vec::new();
 		for child in actual_children {
 			if batch_objects.contains(child) {
@@ -257,11 +268,10 @@ impl Session {
 			let Some(child) = children_map.get(child) else {
 				return Ok(false);
 			};
-			let Some(token) = child.options.tokens.local() else {
+			if child.options.tokens.local().is_none() {
 				return Ok(false);
-			};
-			let resource = tg::Selector::Id(child.node.clone().into());
-			if !self.authorize_token(&resource, permission.into(), token) {
+			}
+			if !self.post_object_batch_authorize_token(child, permission) {
 				authorization_args.push((child.clone(), permission.into()));
 			}
 		}
@@ -272,6 +282,18 @@ impl Session {
 			.all(|output| output.is_some_and(|permissions| permissions.contains(permission)));
 
 		Ok(authorized)
+	}
+
+	fn post_object_batch_authorize_token(
+		&self,
+		child: &tg::Referent<tg::object::Id>,
+		permission: tg::authorization::Permission,
+	) -> bool {
+		let Some(token) = child.options.tokens.local() else {
+			return false;
+		};
+		let resource = tg::Selector::Id(child.node.clone().into());
+		self.authorize_token(&resource, permission.into(), token)
 	}
 
 	async fn post_object_batch_region(


### PR DESCRIPTION
This was found while investigating failed OpenSSL and coreutils builds. `tgld` wrappers were stored with `object_node` tokens, but checkout requires `object_subtree`, even with `--dependencies=false`. Checkout therefore searched the index for a proof. In the warm store, shared loader and library dependencies made these searches large enough to exhaust authorization budgets and fail the build. One captured coreutils batch exhausted after 17,058 fact reads in 1,019 ms.

Duplicate-child rejection causes the same downgrade. Repeated references are normal: a directory can bind two names to one artifact, or a command can reference an artifact in two environment variables. The client supplies a referent for each occurrence, while the server extracts a set of child IDs from the object data. Previously, a second referent for the same child caused an immediate `false` result, before checking its tokens or its authorization within the batch. Reusing an authorized child could therefore leave the parent with only a node token, which causes needlessly expensive proofs for subtree authorization we should have already had.

## Fix

Group each child's distinct local tokens, accept an exact subtree token immediately, and otherwise accept any successful index authorization for that child. Every child must still have a proof before the parent receives subtree permission. When retained, that parent token authorizes a later checkout directly, avoiding the extra search caused by the duplicate-child downgrade.

The included test fails on main and passes with this fix.
