### PR TITLE
fix(index/authz): defer parent pagination without losing shorter paths

### DIFF
--- a/packages/cli/tests/grants/object_get_through_many_parents.nu
+++ b/packages/cli/tests/grants/object_get_through_many_parents.nu
@@ -1,0 +1,30 @@
+use ../../test.nu *
+
+# Getting an object with many parents must succeed when a grant above one of them proves it, because the ancestor search expands a page of parents before it reads the next page.
+
+let searches = {
+	ancestor: { max_edges: 3, page_size: 1 }
+	descendant: { max_depth: 0, max_edges: 0, max_nodes: 0 }
+}
+let server = server spawn --config {
+	authentication: { users: { providers: { insecure: true } } }
+	authorization: { final: $searches, initial: $searches }
+}
+
+let alice = tg login --verbose --name alice | from json
+let bob = tg login --verbose --name bob | from json
+
+# Alice creates eight distinct directories that all contain the same file, all under one grandparent.
+let entries = 0..<8 | each { |index|
+	let n = $index | into string
+	['"p' $n '": tg.directory({ "hub": tg.file("hub"), "pad": tg.file("' $n '") })'] | str join
+} | str join ', '
+let grandparent = tg --token $alice.token put (['tg.directory({ ' $entries ' })'] | str join) | str trim
+let hub = tg --token $alice.token put 'tg.file("hub")' | str trim
+tg --token $alice.token index
+tg --token $alice.token grant $bob.user.id object_subtree $grandparent | ignore
+tg --token $alice.token index
+
+# Bob's grant is two hops above the file, so the ancestor search must climb rather than enumerate every parent.
+let output = tg --token $bob.token get $hub | complete
+success $output "Bob should read the file through the grant on its grandparent."

--- a/packages/index/src/authorize/search/ancestor.rs
+++ b/packages/index/src/authorize/search/ancestor.rs
@@ -7,6 +7,9 @@ use {
 	tangram_client::prelude::*,
 };
 
