### PR TITLE
feat(index/authz): propose isolated public descendant traversal budgets

### DIFF
--- a/packages/cli/tests/grants/object_get_public_grant_from_descendant_search.nu
+++ b/packages/cli/tests/grants/object_get_public_grant_from_descendant_search.nu
@@ -1,0 +1,28 @@
+use ../../test.nu *
+
+# The descendant search must authorize public directory children when the ancestor search cannot reach the grant.
+
+let server = server spawn --config {
+	authentication: { users: { providers: { insecure: true } } }
+	authorization: {
+		initial: { ancestor: { max_edges: 0 } }
+		final: { ancestor: { max_edges: 0 } }
+	}
+}
+
+let alice = tg login --verbose --name alice | from json
+let bob = tg login --verbose --name bob | from json
+
+let directory = tg --token $alice.token put 'tg.directory({ "hello.txt": tg.file("hello") })' | str trim
+tg --token $alice.token index
+let child = tg --token $alice.token children $directory | from json | get 0
+tg --token $alice.token grant public object_subtree $directory | ignore
+tg --token $alice.token index
+
+let output = tg --token $bob.token get $child | complete
+success $output "bob should read a node inside a publicly granted directory"
+
+let config = mktemp
+{} | to json | save -f $config
+let output = with-env { TANGRAM_CONFIG: $config } { tg get $child | complete }
+success $output "an anonymous client should read a node inside a publicly granted directory"

