### PR TITLE
fix(client): preserve object tokens across response locations

### DIFF
--- a/packages/cli/tests/js/authorization/load_replaces_tokens.nu
+++ b/packages/cli/tests/js/authorization/load_replaces_tokens.nu
@@ -1,6 +1,6 @@
 use ../../../test.nu *
 
-# Loading state replaces inherited tokens with the non-empty tokens returned by the server.
+# Loads refresh returned tokens; object loads also retain tokens for other locations.
 
 let server = server spawn
 
@@ -75,7 +75,7 @@ let path = artifact {
 
 let output = tg build $path | from json
 let expected = {
-	object: { local: returned }
+	object: { local: returned, remote: remote }
 	process: { local: returned }
 	sandbox: { local: returned }
 }

--- a/packages/clients/js/package.json
+++ b/packages/clients/js/package.json
@@ -28,9 +28,10 @@
 	},
 	"scripts": {
 		"build": "node build.ts",
-		"check": "tsc --noEmit && oxlint build.ts src",
-		"format": "oxfmt --write build.ts src",
-		"prepack": "bun run build"
+		"check": "tsc --noEmit && oxlint build.ts src tests",
+		"format": "oxfmt --write build.ts src tests",
+		"prepack": "bun run build",
+		"test": "bun test tests"
 	},
 	"dependencies": {
 		"@noble/hashes": "^2.3.0",

--- a/packages/clients/js/src/object.ts
+++ b/packages/clients/js/src/object.ts
@@ -177,7 +177,7 @@ export namespace Object {
 			}
 			this.location = object.options?.location ?? null;
 			this.#stored = true;
-			this.tokens = object.options?.tokens ?? {};
+			this.#tokens = { ...this.#tokens, ...object.options?.tokens };
 		}
 
 		clearStorePromise(promise: Promise<void>): void {
@@ -235,7 +235,7 @@ export namespace Object {
 				output.tokens !== null &&
 				!tg.Authorization.Tokens.isEmpty(output.tokens)
 			) {
-				this.#tokens = { ...output.tokens };
+				this.#tokens = { ...this.#tokens, ...output.tokens };
 			}
 			this.#object = tg.Object.Object.fromData(output.data);
 

--- a/packages/clients/js/tests/authorization.test.ts
+++ b/packages/clients/js/tests/authorization.test.ts
@@ -1,0 +1,88 @@
+import { expect, spyOn, test } from "bun:test";
+import * as tg from "../src/index.ts";
+
+const id =
+	"gph_010000000000000000000000000000000000000000000000000000" as tg.Graph.Id;
+const process = "pcs_010000000000000000000000000000000000000000000000000000";
+const token = (resource: string, permission: string, expires_at: number) =>
+	`0.${Buffer.from(JSON.stringify({ resource, permissions: [permission], expires_at })).toString("base64")}.metadata.signature`;
+const inherited = { local: "inherited", "remote=test": "remote" };
+
+test("inheritance preserves existing process authorization", () => {
+	for (const [permission, expiration] of [
+		["process_node_output", 0],
+		["process_subtree_output", Number.MAX_SAFE_INTEGER],
+	] as const) {
+		const existing = token(process, permission, Number.MAX_SAFE_INTEGER);
+		const state = new tg.Object.State({
+			id,
+			stored: true,
+			tokens: { local: existing },
+		});
+		state.inheritTokens({ local: token(id, "object_node", expiration) });
+		expect(state.tokens).toEqual({ local: existing });
+	}
+});
+
+test("inheritance does not compute the object ID", () => {
+	const state = new tg.Object.State({
+		object: { kind: "graph", value: { nodes: [] } },
+		stored: false,
+	});
+	const objectId = spyOn(tg.client, "objectId").mockReturnValue(id);
+	try {
+		state.inheritTokens({});
+		state.inheritTokens(inherited);
+		expect(objectId).not.toHaveBeenCalled();
+		expect(state.tokens).toEqual(inherited);
+	} finally {
+		objectId.mockRestore();
+	}
+});
+
+test("store refreshes returned tokens and preserves other locations", () => {
+	for (const local of ["returned", undefined]) {
+		const state = new tg.Object.State({ id, stored: false, tokens: inherited });
+		const returned: tg.Authorization.Tokens =
+			local === undefined ? {} : { local };
+		state.finishStore({ node: id, options: { tokens: returned } });
+		returned.local = "mutated";
+		expect(state.tokens).toEqual({
+			local: local ?? "inherited",
+			"remote=test": "remote",
+		});
+		expect(state.stored).toBe(true);
+	}
+});
+
+test("load refreshes returned tokens and preserves concurrent inheritance", async () => {
+	const original = tg.client.getObject;
+	try {
+		for (const returned of [{ local: "returned" }, {}, null, undefined]) {
+			const state = new tg.Object.State({
+				id,
+				stored: true,
+				tokens: inherited,
+			});
+			tg.client.getObject = async (_id, arg) => {
+				expect(arg?.tokens).toEqual(inherited);
+				state.inheritTokens({ "remote=late": "late" });
+				return {
+					data: { kind: "graph", value: { nodes: [] } },
+					...(returned === undefined ? {} : { tokens: returned }),
+				};
+			};
+			await state.load();
+			const local = returned?.local ?? "inherited";
+			if (returned !== undefined && returned !== null)
+				returned.local = "mutated";
+			expect(state.tokens).toEqual({
+				local,
+				"remote=late": "late",
+				"remote=test": "remote",
+			});
+		}
+	} finally {
+		tg.client.getObject = original;
+	}
+});

--- a/packages/clients/rust/src/object/state.rs
+++ b/packages/clients/rust/src/object/state.rs
@@ -8,6 +8,9 @@ use {
 	tangram_futures::task::Shared,
 };
 
+#[cfg(test)]
+mod authorization;
+
 #[derive(Clone, Debug)]
 pub struct State(Arc<RwLock<Inner>>);
 

--- a/packages/clients/rust/src/object/state.rs
+++ b/packages/clients/rust/src/object/state.rs
@@ -202,13 +202,14 @@ impl State {
 		});
 	}
 
