### PR TITLE
fix(server): persist default token signing keys

### DIFF
--- a/packages/cli/tests/checkout/token_restart.nu
+++ b/packages/cli/tests/checkout/token_restart.nu
@@ -1,0 +1,70 @@
+use ../../test.nu *
+
+# Dependency tokens recovered from a reused checkout should authorize object storage after restart.
+
+for preserve_keys in [true false] {
+	# A zero-edge budget makes a tiny fixture reproduce the fallback search exhaustion.
+	let root_token = random chars
+	let server = server spawn --preserve-keys=$preserve_keys --config {
+		authentication: { root: { token: $root_token }, users: { providers: { insecure: true } } }
+		authorization: {
+			final: {
+				ancestor: { max_depth: 0, max_edges: 0, max_nodes: 0 }
+				descendant: { max_depth: 0, max_edges: 0, max_nodes: 0 }
+				subtree: { max_objects: 0 }
+			}
+			index: { delay: null }
+			initial: false
+		}
+		vfs: false
+	}
+	let bob = tg --token $root_token login --verbose --name bob | from json
+	let user = $bob.user.id
+	let library = tg --token $root_token put 'tg.file("library")' | str trim
+	let source = 'tg.file({"contents":"wrapper","dependencies":{"LIBRARY":{"node":LIBRARY}}})'
+		| str replace --all LIBRARY $library
+	let wrapper = tg --token $root_token put $source | str trim
+	tg --token $root_token grant $user object_subtree $wrapper | ignore
+	tg --token $root_token index
+
+	# Recover the dependency referent directly from a checkout, as a wrapper consumer would.
+	let path = tg --token $root_token checkout $wrapper | str trim
+	let reference = xattr_read user.tangram.dependencies $path | from json | first
+	let token = $'http://localhost/($reference)' | url parse | get params
+		| where key == 'tokens[local]' | first | get value
+	let body = $token | split row '.' | get 1 | decode base64 | decode utf-8 | from json
+	assert equal $body.resource $library
+	assert equal $body.permissions [object_subtree]
+	assert equal $body.expires_at 9223372036854775807
+
+	# Store a new parent with the recovered child token before the restart.
+	let source = 'tg.file({"contents":"before restart","dependencies":{"library":{"node":REFERENCE}}})'
+		| str replace REFERENCE $reference
+	let output = tg --token $bob.token put $source | complete
+	success $output 'the checkout dependency token should authorize the object batch before restart'
+
+	let server = server restart $server
+	let warm_path = tg --token $root_token checkout $wrapper | str trim
+	assert equal $warm_path $path
+	let warm_reference = xattr_read user.tangram.dependencies $warm_path | from json | first
+	assert equal $warm_reference $reference
+
+	# Store another parent with the dependency token recovered from the reused checkout.
+	let source = 'tg.file({"contents":"after restart","dependencies":{"library":{"node":REFERENCE}}})'
+		| str replace REFERENCE $warm_reference
+	let warm_output = tg --token $bob.token put $source | complete
+
+	# A separately materialized file receives a current token for the same dependency.
+	let fresh_path = (mktemp --directory) | path join library
+	tg --token $root_token checkout --dependencies=false --path $fresh_path $library | ignore
+	let fresh_token = xattr_read user.tangram.token $fresh_path
+	let query = { 'tokens[local]': $fresh_token } | url build-query
+	let fresh_reference = $'($library)?($query)'
+	let source = 'tg.file({"contents":"after restart","dependencies":{"library":{"node":REFERENCE}}})'
+		| str replace REFERENCE $fresh_reference
+	let output = tg --token $bob.token put $source | complete
+	success $output 'a fresh token should authorize the same object batch without changing the search budget'
+
+	server stop $server
+	success $warm_output 'a dependency token recovered from the reused checkout should authorize the object batch after restart'
+}

--- a/packages/cli/tests/server/token_key_invalid.nu
+++ b/packages/cli/tests/server/token_key_invalid.nu
@@ -18,3 +18,22 @@ for kind in [authentication authorization] {
 	'
 	assert equal (open --raw $path) 'invalid'
 }