+#[cfg(test)]
+mod tests;
+
 enum AncestorTask {
 	Checks(AncestorChecks),
 	GroupMembers {
@@ -69,15 +72,17 @@ pub(super) struct Search {
 	// Reference counting prunes acyclic stale branches; cycles remain live conservatively.
 	live_references: HashMap<Key, usize>,
 	node_checks_started: HashSet<Key>,
-	// Additional pages of a node's parents are deferred so that one object with a high in-degree cannot consume the budget before any of its parents are expanded.
+	// Expand the queued ancestors before reading additional pages of their parents.
 	parent_pages: VecDeque<AncestorTask>,
+	parents_started: HashSet<Key>,
 	pending_nodes: HashMap<tg::Id, PendingAncestorNode>,
 	principal: tg::Principal,
 	queues: BTreeMap<usize, VecDeque<AncestorTask>>,
 	token: Option<(tg::authorization::Body, tg::Id)>,
 	unresolved: HashSet<Key>,
-	visited: HashSet<Key>,
-	visited_subjects: HashSet<(tg::authorization::Subject, Key)>,
+	// Retain the shortest depths, including pruned visits, so later pages can reopen a path.
+	visited: HashMap<Key, usize>,
+	visited_subjects: HashMap<(tg::authorization::Subject, Key), usize>,
 }
 
 impl AncestorTask {
@@ -124,13 +129,13 @@ impl Search {
 		let mut incomplete = HashSet::new();
 		let mut queues = BTreeMap::<_, VecDeque<_>>::new();
 		let unresolved = roots.iter().cloned().collect();
-		let mut visited = HashSet::new();
+		let mut visited = HashMap::new();
 		for root in roots {
 			if !budget.add_node(0) {
 				incomplete.insert(root.clone());
 				continue;
 			}
-			visited.insert(root.clone());
+			visited.insert(root.clone(), 0);
 			queues.entry(0).or_default().push_back(AncestorTask::Node {
 				depth: 0,
 				key: root.clone(),
@@ -145,13 +150,14 @@ impl Search {
 			live_references: HashMap::new(),
 			node_checks_started: HashSet::new(),
 			parent_pages: VecDeque::new(),
+			parents_started: HashSet::new(),
 			pending_nodes: HashMap::new(),
 			principal: principal.clone(),
 			queues,
 			token,
 			unresolved,
 			visited,
-			visited_subjects: HashSet::new(),
+			visited_subjects: HashMap::new(),
 		};
 		for root in roots {
 			search.add_live_reference(state, root.clone());
@@ -173,7 +179,9 @@ impl Search {
 					self.queues.insert(depth, queue);
 				}
 				task
-			} else if let Some(task) = self.parent_pages.pop_front() {
+			} else if reads.is_empty()
+				&& let Some(task) = self.parent_pages.pop_front()
+			{
 				task
 			} else {
 				break;
@@ -204,7 +212,8 @@ impl Search {
 						limit,
 					});
 				},
-				AncestorTask::Node { depth, key } => {
+				AncestorTask::Node { key, .. } => {
+					let depth = self.visited[&key];
 					match state.ancestor_or_descendant(&key) {
 						Outcome::Authorized | Outcome::Denied => continue,
 						Outcome::Exhausted => unreachable!(),
@@ -218,18 +227,7 @@ impl Search {
 						Outcome::Authorized | Outcome::Denied => {},
 						Outcome::Exhausted => unreachable!(),
 						Outcome::Pending => {
-							if state.ancestor_node_is_complete(&key) {
-								for dependency in state.authorization_dependencies(&key) {
-									let dependency_depth = depth + 1;
-									self.add_dependency(state, &key, dependency, dependency_depth);
-									if state.is_authorized(&key) {
-										break;
-									}
-								}
-								if !state.is_authorized(&key) {
-									self.queue_parents(state, depth, &key)?;
-								}
-							} else if let Some(facts) = state.ancestor_facts(&key.0) {
+							if let Some(facts) = state.ancestor_facts(&key.0) {
 								self.expand_node(state, depth, &key, &facts)?;
 							} else if self.pending_nodes.contains_key(&key.0) {
 								deferred.push(AncestorTask::Node { depth, key });
@@ -324,6 +322,7 @@ impl Search {
 				self.apply_checks(state, checks, values);
 			},
 			Read::AncestorNode { depth, key, read } => {
+				let depth = depth.min(self.visited[&key]);
 				self.apply_node_read(state, depth, &key, read, output)?;
 			},
 			Read::GroupMembers {
@@ -353,6 +352,7 @@ impl Search {
 				object,
 				..
 			} => {
+				let depth = depth.min(self.visited[&dependent]);
 				let (after, parents) = output.into_ids()?;
 				if state.is_authorized(&dependent) {
 					return Ok(());
@@ -372,7 +372,7 @@ impl Search {
 				}
 				if let Some(after) = after.clone() {
 					state.set_ancestor_cursor(&dependent, &after);
-					self.parent_pages.push_back(AncestorTask::ObjectParents {
+					self.queue_task(AncestorTask::ObjectParents {
 						after: Some(after),
 						dependent,
 						depth,
@@ -410,6 +410,7 @@ impl Search {
 				process,
 				..
 			} => {
+				let depth = depth.min(self.visited[&dependent]);
 				let (after, parents) = output.into_ids()?;
 				if state.is_authorized(&dependent) {
 					return Ok(());
@@ -428,7 +429,7 @@ impl Search {
 				}
 				if let Some(after) = after.clone() {
 					state.set_ancestor_cursor(&dependent, &after);
-					self.parent_pages.push_back(AncestorTask::ProcessParents {
+					self.queue_task(AncestorTask::ProcessParents {
 						after: Some(after),
 						dependent,
 						depth,
@@ -461,7 +462,8 @@ impl Search {
 		Ok(())
 	}
 
-	fn apply_checks(&mut self, state: &mut State, checks: AncestorChecks, values: Vec<bool>) {
+	fn apply_checks(&mut self, state: &mut State, mut checks: AncestorChecks, values: Vec<bool>) {
+		checks.depth = self.visited[&checks.dependent];
 		debug_assert_eq!(checks.candidates.len(), values.len());
 		for (candidate, value) in std::iter::zip(checks.candidates, values) {
 			if !value {
@@ -617,7 +619,12 @@ impl Search {
 		depth: usize,
 		page: MembershipPage,
 	) -> tg::Result<()> {
-		if state.is_authorized(dependent) {
+		if state.is_authorized(dependent)
+			|| self
+				.visited_subjects
+				.get(&(page.container.clone(), dependent.clone()))
+				!= Some(&depth)
+		{
 			return Ok(());
 		}
 		let next_depth = depth + 1;
@@ -813,6 +820,18 @@ impl Search {
 		let mut stack = std::mem::take(&mut self.incomplete)
 			.into_iter()
 			.collect::<Vec<_>>();
+		stack.extend(
+			self.visited
+				.iter()
+				.filter(|(_, depth)| **depth > self.budget.config.max_depth)
+				.map(|(key, _)| key.clone()),
+		);
+		stack.extend(
+			self.visited_subjects
+				.iter()
+				.filter(|(_, depth)| **depth > self.budget.config.max_depth)
+				.map(|((_, dependent), _)| dependent.clone()),
+		);
 		while let Some(key) = stack.pop() {
 			if state.is_authorized(&key) || !incomplete.insert(key.clone()) {
 				continue;
@@ -822,7 +841,7 @@ impl Search {
 		self.incomplete = incomplete;
 
 		// Preserve complete negative proofs for later roots in the request.
-		for key in &self.visited {
+		for key in self.visited.keys() {
 			if !self.incomplete.contains(key) && !self.is_deferred(key) {
 				state.deny_ancestor_or_descendant(key);
 			}
@@ -880,6 +899,19 @@ impl Search {
 			state.authorize_ancestor_or_descendant(key.clone());
 		}
 		if state.is_authorized(key) {
+			return Ok(());
+		}
+
+		// Revisit the cached dependencies at the current depth.
+		if state.ancestor_node_is_complete(key) {
+			for dependency in state.authorization_dependencies(key) {
+				self.add_dependency(state, key, dependency, depth + 1);
+				if state.is_authorized(key) {
+					return Ok(());
+				}
+			}
+			self.queue_parents(state, depth, key)?;
+
 			return Ok(());
 		}
 
@@ -1033,17 +1065,26 @@ impl Search {
 			|| !matches!(
 				subject,
 				tg::authorization::Subject::Group(_) | tg::authorization::Subject::Organization(_)
-			) || !self
-			.visited_subjects
-			.insert((subject.clone(), dependent.clone()))
-		{
+			) {
 			return;
 		}
-		if !self.budget.add_node(depth) {
+		let key = (subject.clone(), dependent.clone());
+		let previous = self.visited_subjects.get(&key).copied();
+		if previous.is_some_and(|previous| previous <= depth) {
+			return;
+		}
+		if depth > self.budget.config.max_depth {
+			self.visited_subjects.insert(key, depth);
+			return;
+		}
+		if previous.is_none_or(|previous| previous > self.budget.config.max_depth)
+			&& !self.budget.add_node(depth)
+		{
 			self.incomplete.insert(dependent.clone());
 
 			return;
 		}
+		self.visited_subjects.insert(key, depth);
 		self.queues
 			.entry(depth)
 			.or_default()
@@ -1061,7 +1102,12 @@ impl Search {
 		depth: usize,
 		subject: tg::authorization::Subject,
 	) {
-		if state.is_authorized(&dependent) {
+		if state.is_authorized(&dependent)
+			|| self
+				.visited_subjects
+				.get(&(subject.clone(), dependent.clone()))
+				!= Some(&depth)
+		{
 			return;
 		}
 		let task = match subject {
@@ -1112,7 +1158,7 @@ impl Search {
 	}
 
 	fn queue_parents(&mut self, state: &mut State, depth: usize, key: &Key) -> tg::Result<()> {
-		if state.ancestor_parents_are_complete(key) {
+		if state.ancestor_parents_are_complete(key) || !self.parents_started.insert(key.clone()) {
 			return Ok(());
 		}
 		let after = state.ancestor_cursor(key);
@@ -1149,7 +1195,7 @@ impl Search {
 
 			return Ok(());
 		};
-		self.queues.entry(depth).or_default().push_back(task);
+		self.queue_task(task);
 
 		Ok(())
 	}
@@ -1207,18 +1253,21 @@ impl Search {
 			Outcome::Exhausted => unreachable!(),
 			Outcome::Pending => {},
 		}
-		if self.visited.contains(&dependency) {
+		let previous = self.visited.get(&dependency).copied();
+		if previous.is_some_and(|previous| previous <= depth) {
 			return true;
 		}
 		if depth > self.budget.config.max_depth {
-			self.incomplete.insert(dependent.clone());
+			self.visited.insert(dependency, depth);
 			return true;
 		}
-		if !self.budget.add_node(depth) {
+		if previous.is_none_or(|previous| previous > self.budget.config.max_depth)
+			&& !self.budget.add_node(depth)
+		{
 			self.incomplete.insert(dependency);
 			return true;
 		}
-		self.visited.insert(dependency.clone());
+		self.visited.insert(dependency.clone(), depth);
 		self.queues
 			.entry(depth)
 			.or_default()
@@ -1246,11 +1295,23 @@ impl Search {
 			}
 			if let Some(tasks) = self.dormant.remove(&key) {
 				for task in tasks {
-					let depth = task.depth();
-					self.queues.entry(depth).or_default().push_back(task);
+					self.queue_task(task);
 				}
 			}
 			stack.extend(state.authorization_dependencies(&key));
+		}
+	}
+
+	fn queue_task(&mut self, task: AncestorTask) {
+		if matches!(
+			task,
+			AncestorTask::ObjectParents { after: Some(_), .. }
+				| AncestorTask::ProcessParents { after: Some(_), .. }
+		) {
+			self.parent_pages.push_back(task);
+		} else {
+			let depth = task.depth();
+			self.queues.entry(depth).or_default().push_back(task);
 		}
 	}
 

--- a/packages/index/src/authorize/search/ancestor.rs
+++ b/packages/index/src/authorize/search/ancestor.rs
@@ -69,6 +69,8 @@ pub(super) struct Search {
 	// Reference counting prunes acyclic stale branches; cycles remain live conservatively.
 	live_references: HashMap<Key, usize>,
 	node_checks_started: HashSet<Key>,
+	// Additional pages of a node's parents are deferred so that one object with a high in-degree cannot consume the budget before any of its parents are expanded.
+	parent_pages: VecDeque<AncestorTask>,
 	pending_nodes: HashMap<tg::Id, PendingAncestorNode>,
 	principal: tg::Principal,
 	queues: BTreeMap<usize, VecDeque<AncestorTask>>,
@@ -142,6 +144,7 @@ impl Search {
 			incomplete,
 			live_references: HashMap::new(),
 			node_checks_started: HashSet::new(),
+			parent_pages: VecDeque::new(),
 			pending_nodes: HashMap::new(),
 			principal: principal.clone(),
 			queues,
@@ -164,13 +167,17 @@ impl Search {
 		let mut deferred = Vec::new();
 		let mut reads = Vec::new();
 		while reads.len() < limit && !self.unresolved.is_empty() {
-			let Some((depth, mut queue)) = self.queues.pop_first() else {
+			let task = if let Some((depth, mut queue)) = self.queues.pop_first() {
+				let task = queue.pop_front().unwrap();
+				if !queue.is_empty() {
+					self.queues.insert(depth, queue);
+				}
+				task
+			} else if let Some(task) = self.parent_pages.pop_front() {
+				task
+			} else {
 				break;
 			};
-			let task = queue.pop_front().unwrap();
-			if !queue.is_empty() {
-				self.queues.insert(depth, queue);
-			}
 			let node_read_is_pending = matches!(
 				&task,
 				AncestorTask::NodeRead { key, .. }
@@ -365,15 +372,12 @@ impl Search {
 				}
 				if let Some(after) = after.clone() {
 					state.set_ancestor_cursor(&dependent, &after);
-					self.queues
-						.entry(depth)
-						.or_default()
-						.push_back(AncestorTask::ObjectParents {
-							after: Some(after),
-							dependent,
-							depth,
-							object,
-						});
+					self.parent_pages.push_back(AncestorTask::ObjectParents {
+						after: Some(after),
+						dependent,
+						depth,
+						object,
+					});
 				} else {
 					state.complete_ancestor_parents(&dependent);
 				}
@@ -424,16 +428,13 @@ impl Search {
 				}
 				if let Some(after) = after.clone() {
 					state.set_ancestor_cursor(&dependent, &after);
-					self.queues
-						.entry(depth)
-						.or_default()
-						.push_back(AncestorTask::ProcessParents {
-							after: Some(after),
-							dependent,
-							depth,
-							permission,
-							process,
-						});
+					self.parent_pages.push_back(AncestorTask::ProcessParents {
+						after: Some(after),
+						dependent,
+						depth,
+						permission,
+						process,
+					});
 				} else {
 					state.complete_ancestor_parents(&dependent);
 				}
@@ -802,6 +803,7 @@ impl Search {
 	pub(super) fn finish(&mut self, state: &mut State) {
 		if self.unresolved.is_empty() {
 			self.incomplete.clear();
+			self.parent_pages.clear();
 			self.queues.clear();
 			return;
 		}

--- a/packages/index/src/authorize/search/ancestor/tests.rs
+++ b/packages/index/src/authorize/search/ancestor/tests.rs
@@ -1,0 +1,297 @@
+use {super::*, crate::authorize::SearchConfig};
+
+#[test]
+fn shorter_visits_reopen_pruned_dependencies_without_spending_another_node() {
+	for limit in [1, 64] {
+		for [root, middle, parent] in keys() {
+			let mut state = State::default();
+			let mut search = search(&root, &state);
+			assert!(search.add_dependency(&mut state, &root, middle.clone(), 2));
+			let facts = state.set_ancestor_facts(middle.0.clone(), AncestorNodeFacts::default());
+			search.expand_node(&mut state, 2, &middle, &facts).unwrap();
+			assert!(search.add_dependency(&mut state, &middle, parent.clone(), 3));
+			assert_eq!(search.budget.nodes, 2);
+
+			assert!(search.add_dependency(&mut state, &root, middle.clone(), 1));
+			let reads = drain(&mut search, &mut state, limit, empty_output);
+
+			assert!(reads.iter().any(|read| matches!(
+				read,
+				Read::AncestorNode { depth: 2, key, .. } if key == &parent
+			)));
+			assert_eq!(parent_reads(&reads, &middle), 1);
+			assert_eq!(search.budget.nodes, 3);
+			assert!(search.incomplete.is_empty());
+			assert_eq!(state.ancestor_or_descendant(&root), Outcome::Denied);
+		}
+	}
+}
+
+#[test]
+fn shorter_visits_reopen_grant_memberships() {
+	for limit in [1, 64] {
+		let [root, middle, _] = keys()[0].clone();
+		let outer = tg::group::Id::new();
+		let inner = tg::group::Id::new();
+		let subject = tg::authorization::Subject::Group(outer.clone());
+		let mut state = State::default();
+		let mut search = search(&root, &state);
+		search.budget.config.max_nodes = 4;
+		assert!(search.add_dependency(&mut state, &root, middle.clone(), 2));
+		let grant = super::super::Grant {
+			creator: None,
+			implicit: false,
+			permission: middle.1,
+			resource: middle.0.clone(),
+			subject: subject.clone(),
+		};
+		let facts = AncestorNodeFacts {
+			grants: vec![grant],
+			..Default::default()
+		};
+		let facts = state.set_ancestor_facts(middle.0.clone(), facts);
+		search.expand_node(&mut state, 2, &middle, &facts).unwrap();
+		let page = MembershipPage {
+			container: subject,
+			continuation: None,
+			members: vec![inner.clone().into()],
+		};
+		search.apply_members(&mut state, &middle, 2, page).unwrap();
+		assert_eq!(search.budget.nodes, 3);
+
+		assert!(search.add_dependency(&mut state, &root, middle.clone(), 1));
+		let reads = drain(&mut search, &mut state, limit, |read| match read {
+			Read::GroupMembers { group, .. } if group == &outer => ReadOutput::Ids {
+				after: None,
+				ids: vec![inner.clone().into()],
+			},
+			_ => empty_output(read),
+		});
+
+		assert!(reads.iter().any(|read| matches!(
+			read,
+			Read::GroupMembers { depth: 2, group, .. } if group == &inner
+		)));
+		assert_eq!(parent_reads(&reads, &middle), 1);
+		assert_eq!(search.budget.nodes, 4);
+		assert!(search.incomplete.is_empty());
+	}
+}
+
+#[test]
+fn parent_pages_wait_for_the_previous_read_batch() {
+	for [root, parent, _] in keys() {
+		let mut state = State::default();
+		let mut search = search(&root, &state);
+		loop {
+			let reads = search.take_reads(&mut state, 64).unwrap();
+			assert!(!reads.is_empty());
+			let parents = parent_reads(&reads, &root) > 0;
+			for read in reads {
+				let output = match &read {
+					Read::ObjectParents { .. } | Read::ProcessParents { .. } => ReadOutput::Ids {
+						after: Some(vec![1]),
+						ids: vec![parent.0.clone()],
+					},
+					_ => empty_output(&read),
+				};
+				search.apply(&mut state, read, output).unwrap();
+			}
+			if parents {
+				break;
+			}
+		}
+
+		let reads = search.take_reads(&mut state, 64).unwrap();
+		assert!(!reads.is_empty());
+		assert!(
+			reads
+				.iter()
+				.all(|read| matches!(read, Read::AncestorNode { key, .. } if key == &parent))
+		);
+		for read in reads {
+			let output = empty_output(&read);
+			search.apply(&mut state, read, output).unwrap();
+		}
+
+		let reads = search.take_reads(&mut state, 64).unwrap();
+		assert_eq!(reads.len(), 1);
+		assert_eq!(parent_reads(&reads, &parent), 1);
+		for read in reads {
+			let output = empty_output(&read);
+			search.apply(&mut state, read, output).unwrap();
+		}
+
+		let reads = search.take_reads(&mut state, 64).unwrap();
+		assert_eq!(reads.len(), 1);
+		assert!(matches!(
+			&reads[0],
+			Read::ObjectParents { after: Some(_), dependent, .. }
+				| Read::ProcessParents { after: Some(_), dependent, .. } if dependent == &root
+		));
+	}
+}
+
+#[test]
+fn pruned_visits_remain_incomplete_until_they_can_be_expanded() {
+	for [root, middle, parent] in keys() {
+		let mut state = State::default();
+		let mut search = search(&root, &state);
+		search.budget.config.max_nodes = 2;
+		assert!(search.add_dependency(&mut state, &root, middle, 1));
+		assert!(search.add_dependency(&mut state, &root, parent.clone(), 3));
+		assert!(search.add_dependency(&mut state, &root, parent.clone(), 1));
+
+		let reads = drain(&mut search, &mut state, 64, empty_output);
+
+		assert!(
+			!reads
+				.iter()
+				.any(|read| matches!(read, Read::AncestorNode { key, .. } if key == &parent))
+		);
+		assert_eq!(search.budget.nodes, 2);
+		assert!(search.incomplete.contains(&root));
+		assert_eq!(state.ancestor_or_descendant(&root), Outcome::Pending);
+	}
+}
+
+#[test]
+fn a_deferred_parent_page_uses_the_improved_depth() {
+	for [root, middle, parent] in keys() {
+		let mut state = State::default();
+		let mut search = search(&root, &state);
+		assert!(search.add_dependency(&mut state, &root, middle.clone(), 2));
+		search.queue_parents(&mut state, 2, &middle).unwrap();
+		let read = match &middle.1 {
+			tg::authorization::Permission::Object(_) => Read::ObjectParents {
+				after: Some(vec![1]),
+				dependent: middle.clone(),
+				depth: 2,
+				limit: 1,
+				object: middle.0.clone().try_into().unwrap(),
+			},
+			tg::authorization::Permission::Process(permission) => Read::ProcessParents {
+				after: Some(vec![1]),
+				dependent: middle.clone(),
+				depth: 2,
+				limit: 1,
+				permission: *permission,
+				process: middle.0.clone().try_into().unwrap(),
+			},
+			_ => unreachable!(),
+		};
+		assert!(search.add_dependency(&mut state, &root, middle, 1));
+		let output = ReadOutput::Ids {
+			after: None,
+			ids: vec![parent.0.clone()],
+		};
+		search.apply(&mut state, read, output).unwrap();
+
+		let reads = drain(&mut search, &mut state, 64, empty_output);
+
+		assert!(reads.iter().any(|read| matches!(
+			read,
+			Read::AncestorNode { depth: 2, key, .. } if key == &parent
+		)));
+		assert!(search.incomplete.is_empty());
+	}
+}
+
+fn drain(
+	search: &mut Search,
+	state: &mut State,
+	limit: usize,
+	mut output: impl FnMut(&Read) -> ReadOutput,
+) -> Vec<Read> {
+	let mut all_reads = Vec::new();
+	for _ in 0..100 {
+		let reads = search.take_reads(state, limit).unwrap();
+		if reads.is_empty() {
+			search.finish(state);
+			return all_reads;
+		}
+		for read in reads {
+			let output = output(&read);
+			all_reads.push(read.clone());
+			search.apply(state, read, output).unwrap();
+		}
+	}
+	panic!("the ancestor search did not finish");
+}
+
+fn empty_output(read: &Read) -> ReadOutput {
+	match read {
+		Read::AncestorChecks(checks) => ReadOutput::Bools(vec![false; checks.candidates.len()]),
+		Read::AncestorNode { read, .. } => match read {
+			AncestorNodeRead::ObjectProcesses { .. } => ReadOutput::ObjectProcesses {
+				after: None,
+				processes: Vec::new(),
+			},
+			AncestorNodeRead::Process { .. } => ReadOutput::Process(None),
+			AncestorNodeRead::ResourceGrants { .. } => ReadOutput::Grants {
+				after: None,
+				grants: Vec::new(),
+			},
+			AncestorNodeRead::TargetTags { .. } => ReadOutput::Tags {
+				after: None,
+				tags: Vec::new(),
+			},
+			_ => panic!("unexpected ancestor node read: {read:?}"),
+		},
+		Read::GroupMembers { .. }
+		| Read::ObjectParents { .. }
+		| Read::OrganizationMembers { .. }
+		| Read::ProcessParents { .. } => ReadOutput::Ids {
+			after: None,
+			ids: Vec::new(),
+		},
+		_ => panic!("unexpected ancestor read: {read:?}"),
+	}
+}
+
+fn keys() -> [[Key; 3]; 2] {
+	let objects = [0, 1, 2].map(|value| {
+		let object = tg::object::Id::new(tg::object::Kind::Blob, &vec![value].into());
+		let permission = tg::authorization::Permission::Object(
+			tg::authorization::permission::object::Permission::Subtree,
+		);
+		(object.into(), permission)
+	});
+	let processes = std::array::from_fn(|_| {
+		let process = tg::process::Id::new();
+		let permission = tg::authorization::Permission::Process(
+			tg::authorization::permission::process::Permission::Subtree,
+		);
+		(process.into(), permission)
+	});
+	[objects, processes]
+}
+
+fn parent_reads(reads: &[Read], key: &Key) -> usize {
+	reads
+		.iter()
+		.filter(|read| {
+			matches!(
+				read,
+				Read::ObjectParents { dependent, .. } | Read::ProcessParents { dependent, .. }
+					if dependent == key
+			)
+		})
+		.count()
+}
+
+fn search(root: &Key, state: &State) -> Search {
+	let config = SearchConfig {
+		max_depth: 2,
+		max_edges: 8,
+		max_nodes: 3,
+		page_size: 1,
+	};
+	Search::new(
+		config,
+		&tg::Principal::Anonymous,
+		std::slice::from_ref(root),
+		None,
+		state,
+	)
+}


### PR DESCRIPTION
Authorizing an object with many parents could exhaust the ancestor edge budget before the search climbed to a grant. Defer additional object and process parent pages until queued ancestor work and its outstanding reads have completed.

Track the shortest depth for node and membership visits, and revisit cached dependencies when a shorter path appears. This lets later pages reopen depth-pruned paths without charging for a node twice or restarting parent pagination. Add a CLI regression and five scheduler tests covering pagination, shorter paths, memberships, and budget accounting.

Validation:

- `bun run format`
- `bun run check` — passed without warnings.
- `cargo test --package tangram_index --all-features --lib authorize` — 77 passed.
- Eight focused CLI grants tests — passed against an explicitly rebuilt binary. An earlier fanout test run reported exhaustion; it passed all ten repeated runs after rebuilding.
- Scheduler tests cover single reads and batches of 64.