-	pub(crate) fn finish_store(&self, object: tg::Referent<tg::object::Id>) -> tg::Result<()> {
+	pub(crate) fn finish_store(&self, mut object: tg::Referent<tg::object::Id>) -> tg::Result<()> {
 		let mut inner = self.0.write().unwrap();
 		if inner.id.as_ref() != Some(&object.node) {
 			return Err(tg::error!("invalid object batch output"));
 		}
 		inner.location = object.options.location;
 		inner.stored = true;
+		object.options.tokens.inherit(&inner.tokens);
 		inner.tokens = object.options.tokens;
 
 		Ok(())
@@ -380,7 +381,7 @@ impl State {
 		H: tg::Handle,
 	{
 		// Load the object.
-		let Some(output) = handle.try_get_object(&id, arg).await? else {
+		let Some(mut output) = handle.try_get_object(&id, arg).await? else {
 			return Ok(None);
 		};
 
@@ -392,6 +393,7 @@ impl State {
 		// Update the state.
 		let mut inner = self.0.write().unwrap();
 		if !output.tokens.is_empty() {
+			output.tokens.inherit(&inner.tokens);
 			inner.tokens = output.tokens;
 		}
 		inner.object.replace(object.clone());

--- a/packages/clients/rust/src/object/state/authorization.rs
+++ b/packages/clients/rust/src/object/state/authorization.rs
@@ -1,0 +1,138 @@
+use {
+	super::*,
+	tangram_http::response::builder::Ext as _,
+	tg::authorization::{Permission, Tokens, permission::object::Permission::Node},
+};
+
+#[test]
+fn inheritance_preserves_existing_process_authorization() {
+	let state = State::with_id(tg::File::with_contents("object").id());
+	let process = tg::process::Id::new();
+	for (permission, expiration) in [
+		(
+			tg::authorization::permission::process::Permission::NodeOutput,
+			0,
+		),
+		(
+			tg::authorization::permission::process::Permission::SubtreeOutput,
+			i64::MAX,
+		),
+	] {
+		let existing = tokens(
+			process.clone().into(),
+			Permission::Process(permission),
+			i64::MAX,
+		);
+		state.set_tokens(existing.clone());
+		let incoming = tokens(state.id().into(), Permission::Object(Node), expiration);
+		state.inherit_tokens(&incoming);
+		assert_eq!(state.tokens(), existing);
+	}
+}
+
+#[test]
+fn inheritance_does_not_compute_the_object_id() {
+	let graph = tg::Graph::with_nodes(Vec::new());
+	let state = graph.state();
+	assert!(state.try_get_id().is_none());
+	state.inherit_tokens(&Tokens::default());
+	let parent = tg::File::with_contents("parent");
+	state.inherit_tokens(&inherited(&parent.id().into()));
+	assert!(state.try_get_id().is_none());
+}
+
+#[test]
+fn store_refreshes_returned_tokens_and_preserves_other_locations() {
+	let state = State::with_id(tg::File::with_contents("object").id());
+	let inherited = inherited(&state.id());
+	for returned in [
+		tokens(state.id().into(), Permission::Object(Node), i64::MAX),
+		Tokens::default(),
+	] {
+		state.set_tokens(inherited.clone());
+		let local = returned.local().or(inherited.local()).cloned();
+		let options = tg::referent::Options {
+			tokens: returned,
+			..Default::default()
+		};
+		state
+			.finish_store(tg::Referent::new(state.id(), options))
+			.unwrap();
+		let mut expected = inherited.clone();
+		expected.set_local(local.unwrap());
+		assert_eq!(state.tokens(), expected);
+		assert!(state.stored());
+	}
+}
+
+#[tokio::test]
+async fn load_refreshes_returned_tokens_and_preserves_concurrent_inheritance() {
+	let file = tg::File::with_contents("object");
+	let inherited = inherited(&file.id().into());
+	let bytes = file
+		.state()
+		.object()
+		.unwrap()
+		.to_data()
+		.serialize()
+		.unwrap();
+	for returned in [
+		tokens(file.id().into(), Permission::Object(Node), i64::MAX),
+		Tokens::default(),
+	] {
+		let state = State::with_id(file.id());
+		state.set_tokens(inherited.clone());
+		let mut late = Tokens::default();
+		late.set(remote("late"), inherited.local().unwrap().clone());
+		let mut expected = inherited.clone();
+		if let Some(token) = returned.local() {
+			expected.set_local(token.clone());
+		}
+		expected.set(remote("late"), inherited.local().unwrap().clone());
+		let mut client = tg::Client::new(tg::Arg::default()).unwrap();
+		let service = tower::service_fn({
+			let bytes = bytes.clone();
+			let state = state.clone();
+			move |_| {
+				state.inherit_tokens(&late);
+				let response = http::Response::builder()
+					.header_json(tg::object::get::TOKENS_HEADER, &returned)
+					.unwrap()
+					.bytes(bytes.clone())
+					.unwrap()
+					.map(tangram_http::body::Ext::boxed);
+				async move { Ok(response) }
+			}
+		});
+		Arc::get_mut(&mut client.0).unwrap().service = crate::http::Service::new(service);
+		state.load_with_handle(&client).await.unwrap();
+		assert_eq!(state.tokens(), expected);
+	}
+}
+
+fn inherited(id: &tg::object::Id) -> Tokens {
+	let mut tokens = tokens(id.clone().into(), Permission::Object(Node), i64::MAX - 1);
+	tokens.set(remote("test"), tokens.local().unwrap().clone());
+	tokens
+}
+
+fn remote(name: &str) -> tg::Location {
+	tg::Location::Remote(tg::location::Remote {
+		name: name.into(),
+		region: None,
+	})
+}
+
+fn tokens(resource: tg::Id, permission: Permission, expires_at: i64) -> Tokens {
+	let body = tg::authorization::Body {
+		expires_at,
+		permissions: vec![permission],
+		resource,
+	};
+	let key = tg::authorization::PrivateKey::new(
+		"test",
+		tg::authorization::Algorithm::Ed25519,
+		vec![0; 32],
+	);
+	Tokens::with_local(Some(tg::authorization::Token::sign(body, &key).unwrap()))
+}


### PR DESCRIPTION
Object load and store responses replaced the entire token map, discarding authorization for locations absent from the response, including tokens inherited during a pending load.

Instead, merge response tokens by location in the JavaScript and Rust object states. Returned tokens still replace entries for the same location, preserving token refresh and linear directory descent. Ancestor inheritance keeps its existing behavior.