+
+# Validate the private key independently of the configured public keys.
+let server = server spawn --config {
+	authorization: { tokens: { public_keys: [] } }
+	vfs: false
+}
+server stop $server
+let path = $server.directory | path join 'authorization.key'
+'invalid' | save -f $path
+
+let output = tangram -c $server.config_path -d $server.directory serve | complete
+failure $output 'the server must reject a damaged private key'
+snapshot $output.stderr '
+	error an error occurred
+	-> failed to start the server
+	-> invalid private key
+
+'
+assert equal (open --raw $path) 'invalid'

--- a/packages/cli/tests/server/token_key_invalid.nu
+++ b/packages/cli/tests/server/token_key_invalid.nu
@@ -1,0 +1,20 @@
+use ../../test.nu *
+
+# A damaged persisted token key prevents startup instead of silently invalidating existing tokens.
+
+for kind in [authentication authorization] {
+	let server = server spawn --config { vfs: false }
+	server stop $server
+	let path = $server.directory | path join $'($kind).key'
+	'invalid' | save -f $path
+
+	let output = tangram -c $server.config_path -d $server.directory serve | complete
+	failure $output 'the server must reject a damaged private key'
+	snapshot $output.stderr '
+		error an error occurred
+		-> failed to start the server
+		-> invalid private key
+
+	'
+	assert equal (open --raw $path) 'invalid'
+}

--- a/packages/cli/tests/server/token_keys.nu
+++ b/packages/cli/tests/server/token_keys.nu
@@ -1,0 +1,35 @@
+use ../../test.nu *
+
+# Default token keys are private to their server directory and survive graceful and abrupt restarts.
+
+let server = server spawn --config { vfs: false }
+let keys = [authentication authorization] | each { |kind|
+	let path = $server.directory | path join $'($kind).key'
+	assert equal (ls -l $path | get mode | first) 'rw-------'
+	let bytes = open --raw $path | into binary
+	assert equal ($bytes | bytes length) 32
+	{ kind: $kind, hash: ($bytes | hash sha256) }
+}
+assert not equal $keys.0.hash $keys.1.hash
+
+let server = server restart $server
+for key in $keys {
+	let path = $server.directory | path join $'($key.kind).key'
+	assert equal (open --raw $path | hash sha256) $key.hash
+}
+
+let pid = open ($server.directory | path join 'lock') | into int
+kill --signal 9 $pid
+wait_until { ps | where pid == $pid | is-empty } 'the server must stop'
+let server = server start $server
+for key in $keys {
+	let path = $server.directory | path join $'($key.kind).key'
+	assert equal (open --raw $path | hash sha256) $key.hash
+}
+server stop $server
+
+let other = server spawn --config { vfs: false }
+for key in $keys {
+	let path = $other.directory | path join $'($key.kind).key'
+	assert not equal (open --raw $path | hash sha256) $key.hash
+}

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -1806,11 +1806,11 @@ async fn load_token_keys(config: Option<&config::TokenKeys>, path: &Path) -> tg:
 				},
 				None => load_or_create_token_private_key(config, path).await?,
 			};
-			Some(tg::authorization::PrivateKey::new(
-				config.name.clone(),
-				config.algorithm,
-				bytes,
-			))
+			let key =
+				tg::authorization::PrivateKey::new(config.name.clone(), config.algorithm, bytes);
+			tg::authorization::PublicKey::from_private_key(&key)?;
+
+			Some(key)
 		},
 		None => None,
 	};

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -16,7 +16,7 @@ use {
 		collections::BTreeMap,
 		ops::{ControlFlow, Deref},
 		os::fd::AsRawFd as _,
-		path::PathBuf,
+		path::{Path, PathBuf},
 		sync::{Arc, Mutex, atomic::AtomicU64},
 	},
 	tangram_client::prelude::*,
