### PR TITLE
fix: return authorization for blob writes

### DIFF
--- a/packages/cli/src/write.rs
+++ b/packages/cli/src/write.rs
@@ -36,7 +36,7 @@ impl Cli {
 				.await
 				.map_err(|error| tg::error!(!error, "failed to write the blob"))?
 		};
-		Self::print_id(&output.blob);
+		Self::print_id(&output.blob.node);
 		Ok(())
 	}
 }

--- a/packages/cli/tests/blob/write_authorization.nu
+++ b/packages/cli/tests/blob/write_authorization.nu
@@ -1,0 +1,21 @@
+use ../../test.nu *
+
+# Writing bytes returns subtree authorization for the blob.
+
+let server = server spawn
+let socket = $server.url | str replace 'http+unix://' '' | url decode
+
+let output = (
+	'hello'
+	| into binary
+	| http post
+		--headers { 'Content-Type': 'application/octet-stream' }
+		--unix-socket $socket
+		'http://localhost/write'
+)
+let uri = $'http://localhost/($output.blob)' | url parse
+let tokens = $uri.params | where key == 'tokens[local]'
+assert equal ($tokens | length) 1 'the write should return an authorization token'
+let body = $tokens.0.value | split row '.' | get 1 | decode base64 | decode utf-8 | from json
+assert equal $body.resource ($uri.path | str substring 1..)
+assert equal $body.permissions [object_subtree]

--- a/packages/clients/js/src/client/write.ts
+++ b/packages/clients/js/src/client/write.ts
@@ -8,7 +8,7 @@ export namespace Write {
 	};
 
 	export type Output = {
-		blob: tg.Blob.Id;
+		blob: tg.Referent<tg.Blob.Id>;
 	};
 }
 
@@ -27,7 +27,7 @@ export async function write(
 					: argOrBytes,
 			),
 		);
-		return (output as tg.Write.Output).blob;
+		return (output as tg.Write.Output).blob.node;
 	}
 	let method = "POST";
 	let uri = new Uri({
@@ -55,7 +55,10 @@ export async function write(
 	if (response.status < 200 || response.status >= 300) {
 		throw tg.Error.fromData(await response.json<tg.Error.Data>());
 	}
-	return await response.json<tg.Write.Output>();
+	let output = await response.json<{ blob: string }>();
+	return {
+		blob: tg.Referent.fromDataString(output.blob, (id) => id as tg.Blob.Id),
+	};
 }
 
 async function* singleBytes(

--- a/packages/clients/rust/src/blob/handle.rs
+++ b/packages/clients/rust/src/blob/handle.rs
@@ -231,7 +231,7 @@ impl Blob {
 	{
 		let arg = tg::write::Arg::default();
 		let output = handle.write(arg, reader).boxed().await?;
-		let blob = Self::with_id(output.blob);
+		let blob = Self::with_referent(output.blob);
 		Ok(blob)
 	}
 

--- a/packages/clients/rust/src/write.rs
+++ b/packages/clients/rust/src/write.rs
@@ -14,9 +14,11 @@ pub struct Arg {
 	pub checkout_pointers: Option<bool>,
 }
 
+#[serde_as]
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct Output {
-	pub blob: tg::blob::Id,
+	#[serde_as(as = "DisplayFromStr")]
+	pub blob: tg::Referent<tg::blob::Id>,
 }
 
 impl tg::Session {

--- a/packages/server/src/log.rs
+++ b/packages/server/src/log.rs
@@ -166,7 +166,7 @@ impl Session {
 		blob_bytes.extend_from_slice(&entries_bytes);
 
 		let arg = tg::write::Arg::default();
-		let blob = self.write(arg, Cursor::new(blob_bytes)).await?.blob;
+		let blob = self.write(arg, Cursor::new(blob_bytes)).await?.blob.node;
 		data.log = Some(tg::Referent::with_node(blob.clone()));
 		let touched_at = self.server.clock.unix_timestamp()?;
 

--- a/packages/server/src/write.rs
+++ b/packages/server/src/write.rs
@@ -39,8 +39,17 @@ impl Session {
 		arg: tg::write::Arg,
 		reader: impl AsyncRead,
 	) -> tg::Result<tg::write::Output> {
-		// Get the touch time.
+		// Get the timestamps.
 		let touched_at = self.server.clock.unix_timestamp()?;
+		let grant_expires_at = touched_at
+			+ self
+				.server
+				.config
+				.object
+				.grant_time_to_live
+				.as_secs()
+				.to_i64()
+				.unwrap();
 
 		// Create the destination.
 		let destination =
@@ -97,7 +106,7 @@ impl Session {
 		// Store and index the blob.
 		let store_args = Self::write_store_args(&blob, checkout_pointer.as_ref());
 		let index_arg = self
-			.write_index_arg(&blob, checkout_pointer, touched_at)
+			.write_index_arg(&blob, checkout_pointer, touched_at, grant_expires_at)
 			.await?;
 		self.server
 			.put_object_batch_and_index(store_args, index_arg)
@@ -105,9 +114,15 @@ impl Session {
 			.map_err(|error| tg::error!(!error, "failed to store and index the blob"))?;
 
 		// Create the output.
-		let output = tg::write::Output {
-			blob: blob.id.clone(),
-		};
+		let token = self.create_token(
+			blob.id.clone().into(),
+			vec![tg::authorization::Permission::Object(
+				tg::authorization::permission::object::Permission::Subtree,
+			)],
+			grant_expires_at,
+		)?;
+		let blob = tg::Referent::with_node_and_token(blob.id.clone(), token);
+		let output = tg::write::Output { blob };
 
 		Ok(output)
 	}
@@ -474,16 +489,8 @@ impl Session {
 		blob: &Output,
 		checkout_pointer: Option<(tg::artifact::Id, Option<PathBuf>)>,
 		touched_at: i64,
+		grant_expires_at: i64,
 	) -> tg::Result<tangram_index::batch::Arg> {
-		let grant_expires_at = touched_at
-			+ self
-				.server
-				.config
-				.object
-				.grant_time_to_live
-				.as_secs()
-				.to_i64()
-				.unwrap();
 		let (put_checkout_args, put_object_args, put_grant_args) = Self::write_index_args(
 			blob,
 			checkout_pointer,


### PR DESCRIPTION
`Blob::with_reader` writes bytes through `/write`, which grants subtree access but returns only the blob ID. Storing a parent file with that handle therefore supplies no contents token, so batch storage issues only node authorization. Checkout then needs a graph search that can exhaust.

Return a token-bearing blob reference from `/write` and preserve it in `Blob::with_reader`. The token covers the written blob and uses the existing grant's expiry.

The test writes one blob and checks the returned token's resource and subtree permission. It fails before the fix and passes afterward.
