### PR TITLE
feat(client): resolve artifact handles during unrender

### DIFF
--- a/packages/cli/tests/checkout/client_references.nu
+++ b/packages/cli/tests/checkout/client_references.nu
@@ -1,7 +1,7 @@
 use ../../test.nu *
 use ../lib/vfs.nu
 
-# The Rust client recovers checkout tokens to load unrendered file and directory paths.
+# Recover checkout tokens for an unrendered client path.
 
 const repository_path = path self '../../../..'
 
@@ -34,13 +34,13 @@ if (($env.TANGRAM_TEST_VFS? | default '') | str length) > 0 {
 	assert equal ($directory_path | path expand) (vfs root $server.directory $directory)
 }
 
-# Exercise the capacity fallback that retains only the file token.
+# Simulate a checkout that retained only the file token.
 let fallback = artifact (file --xattrs {
 	'user.tangram.dependencies': ([$directory] | to json --raw)
 	'user.tangram.token': (xattr_read user.tangram.token $wrapper_path)
 } wrapper)
 
-# A parent token needs one edge, while an unguided search exhausts the budget.
+# Limit graph search so the parent token is necessary.
 let config = $server.config | merge deep {
 	authorization: {
 		final: {

--- a/packages/clients/rust/src/template/handle.rs
+++ b/packages/clients/rust/src/template/handle.rs
@@ -109,7 +109,7 @@ impl Template {
 
 	/// Unrender a string using a resolver for each artifact occurrence.
 	///
-	/// The resolver may return `None` to keep a bare handle, or a handle with the same ID to retain its state.
+	/// Returning `None` keeps a bare handle; a same-ID handle retains its state.
 	/// Resolver errors are propagated; tokens are not verified.
 	pub fn unrender_with<F>(prefix: &str, string: &str, mut f: F) -> tg::Result<Self>
 	where

--- a/packages/clients/rust/src/template/handle.rs
+++ b/packages/clients/rust/src/template/handle.rs
@@ -104,18 +104,42 @@ impl Template {
 	}
 
 	pub fn unrender(prefix: &str, string: &str) -> tg::Result<Self> {
+		Self::unrender_with(prefix, string, |_| Ok(None))
+	}
+
+	/// Unrender a string using a resolver for each artifact occurrence.
+	///
+	/// The resolver may return `None` to keep a bare handle, or a handle with the same ID to retain its state.
+	/// Resolver errors are propagated; tokens are not verified.
+	pub fn unrender_with<F>(prefix: &str, string: &str, mut f: F) -> tg::Result<Self>
+	where
+		F: FnMut(tg::artifact::Id) -> tg::Result<Option<tg::Artifact>>,
+	{
+		// Parse the template.
 		let data = Data::unrender(prefix, string)?;
-		let components = data.components.into_iter().map(|data| match data {
-			tg::template::data::Component::Artifact(referent) => {
-				let artifact = tg::Artifact::with_referent(referent);
-				Component::Artifact(artifact)
-			},
-			tg::template::data::Component::String(string) => Component::String(string),
-			tg::template::data::Component::Placeholder(data) => {
-				Component::Placeholder(tg::Placeholder { name: data.name })
-			},
-		});
-		Ok(Self::with_components(components))
+		let mut template = Self::try_from_data(data)?;
+
+		// Resolve the artifacts.
+		for component in &mut template.components {
+			let Component::Artifact(artifact) = component else {
+				continue;
+			};
+			let id = artifact.id();
+			let Some(resolved) = f(id.clone()).map_err(
+				|error| tg::error!(!error, %id, "failed to resolve an unrendered artifact"),
+			)?
+			else {
+				continue;
+			};
+			if resolved.id() != id {
+				return Err(
+					tg::error!(expected = %id, actual = %resolved.id(), "the resolved artifact has a different ID"),
+				);
+			}
+			*artifact = resolved;
+		}
+
+		Ok(template)
 	}
 }
 
@@ -210,7 +234,10 @@ impl From<tg::Symlink> for Component {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use {
+		super::*,
+		std::{collections::BTreeMap, error::Error as _},
+	};
 
 	// Unrendering a store path back into a template splits it into the surrounding string and artifact components.
 	#[test]
@@ -242,5 +269,86 @@ mod tests {
 		let left = template.components().get(2).unwrap().unwrap_string_ref();
 		let right = " bar";
 		assert_eq!(left, right);
+	}
+
+	#[test]
+	fn unrender_with() {
+		let directory = tg::Directory::with_entries(BTreeMap::new());
+		directory
+			.state()
+			.set_location(Some("remote".parse().unwrap()));
+		let id: tg::artifact::Id = directory.id().into();
+		let file = tg::File::with_contents("unresolved").id();
+		let string = format!("α -L/store/{id}/lib /store/{file} /store/{id}/include");
+		let mut ids = Vec::new();
+		let template = tg::Template::unrender_with("/store", &string, |parsed| {
+			ids.push(parsed.clone());
+			Ok((parsed == id).then(|| directory.clone().into()))
+		})
+		.unwrap();
+		assert_eq!(ids, [id.clone(), file.clone().into(), id]);
+		let expected = tg::Template::with_components([
+			Component::String("α -L".into()),
+			Component::Artifact(directory.clone().into()),
+			Component::String("/lib ".into()),
+			Component::Artifact(tg::File::with_id(file).into()),
+			Component::String(" ".into()),
+			Component::Artifact(directory.clone().into()),
+			Component::String("/include".into()),
+		]);
+		assert_eq!(template.to_data(), expected.to_data());
+		for artifact in template
+			.artifacts()
+			.filter(|artifact| artifact.is_directory())
+		{
+			assert_eq!(artifact.state().identity(), directory.state().identity());
+		}
+		let unresolved = template.artifacts().nth(1).unwrap();
+		assert!(unresolved.state().object().is_none());
+	}
+
+	#[test]
+	fn unrender_with_different_id() {
+		let file = tg::File::with_contents("original");
+		let other = tg::File::with_contents("other");
+		let string = format!("/store/{}", file.id());
+		let error =
+			tg::Template::unrender_with("/store", &string, |_| Ok(Some(other.clone().into())))
+				.unwrap_err();
+		assert_eq!(
+			error.message().unwrap(),
+			"the resolved artifact has a different ID"
+		);
+	}
+
+	#[test]
+	fn unrender_with_error() {
+		let id = tg::File::with_contents("file").id();
+		let string = format!("/store/{id} /store/{id}");
+		let mut calls = 0;
+		let error = tg::Template::unrender_with("/store", &string, |_| {
+			calls += 1;
+			Err(tg::error!("invalid checkout metadata"))
+		})
+		.unwrap_err();
+		assert_eq!(calls, 1);
+		assert_eq!(
+			error.source().unwrap().to_string(),
+			"invalid checkout metadata"
+		);
+	}
+
+	#[test]
+	fn unrender_with_text() {
+		for string in ["", "ordinary text", "/store/fil_invalid"] {
+			let template = tg::Template::unrender_with("/store", string, |_| {
+				panic!("text should not invoke the resolver")
+			})
+			.unwrap();
+			let rendered = template
+				.try_render_sync(|component| Ok(Cow::Borrowed(component.unwrap_string_ref())))
+				.unwrap();
+			assert_eq!(rendered, string);
+		}
 	}
 }

--- a/packages/clients/rust/tests/checkout.rs
+++ b/packages/clients/rust/tests/checkout.rs
@@ -18,7 +18,7 @@ async fn unrender() {
 	let path = fixture.directory.join("lib/libexample.so");
 	let path = path.to_str().unwrap();
 
-	// A leaf token cannot authorize the directory retained by unrender.
+	// The leaf token cannot authorize the retained directory.
 	let template = tg::Template::unrender(prefix, path).unwrap();
 	let directory = template.artifacts().next().unwrap();
 	assert!(directory.is_directory());
@@ -31,7 +31,7 @@ async fn unrender() {
 	);
 	assert!(load(metadata, prefix, path).await.is_err());
 
-	// Exercise dependency tokens independently when the provider retains them.
+	// Use dependency tokens when they are retained.
 	let mut metadata = tg::file::checkout::read(&fixture.wrapper).unwrap();
 	if metadata
 		.dependencies
@@ -44,7 +44,7 @@ async fn unrender() {
 	let file = load(metadata, prefix, path).await.unwrap();
 	assert_eq!(file.id(), fixture.file);
 
-	// Fall back to the wrapper's token when dependency tokens are absent.
+	// Fall back to the wrapper token when dependency tokens are absent.
 	let metadata = tg::file::checkout::read(&fixture.wrapper_without_dependency_tokens).unwrap();
 	assert!(
 		metadata
@@ -56,7 +56,7 @@ async fn unrender() {
 	let file = load(metadata, prefix, path).await.unwrap();
 	assert_eq!(file.id(), fixture.file);
 
-	// A file-rooted path uses the file's own token.
+	// A file-rooted path uses its own token.
 	let path = fixture.file_path.to_str().unwrap();
 	let metadata = tg::file::checkout::read(&fixture.file_path).unwrap();
 	let file = load(metadata, prefix, path).await.unwrap();
@@ -68,7 +68,6 @@ async fn load(
 	prefix: &str,
 	path: &str,
 ) -> tg::Result<tg::File> {
-	// Attach the recovered tokens to the unrendered artifacts.
 	let file_tokens = tg::authorization::Tokens::with_local(metadata.token);
 	let template = tg::Template::unrender_with(prefix, path, |id| {
 		let mut options = metadata
@@ -83,7 +82,6 @@ async fn load(
 		Ok(Some(tg::Artifact::with_referent(referent)))
 	})?;
 
-	// Resolve the path and load the file in a fresh client.
 	let client = tg::Client::with_env(tg::Arg::default())?;
 	let file = match template.components() {
 		[tg::template::Component::Artifact(artifact)] => artifact.clone(),

--- a/packages/clients/rust/tests/checkout.rs
+++ b/packages/clients/rust/tests/checkout.rs
@@ -69,19 +69,19 @@ async fn load(
 	path: &str,
 ) -> tg::Result<tg::File> {
 	// Attach the recovered tokens to the unrendered artifacts.
-	let template = tg::Template::unrender(prefix, path)?;
 	let file_tokens = tg::authorization::Tokens::with_local(metadata.token);
-	for artifact in template.artifacts() {
-		let mut tokens = metadata
+	let template = tg::Template::unrender_with(prefix, path, |id| {
+		let mut options = metadata
 			.dependencies
 			.iter()
 			.flatten()
-			.find(|reference| reference.node() == &tg::reference::Node::Id(artifact.id().into()))
-			.map(|reference| reference.options().tokens.clone())
+			.find(|reference| reference.node() == &tg::reference::Node::Id(id.clone().into()))
+			.map(|reference| reference.options().clone())
 			.unwrap_or_default();
-		tokens.inherit(&file_tokens);
-		artifact.state().set_tokens(tokens);
-	}
+		options.tokens.inherit(&file_tokens);
+		let referent = tg::Referent::new(id, options.into());
+		Ok(Some(tg::Artifact::with_referent(referent)))
+	})?;
 
 	// Resolve the path and load the file in a fresh client.
 	let client = tg::Client::with_env(tg::Arg::default())?;


### PR DESCRIPTION
Rendered paths retain artifact IDs but lose the authorization and location carried by their handles. Add `Template::unrender_with`, which lets a caller resolve each parsed artifact ID to an existing handle.

The resolver may return `None` for a bare handle. A returned handle must have the same ID, and retains its tokens, location, and cached state. Resolver errors are propagated; the parser does not read files or verify tokens. Existing `Template::unrender` keeps its current behavior.

The checkout integration test uses the resolver for dependency tokens, wrapper-token fallback, and direct file tokens. Unit tests cover retained state, repeated and unresolved artifacts, text input, resolver errors, and ID mismatches.

Stacked on #1116 only to support using `tg::checkout::file::read` in the integration test.