@@ -1007,10 +1007,17 @@ impl Server {
 		let next_watch_id = AtomicU64::new(0);
 		let watches = DashMap::default();
 
-		// Create the token keys.
-		let authentication_tokens =
-			load_token_keys(Some(&config.authentication.tokens.keys)).await?;
-		let authorization_tokens = load_token_keys(config.authorization.tokens.as_ref()).await?;
+		// Load or create the token keys.
+		let authentication_tokens = load_token_keys(
+			Some(&config.authentication.tokens.keys),
+			&path.join("authentication.key"),
+		)
+		.await?;
+		let authorization_tokens = load_token_keys(
+			config.authorization.tokens.as_ref(),
+			&path.join("authorization.key"),
+		)
+		.await?;
 
 		// Create the billing provider.
 		let billing = config
@@ -1788,7 +1795,7 @@ fn authorization_search_config(
 	}
 }
 
-async fn load_token_keys(config: Option<&config::TokenKeys>) -> tg::Result<Tokens> {
+async fn load_token_keys(config: Option<&config::TokenKeys>, path: &Path) -> tg::Result<Tokens> {
 	let private_key = match config.and_then(|config| config.private_key.as_ref()) {
 		Some(config) => {
 			let bytes = match &config.path {
@@ -1797,15 +1804,7 @@ async fn load_token_keys(config: Option<&config::TokenKeys>) -> tg::Result<Token
 						|error| tg::error!(!error, path = %path.display(), "failed to read the private key"),
 					)?,
 				},
-				None => match config.algorithm {
-					tg::authorization::Algorithm::Ed25519 => {
-						tg::authorization::PrivateKey::generate(
-							config.name.clone(),
-							config.algorithm,
-						)?
-						.bytes
-					},
-				},
+				None => load_or_create_token_private_key(config, path).await?,
 			};
 			Some(tg::authorization::PrivateKey::new(
 				config.name.clone(),
@@ -1856,6 +1855,54 @@ async fn load_token_keys(config: Option<&config::TokenKeys>) -> tg::Result<Token
 	};
 
 	Ok(tokens)
+}
+
+async fn load_or_create_token_private_key(
+	config: &config::TokenPrivateKey,
+	path: &Path,
+) -> tg::Result<Vec<u8>> {
+	// Reuse the private key for the lifetime of the server directory.
+	match tokio::fs::read(path).await {
+		Ok(bytes) => return Ok(bytes),
+		Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+		Err(error) => {
+			return Err(
+				tg::error!(!error, path = %path.display(), "failed to read the private key"),
+			);
+		},
+	}
+
+	// Publish a complete key while the server holds the directory lock.
+	let key = tg::authorization::PrivateKey::generate(config.name.clone(), config.algorithm)?;
+	let directory = path.parent().unwrap();
+	let temp_path = directory.join("tmp").join(uuid::Uuid::now_v7().to_string());
+	let mut file = tokio::fs::OpenOptions::new()
+		.write(true)
+		.create_new(true)
+		.mode(0o600)
+		.open(&temp_path)
+		.await
+		.map_err(|error| tg::error!(!error, "failed to create the temporary private key file"))?;
+	scopeguard::defer! {
+		std::fs::remove_file(&temp_path).ok();
+	}
+	file.write_all(&key.bytes)
+		.await
+		.map_err(|error| tg::error!(!error, "failed to write the private key"))?;
+	file.sync_all()
+		.await
+		.map_err(|error| tg::error!(!error, "failed to sync the private key"))?;
+	tokio::fs::rename(&temp_path, path).await.map_err(
+		|error| tg::error!(!error, path = %path.display(), "failed to persist the private key"),
+	)?;
+	tokio::fs::File::open(directory)
+		.await
+		.map_err(|error| tg::error!(!error, "failed to open the private key directory"))?
+		.sync_all()
+		.await
+		.map_err(|error| tg::error!(!error, "failed to sync the private key directory"))?;
+
+	Ok(key.bytes)
 }
 
 fn validate_capacity_threshold(


### PR DESCRIPTION
Default token signing keys were regenerated on every server start, invalidating permanent authorization tokens stored in checkout xattrs. Persist the default authentication and authorization keys as `authentication.key` and `authorization.key` in the Tangram directory so cached checkout references and login tokens remain usable across restarts.

Create each key with mode `0600`, sync it, and atomically rename it into place while holding the existing directory lock. Reuse the stored key on subsequent starts and continue honoring explicitly configured key paths.

Add CLI coverage for checkout dependency tokens across restart, graceful and abrupt restart of the key files, file permissions, independent server keys, and startup rejection of damaged keys.