--- a/packages/index/src/authorize.rs
+++ b/packages/index/src/authorize.rs
@@ -54,6 +54,8 @@ pub struct Config {
 	#[tangram_serialize(id = 0)]
 	pub ancestor: SearchConfig,
 
+	/// The limits for each of the principal and public descendant traversals.
+	/// Each traversal receives the full node and edge allowance per target.
 	#[tangram_serialize(id = 1)]
 	pub descendant: SearchConfig,
 

--- a/packages/index/src/authorize/search.rs
+++ b/packages/index/src/authorize/search.rs
@@ -693,7 +693,7 @@ impl AncestorOrDescendantSearch {
 					let mut search = self.descendant.take().unwrap();
 					if search.finish(state) == Outcome::Exhausted {
 						self.descendant_exhausted
-							.extend(search.unresolved.iter().cloned());
+							.extend(search.unresolved().iter().cloned());
 					}
 					search.reset_visited_if_complete();
 					state.set_descendant(search);

--- a/packages/index/src/authorize/search.rs
+++ b/packages/index/src/authorize/search.rs
@@ -1444,8 +1444,15 @@ mod tests {
 	fn an_ancestor_grant_page_authorizes_before_the_node_is_complete() {
 		let root = key();
 		let mut state = State::default();
+		let config = crate::authorize::Config {
+			descendant: crate::authorize::SearchConfig {
+				max_nodes: 0,
+				..Default::default()
+			},
+			..Default::default()
+		};
 		let mut search = AncestorOrDescendantSearch::new(
-			crate::authorize::Config::default(),
+			config,
 			&tg::Principal::Anonymous,
 			std::slice::from_ref(&root),
 			None,

--- a/packages/index/src/authorize/search/descendant.rs
+++ b/packages/index/src/authorize/search/descendant.rs
@@ -10,6 +10,28 @@ use {
 #[cfg(test)]
 mod tests;
 
+pub(super) struct Search {
+	phase: Phase,
+	principal: Traversal,
+	public: Traversal,
+}
+
+enum Phase {
+	Principal,
+	Public,
+}
+
+struct Traversal {
+	authorization_revision: usize,
+	budget: Budget,
+	complete: bool,
+	exhausted: bool,
+	queues: BTreeMap<usize, VecDeque<DescendantTask>>,
+	unresolved: HashSet<Key>,
+	visited: HashSet<Key>,
+	visited_subjects: HashSet<tg::authorization::Subject>,
+}
+
 enum DescendantTask {
 	Checks(DescendantChecks),
 	Member {
@@ -64,17 +86,6 @@ enum DescendantTask {
 	},
 }
 
-pub(super) struct Search {
-	authorization_revision: usize,
-	budget: Budget,
-	complete: bool,
-	pub(super) exhausted: bool,
-	queues: BTreeMap<usize, VecDeque<DescendantTask>>,
-	pub(super) unresolved: HashSet<Key>,
-	visited: HashSet<Key>,
-	visited_subjects: HashSet<tg::authorization::Subject>,
-}
-
 impl Search {
 	#[must_use]
 	pub(super) fn new(
@@ -84,9 +95,99 @@ impl Search {
 		targets: Vec<Key>,
 		token: Option<(&tg::authorization::Body, &tg::Id)>,
 	) -> Self {
+		// Collect the principal and token sources.
+		let mut sources = inherent_sources(principal);
+		if let Some((body, resource)) = token {
+			sources.extend(
+				body.permissions
+					.iter()
+					.map(|permission| (resource.clone(), *permission)),
+			);
+		}
+
+		// Give public grants a separate budget so they cannot consume the principal or token traversal's capacity.
+		let subject = principal.try_to_subject().ok();
+		let principal = Traversal::new(config, state, targets.clone(), subject, sources);
+		let subject = Some(tg::authorization::Subject::Public);
+		let public = Traversal::new(config, state, targets, subject, Vec::new());
+
+		Self {
+			phase: Phase::Principal,
+			principal,
+			public,
+		}
+	}
+
+	pub(super) fn add_targets(
+		&mut self,
+		config: crate::authorize::SearchConfig,
+		targets: Vec<Key>,
+	) {
+		self.principal.add_targets(config, targets.clone());
+		self.public.add_targets(config, targets);
+		self.phase = Phase::Principal;
+	}
+
+	pub(super) fn take_reads(&mut self, state: &mut State, limit: usize) -> Vec<Read> {
+		if matches!(self.phase, Phase::Principal) {
+			let reads = self.principal.take_reads(state, limit);
+			if !reads.is_empty() || self.principal.unresolved.is_empty() {
+				return reads;
+			}
+			// Switch only after the principal traversal's reads have been applied.
+			self.phase = Phase::Public;
+		}
+		self.public.take_reads(state, limit)
+	}
+
+	pub(super) fn apply(
+		&mut self,
+		state: &mut State,
+		read: Read,
+		output: ReadOutput,
+	) -> tg::Result<()> {
+		self.traversal_mut().apply(state, read, output)?;
+		Ok(())
+	}
+
+	#[must_use]
+	pub(super) fn finish(&mut self, state: &mut State) -> Outcome {
+		self.traversal_mut().finish(state)
+	}
+
+	#[must_use]
+	pub(super) fn unresolved(&self) -> &HashSet<Key> {
+		match self.phase {
+			Phase::Principal => &self.principal.unresolved,
+			Phase::Public => &self.public.unresolved,
+		}
+	}
+
+	pub(super) fn reset_visited_if_complete(&mut self) {
+		self.principal.reset_visited_if_complete();
+		self.public.reset_visited_if_complete();
+	}
+
+	fn traversal_mut(&mut self) -> &mut Traversal {
+		match self.phase {
+			Phase::Principal => &mut self.principal,
+			Phase::Public => &mut self.public,
+		}
+	}
+}
+
+impl Traversal {
+	#[must_use]
+	fn new(
+		config: crate::authorize::SearchConfig,
+		state: &State,
+		targets: Vec<Key>,
+		subject: Option<tg::authorization::Subject>,
+		sources: Vec<Key>,
+	) -> Self {
 		let authorization_revision = state.authorization_revision();
 		let budget = Budget::with_root_total(config, targets.len());
-		// Public grants are checked only by the ancestor search, so a descendant search cannot deny.
+		// The traversal does not expand every authorization relationship, so it cannot deny.
 		let complete = false;
 		let unresolved = targets.into_iter().collect();
 		if config.max_nodes == 0 {
@@ -104,21 +205,13 @@ impl Search {
 
 		let mut queues = BTreeMap::<_, VecDeque<_>>::new();
 		let visited = HashSet::new();
-		if let Ok(subject) = principal.try_to_subject() {
+		if let Some(subject) = subject {
 			queues
 				.entry(0)
 				.or_default()
 				.push_back(DescendantTask::Subject { depth: 0, subject });
 		}
 
-		let mut sources = inherent_sources(principal);
-		if let Some((body, resource)) = token {
-			sources.extend(
-				body.permissions
-					.iter()
-					.map(|permission| (resource.clone(), *permission)),
-			);
-		}
 		let mut sources_seen = HashSet::new();
 		for key in sources {
 			if !sources_seen.insert(key.clone()) {
@@ -142,11 +235,7 @@ impl Search {
 		}
 	}
 
-	pub(super) fn add_targets(
-		&mut self,
-		config: crate::authorize::SearchConfig,
-		targets: Vec<Key>,
-	) {
+	fn add_targets(&mut self, config: crate::authorize::SearchConfig, targets: Vec<Key>) {
 		let added = targets
 			.into_iter()
 			.filter(|target| self.unresolved.insert(target.clone()))
@@ -157,7 +246,7 @@ impl Search {
 		}
 	}
 
-	pub(super) fn take_reads(&mut self, state: &mut State, limit: usize) -> Vec<Read> {
+	fn take_reads(&mut self, state: &mut State, limit: usize) -> Vec<Read> {
 		assert!(limit > 0);
 		for key in state.authorization_changes_since(&mut self.authorization_revision) {
 			self.unresolved.remove(&key);
@@ -286,12 +375,7 @@ impl Search {
 		reads
 	}
 
-	pub(super) fn apply(
-		&mut self,
-		state: &mut State,
-		read: Read,
-		output: ReadOutput,
-	) -> tg::Result<()> {
+	fn apply(&mut self, state: &mut State, read: Read, output: ReadOutput) -> tg::Result<()> {
 		if self.exhausted {
 			self.requeue_read(read)?;
 
@@ -689,7 +773,7 @@ impl Search {
 	}
 
 	#[must_use]
-	pub(super) fn finish(&mut self, state: &mut State) -> Outcome {
+	fn finish(&mut self, state: &mut State) -> Outcome {
 		if self.unresolved.is_empty() {
 			return Outcome::Authorized;
 		}
@@ -703,7 +787,7 @@ impl Search {
 		Outcome::Denied
 	}
 
-	pub(super) fn reset_visited_if_complete(&mut self) {
+	fn reset_visited_if_complete(&mut self) {
 		if self.queues.is_empty() && !self.exhausted {
 			self.visited.clear();
 		}

--- a/packages/index/src/authorize/search/descendant.rs
+++ b/packages/index/src/authorize/search/descendant.rs
@@ -7,6 +7,9 @@ use {
 	tangram_client::prelude::*,
 };
 
+#[cfg(test)]
+mod tests;
+
 enum DescendantTask {
 	Checks(DescendantChecks),
 	Member {

--- a/packages/index/src/authorize/search/descendant/tests.rs
+++ b/packages/index/src/authorize/search/descendant/tests.rs
@@ -1,0 +1,156 @@
+use super::*;
+
+#[test]
+fn principal_and_token_proofs_finish_before_public_enumeration() {
+	let config = crate::authorize::SearchConfig {
+		max_edges: 2,
+		max_nodes: 3,
+		..Default::default()
+	};
+	let parent = object_key(
+		0,
+		tg::authorization::permission::object::Permission::Subtree,
+	);
+	let child = object_key(1, tg::authorization::permission::object::Permission::Node);
+	let body = tg::authorization::Body {
+		expires_at: i64::MAX,
+		permissions: vec![parent.1],
+		resource: parent.0.clone(),
+	};
+	for token in [None, Some((&body, &parent.0))] {
+		let principal = if token.is_some() {
+			tg::Principal::Anonymous
+		} else {
+			tg::Principal::Runner(tg::runner::Id::new())
+		};
+		let mut state = State::default();
+		let mut search = Search::new(config, &principal, &state, vec![child.clone()], token);
+		if token.is_none() {
+			let reads = search.take_reads(&mut state, 8);
+			let [read] = reads.try_into().unwrap();
+			let subject = principal.to_subject();
+			assert!(
+				matches!(&read, Read::SubjectGrants { subject: value, .. } if *value == subject)
+			);
+			let output = grants(&subject, std::slice::from_ref(&parent));
+			search.apply(&mut state, read, output).unwrap();
+		}
+
+		let reads = search.take_reads(&mut state, 8);
+		let [read] = reads.try_into().unwrap();
+		assert!(matches!(&read, Read::DescendantChecks(_)));
+		search
+			.apply(&mut state, read, ReadOutput::Bools(vec![true]))
+			.unwrap();
+
+		assert!(search.take_reads(&mut state, 8).is_empty());
+		assert_eq!(search.finish(&mut state), Outcome::Authorized);
+		assert!(state.is_authorized(&child));
+	}
+}
+
+#[test]
+fn public_grants_have_an_independent_budget() {
+	let config = crate::authorize::SearchConfig {
+		max_edges: 1,
+		max_nodes: 2,
+		..Default::default()
+	};
+	let principal = tg::Principal::Runner(tg::runner::Id::new());
+	let target = object_key(0, tg::authorization::permission::object::Permission::Node);
+	let unrelated = object_key(1, tg::authorization::permission::object::Permission::Node);
+	let mut state = State::default();
+	let mut search = Search::new(config, &principal, &state, vec![target.clone()], None);
+
+	let reads = search.take_reads(&mut state, 8);
+	let [read] = reads.try_into().unwrap();
+	let subject = principal.to_subject();
+	assert!(matches!(&read, Read::SubjectGrants { subject: value, .. } if *value == subject));
+	let output = grants(&subject, &[unrelated]);
+	search.apply(&mut state, read, output).unwrap();
+
+	let reads = search.take_reads(&mut state, 8);
+	let [read] = reads.try_into().unwrap();
+	let subject = tg::authorization::Subject::Public;
+	assert!(matches!(&read, Read::SubjectGrants { subject: value, .. } if *value == subject));
+	let output = grants(&subject, std::slice::from_ref(&target));
+	search.apply(&mut state, read, output).unwrap();
+
+	assert!(search.take_reads(&mut state, 8).is_empty());
+	assert_eq!(search.finish(&mut state), Outcome::Authorized);
+	assert!(state.is_authorized(&target));
+}
+
+#[test]
+fn adding_targets_resumes_both_traversals() {
+	let config = crate::authorize::SearchConfig {
+		max_edges: 1,
+		max_nodes: 2,
+		..Default::default()
+	};
+	let principal = tg::Principal::Runner(tg::runner::Id::new());
+	let private = [
+		object_key(0, tg::authorization::permission::object::Permission::Node),
+		object_key(1, tg::authorization::permission::object::Permission::Node),
+	];
+	let public = [
+		object_key(2, tg::authorization::permission::object::Permission::Node),
+		object_key(3, tg::authorization::permission::object::Permission::Node),
+	];
+	let mut state = State::default();
+	let mut search = Search::new(config, &principal, &state, vec![private[1].clone()], None);
+
+	for (subject, keys) in [
+		(principal.to_subject(), &private),
+		(tg::authorization::Subject::Public, &public),
+	] {
+		let reads = search.take_reads(&mut state, 8);
+		let [read] = reads.try_into().unwrap();
+		assert!(matches!(&read, Read::SubjectGrants { subject: value, .. } if *value == subject));
+		let output = grants(&subject, keys);
+		search.apply(&mut state, read, output).unwrap();
+	}
+	assert!(search.take_reads(&mut state, 8).is_empty());
+	assert_eq!(search.finish(&mut state), Outcome::Exhausted);
+	search.reset_visited_if_complete();
+
+	search.add_targets(config, vec![public[1].clone()]);
+	for (subject, keys) in [
+		(principal.to_subject(), &private),
+		(tg::authorization::Subject::Public, &public),
+	] {
+		let reads = search.take_reads(&mut state, 8);
+		let [read] = reads.try_into().unwrap();
+		assert!(matches!(&read, Read::SubjectGrants { subject: value, .. } if *value == subject));
+		let output = grants(&subject, keys);
+		search.apply(&mut state, read, output).unwrap();
+	}
+
+	assert!(search.take_reads(&mut state, 8).is_empty());
+	assert_eq!(search.finish(&mut state), Outcome::Authorized);
+	assert!(state.is_authorized(&private[1]));
+	assert!(state.is_authorized(&public[1]));
+}
+
+fn grants(subject: &tg::authorization::Subject, keys: &[Key]) -> ReadOutput {
+	let grants = keys
+		.iter()
+		.map(|(resource, permission)| super::super::Grant {
+			creator: None,
+			implicit: false,
+			permission: *permission,
+			resource: resource.clone(),
+			subject: subject.clone(),
+		})
+		.collect();
+	ReadOutput::Grants {
+		after: None,
+		grants,
+	}
+}
+
+fn object_key(value: u8, permission: tg::authorization::permission::object::Permission) -> Key {
+	let object = tg::object::Id::new(tg::object::Kind::Blob, &vec![value].into());
+	let permission = tg::authorization::Permission::Object(permission);
+	(object.into(), permission)
+}


### PR DESCRIPTION
Reading a child of a publicly granted directory can fail with authorization exhaustion when the ancestor search cannot reach the grant. This draft proposes adding a public descendant traversal and changing how descendant search budgets are allocated.

The proposed search has two phases:

1. Search principal grants, memberships, inherent permissions, and token permissions first.
2. Search public grants for unresolved targets once the principal traversal has no further reads, including when it exhausts its budget.

Both phases reuse the existing traversal implementation, with separate budgets and queues. They share authorization results and retain queued work when additional targets extend their budgets. Keeping public enumeration separate prevents unrelated public grants from consuming capacity needed by existing principal or token proofs.

**The design decisions proposed for review are sequential scheduling and applying the configured descendant limits independently to each traversal.** Each traversal receives the full node and edge allowance per target, so the total descendant allowance can reach twice its previous value. Public lookup may wait for principal exhaustion and can still exhaust its own budget in a large public catalog.

The two commits separate tests from implementation. The first adds tests for signed-in and anonymous public reads, traversal ordering, budget isolation, and resumption, and isolates the existing ancestor test. Against the base implementation, the CLI regression and two unit tests fail; the other 73 authorization tests pass. The second implements the proposal and makes the tests pass.

Validation:

- `bun run format`
- `bun run check` — passed without warnings
- `cargo test --package tangram_index --all-features authorize` — 75 passed
- `nu packages/cli/test.nu --no-cloud --jobs 4 --no-progress-details 'grants/'` — 163 passed
