### PR TITLE
fix(index): preserve node and grant propagation versions

### DIFF
--- a/packages/index/src/fdb/clean.rs
+++ b/packages/index/src/fdb/clean.rs
@@ -1,4 +1,5 @@
 mod key;
+mod update;
 pub(super) use key::{ItemKind, Key};
 
 use {
@@ -319,7 +320,19 @@ impl Index {
 			}
 		}
 
-		output.done = grants == 0 && candidates.is_empty();
+		let remaining_batch_size = remaining_batch_size.saturating_sub(candidates.len());
+		let propagated_versions = crate::fdb::propagate!(
+			Self::clean_update_propagated_versions(
+				txn,
+				subspace,
+				remaining_batch_size,
+				partition_start,
+				partition_end,
+				partition_total,
+			)
+			.await
+		);
+		output.done = grants == 0 && candidates.is_empty() && propagated_versions == 0;
 
 		Ok(ControlFlow::Break(output))
 	}
@@ -773,6 +786,7 @@ impl Index {
 		txn.clear(&key);
 
 		let id_bytes = id.to_bytes();
+		Self::clear_update_propagated_versions(txn, subspace, id_bytes.as_ref());
 
 		let prefix = (Kind::ObjectChild.to_i32().unwrap(), id_bytes.as_ref());
 		let prefix = Self::pack(subspace, &prefix);
@@ -866,6 +880,7 @@ impl Index {
 			.and_then(|process| process.sandbox);
 		txn.clear(&key);
 		let id_bytes = id.to_bytes();
+		Self::clear_update_propagated_versions(txn, subspace, id_bytes.as_ref());
 
 		let prefix = (Kind::ProcessChild.to_i32().unwrap(), id_bytes.as_ref());
 		let prefix = Self::pack(subspace, &prefix);

--- a/packages/index/src/fdb/clean/update.rs
+++ b/packages/index/src/fdb/clean/update.rs
@@ -1,0 +1,92 @@
+use {
+	crate::fdb::{Index, Kind, update::Key},
+	foundationdb as fdb,
+	foundationdb_tuple::{self as fdbt, Subspace},
+	futures::future,
+	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
+	tangram_client::prelude::*,
+};
+
+impl Index {
+	pub(super) async fn clean_update_propagated_versions(
+		txn: &crate::fdb::Transaction,
+		subspace: &Subspace,
+		batch_size: usize,
+		partition_start: u64,
+		partition_end: u64,
+		partition_total: u64,
+	) -> tg::Result<ControlFlow<usize, fdb::FdbError>> {
+		let mut candidates = Vec::new();
+		for (kind, key_kind) in [
+			(crate::update::Kind::Grant, Kind::GrantUpdateClean),
+			(crate::update::Kind::Node, Kind::NodeUpdateClean),
+		] {
+			if candidates.len() == batch_size {
+				break;
+			}
+			// An older update in any partition can still propagate to an item in this partition.
+			let oldest = crate::fdb::propagate!(
+				Self::try_get_oldest_update_transaction_id_with_transaction(
+					txn,
+					subspace,
+					kind,
+					partition_total,
+				)
+				.await
+			);
+			for partition in partition_start..partition_end {
+				let remaining = batch_size.saturating_sub(candidates.len());
+				if remaining == 0 {
+					break;
+				}
+				let key_kind = key_kind.to_i32().unwrap();
+				let begin = Self::pack(subspace, &(key_kind, partition));
+				let end = if let Some(oldest) = oldest {
+					// Exclude the entire oldest transaction, including its first versionstamp.
+					let mut bytes = [0; 12];
+					bytes[..8].copy_from_slice(&oldest.to_be_bytes());
+					let version = fdbt::Versionstamp::from(bytes);
+					Self::pack(subspace, &(key_kind, partition, version))
+				} else {
+					Subspace::from_bytes(begin.clone()).range().1
+				};
+				let range = fdb::RangeOption {
+					begin: fdb::KeySelector::first_greater_or_equal(begin),
+					end: fdb::KeySelector::first_greater_or_equal(end),
+					limit: Some(remaining),
+					mode: fdb::options::StreamingMode::WantAll,
+					..Default::default()
+				};
+				let result = txn.get_range(&range, 1, false).await;
+				let entries = crate::fdb::retry!(result);
+				for entry in entries {
+					let crate::fdb::Key::Update(Key::Clean {
+						id, kind, version, ..
+					}) = Self::unpack(subspace, entry.key())?
+					else {
+						return Err(tg::error!("expected an update clean key"));
+					};
+					let key = crate::fdb::Key::Update(Key::PropagatedVersion { id, kind });
+					let key = Self::pack(subspace, &key);
+					candidates.push((entry.key().to_vec(), key, version));
+				}
+			}
+		}
+
+		// Read the current versions together, retaining conflicts with concurrent propagation.
+		let futures = candidates.iter().map(|(_, key, _)| txn.get(key, false));
+		let result = future::try_join_all(futures).await;
+		let values = crate::fdb::retry!(result);
+		for ((clean_key, key, version), value) in std::iter::zip(&candidates, values) {
+			// A stale cleanup entry must not delete a version recorded by a subsequent propagation.
+			if value.is_some_and(|value| value.as_ref() == version.as_bytes()) {
+				txn.clear(key);
+			}
+			txn.clear(clean_key);
+		}
+		let count = candidates.len();
+
+		Ok(ControlFlow::Break(count))
+	}
+}

--- a/packages/index/src/fdb/key.rs
+++ b/packages/index/src/fdb/key.rs
@@ -81,6 +81,10 @@ pub enum Kind {
 	StorageUpdateVersion = 63,
 	UsageStarted = 64,
 	UsageUnavailable = 65,
+	GrantUpdatePropagatedVersion = 66,
+	NodeUpdatePropagatedVersion = 67,
+	GrantUpdateClean = 71,
+	NodeUpdateClean = 72,
 }
 
 impl fdbt::TuplePack for Key {
@@ -572,6 +576,22 @@ impl fdbt::TuplePack for Key {
 			)
 				.pack(w, tuple_depth),
 
+			Key::Update(crate::fdb::update::Key::PropagatedVersion { id, kind }) => {
+				let key_kind = match kind {
+					crate::fdb::update::Kind::Grant(_) => Kind::GrantUpdatePropagatedVersion,
+					crate::fdb::update::Kind::Node => Kind::NodeUpdatePropagatedVersion,
+					crate::fdb::update::Kind::Storage(_) => unreachable!(),
+				};
+				key_kind.to_i32().unwrap().pack(w, tuple_depth)?;
+				let id = match id {
+					tg::Either::Left(id) => id.to_bytes(),
+					tg::Either::Right(id) => id.to_bytes(),
+				};
+				let mut offset = id.as_ref().pack(w, tuple_depth)?;
+				offset += pack_update_kind(w, tuple_depth, kind)?;
+				Ok(offset)
+			},
+
 			Key::Update(crate::fdb::update::Key::Update { id, kind }) => {
 				let key_kind = match kind {
 					crate::fdb::update::Kind::Grant(_) => Kind::GrantUpdate,
@@ -588,14 +608,25 @@ impl fdbt::TuplePack for Key {
 				Ok(offset)
 			},
 
-			Key::Update(crate::fdb::update::Key::UpdateVersion {
-				id,
-				kind,
-				partition,
-				version,
-			}) => {
+			Key::Update(
+				crate::fdb::update::Key::UpdateVersion {
+					id,
+					kind,
+					partition,
+					version,
+				}
+				| crate::fdb::update::Key::Clean {
+					id,
+					kind,
+					partition,
+					version,
+				},
+			) => {
+				let clean = matches!(self, Key::Update(crate::fdb::update::Key::Clean { .. }));
 				let key_kind = match kind {
+					crate::fdb::update::Kind::Grant(_) if clean => Kind::GrantUpdateClean,
 					crate::fdb::update::Kind::Grant(_) => Kind::GrantUpdateVersion,
+					crate::fdb::update::Kind::Node if clean => Kind::NodeUpdateClean,
 					crate::fdb::update::Kind::Node => Kind::NodeUpdateVersion,
 					crate::fdb::update::Kind::Storage(_) => Kind::StorageUpdateVersion,
 				};
@@ -1486,6 +1517,27 @@ impl fdbt::TupleUnpack<'_> for Key {
 				Ok((input, key))
 			},
 
+			Kind::GrantUpdatePropagatedVersion | Kind::NodeUpdatePropagatedVersion => {
+				let update_kind = match kind {
+					Kind::GrantUpdatePropagatedVersion => crate::update::Kind::Grant,
+					Kind::NodeUpdatePropagatedVersion => crate::update::Kind::Node,
+					_ => unreachable!(),
+				};
+				let (input, id): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
+				let id = tg::Id::from_slice(&id)
+					.map_err(|_| fdbt::PackError::Message("invalid id".into()))?;
+				let id = if let Ok(id) = tg::process::Id::try_from(id.clone()) {
+					tg::Either::Right(id)
+				} else if let Ok(id) = tg::object::Id::try_from(id) {
+					tg::Either::Left(id)
+				} else {
+					return Err(fdbt::PackError::Message("invalid id".into()));
+				};
+				let (input, kind) = unpack_update_kind(input, tuple_depth, update_kind)?;
+				let key = Key::Update(crate::fdb::update::Key::PropagatedVersion { id, kind });
+				Ok((input, key))
+			},
+
 			Kind::GrantUpdate | Kind::NodeUpdate | Kind::StorageUpdate => {
 				let update_kind = match kind {
 					Kind::GrantUpdate => crate::update::Kind::Grant,
@@ -1510,10 +1562,15 @@ impl fdbt::TupleUnpack<'_> for Key {
 				))
 			},
 
-			Kind::GrantUpdateVersion | Kind::NodeUpdateVersion | Kind::StorageUpdateVersion => {
+			Kind::GrantUpdateClean
+			| Kind::GrantUpdateVersion
+			| Kind::NodeUpdateClean
+			| Kind::NodeUpdateVersion
+			| Kind::StorageUpdateVersion => {
+				let clean = matches!(kind, Kind::GrantUpdateClean | Kind::NodeUpdateClean);
 				let update_kind = match kind {
-					Kind::GrantUpdateVersion => crate::update::Kind::Grant,
-					Kind::NodeUpdateVersion => crate::update::Kind::Node,
+					Kind::GrantUpdateClean | Kind::GrantUpdateVersion => crate::update::Kind::Grant,
+					Kind::NodeUpdateClean | Kind::NodeUpdateVersion => crate::update::Kind::Node,
 					Kind::StorageUpdateVersion => crate::update::Kind::Storage,
 					_ => unreachable!(),
 				};
@@ -1530,12 +1587,22 @@ impl fdbt::TupleUnpack<'_> for Key {
 					return Err(fdbt::PackError::Message("invalid id".into()));
 				};
 				let (input, kind) = unpack_update_kind(input, tuple_depth, update_kind)?;
-				let key = Key::Update(crate::fdb::update::Key::UpdateVersion {
-					id,
-					kind,
-					partition,
-					version,
-				});
+				let key = if clean {
+					crate::fdb::update::Key::Clean {
+						id,
+						kind,
+						partition,
+						version,
+					}
+				} else {
+					crate::fdb::update::Key::UpdateVersion {
+						id,
+						kind,
+						partition,
+						version,
+					}
+				};
+				let key = Key::Update(key);
 				Ok((input, key))
 			},
 		}

--- a/packages/index/src/fdb/update.rs
+++ b/packages/index/src/fdb/update.rs
@@ -292,7 +292,8 @@ impl Index {
 				..Default::default()
 			};
 			async move {
-				let result = txn.get_range(&range, 1, false).await;
+				// A snapshot is sufficient because processing an update atomically preserves its version in downstream work.
+				let result = txn.get_range(&range, 1, true).await;
 				let entries = crate::fdb::retry!(result);
 				let Some(entry) = entries.first() else {
 					return Ok(ControlFlow::Break(None));
@@ -567,15 +568,13 @@ impl Index {
 			};
 
 			if let Some(source) = source {
-				let propagate = if source == Source::Put || changed {
-					true
-				} else {
-					let propagated_version = crate::fdb::propagate!(
-						Self::try_get_update_propagated_version(txn, subspace, &id, &kind).await
-					);
-					propagated_version
-						.is_some_and(|propagated_version| version < propagated_version)
-				};
+				let propagated_version = crate::fdb::propagate!(
+					Self::try_get_update_propagated_version(txn, subspace, &id, &kind).await
+				);
+				let propagate = source == Source::Put
+					|| changed || propagated_version
+					.as_ref()
+					.is_some_and(|propagated_version| version < *propagated_version);
 				if propagate {
 					crate::fdb::propagate!(
 						Self::enqueue_parents(txn, subspace, &id, &kind, &version, partition_total)
@@ -592,6 +591,18 @@ impl Index {
 						tg::Either::Right(id) => id.to_bytes(),
 					};
 					let partition = Self::partition_for_id(id_bytes.as_ref(), partition_total);
+					// Keep one cleanup entry for the retained propagated version.
+					if let Some(previous) =
+						propagated_version.filter(|previous| *previous != version)
+					{
+						let key = crate::fdb::Key::Update(Key::Clean {
+							id: id.clone(),
+							kind: kind.clone(),
+							partition,
+							version: previous,
+						});
+						txn.clear(&Self::pack(subspace, &key));
+					}
 					let key = crate::fdb::Key::Update(Key::Clean {
 						id: id.clone(),
 						kind: kind.clone(),

--- a/packages/index/src/fdb/update.rs
+++ b/packages/index/src/fdb/update.rs
@@ -1,4 +1,6 @@
 mod key;
+#[cfg(test)]
+mod tests;
 
 pub(super) use key::{Key, Kind, StorageKind};
 
@@ -406,7 +408,21 @@ impl Index {
 			let result = txn.get(&key, false).await;
 			let value = crate::fdb::retry!(result);
 
-			let Some(value) = value else {
+			// A consumed payload does not imply that every queued version has propagated.
+			let value = if let Some(value) = value {
+				value.to_vec()
+			} else if !matches!(kind, Kind::Storage(_)) {
+				let propagated_version = crate::fdb::propagate!(
+					Self::try_get_update_propagated_version(txn, subspace, &id, &kind).await
+				);
+				if propagated_version.is_none_or(|propagated_version| version >= propagated_version)
+				{
+					Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
+					output.count += 1;
+					continue;
+				}
+				serialize_update(&kind, Source::Propagate)?
+			} else {
 				Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
 				output.count += 1;
 				continue;
@@ -550,15 +566,40 @@ impl Index {
 				},
 			};
 
-			if !matches!(kind, Kind::Storage(_))
-				&& match source.unwrap() {
-					Source::Put => true,
-					Source::Propagate => changed,
-				} {
-				crate::fdb::propagate!(
-					Self::enqueue_parents(txn, subspace, &id, &kind, &version, partition_total,)
-						.await
-				);
+			if let Some(source) = source {
+				let propagate = if source == Source::Put || changed {
+					true
+				} else {
+					let propagated_version = crate::fdb::propagate!(
+						Self::try_get_update_propagated_version(txn, subspace, &id, &kind).await
+					);
+					propagated_version
+						.is_some_and(|propagated_version| version < propagated_version)
+				};
+				if propagate {
+					crate::fdb::propagate!(
+						Self::enqueue_parents(txn, subspace, &id, &kind, &version, partition_total)
+							.await
+					);
+					// Remember the version used to enqueue the parents, including an older version for an unchanged item.
+					let key = crate::fdb::Key::Update(Key::PropagatedVersion {
+						id: id.clone(),
+						kind: kind.clone(),
+					});
+					txn.set(&Self::pack(subspace, &key), version.as_bytes());
+					let id_bytes = match &id {
+						tg::Either::Left(id) => id.to_bytes(),
+						tg::Either::Right(id) => id.to_bytes(),
+					};
+					let partition = Self::partition_for_id(id_bytes.as_ref(), partition_total);
+					let key = crate::fdb::Key::Update(Key::Clean {
+						id: id.clone(),
+						kind: kind.clone(),
+						partition,
+						version: version.clone(),
+					});
+					txn.set(&Self::pack(subspace, &key), &[]);
+				}
 			}
 
 			let continued = if let Some(cursor) = next_cursor {
@@ -596,6 +637,49 @@ impl Index {
 		}
 
 		Ok(ControlFlow::Break(output))
+	}
+
+	async fn try_get_update_propagated_version(
+		txn: &crate::fdb::Transaction,
+		subspace: &Subspace,
+		id: &tg::Either<tg::object::Id, tg::process::Id>,
+		kind: &Kind,
+	) -> tg::Result<ControlFlow<Option<fdbt::Versionstamp>, fdb::FdbError>> {
+		let key = crate::fdb::Key::Update(Key::PropagatedVersion {
+			id: id.clone(),
+			kind: kind.clone(),
+		});
+		let key = Self::pack(subspace, &key);
+		let result = txn.get(&key, false).await;
+		let value = crate::fdb::retry!(result);
+		let version = value
+			.map(|value| {
+				let bytes: [u8; 12] = value.as_ref().try_into().map_err(|error| {
+					tg::error!(
+						!error,
+						"failed to deserialize the propagated update version"
+					)
+				})?;
+				Ok::<_, tg::Error>(fdbt::Versionstamp::from(bytes))
+			})
+			.transpose()?;
+
+		Ok(ControlFlow::Break(version))
+	}
+
+	pub(super) fn clear_update_propagated_versions(
+		txn: &crate::fdb::Transaction,
+		subspace: &Subspace,
+		id: &[u8],
+	) {
+		for kind in [
+			KeyKind::GrantUpdatePropagatedVersion,
+			KeyKind::NodeUpdatePropagatedVersion,
+		] {
+			let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), id));
+			let (_, end) = Subspace::from_bytes(prefix.clone()).range();
+			txn.clear_range(&prefix, &end);
+		}
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -1093,6 +1177,7 @@ impl Index {
 				let Some(object) = crate::fdb::propagate!(
 					Self::try_get_object_with_transaction(txn, subspace, id).await
 				) else {
+					Self::clear_update_propagated_versions(txn, subspace, id.to_bytes().as_ref());
 					return Ok(ControlFlow::Break(()));
 				};
 				let partition = Self::partition_for_id(id.to_bytes().as_ref(), partition_total);
@@ -1106,6 +1191,7 @@ impl Index {
 				let Some(process) = crate::fdb::propagate!(
 					Self::try_get_process_with_transaction(txn, subspace, id).await
 				) else {
+					Self::clear_update_propagated_versions(txn, subspace, id.to_bytes().as_ref());
 					return Ok(ControlFlow::Break(()));
 				};
 				let partition = Self::partition_for_id(id.to_bytes().as_ref(), partition_total);

--- a/packages/index/src/fdb/update/key.rs
+++ b/packages/index/src/fdb/update/key.rs
@@ -2,6 +2,20 @@ use {foundationdb_tuple as fdbt, tangram_client::prelude::*};
 
 #[derive(Clone, Debug)]
 pub enum Key {
+	/// A version-ordered candidate for regular cleaning after older updates have drained.
+	Clean {
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+		kind: Kind,
+		partition: u64,
+		version: fdbt::Versionstamp,
+	},
+	/// The version last used to enqueue this item's parent updates.
+	/// An older unchanged update must enqueue the parents again using its older version.
+	/// Regular cleaning removes this key once the queue has advanced beyond its version.
+	PropagatedVersion {
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+		kind: Kind,
+	},
 	Update {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,

--- a/packages/index/src/fdb/update/tests.rs
+++ b/packages/index/src/fdb/update/tests.rs
@@ -1,0 +1,331 @@
+use {
+	super::{Index, Key, Kind},
+	foundationdb as fdb,
+	futures::FutureExt as _,
+	std::{collections::BTreeMap, ops::ControlFlow, panic::AssertUnwindSafe, sync::OnceLock},
+	tangram_client::prelude::*,
+};
+
+mod clean;
+
+static NETWORK: OnceLock<fdb::api::NetworkAutoStop> = OnceLock::new();
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn coalesced_updates_preserve_the_oldest_version() {
+	run(async |index| reproduce(index, false).await).await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn late_updates_preserve_the_oldest_version() {
+	run(async |index| reproduce(index, true).await).await;
+}
+
+async fn run(test: impl AsyncFnOnce(&Index)) {
+	NETWORK.get_or_init(|| {
+		// SAFETY: The network is initialized once and outlives every test database and runtime.
+		unsafe { fdb::boot() }
+	});
+	let options = crate::fdb::Options {
+		authorize: crate::fdb::AuthorizeConfig { concurrency: 1 },
+		cluster: std::env::var_os("FDB_CLUSTER_FILE")
+			.expect("set FDB_CLUSTER_FILE")
+			.into(),
+		instance: Some(format!(
+			"index_update_test_{:032x}/",
+			rand::random::<u128>()
+		)),
+		max_process_depth: None,
+		partition_total: 2,
+		read_request_batch_size: 1,
+		read_transaction_concurrency: 1,
+		usage_partition_total: 1,
+		write_operation_batch_size: 1024,
+		write_transaction_concurrency: 1,
+	};
+	let index = Index::new(&options).unwrap();
+	let result = AssertUnwindSafe(test(&index)).catch_unwind().await;
+	crate::fdb::run(&index.database, |txn| {
+		let (begin, end) = index.subspace.range();
+		async move {
+			txn.clear_range(&begin, &end);
+			Ok(ControlFlow::Break(()))
+		}
+	})
+	.await
+	.unwrap();
+	if let Err(error) = result {
+		std::panic::resume_unwind(error);
+	}
+}
+
+async fn reproduce(index: &Index, late: bool) {
+	// Establish a directory chain whose metadata is incomplete until the leaf arrives.
+	let mut leaf = directory(&[]);
+	let mut middle = directory(&[("leaf", leaf.id.clone())]);
+	let top = directory(&[("middle", middle.id.clone())]);
+	put(index, vec![top.clone(), middle.clone()]).await;
+	drain(index).await;
+	assert_eq!(count(index, &top.id).await, None);
+	leaf.metadata.subtree = tg::object::metadata::Subtree {
+		count: Some(1),
+		depth: Some(1),
+		size: Some(leaf.metadata.node.size),
+		solvable: Some(false),
+		solved: Some(true),
+	};
+	leaf.storage.subtree = true;
+	put(index, vec![leaf.clone()]).await;
+	if !late {
+		step(index).await;
+	}
+	let cutoff = index.get_transaction_id().await.unwrap();
+	let entries = queue(index).await;
+	let Key::UpdateVersion { version, .. } = &entries[0] else {
+		unreachable!()
+	};
+	let version = version.clone();
+
+	// Place the newer middle update before the older work in the partition scan order.
+	let old = if late { &leaf.id } else { &middle.id };
+	partition(index, old, 1).await;
+	middle.metadata.subtree = tg::object::metadata::Subtree {
+		count: Some(2),
+		depth: Some(2),
+		size: Some(middle.metadata.node.size + leaf.metadata.node.size),
+		solvable: Some(false),
+		solved: Some(true),
+	};
+	put(index, vec![middle.clone()]).await;
+	partition_newest(index, &middle.id, 0).await;
+	step(index).await;
+	assert_eq!(count(index, &middle.id).await, Some(2));
+	partition(index, &top.id, 1).await;
+	if late {
+		step(index).await;
+	}
+	step(index).await;
+
+	// Waiting must still include the top directory even though its metadata is unchanged locally.
+	let oldest = index
+		.try_get_oldest_update_transaction_id(crate::update::Kind::Node)
+		.await
+		.unwrap();
+	assert!(
+		oldest.is_some_and(|version| version <= cutoff),
+		"the wait cutoff lost its pending propagation: {oldest:?} > {cutoff}"
+	);
+	assert_eq!(count(index, &top.id).await, None);
+	drain(index).await;
+	assert_eq!(count(index, &top.id).await, Some(3));
+
+	// Repeating an already covered propagation must not walk the ancestors again.
+	crate::fdb::run(&index.database, |txn| {
+		let id = tg::Either::Left(middle.id.clone());
+		let version = &version;
+		async move {
+			Index::enqueue_update_propagate(&txn, &index.subspace, &id, &Kind::Node, version, 2)
+				.await
+		}
+	})
+	.await
+	.unwrap();
+	step(index).await;
+	let entries = queue(index).await;
+	assert!(entries.is_empty());
+
+	// Collection must remove the retained versions along with their objects.
+	let arg = crate::clean::Arg {
+		batch_size: 100,
+		max_object_touched_at: 0,
+		max_process_touched_at: 0,
+		max_sandbox_touched_at: 0,
+		now: 0,
+		partition_end: 2,
+		partition_start: 0,
+	};
+	let mut done = false;
+	for _ in 0..10 {
+		if index.clean(arg.clone()).await.unwrap().done {
+			done = true;
+			break;
+		}
+	}
+	assert!(done);
+	let ids = [leaf.id, middle.id, top.id];
+	assert!(
+		index
+			.try_get_objects(&ids)
+			.await
+			.unwrap()
+			.iter()
+			.all(Option::is_none)
+	);
+	crate::fdb::run(&index.database, |txn| {
+		let ids = &ids;
+		async move {
+			for id in ids {
+				let id = tg::Either::Left(id.clone());
+				let version = crate::fdb::propagate!(
+					Index::try_get_update_propagated_version(
+						&txn,
+						&index.subspace,
+						&id,
+						&Kind::Node
+					)
+					.await
+				);
+				assert!(version.is_none());
+			}
+			Ok(ControlFlow::Break(()))
+		}
+	})
+	.await
+	.unwrap();
+}
+
+fn directory(children: &[(&str, tg::object::Id)]) -> crate::object::put::Arg {
+	let entries = children
+		.iter()
+		.map(|(name, id)| ((*name).to_owned(), id.to_string()))
+		.collect::<BTreeMap<_, _>>();
+	let data: tg::directory::Data =
+		serde_json::from_value(serde_json::json!({ "entries": entries })).unwrap();
+	let bytes = data.serialize().unwrap();
+	let id = tg::object::Id::new(tg::object::Kind::Directory, &bytes);
+	let metadata = tg::object::Metadata {
+		node: tg::object::metadata::Node {
+			size: bytes.len() as u64,
+			solvable: false,
+			solved: true,
+		},
+		subtree: tg::object::metadata::Subtree::default(),
+	};
+	crate::object::put::Arg {
+		checkout: None,
+		children: children.iter().map(|(_, id)| id.clone()).collect(),
+		id,
+		metadata,
+		put: [1; 16],
+		storage: crate::object::Storage::default(),
+		time_to_touch: std::time::Duration::ZERO,
+		touched_at: 0,
+	}
+}
+
+async fn count(index: &Index, id: &tg::object::Id) -> Option<u64> {
+	index
+		.try_get_objects(std::slice::from_ref(id))
+		.await
+		.unwrap()[0]
+		.as_ref()
+		.unwrap()
+		.metadata
+		.subtree
+		.count
+}
+
+async fn put(index: &Index, objects: Vec<crate::object::put::Arg>) {
+	let items = objects
+		.into_iter()
+		.map(crate::batch::Item::PutObject)
+		.collect();
+	let arg = crate::batch::Arg { items };
+	index.batch(arg).await.unwrap();
+}
+
+async fn drain(index: &Index) {
+	for _ in 0..100 {
+		if index
+			.update_batch(crate::update::Kind::Node, 1024, 0, 2)
+			.await
+			.unwrap()
+			.count == 0
+		{
+			return;
+		}
+	}
+	panic!("the node updates did not drain");
+}
+
+async fn step(index: &Index) {
+	assert_eq!(
+		index
+			.update_batch(crate::update::Kind::Node, 1, 0, 2)
+			.await
+			.unwrap()
+			.count,
+		1
+	);
+}
+
+async fn queue(index: &Index) -> Vec<Key> {
+	crate::fdb::run(&index.database, |txn| async move {
+		let begin = Index::pack(&index.subspace, &(61i32,));
+		let end = Index::pack(&index.subspace, &(62i32,));
+		let range = fdb::RangeOption::from((begin.as_slice(), end.as_slice()));
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
+		let entries = entries
+			.iter()
+			.map(|entry| {
+				let crate::fdb::Key::Update(key) = Index::unpack(&index.subspace, entry.key())?
+				else {
+					unreachable!()
+				};
+				Ok(key)
+			})
+			.collect::<tg::Result<Vec<_>>>()?;
+		Ok(ControlFlow::Break(entries))
+	})
+	.await
+	.unwrap()
+}
+
+async fn partition(index: &Index, id: &tg::object::Id, partition: u64) {
+	move_entries(index, id, partition, false).await;
+}
+
+async fn partition_newest(index: &Index, id: &tg::object::Id, partition: u64) {
+	move_entries(index, id, partition, true).await;
+}
+
+async fn move_entries(index: &Index, id: &tg::object::Id, partition: u64, newest: bool) {
+	let id = tg::Either::Left(id.clone());
+	let mut entries = queue(index)
+		.await
+		.into_iter()
+		.filter(|key| matches!(key, Key::UpdateVersion { id: entry, .. } if *entry == id))
+		.collect::<Vec<_>>();
+	entries.sort_by_key(|entry| match entry {
+		Key::UpdateVersion { version, .. } => version.clone(),
+		_ => unreachable!(),
+	});
+	if newest {
+		entries = vec![entries.pop().unwrap()];
+	}
+	crate::fdb::run(&index.database, |txn| {
+		let entries = &entries;
+		let id = &id;
+		async move {
+			for entry in entries {
+				let key = Index::pack(&index.subspace, &crate::fdb::Key::Update(entry.clone()));
+				txn.clear(&key);
+				let Key::UpdateVersion { version, .. } = entry else {
+					unreachable!()
+				};
+				let key = crate::fdb::Key::Update(Key::UpdateVersion {
+					id: id.clone(),
+					kind: Kind::Node,
+					partition,
+					version: version.clone(),
+				});
+				txn.set(&Index::pack(&index.subspace, &key), &[]);
+			}
+			Ok(ControlFlow::Break(()))
+		}
+	})
+	.await
+	.unwrap();
+}

--- a/packages/index/src/fdb/update/tests/clean.rs
+++ b/packages/index/src/fdb/update/tests/clean.rs
@@ -147,6 +147,7 @@ async fn cleaning_respects_other_partitions_and_newer_versions() {
 		] {
 			enqueue(index, &id, &kind).await;
 			drain(index).await;
+			let previous = version(index, &id, &kind).await.unwrap();
 			enqueue(index, &blocker_id, &kind).await;
 			assign(index, &blocker_id, &kind, queue, other_partition).await;
 			enqueue(index, &id, &kind).await;
@@ -156,6 +157,25 @@ async fn cleaning_respects_other_partitions_and_newer_versions() {
 				.await
 				.unwrap();
 			let expected = version(index, &id, &kind).await.unwrap();
+
+			// Recreate a stale cleanup entry to verify that it cannot delete a newer version.
+			crate::fdb::run(&index.database, |txn| {
+				let id = &id;
+				let kind = &kind;
+				let previous = &previous;
+				async move {
+					let key = crate::fdb::Key::Update(Key::Clean {
+						id: id.clone(),
+						kind: kind.clone(),
+						partition,
+						version: previous.clone(),
+					});
+					txn.set(&Index::pack(&index.subspace, &key), &[]);
+					Ok(ControlFlow::Break(()))
+				}
+			})
+			.await
+			.unwrap();
 
 			// The old cleanup entry is eligible, but the current version is still needed.
 			let output = index
@@ -241,6 +261,109 @@ async fn concurrent_propagation_conflicts_with_cleaning() {
 		assert_eq!(version(index, &id, &Kind::Node).await, Some(expected));
 		index.clean(clean_arg(100, 0, 2)).await.unwrap();
 		assert!(version(index, &id, &Kind::Node).await.is_none());
+	})
+	.await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn unrelated_queue_progress_does_not_conflict_with_cleaning() {
+	run(async |index| {
+		let mut object = directory(&[]);
+		object.touched_at = 100;
+		let id = tg::Either::Left(object.id.clone());
+		let missing = tg::object::Id::new(tg::object::Kind::Directory, &vec![0].into());
+		let mut unrelated = directory(&[("missing", missing)]);
+		unrelated.touched_at = 100;
+		let unrelated_id = tg::Either::Left(unrelated.id.clone());
+		put(index, vec![object, unrelated]).await;
+		drain(index).await;
+		let subject = tg::authorization::Subject::User(tg::user::Id::new());
+		for (kind, queue) in [
+			(Kind::Grant(subject), crate::update::Kind::Grant),
+			(Kind::Node, crate::update::Kind::Node),
+		] {
+			index.clean(clean_arg(100, 0, 2)).await.unwrap();
+			enqueue(index, &id, &kind).await;
+			drain(index).await;
+			enqueue(index, &unrelated_id, &kind).await;
+
+			// Pause cleanup after it has read the queue heads and selected this item's version.
+			let transaction = index.database.create_trx().unwrap();
+			let transaction = crate::fdb::Transaction::new(transaction);
+			let arg = crate::fdb::clean::TransactionArg {
+				batch_size: 100,
+				max_object_touched_at: 0,
+				max_process_touched_at: 0,
+				max_sandbox_touched_at: 0,
+				now: 0,
+				partition_end: 2,
+				partition_start: 0,
+				partition_total: 2,
+				subspace: &index.subspace,
+				txn: &transaction,
+				usage_partition_total: 1,
+			};
+			let ControlFlow::Break(output) = Index::clean_with_transaction(arg).await.unwrap()
+			else {
+				panic!("the cleaning transaction failed");
+			};
+			assert!(!output.done);
+
+			// Consuming another item's queue entry must not invalidate the cleanup transaction.
+			assert_eq!(index.update_batch(queue, 100, 0, 2).await.unwrap().count, 1);
+			transaction.take().unwrap().commit().await.unwrap();
+			assert!(version(index, &id, &kind).await.is_none());
+		}
+	})
+	.await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn replacing_propagated_versions_replaces_cleanup_entries() {
+	run(async |index| {
+		let mut object = directory(&[]);
+		object.touched_at = 100;
+		let id = tg::Either::Left(object.id.clone());
+		put(index, vec![object]).await;
+		drain(index).await;
+		let subject = tg::authorization::Subject::User(tg::user::Id::new());
+		for kind in [Kind::Grant(subject), Kind::Node] {
+			enqueue(index, &id, &kind).await;
+			drain(index).await;
+			let previous = version(index, &id, &kind).await.unwrap();
+			for _ in 0..4 {
+				enqueue(index, &id, &kind).await;
+				drain(index).await;
+				assert_eq!(
+					count_clean_entries(index).await,
+					count_versions(index).await
+				);
+			}
+
+			// Lowering the propagated version must replace the cleanup entry as well.
+			crate::fdb::run(&index.database, |txn| {
+				let id = &id;
+				let kind = &kind;
+				let previous = &previous;
+				async move {
+					Index::enqueue_update_propagate(&txn, &index.subspace, id, kind, previous, 2)
+						.await
+				}
+			})
+			.await
+			.unwrap();
+			drain(index).await;
+			assert_eq!(version(index, &id, &kind).await, Some(previous));
+			assert_eq!(
+				count_clean_entries(index).await,
+				count_versions(index).await
+			);
+		}
+		index.clean(clean_arg(100, 0, 2)).await.unwrap();
+		assert_eq!(count_clean_entries(index).await, 0);
+		assert_eq!(count_versions(index).await, 0);
 	})
 	.await;
 }

--- a/packages/index/src/fdb/update/tests/clean.rs
+++ b/packages/index/src/fdb/update/tests/clean.rs
@@ -1,0 +1,373 @@
+use {
+	super::{Index, Key, Kind, directory, put, run},
+	num_traits::ToPrimitive as _,
+	std::ops::ControlFlow,
+	tangram_client::prelude::*,
+};
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn cleans_versions_after_collecting_their_objects_and_processes() {
+	run(async |index| {
+		let object = directory(&[]);
+		let object_id = object.id.clone();
+		let process = crate::process::put::Arg {
+			cached: false,
+			children: None,
+			command: object_id.clone(),
+			data: None,
+			error: None,
+			id: tg::process::Id::new(),
+			location: None,
+			log: None,
+			metadata: tg::process::Metadata::default(),
+			options: tg::referent::Options::default(),
+			output: None,
+			parent: None,
+			sandbox: None,
+			storage: crate::process::Storage::default(),
+			time_to_touch: std::time::Duration::ZERO,
+			touched_at: 0,
+		};
+		let process_id = process.id.clone();
+		let ids = [
+			tg::Either::Left(object_id.clone()),
+			tg::Either::Right(process_id.clone()),
+		];
+		let subject = tg::authorization::Subject::User(tg::user::Id::new());
+		let kinds = [Kind::Grant(subject), Kind::Node];
+		let arg = crate::batch::Arg {
+			items: vec![
+				crate::batch::Item::PutObject(object),
+				crate::batch::Item::PutProcess(process),
+			],
+		};
+		index.batch(arg).await.unwrap();
+		for id in &ids {
+			for kind in &kinds {
+				enqueue(index, id, kind).await;
+			}
+		}
+		drain(index).await;
+		for id in &ids {
+			for kind in &kinds {
+				assert!(version(index, id, kind).await.is_some());
+			}
+		}
+		for _ in 0..100 {
+			let before = count_clean_entries(index).await;
+			let output = index.clean(clean_arg(1, 0, 2)).await.unwrap();
+			let deleted = output.objects.len() + output.processes.len();
+			assert!(before - count_clean_entries(index).await + deleted <= 1);
+			if output.done {
+				break;
+			}
+		}
+		assert!(index.try_get_objects(&[object_id]).await.unwrap()[0].is_none());
+		assert!(index.try_get_processes(&[process_id]).await.unwrap()[0].is_none());
+		assert_eq!(count_versions(index).await, 0);
+
+		// Stale updates must not leave orphaned versions after their objects and processes are gone.
+		for id in &ids {
+			for kind in &kinds {
+				enqueue(index, id, kind).await;
+			}
+		}
+		drain(index).await;
+		for _ in 0..100 {
+			if index.clean(clean_arg(1, 0, 2)).await.unwrap().done {
+				break;
+			}
+		}
+		assert_eq!(count_versions(index).await, 0);
+		assert_eq!(count_clean_entries(index).await, 0);
+	})
+	.await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn cleans_versions_without_collecting_the_objects() {
+	run(async |index| {
+		let mut object = directory(&[]);
+		object.touched_at = 100;
+		let id = tg::Either::Left(object.id.clone());
+		put(index, vec![object]).await;
+		let subjects = [
+			tg::authorization::Subject::Process(tg::process::Id::new()),
+			tg::authorization::Subject::Process(tg::process::Id::new()),
+		];
+		for subject in subjects {
+			enqueue(index, &id, &Kind::Grant(subject)).await;
+		}
+		drain(index).await;
+		assert_eq!(count_versions(index).await, 3);
+		let mut done = false;
+		for _ in 0..20 {
+			let before = count_versions(index).await;
+			let clean_before = count_clean_entries(index).await;
+			let output = index.clean(clean_arg(1, 0, 2)).await.unwrap();
+			let after = count_versions(index).await;
+			assert!(before - after <= 1);
+			assert!(clean_before - count_clean_entries(index).await <= 1);
+			if output.done {
+				done = true;
+				break;
+			}
+		}
+		assert!(done);
+		assert_eq!(count_versions(index).await, 0);
+		assert_eq!(count_clean_entries(index).await, 0);
+		let object = id.left().unwrap();
+		assert!(index.try_get_objects(&[object]).await.unwrap()[0].is_some());
+	})
+	.await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn cleaning_respects_other_partitions_and_newer_versions() {
+	run(async |index| {
+		let mut object = directory(&[]);
+		object.touched_at = 100;
+		let missing = tg::object::Id::new(tg::object::Kind::Directory, &vec![0].into());
+		let mut blocker = directory(&[("missing", missing)]);
+		blocker.touched_at = 100;
+		let partition = Index::partition_for_id(object.id.to_bytes().as_ref(), 2);
+		let other_partition = 1 - partition;
+		let id = tg::Either::Left(object.id.clone());
+		let blocker_id = tg::Either::Left(blocker.id.clone());
+		put(index, vec![object, blocker]).await;
+		drain(index).await;
+		index.clean(clean_arg(100, 0, 2)).await.unwrap();
+		let subject = tg::authorization::Subject::User(tg::user::Id::new());
+		for (kind, queue) in [
+			(Kind::Grant(subject), crate::update::Kind::Grant),
+			(Kind::Node, crate::update::Kind::Node),
+		] {
+			enqueue(index, &id, &kind).await;
+			drain(index).await;
+			enqueue(index, &blocker_id, &kind).await;
+			assign(index, &blocker_id, &kind, queue, other_partition).await;
+			enqueue(index, &id, &kind).await;
+			assign(index, &id, &kind, queue, partition).await;
+			index
+				.update_batch(queue, 100, partition, partition + 1)
+				.await
+				.unwrap();
+			let expected = version(index, &id, &kind).await.unwrap();
+
+			// The old cleanup entry is eligible, but the current version is still needed.
+			let output = index
+				.clean(clean_arg(100, partition, partition + 1))
+				.await
+				.unwrap();
+			assert!(!output.done);
+			assert_eq!(version(index, &id, &kind).await, Some(expected.clone()));
+			let output = index
+				.clean(clean_arg(100, partition, partition + 1))
+				.await
+				.unwrap();
+			assert!(
+				output.done,
+				"blocked versions must not keep the cleaner busy"
+			);
+
+			// An update at exactly the recorded version also prevents its collection.
+			drain(index).await;
+			crate::fdb::run(&index.database, |txn| {
+				let id = &blocker_id;
+				let kind = &kind;
+				let expected = &expected;
+				async move {
+					Index::enqueue_update_propagate(&txn, &index.subspace, id, kind, expected, 2)
+						.await
+				}
+			})
+			.await
+			.unwrap();
+			index.clean(clean_arg(100, 0, 2)).await.unwrap();
+			assert_eq!(version(index, &id, &kind).await, Some(expected));
+
+			// Collection is restricted to the cleaner's assigned partitions.
+			drain(index).await;
+			index
+				.clean(clean_arg(100, other_partition, other_partition + 1))
+				.await
+				.unwrap();
+			assert!(version(index, &id, &kind).await.is_some());
+			index
+				.clean(clean_arg(100, partition, partition + 1))
+				.await
+				.unwrap();
+			assert!(version(index, &id, &kind).await.is_none());
+		}
+	})
+	.await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn concurrent_propagation_conflicts_with_cleaning() {
+	run(async |index| {
+		let mut object = directory(&[]);
+		object.touched_at = 100;
+		let id = tg::Either::Left(object.id.clone());
+		put(index, vec![object]).await;
+		drain(index).await;
+		let transaction = index.database.create_trx().unwrap();
+		let transaction = crate::fdb::Transaction::new(transaction);
+		let arg = crate::fdb::clean::TransactionArg {
+			batch_size: 100,
+			max_object_touched_at: 0,
+			max_process_touched_at: 0,
+			max_sandbox_touched_at: 0,
+			now: 0,
+			partition_end: 2,
+			partition_start: 0,
+			partition_total: 2,
+			subspace: &index.subspace,
+			txn: &transaction,
+			usage_partition_total: 1,
+		};
+		let ControlFlow::Break(output) = Index::clean_with_transaction(arg).await.unwrap() else {
+			panic!("the cleaning transaction failed");
+		};
+		assert!(!output.done);
+		enqueue(index, &id, &Kind::Node).await;
+		drain(index).await;
+		let expected = version(index, &id, &Kind::Node).await.unwrap();
+		assert!(transaction.take().unwrap().commit().await.is_err());
+		assert_eq!(version(index, &id, &Kind::Node).await, Some(expected));
+		index.clean(clean_arg(100, 0, 2)).await.unwrap();
+		assert!(version(index, &id, &Kind::Node).await.is_none());
+	})
+	.await;
+}
+
+async fn assign(
+	index: &Index,
+	id: &tg::Either<tg::object::Id, tg::process::Id>,
+	kind: &Kind,
+	queue: crate::update::Kind,
+	partition: u64,
+) {
+	crate::fdb::run(&index.database, |txn| async move {
+		let key_kind = super::super::update_version_key_kind(queue)
+			.to_i32()
+			.unwrap();
+		let prefix = Index::pack(&index.subspace, &(key_kind,));
+		let subspace = foundationdb_tuple::Subspace::from_bytes(prefix);
+		let range = foundationdb::RangeOption::from(&subspace);
+		let result = txn.get_range(&range, 1, false).await;
+		for entry in crate::fdb::retry!(result) {
+			let crate::fdb::Key::Update(Key::UpdateVersion {
+				id: entry_id,
+				version,
+				..
+			}) = Index::unpack(&index.subspace, entry.key())?
+			else {
+				unreachable!();
+			};
+			if entry_id != *id {
+				continue;
+			}
+			txn.clear(entry.key());
+			let key = crate::fdb::Key::Update(Key::UpdateVersion {
+				id: id.clone(),
+				kind: kind.clone(),
+				partition,
+				version,
+			});
+			txn.set(&Index::pack(&index.subspace, &key), &[]);
+		}
+		Ok(ControlFlow::Break(()))
+	})
+	.await
+	.unwrap();
+}
+
+async fn version(
+	index: &Index,
+	id: &tg::Either<tg::object::Id, tg::process::Id>,
+	kind: &Kind,
+) -> Option<foundationdb_tuple::Versionstamp> {
+	crate::fdb::run(&index.database, |txn| async move {
+		Index::try_get_update_propagated_version(&txn, &index.subspace, id, kind).await
+	})
+	.await
+	.unwrap()
+}
+
+async fn enqueue(index: &Index, id: &tg::Either<tg::object::Id, tg::process::Id>, kind: &Kind) {
+	crate::fdb::run(&index.database, |txn| async move {
+		Index::enqueue_update_with_kind(
+			&txn,
+			&index.subspace,
+			id,
+			kind,
+			super::super::Source::Put,
+			2,
+		);
+		Ok(ControlFlow::Break(()))
+	})
+	.await
+	.unwrap();
+}
+
+async fn drain(index: &Index) {
+	for _ in 0..100 {
+		let mut count = 0;
+		for kind in [crate::update::Kind::Grant, crate::update::Kind::Node] {
+			count += index.update_batch(kind, 100, 0, 2).await.unwrap().count;
+		}
+		if count == 0 {
+			return;
+		}
+	}
+	panic!("the updates did not drain");
+}
+
+fn clean_arg(batch_size: usize, partition_start: u64, partition_end: u64) -> crate::clean::Arg {
+	crate::clean::Arg {
+		batch_size,
+		max_object_touched_at: 0,
+		max_process_touched_at: 0,
+		max_sandbox_touched_at: 0,
+		now: 0,
+		partition_end,
+		partition_start,
+	}
+}
+
+async fn count_versions(index: &Index) -> usize {
+	let kinds = [
+		crate::fdb::Kind::GrantUpdatePropagatedVersion,
+		crate::fdb::Kind::NodeUpdatePropagatedVersion,
+	];
+	count_keys(index, &kinds).await
+}
+
+async fn count_clean_entries(index: &Index) -> usize {
+	let kinds = [
+		crate::fdb::Kind::GrantUpdateClean,
+		crate::fdb::Kind::NodeUpdateClean,
+	];
+	count_keys(index, &kinds).await
+}
+
+async fn count_keys(index: &Index, kinds: &[crate::fdb::Kind]) -> usize {
+	crate::fdb::run(&index.database, |txn| async move {
+		let mut count = 0;
+		for kind in kinds {
+			let prefix = Index::pack(&index.subspace, &(kind.to_i32().unwrap(),));
+			let subspace = foundationdb_tuple::Subspace::from_bytes(prefix);
+			let range = foundationdb::RangeOption::from(&subspace);
+			let result = txn.get_range(&range, 1, false).await;
+			count += crate::fdb::retry!(result).len();
+		}
+		Ok(ControlFlow::Break(count))
+	})
+	.await
+	.unwrap()
+}

--- a/packages/index/src/lmdb/clean.rs
+++ b/packages/index/src/lmdb/clean.rs
@@ -1,4 +1,5 @@
 mod key;
+mod update;
 pub(super) use key::{ItemKind, Key};
 
 use {
@@ -234,7 +235,14 @@ impl Index {
 			}
 		}
 
-		output.done = grants == 0 && candidates.is_empty();
+		let remaining_batch_size = remaining_batch_size.saturating_sub(candidates.len());
+		let propagated_versions = Self::clean_update_propagated_versions(
+			db,
+			subspace,
+			transaction,
+			remaining_batch_size,
+		)?;
+		output.done = grants == 0 && candidates.is_empty() && propagated_versions == 0;
 
 		Ok(output)
 	}
@@ -687,6 +695,7 @@ impl Index {
 			.map_err(|error| tg::error!(!error, "failed to delete object"))?;
 
 		let id_bytes = id.to_bytes();
+		Self::clear_update_propagated_versions(db, subspace, transaction, id_bytes.as_ref())?;
 		let prefix = &(Kind::ObjectChild.to_i32().unwrap(), id_bytes.as_ref());
 		let prefix = Self::pack(subspace, prefix);
 		let iter = db
@@ -768,6 +777,7 @@ impl Index {
 		db.delete(transaction, &key)
 			.map_err(|error| tg::error!(!error, "failed to delete process"))?;
 		let id_bytes = id.to_bytes();
+		Self::clear_update_propagated_versions(db, subspace, transaction, id_bytes.as_ref())?;
 		let prefix = &(Kind::ProcessChild.to_i32().unwrap(), id_bytes.as_ref());
 		let prefix = Self::pack(subspace, prefix);
 		let iter = db

--- a/packages/index/src/lmdb/clean/update.rs
+++ b/packages/index/src/lmdb/clean/update.rs
@@ -1,0 +1,76 @@
+use {
+	crate::lmdb::{Db, Index, Kind, update::Key},
+	foundationdb_tuple as fdbt, heed as lmdb,
+	num_traits::ToPrimitive as _,
+	std::ops::Bound,
+	tangram_client::prelude::*,
+};
+
+impl Index {
+	pub(super) fn clean_update_propagated_versions(
+		db: &Db,
+		subspace: &fdbt::Subspace,
+		transaction: &mut lmdb::RwTxn<'_>,
+		batch_size: usize,
+	) -> tg::Result<usize> {
+		let mut candidates = Vec::new();
+		for (kind, key_kind) in [
+			(crate::update::Kind::Grant, Kind::GrantUpdateClean),
+			(crate::update::Kind::Node, Kind::NodeUpdateClean),
+		] {
+			let remaining = batch_size.saturating_sub(candidates.len());
+			if remaining == 0 {
+				break;
+			}
+			let oldest = Self::try_get_oldest_update_transaction_id_with_transaction(
+				db,
+				subspace,
+				transaction,
+				kind,
+			)?;
+			let key_kind = key_kind.to_i32().unwrap();
+			let begin = Self::pack(subspace, &(key_kind,));
+			let end = if let Some(oldest) = oldest {
+				Self::pack(subspace, &(key_kind, oldest))
+			} else {
+				fdbt::Subspace::from_bytes(begin.clone()).range().1
+			};
+			let range = (
+				Bound::Included(begin.as_slice()),
+				Bound::Excluded(end.as_slice()),
+			);
+			let entries = db
+				.range(transaction, &range)
+				.map_err(|error| tg::error!(!error, "failed to get the update clean keys"))?;
+			for entry in entries.take(remaining) {
+				let (clean_key, _) = entry
+					.map_err(|error| tg::error!(!error, "failed to read an update clean key"))?;
+				let crate::lmdb::Key::Update(Key::Clean { id, kind, version }) =
+					Self::unpack(subspace, clean_key)?
+				else {
+					return Err(tg::error!("expected an update clean key"));
+				};
+				let key = crate::lmdb::Key::Update(Key::PropagatedVersion { id, kind });
+				let key = Self::pack(subspace, &key);
+				candidates.push((clean_key.to_vec(), key, version));
+			}
+		}
+
+		for (clean_key, key, version) in &candidates {
+			let value = db.get(transaction, key).map_err(|error| {
+				tg::error!(!error, "failed to get the propagated update version")
+			})?;
+			// A stale cleanup entry must not delete a version recorded by a subsequent propagation.
+			if value.is_some_and(|value| value == version.to_be_bytes()) {
+				db.delete(transaction, key).map_err(|error| {
+					tg::error!(!error, "failed to delete the propagated update version")
+				})?;
+			}
+			db.delete(transaction, clean_key)
+				.map_err(|error| tg::error!(!error, "failed to delete the update clean key"))?;
+		}
+		let count = candidates.len();
+
+		Ok(count)
+	}
+}

--- a/packages/index/src/lmdb/key.rs
+++ b/packages/index/src/lmdb/key.rs
@@ -81,6 +81,10 @@ pub enum Kind {
 	StorageUpdateVersion = 63,
 	UsageStarted = 64,
 	UsageUnavailable = 65,
+	GrantUpdatePropagatedVersion = 66,
+	NodeUpdatePropagatedVersion = 67,
+	GrantUpdateClean = 71,
+	NodeUpdateClean = 72,
 }
 
 impl fdbt::TuplePack for Key {
@@ -540,6 +544,22 @@ impl fdbt::TuplePack for Key {
 			)
 				.pack(w, tuple_depth),
 
+			Key::Update(crate::lmdb::update::Key::PropagatedVersion { id, kind }) => {
+				let key_kind = match kind {
+					crate::lmdb::update::Kind::Grant(_) => Kind::GrantUpdatePropagatedVersion,
+					crate::lmdb::update::Kind::Node => Kind::NodeUpdatePropagatedVersion,
+					crate::lmdb::update::Kind::Storage(_) => unreachable!(),
+				};
+				key_kind.to_i32().unwrap().pack(w, tuple_depth)?;
+				let id = match id {
+					tg::Either::Left(id) => id.to_bytes(),
+					tg::Either::Right(id) => id.to_bytes(),
+				};
+				let mut offset = id.as_ref().pack(w, tuple_depth)?;
+				offset += pack_update_kind(w, tuple_depth, kind)?;
+				Ok(offset)
+			},
+
 			Key::Update(crate::lmdb::update::Key::Update { id, kind }) => {
 				let key_kind = match kind {
 					crate::lmdb::update::Kind::Grant(_) => Kind::GrantUpdate,
@@ -556,9 +576,15 @@ impl fdbt::TuplePack for Key {
 				Ok(offset)
 			},
 
-			Key::Update(crate::lmdb::update::Key::UpdateVersion { id, kind, version }) => {
+			Key::Update(
+				crate::lmdb::update::Key::UpdateVersion { id, kind, version }
+				| crate::lmdb::update::Key::Clean { id, kind, version },
+			) => {
+				let clean = matches!(self, Key::Update(crate::lmdb::update::Key::Clean { .. }));
 				let key_kind = match kind {
+					crate::lmdb::update::Kind::Grant(_) if clean => Kind::GrantUpdateClean,
 					crate::lmdb::update::Kind::Grant(_) => Kind::GrantUpdateVersion,
+					crate::lmdb::update::Kind::Node if clean => Kind::NodeUpdateClean,
 					crate::lmdb::update::Kind::Node => Kind::NodeUpdateVersion,
 					crate::lmdb::update::Kind::Storage(_) => Kind::StorageUpdateVersion,
 				};
@@ -1431,6 +1457,27 @@ impl fdbt::TupleUnpack<'_> for Key {
 				Ok((input, key))
 			},
 
+			Kind::GrantUpdatePropagatedVersion | Kind::NodeUpdatePropagatedVersion => {
+				let update_kind = match kind {
+					Kind::GrantUpdatePropagatedVersion => crate::update::Kind::Grant,
+					Kind::NodeUpdatePropagatedVersion => crate::update::Kind::Node,
+					_ => unreachable!(),
+				};
+				let (input, id): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
+				let id = tg::Id::from_slice(&id)
+					.map_err(|_| fdbt::PackError::Message("invalid id".into()))?;
+				let id = if let Ok(id) = tg::process::Id::try_from(id.clone()) {
+					tg::Either::Right(id)
+				} else if let Ok(id) = tg::object::Id::try_from(id) {
+					tg::Either::Left(id)
+				} else {
+					return Err(fdbt::PackError::Message("invalid id".into()));
+				};
+				let (input, kind) = unpack_update_kind(input, tuple_depth, update_kind)?;
+				let key = Key::Update(crate::lmdb::update::Key::PropagatedVersion { id, kind });
+				Ok((input, key))
+			},
+
 			Kind::GrantUpdate | Kind::NodeUpdate | Kind::StorageUpdate => {
 				let update_kind = match kind {
 					Kind::GrantUpdate => crate::update::Kind::Grant,
@@ -1455,10 +1502,15 @@ impl fdbt::TupleUnpack<'_> for Key {
 				))
 			},
 
-			Kind::GrantUpdateVersion | Kind::NodeUpdateVersion | Kind::StorageUpdateVersion => {
+			Kind::GrantUpdateClean
+			| Kind::GrantUpdateVersion
+			| Kind::NodeUpdateClean
+			| Kind::NodeUpdateVersion
+			| Kind::StorageUpdateVersion => {
+				let clean = matches!(kind, Kind::GrantUpdateClean | Kind::NodeUpdateClean);
 				let update_kind = match kind {
-					Kind::GrantUpdateVersion => crate::update::Kind::Grant,
-					Kind::NodeUpdateVersion => crate::update::Kind::Node,
+					Kind::GrantUpdateClean | Kind::GrantUpdateVersion => crate::update::Kind::Grant,
+					Kind::NodeUpdateClean | Kind::NodeUpdateVersion => crate::update::Kind::Node,
 					Kind::StorageUpdateVersion => crate::update::Kind::Storage,
 					_ => unreachable!(),
 				};
@@ -1474,10 +1526,12 @@ impl fdbt::TupleUnpack<'_> for Key {
 					return Err(fdbt::PackError::Message("invalid id".into()));
 				};
 				let (input, kind) = unpack_update_kind(input, tuple_depth, update_kind)?;
-				Ok((
-					input,
-					Key::Update(crate::lmdb::update::Key::UpdateVersion { id, kind, version }),
-				))
+				let key = if clean {
+					crate::lmdb::update::Key::Clean { id, kind, version }
+				} else {
+					crate::lmdb::update::Key::UpdateVersion { id, kind, version }
+				};
+				Ok((input, Key::Update(key)))
 			},
 		}
 	}

--- a/packages/index/src/lmdb/tests.rs
+++ b/packages/index/src/lmdb/tests.rs
@@ -10,6 +10,7 @@ mod reader;
 mod storage;
 mod update;
 mod usage;
+mod versions;
 
 use super::{Config, Index};
 

--- a/packages/index/src/lmdb/tests/versions.rs
+++ b/packages/index/src/lmdb/tests/versions.rs
@@ -1,0 +1,187 @@
+use {
+	super::super::{
+		Index, Key,
+		update::{Kind, Source},
+	},
+	std::collections::BTreeSet,
+	tangram_client::prelude::*,
+};
+
+mod clean;
+
+#[tokio::test]
+async fn a_batch_preserves_an_older_propagation_when_combining_updates() {
+	let (_dir, index) = super::new_index();
+	let leaf = object(0, []);
+	let middle = object(1, [leaf.id.clone()]);
+	let top = object(2, [middle.id.clone()]);
+	put(&index, vec![middle.clone(), top.clone()]).await;
+	drain(&index, crate::update::Kind::Node).await;
+	put(&index, vec![leaf.clone()]).await;
+	let cutoff = index.get_transaction_id().await.unwrap();
+	let mut middle = middle;
+	middle.metadata.subtree = tg::object::metadata::Subtree {
+		count: Some(2),
+		depth: Some(2),
+		size: Some(0),
+		solvable: Some(false),
+		solved: Some(true),
+	};
+	put(&index, vec![middle]).await;
+
+	// Select both entries before the leaf lowers the middle's pending version.
+	{
+		let mut transaction = index.env.write_txn().unwrap();
+		let output = Index::update_batch_with_transaction(
+			&index.db,
+			&index.subspace,
+			&mut transaction,
+			2,
+			crate::update::Kind::Node,
+			None,
+			1,
+		)
+		.unwrap();
+		assert_eq!(output.count, 2);
+		transaction.commit().unwrap();
+	}
+	let oldest = index
+		.try_get_oldest_update_transaction_id(crate::update::Kind::Node)
+		.await
+		.unwrap();
+	assert!(oldest.is_some_and(|version| version <= cutoff));
+	let objects = index
+		.try_get_objects(std::slice::from_ref(&top.id))
+		.await
+		.unwrap();
+	assert_eq!(objects[0].as_ref().unwrap().metadata.subtree.count, None);
+	drain(&index, crate::update::Kind::Node).await;
+	let objects = index.try_get_objects(&[top.id]).await.unwrap();
+	assert_eq!(objects[0].as_ref().unwrap().metadata.subtree.count, Some(3));
+}
+
+#[tokio::test]
+async fn propagation_versions_reset_and_repeated_updates_stop() {
+	let (_dir, index) = super::new_index();
+	let child = object(0, []);
+	let parent = object(1, [child.id.clone()]);
+	put(&index, vec![child.clone(), parent.clone()]).await;
+	drain(&index, crate::update::Kind::Node).await;
+	let subject = tg::authorization::Subject::User(tg::user::Id::new());
+	for (kind, queue) in [
+		(Kind::Node, crate::update::Kind::Node),
+		(Kind::Grant(subject.clone()), crate::update::Kind::Grant),
+	] {
+		for (source, version, propagated) in [
+			(Source::Put, 100, true),
+			(Source::Propagate, 90, true),
+			(Source::Propagate, 90, false),
+			(Source::Propagate, 110, false),
+			(Source::Put, 200, true),
+			(Source::Propagate, 150, true),
+		] {
+			{
+				let mut transaction = index.env.write_txn().unwrap();
+				Index::enqueue_update_with_kind(
+					&index.db,
+					&index.subspace,
+					&mut transaction,
+					tg::Either::Left(child.id.clone()),
+					kind.clone(),
+					source,
+					Some(version),
+				)
+				.unwrap();
+				transaction.commit().unwrap();
+			}
+			assert_eq!(index.update_batch(queue, 1).await.unwrap().count, 1);
+			let oldest = index
+				.try_get_oldest_update_transaction_id(queue)
+				.await
+				.unwrap();
+			assert_eq!(
+				oldest,
+				propagated.then_some(version),
+				"{kind:?}, {source:?}, {version}"
+			);
+			drain(&index, queue).await;
+		}
+	}
+
+	// Retained propagation versions must neither prevent collection nor survive the objects.
+	let arg = crate::clean::Arg {
+		batch_size: 100,
+		max_object_touched_at: 0,
+		max_process_touched_at: 0,
+		max_sandbox_touched_at: 0,
+		now: 0,
+		partition_end: 1,
+		partition_start: 0,
+	};
+	let mut done = false;
+	for _ in 0..10 {
+		if index.clean(arg.clone()).await.unwrap().done {
+			done = true;
+			break;
+		}
+	}
+	assert!(done);
+	let ids = [child.id, parent.id];
+	assert!(
+		index
+			.try_get_objects(&ids)
+			.await
+			.unwrap()
+			.iter()
+			.all(Option::is_none)
+	);
+	let transaction = index.env.read_txn().unwrap();
+	for id in ids {
+		for kind in [Kind::Node, Kind::Grant(subject.clone())] {
+			let key = Key::Update(super::super::update::Key::PropagatedVersion {
+				id: tg::Either::Left(id.clone()),
+				kind,
+			});
+			assert!(
+				index
+					.db
+					.get(&transaction, &Index::pack(&index.subspace, &key))
+					.unwrap()
+					.is_none()
+			);
+		}
+	}
+}
+
+fn object(id: u8, children: impl IntoIterator<Item = tg::object::Id>) -> crate::object::put::Arg {
+	let id = tg::object::Id::new(tg::object::Kind::Directory, &vec![id].into());
+	let children = children.into_iter().collect::<BTreeSet<_>>();
+	crate::object::put::Arg {
+		checkout: None,
+		children,
+		id,
+		metadata: tg::object::Metadata::default(),
+		put: [1; 16],
+		storage: crate::object::Storage::default(),
+		time_to_touch: std::time::Duration::ZERO,
+		touched_at: 0,
+	}
+}
+
+async fn put(index: &Index, objects: Vec<crate::object::put::Arg>) {
+	let items = objects
+		.into_iter()
+		.map(crate::batch::Item::PutObject)
+		.collect();
+	let arg = crate::batch::Arg { items };
+	index.batch(arg).await.unwrap();
+}
+
+async fn drain(index: &Index, kind: crate::update::Kind) {
+	for _ in 0..100 {
+		if index.update_batch(kind, 100).await.unwrap().count == 0 {
+			return;
+		}
+	}
+	panic!("the updates did not drain");
+}

--- a/packages/index/src/lmdb/tests/versions/clean.rs
+++ b/packages/index/src/lmdb/tests/versions/clean.rs
@@ -149,6 +149,21 @@ async fn cleaning_retains_pending_versions_and_ignores_stale_entries() {
 		assert!(expected > oldest);
 		enqueue(&index, &blocker, &kind, Some(oldest));
 
+		// Recreate a stale cleanup entry to verify that it cannot delete a newer version.
+		{
+			let mut transaction = index.env.write_txn().unwrap();
+			let key = crate::lmdb::Key::Update(crate::lmdb::update::Key::Clean {
+				id: id.clone(),
+				kind: kind.clone(),
+				version: previous,
+			});
+			index
+				.db
+				.put(&mut transaction, &Index::pack(&index.subspace, &key), &[])
+				.unwrap();
+			transaction.commit().unwrap();
+		}
+
 		// The old cleanup entry is eligible, but the current version is still needed.
 		assert!(!index.clean(clean_arg(1)).await.unwrap().done);
 		assert_eq!(version(&index, &id, &kind), Some(expected));
@@ -163,6 +178,31 @@ async fn cleaning_retains_pending_versions_and_ignores_stale_entries() {
 		index.clean(clean_arg(100)).await.unwrap();
 		assert!(version(&index, &id, &kind).is_none());
 	}
+}
+
+#[tokio::test]
+async fn replacing_propagated_versions_replaces_cleanup_entries() {
+	let (_dir, index) = super::super::new_index();
+	let mut object = object(0, []);
+	object.touched_at = 100;
+	let id = tg::Either::Left(object.id.clone());
+	put(&index, vec![object]).await;
+	drain(&index, crate::update::Kind::Node).await;
+	let subject = tg::authorization::Subject::User(tg::user::Id::new());
+	for (kind, queue) in [
+		(Kind::Grant(subject), crate::update::Kind::Grant),
+		(Kind::Node, crate::update::Kind::Node),
+	] {
+		for expected in [100, 200, 150, 150, 300, 50] {
+			enqueue(&index, &id, &kind, Some(expected));
+			drain(&index, queue).await;
+			assert_eq!(version(&index, &id, &kind), Some(expected));
+			assert_eq!(count_clean_entries(&index), count_versions(&index));
+		}
+	}
+	index.clean(clean_arg(100)).await.unwrap();
+	assert_eq!(count_clean_entries(&index), 0);
+	assert_eq!(count_versions(&index), 0);
 }
 
 fn version(

--- a/packages/index/src/lmdb/tests/versions/clean.rs
+++ b/packages/index/src/lmdb/tests/versions/clean.rs
@@ -1,0 +1,246 @@
+use {
+	super::{Index, Kind, Source, drain, object, put},
+	num_traits::ToPrimitive as _,
+	tangram_client::prelude::*,
+};
+
+#[tokio::test]
+async fn cleans_versions_after_collecting_their_objects_and_processes() {
+	let (_dir, index) = super::super::new_index();
+	let object = object(0, []);
+	let object_id = object.id.clone();
+	let process = crate::process::put::Arg {
+		cached: false,
+		children: None,
+		command: object_id.clone(),
+		data: None,
+		error: None,
+		id: tg::process::Id::new(),
+		location: None,
+		log: None,
+		metadata: tg::process::Metadata::default(),
+		options: tg::referent::Options::default(),
+		output: None,
+		parent: None,
+		sandbox: None,
+		storage: crate::process::Storage::default(),
+		time_to_touch: std::time::Duration::ZERO,
+		touched_at: 0,
+	};
+	let process_id = process.id.clone();
+	let ids = [
+		tg::Either::Left(object_id.clone()),
+		tg::Either::Right(process_id.clone()),
+	];
+	let subject = tg::authorization::Subject::User(tg::user::Id::new());
+	let kinds = [Kind::Grant(subject), Kind::Node];
+	let arg = crate::batch::Arg {
+		items: vec![
+			crate::batch::Item::PutObject(object),
+			crate::batch::Item::PutProcess(process),
+		],
+	};
+	index.batch(arg).await.unwrap();
+	for id in &ids {
+		for kind in &kinds {
+			enqueue(&index, id, kind, None);
+		}
+	}
+	for queue in [crate::update::Kind::Grant, crate::update::Kind::Node] {
+		drain(&index, queue).await;
+	}
+	for id in &ids {
+		for kind in &kinds {
+			assert!(version(&index, id, kind).is_some());
+		}
+	}
+	for _ in 0..100 {
+		let before = count_clean_entries(&index);
+		let output = index.clean(clean_arg(1)).await.unwrap();
+		let deleted = output.objects.len() + output.processes.len();
+		assert!(before - count_clean_entries(&index) + deleted <= 1);
+		if output.done {
+			break;
+		}
+	}
+	assert!(index.try_get_objects(&[object_id]).await.unwrap()[0].is_none());
+	assert!(index.try_get_processes(&[process_id]).await.unwrap()[0].is_none());
+	assert_eq!(count_versions(&index), 0);
+
+	// Stale updates must not leave orphaned versions after their objects and processes are gone.
+	for id in &ids {
+		for kind in &kinds {
+			enqueue(&index, id, kind, None);
+		}
+	}
+	for queue in [crate::update::Kind::Grant, crate::update::Kind::Node] {
+		drain(&index, queue).await;
+	}
+	for _ in 0..100 {
+		if index.clean(clean_arg(1)).await.unwrap().done {
+			break;
+		}
+	}
+	assert_eq!(count_versions(&index), 0);
+	assert_eq!(count_clean_entries(&index), 0);
+}
+
+#[tokio::test]
+async fn cleans_versions_without_collecting_the_objects() {
+	let (_dir, index) = super::super::new_index();
+	let mut object = object(0, []);
+	object.touched_at = 100;
+	let id = tg::Either::Left(object.id.clone());
+	put(&index, vec![object]).await;
+	let subjects = [
+		tg::authorization::Subject::Process(tg::process::Id::new()),
+		tg::authorization::Subject::Process(tg::process::Id::new()),
+	];
+	for subject in subjects {
+		enqueue(&index, &id, &Kind::Grant(subject), None);
+	}
+	for kind in [crate::update::Kind::Grant, crate::update::Kind::Node] {
+		drain(&index, kind).await;
+	}
+	assert_eq!(count_versions(&index), 3);
+	let mut done = false;
+	for _ in 0..20 {
+		let before = count_versions(&index);
+		let clean_before = count_clean_entries(&index);
+		let output = index.clean(clean_arg(1)).await.unwrap();
+		let after = count_versions(&index);
+		assert!(before - after <= 1);
+		assert!(clean_before - count_clean_entries(&index) <= 1);
+		if output.done {
+			done = true;
+			break;
+		}
+	}
+	assert!(done);
+	assert_eq!(count_versions(&index), 0);
+	assert_eq!(count_clean_entries(&index), 0);
+	let object = id.left().unwrap();
+	assert!(index.try_get_objects(&[object]).await.unwrap()[0].is_some());
+}
+
+#[tokio::test]
+async fn cleaning_retains_pending_versions_and_ignores_stale_entries() {
+	let (_dir, index) = super::super::new_index();
+	let mut object = object(0, []);
+	object.touched_at = 100;
+	let id = tg::Either::Left(object.id.clone());
+	put(&index, vec![object]).await;
+	drain(&index, crate::update::Kind::Node).await;
+	index.clean(clean_arg(100)).await.unwrap();
+	let blocker = tg::Either::Right(tg::process::Id::new());
+	let subject = tg::authorization::Subject::User(tg::user::Id::new());
+	for (kind, queue) in [
+		(Kind::Grant(subject), crate::update::Kind::Grant),
+		(Kind::Node, crate::update::Kind::Node),
+	] {
+		enqueue(&index, &id, &kind, None);
+		drain(&index, queue).await;
+		let previous = version(&index, &id, &kind).unwrap();
+		let oldest = index.get_transaction_id().await.unwrap();
+		assert!(oldest > previous, "oldest {oldest}, previous {previous}");
+		enqueue(&index, &id, &kind, None);
+		drain(&index, queue).await;
+		let expected = version(&index, &id, &kind).unwrap();
+		assert!(expected > oldest);
+		enqueue(&index, &blocker, &kind, Some(oldest));
+
+		// The old cleanup entry is eligible, but the current version is still needed.
+		assert!(!index.clean(clean_arg(1)).await.unwrap().done);
+		assert_eq!(version(&index, &id, &kind), Some(expected));
+		assert!(index.clean(clean_arg(100)).await.unwrap().done);
+
+		// An update at exactly the recorded version also prevents its collection.
+		drain(&index, queue).await;
+		enqueue(&index, &blocker, &kind, Some(expected));
+		index.clean(clean_arg(100)).await.unwrap();
+		assert_eq!(version(&index, &id, &kind), Some(expected));
+		drain(&index, queue).await;
+		index.clean(clean_arg(100)).await.unwrap();
+		assert!(version(&index, &id, &kind).is_none());
+	}
+}
+
+fn version(
+	index: &Index,
+	id: &tg::Either<tg::object::Id, tg::process::Id>,
+	kind: &Kind,
+) -> Option<u64> {
+	let transaction = index.env.read_txn().unwrap();
+	let key = crate::lmdb::Key::Update(crate::lmdb::update::Key::PropagatedVersion {
+		id: id.clone(),
+		kind: kind.clone(),
+	});
+	index
+		.db
+		.get(&transaction, &Index::pack(&index.subspace, &key))
+		.unwrap()
+		.map(|bytes| u64::from_be_bytes(bytes.try_into().unwrap()))
+}
+
+fn enqueue(
+	index: &Index,
+	id: &tg::Either<tg::object::Id, tg::process::Id>,
+	kind: &Kind,
+	version: Option<u64>,
+) {
+	let mut transaction = index.env.write_txn().unwrap();
+	Index::enqueue_update_with_kind(
+		&index.db,
+		&index.subspace,
+		&mut transaction,
+		id.clone(),
+		kind.clone(),
+		Source::Put,
+		version,
+	)
+	.unwrap();
+	transaction.commit().unwrap();
+}
+
+fn clean_arg(batch_size: usize) -> crate::clean::Arg {
+	crate::clean::Arg {
+		batch_size,
+		max_object_touched_at: 0,
+		max_process_touched_at: 0,
+		max_sandbox_touched_at: 0,
+		now: 0,
+		partition_end: 1,
+		partition_start: 0,
+	}
+}
+
+fn count_versions(index: &Index) -> usize {
+	let kinds = [
+		crate::lmdb::Kind::GrantUpdatePropagatedVersion,
+		crate::lmdb::Kind::NodeUpdatePropagatedVersion,
+	];
+	count_keys(index, &kinds)
+}
+
+fn count_clean_entries(index: &Index) -> usize {
+	let kinds = [
+		crate::lmdb::Kind::GrantUpdateClean,
+		crate::lmdb::Kind::NodeUpdateClean,
+	];
+	count_keys(index, &kinds)
+}
+
+fn count_keys(index: &Index, kinds: &[crate::lmdb::Kind]) -> usize {
+	let transaction = index.env.read_txn().unwrap();
+	let mut count = 0;
+	for kind in kinds {
+		let prefix = Index::pack(&index.subspace, &(kind.to_i32().unwrap(),));
+		count += index
+			.db
+			.prefix_iter(&transaction, &prefix)
+			.unwrap()
+			.map(Result::unwrap)
+			.count();
+	}
+	count
+}

--- a/packages/index/src/lmdb/update.rs
+++ b/packages/index/src/lmdb/update.rs
@@ -16,6 +16,8 @@ use {
 pub(super) struct GrantUpdate {
 	#[tangram_serialize(id = 0)]
 	pub source: Source,
+	#[tangram_serialize(id = 1)]
+	pub version: u64,
 }
 
 #[derive(
@@ -24,6 +26,8 @@ pub(super) struct GrantUpdate {
 pub(super) struct NodeUpdate {
 	#[tangram_serialize(id = 0)]
 	pub source: Source,
+	#[tangram_serialize(id = 1)]
+	pub version: u64,
 }
 
 #[derive(
@@ -70,8 +74,8 @@ struct GrantCover {
 }
 
 impl GrantUpdate {
-	pub fn new(source: Source) -> Self {
-		Self { source }
+	pub fn new(source: Source, version: u64) -> Self {
+		Self { source, version }
 	}
 
 	pub fn serialize(&self) -> tg::Result<Vec<u8>> {
@@ -86,8 +90,8 @@ impl GrantUpdate {
 }
 
 impl NodeUpdate {
-	pub fn new(source: Source) -> Self {
-		Self { source }
+	pub fn new(source: Source, version: u64) -> Self {
+		Self { source, version }
 	}
 
 	pub fn serialize(&self) -> tg::Result<Vec<u8>> {
@@ -215,11 +219,15 @@ impl Index {
 				.map_err(|error| tg::error!(!error, "failed to get update key"))?
 				.ok_or_else(|| tg::error!("expected an update key for the update version key"))?;
 
-			let source = match &kind {
-				Kind::Grant(_) | Kind::Node => Some(deserialize_source_update(&kind, value)?),
+			// A preceding item can lower the pending version after this batch selected its queue entry.
+			let (source, version) = match &kind {
+				Kind::Grant(_) | Kind::Node => {
+					let (source, version) = deserialize_source_update(&kind, value)?;
+					(Some(source), version)
+				},
 				Kind::Storage(_) => {
 					StorageUpdate::deserialize(value)?;
-					None
+					(None, version)
 				},
 			};
 
@@ -293,12 +301,59 @@ impl Index {
 				) => return Err(tg::error!("unsupported LMDB storage update kind")),
 			};
 
-			if !matches!(kind, Kind::Storage(_))
-				&& match source.unwrap() {
-					Source::Put => true,
-					Source::Propagate => changed,
-				} {
-				Self::enqueue_parents(db, subspace, transaction, &id, &kind, version)?;
+			if let Some(source) = source {
+				let key = crate::lmdb::Key::Update(Key::PropagatedVersion {
+					id: id.clone(),
+					kind: kind.clone(),
+				});
+				let key = Self::pack(subspace, &key);
+				let propagated_version = db
+					.get(transaction, &key)
+					.map_err(|error| {
+						tg::error!(!error, "failed to get the propagated update version")
+					})?
+					.map(|bytes| bytes.try_into().map(u64::from_be_bytes))
+					.transpose()
+					.map_err(|error| {
+						tg::error!(
+							!error,
+							"failed to deserialize the propagated update version"
+						)
+					})?;
+				// Propagate an older version even when the item's metadata or grants are unchanged.
+				if source == Source::Put
+					|| changed || propagated_version
+					.is_some_and(|propagated_version| version < propagated_version)
+				{
+					Self::enqueue_parents(db, subspace, transaction, &id, &kind, version)?;
+					let item = match &id {
+						tg::Either::Left(id) => {
+							crate::lmdb::Key::Object(crate::lmdb::object::Key::Object(id.clone()))
+						},
+						tg::Either::Right(id) => crate::lmdb::Key::Process(
+							crate::lmdb::process::Key::Process(id.clone()),
+						),
+					};
+					if db
+						.get(transaction, &Self::pack(subspace, &item))
+						.map_err(|error| tg::error!(!error, "failed to get the update item"))?
+						.is_some()
+					{
+						db.put(transaction, &key, &version.to_be_bytes())
+							.map_err(|error| {
+								tg::error!(!error, "failed to put the propagated update version")
+							})?;
+						let key = crate::lmdb::Key::Update(Key::Clean {
+							id: id.clone(),
+							kind: kind.clone(),
+							version,
+						});
+						db.put(transaction, &Self::pack(subspace, &key), &[])
+							.map_err(|error| {
+								tg::error!(!error, "failed to put the update clean key")
+							})?;
+					}
+				}
 			}
 
 			let key = crate::lmdb::Key::Update(crate::lmdb::update::Key::Update {
@@ -1857,6 +1912,8 @@ impl Index {
 			kind: kind.clone(),
 		});
 		let key = Self::pack(subspace, &key);
+		let mut source = source;
+		let mut version = version.unwrap_or_else(|| transaction.id() as u64);
 		if let Some(existing) = db
 			.get(transaction, &key)
 			.map_err(|error| tg::error!(!error, "failed to get update key"))?
@@ -1864,26 +1921,60 @@ impl Index {
 			if matches!(kind, Kind::Storage(_)) {
 				return Ok(());
 			}
-			let existing = deserialize_source_update(&kind, existing)?;
-			if existing == Source::Propagate && source == Source::Put {
-				let value = serialize_update(&kind, source)?;
-				db.put(transaction, &key, &value)
-					.map_err(|error| tg::error!(!error, "failed to put update key"))?;
+			let (existing_source, existing_version) = deserialize_source_update(&kind, existing)?;
+			if existing_source == Source::Put {
+				source = Source::Put;
 			}
-			return Ok(());
+			version = version.min(existing_version);
+			if source == existing_source && version == existing_version {
+				return Ok(());
+			}
+			if version != existing_version {
+				let key = crate::lmdb::Key::Update(Key::UpdateVersion {
+					id: id.clone(),
+					kind: kind.clone(),
+					version: existing_version,
+				});
+				db.delete(transaction, &Self::pack(subspace, &key))
+					.map_err(|error| {
+						tg::error!(!error, "failed to delete the update version key")
+					})?;
+			}
 		}
 
-		let value = serialize_update(&kind, source)?;
+		let value = serialize_update(&kind, source, version)?;
 		db.put(transaction, &key, &value)
 			.map_err(|error| tg::error!(!error, "failed to put update key"))?;
 
-		let version = version.unwrap_or_else(|| transaction.id() as u64);
 		let key =
 			crate::lmdb::Key::Update(crate::lmdb::update::Key::UpdateVersion { id, kind, version });
 		let key = Self::pack(subspace, &key);
 		db.put(transaction, &key, &[])
 			.map_err(|error| tg::error!(!error, "failed to put update version key"))?;
 
+		Ok(())
+	}
+
+	pub(super) fn clear_update_propagated_versions(
+		db: &Db,
+		subspace: &fdbt::Subspace,
+		transaction: &mut lmdb::RwTxn<'_>,
+		id: &[u8],
+	) -> tg::Result<()> {
+		for kind in [
+			KeyKind::GrantUpdatePropagatedVersion,
+			KeyKind::NodeUpdatePropagatedVersion,
+		] {
+			let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), id));
+			let (_, end) = fdbt::Subspace::from_bytes(prefix.clone()).range();
+			let range = (
+				std::ops::Bound::Included(prefix.as_slice()),
+				std::ops::Bound::Excluded(end.as_slice()),
+			);
+			db.delete_range(transaction, &range).map_err(|error| {
+				tg::error!(!error, "failed to delete the propagated update versions")
+			})?;
+		}
 		Ok(())
 	}
 }
@@ -1896,20 +1987,26 @@ fn update_version_key_kind(kind: crate::update::Kind) -> KeyKind {
 	}
 }
 
-fn deserialize_source_update(kind: &Kind, bytes: &[u8]) -> tg::Result<Source> {
-	let source = match kind {
-		Kind::Grant(_) => GrantUpdate::deserialize(bytes)?.source,
-		Kind::Node => NodeUpdate::deserialize(bytes)?.source,
+fn deserialize_source_update(kind: &Kind, bytes: &[u8]) -> tg::Result<(Source, u64)> {
+	let output = match kind {
+		Kind::Grant(_) => {
+			let update = GrantUpdate::deserialize(bytes)?;
+			(update.source, update.version)
+		},
+		Kind::Node => {
+			let update = NodeUpdate::deserialize(bytes)?;
+			(update.source, update.version)
+		},
 		Kind::Storage(_) => return Err(tg::error!("expected a source update")),
 	};
 
-	Ok(source)
+	Ok(output)
 }
 
-fn serialize_update(kind: &Kind, source: Source) -> tg::Result<Vec<u8>> {
+fn serialize_update(kind: &Kind, source: Source, version: u64) -> tg::Result<Vec<u8>> {
 	let value = match kind {
-		Kind::Grant(_) => GrantUpdate::new(source).serialize()?,
-		Kind::Node => NodeUpdate::new(source).serialize()?,
+		Kind::Grant(_) => GrantUpdate::new(source, version).serialize()?,
+		Kind::Node => NodeUpdate::new(source, version).serialize()?,
 		Kind::Storage(_) => StorageUpdate::new().serialize()?,
 	};
 

--- a/packages/index/src/lmdb/update.rs
+++ b/packages/index/src/lmdb/update.rs
@@ -339,6 +339,20 @@ impl Index {
 						.map_err(|error| tg::error!(!error, "failed to get the update item"))?
 						.is_some()
 					{
+						// Keep one cleanup entry for the retained propagated version.
+						if let Some(previous) =
+							propagated_version.filter(|previous| *previous != version)
+						{
+							let key = crate::lmdb::Key::Update(Key::Clean {
+								id: id.clone(),
+								kind: kind.clone(),
+								version: previous,
+							});
+							db.delete(transaction, &Self::pack(subspace, &key))
+								.map_err(|error| {
+									tg::error!(!error, "failed to delete the update clean key")
+								})?;
+						}
 						db.put(transaction, &key, &version.to_be_bytes())
 							.map_err(|error| {
 								tg::error!(!error, "failed to put the propagated update version")

--- a/packages/index/src/lmdb/update/key.rs
+++ b/packages/index/src/lmdb/update/key.rs
@@ -2,6 +2,19 @@ use tangram_client::prelude::*;
 
 #[derive(Clone, Debug)]
 pub enum Key {
+	/// A version-ordered candidate for regular cleaning after older updates have drained.
+	Clean {
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+		kind: Kind,
+		version: u64,
+	},
+	/// The version last used to enqueue this item's parent updates.
+	/// An older unchanged update must enqueue the parents again using its older version.
+	/// Regular cleaning removes this key once the queue has advanced beyond its version.
+	PropagatedVersion {
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+		kind: Kind,
+	},
 	Update {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,


### PR DESCRIPTION
An index wait can finish early when an older metadata or grant update is processed after a newer update. For example, propagation from version 90 must still be covered by a wait at version 100 even if a version-200 update has already consumed the shared payload or made the local state complete.

Retain propagation versions in FoundationDB and LMDB so older updates continue to parents even when the local state is unchanged. Preserve the minimum pending version when LMDB combines updates and stop already-covered repeats.

Regular cleaning reclaims these versions once every partition of the corresponding update queue has advanced beyond them. Version-ordered cleanup entries let the cleaner select eligible records within its existing shared batch budget, including records on objects that remain cached. Queue progress is read from the transaction snapshot to avoid conflicts with unrelated indexing; the current-version check and deletion retain conflict protection. Replacing a propagated version also removes its previous cleanup entry, keeping repeated updates from accumulating obsolete entries. Object and process collection also removes their retained versions; regular cleaning removes leftover cleanup entries.

Validation:

- Added FoundationDB and LMDB regressions for coalesced updates, late arrivals, repeated propagation, and cleanup. Both original FoundationDB regressions were verified failing on unchanged `main` and passing with the fix, using real commit versionstamps.
- The new retention regressions fail before the cleanup change and pass afterward. Additional coverage checks other partitions, equal-version pending work, stale cleanup entries, concurrent replacement, shared batch limits, and object/process collection followed by stale updates.
- Three additional regressions were verified failing before the performance fixes and passing afterward: unrelated queue progress does not abort cleanup, and propagated-version replacements retain one cleanup entry in each backend.
- All 145 index tests passed, including the FoundationDB tests with `FDB_CLUSTER_FILE` and `--include-ignored`.
- The rebased #1109 stack passed all 153 index tests, including FoundationDB, and 46 CLI index/clean tests with `--no-cloud`; one cloud-only archive test was skipped.
- `bun run check` and `bun run format` passed.
