### PR TITLE
fix(index): preserve storage update propagation versions

### DIFF
--- a/packages/index/src/fdb/key.rs
+++ b/packages/index/src/fdb/key.rs
@@ -83,8 +83,8 @@ pub enum Kind {
 	UsageUnavailable = 65,
 	GrantUpdatePropagatedVersion = 66,
 	NodeUpdatePropagatedVersion = 67,
-	StorageAddition = 68,
-	StoragePropagation = 69,
+	StorageUpdatePropagatedVersion = 69,
+	StorageUpdatePutVersion = 68,
 	GrantUpdateClean = 71,
 	NodeUpdateClean = 72,
 }
@@ -595,14 +595,14 @@ impl fdbt::TuplePack for Key {
 			},
 
 			Key::Update(
-				crate::fdb::update::Key::StorageAddition { account, id }
-				| crate::fdb::update::Key::StoragePropagation { account, id },
+				crate::fdb::update::Key::StorageUpdatePropagatedVersion { account, id }
+				| crate::fdb::update::Key::StorageUpdatePutVersion { account, id },
 			) => {
 				let kind = match self {
-					Key::Update(crate::fdb::update::Key::StorageAddition { .. }) => {
-						Kind::StorageAddition
-					},
-					_ => Kind::StoragePropagation,
+					Key::Update(crate::fdb::update::Key::StorageUpdatePropagatedVersion {
+						..
+					}) => Kind::StorageUpdatePropagatedVersion,
+					_ => Kind::StorageUpdatePutVersion,
 				};
 				let id = match id {
 					tg::Either::Left(id) => id.to_bytes(),
@@ -1541,7 +1541,7 @@ impl fdbt::TupleUnpack<'_> for Key {
 				Ok((input, key))
 			},
 
-			Kind::StorageAddition | Kind::StoragePropagation => {
+			Kind::StorageUpdatePropagatedVersion | Kind::StorageUpdatePutVersion => {
 				let (input, id): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
 				let id = tg::Id::from_slice(&id)
 					.map_err(|_| fdbt::PackError::Message("invalid id".into()))?;
@@ -1558,10 +1558,10 @@ impl fdbt::TupleUnpack<'_> for Key {
 				let account = crate::usage::Account::try_from(account)
 					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
 				let key = match kind {
-					Kind::StorageAddition => {
-						crate::fdb::update::Key::StorageAddition { account, id }
+					Kind::StorageUpdatePropagatedVersion => {
+						crate::fdb::update::Key::StorageUpdatePropagatedVersion { account, id }
 					},
-					_ => crate::fdb::update::Key::StoragePropagation { account, id },
+					_ => crate::fdb::update::Key::StorageUpdatePutVersion { account, id },
 				};
 				Ok((input, Key::Update(key)))
 			},
@@ -1667,15 +1667,6 @@ fn pack_update_kind<W: std::io::Write>(
 		crate::fdb::update::Kind::Grant(subject) => subject.to_string().pack(w, tuple_depth),
 		crate::fdb::update::Kind::Node => ().pack(w, tuple_depth),
 		crate::fdb::update::Kind::Storage(kind) => match kind {
-			crate::fdb::update::StorageKind::Add {
-				account,
-				touched_at,
-			} => {
-				let mut offset = 0i32.pack(w, tuple_depth)?;
-				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
-				offset += touched_at.pack(w, tuple_depth)?;
-				Ok(offset)
-			},
 			crate::fdb::update::StorageKind::Clean(account) => {
 				let mut offset = 1i32.pack(w, tuple_depth)?;
 				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
@@ -1687,6 +1678,15 @@ fn pack_update_kind<W: std::io::Write>(
 				touched_at,
 			} => {
 				let mut offset = 3i32.pack(w, tuple_depth)?;
+				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
+				offset += touched_at.pack(w, tuple_depth)?;
+				Ok(offset)
+			},
+			crate::fdb::update::StorageKind::Put {
+				account,
+				touched_at,
+			} => {
+				let mut offset = 0i32.pack(w, tuple_depth)?;
 				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
 				offset += touched_at.pack(w, tuple_depth)?;
 				Ok(offset)
@@ -1722,7 +1722,7 @@ fn unpack_update_kind(
 					let account = crate::usage::Account::try_from(account)
 						.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
 					let kind = match kind {
-						0 => crate::fdb::update::StorageKind::Add {
+						0 => crate::fdb::update::StorageKind::Put {
 							account,
 							touched_at,
 						},

--- a/packages/index/src/fdb/key.rs
+++ b/packages/index/src/fdb/key.rs
@@ -83,6 +83,8 @@ pub enum Kind {
 	UsageUnavailable = 65,
 	GrantUpdatePropagatedVersion = 66,
 	NodeUpdatePropagatedVersion = 67,
+	StorageAddition = 68,
+	StoragePropagation = 69,
 	GrantUpdateClean = 71,
 	NodeUpdateClean = 72,
 }
@@ -590,6 +592,28 @@ impl fdbt::TuplePack for Key {
 				let mut offset = id.as_ref().pack(w, tuple_depth)?;
 				offset += pack_update_kind(w, tuple_depth, kind)?;
 				Ok(offset)
+			},
+
+			Key::Update(
+				crate::fdb::update::Key::StorageAddition { account, id }
+				| crate::fdb::update::Key::StoragePropagation { account, id },
+			) => {
+				let kind = match self {
+					Key::Update(crate::fdb::update::Key::StorageAddition { .. }) => {
+						Kind::StorageAddition
+					},
+					_ => Kind::StoragePropagation,
+				};
+				let id = match id {
+					tg::Either::Left(id) => id.to_bytes(),
+					tg::Either::Right(id) => id.to_bytes(),
+				};
+				(
+					kind.to_i32().unwrap(),
+					id.as_ref(),
+					account.id().to_bytes().as_ref(),
+				)
+					.pack(w, tuple_depth)
 			},
 
 			Key::Update(crate::fdb::update::Key::Update { id, kind }) => {
@@ -1515,6 +1539,31 @@ impl fdbt::TupleUnpack<'_> for Key {
 					version,
 				});
 				Ok((input, key))
+			},
+
+			Kind::StorageAddition | Kind::StoragePropagation => {
+				let (input, id): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
+				let id = tg::Id::from_slice(&id)
+					.map_err(|_| fdbt::PackError::Message("invalid id".into()))?;
+				let id = if let Ok(id) = tg::process::Id::try_from(id.clone()) {
+					tg::Either::Right(id)
+				} else if let Ok(id) = tg::object::Id::try_from(id) {
+					tg::Either::Left(id)
+				} else {
+					return Err(fdbt::PackError::Message("invalid id".into()));
+				};
+				let (input, account): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
+				let account = tg::Id::from_slice(&account)
+					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
+				let account = crate::usage::Account::try_from(account)
+					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
+				let key = match kind {
+					Kind::StorageAddition => {
+						crate::fdb::update::Key::StorageAddition { account, id }
+					},
+					_ => crate::fdb::update::Key::StoragePropagation { account, id },
+				};
+				Ok((input, Key::Update(key)))
 			},
 
 			Kind::GrantUpdatePropagatedVersion | Kind::NodeUpdatePropagatedVersion => {

--- a/packages/index/src/fdb/update.rs
+++ b/packages/index/src/fdb/update.rs
@@ -38,6 +38,9 @@ pub(super) struct NodeUpdate {
 pub(super) struct StorageUpdate {
 	#[tangram_serialize(default, id = 0, skip_serializing_if = "Option::is_none")]
 	pub cursor: Option<StorageCursor>,
+
+	#[tangram_serialize(default, id = 1, skip_serializing_if = "Option::is_none")]
+	pub version: Option<[u8; 12]>,
 }
 
 #[derive(
@@ -148,7 +151,10 @@ impl NodeUpdate {
 
 impl StorageUpdate {
 	pub fn new() -> Self {
-		Self { cursor: None }
+		Self {
+			cursor: None,
+			version: None,
+		}
 	}
 
 	pub fn serialize(&self) -> tg::Result<Vec<u8>> {
@@ -398,7 +404,8 @@ impl Index {
 		}
 
 		let mut output = crate::update::Output::default();
-		for (partition, version, id, kind) in entries {
+		for (partition, queued_version, id, kind) in entries {
+			let mut version = queued_version.clone();
 			let key = Self::pack(
 				subspace,
 				&crate::fdb::Key::Update(crate::fdb::update::Key::Update {
@@ -412,28 +419,68 @@ impl Index {
 			// A consumed payload does not imply that every queued version has propagated.
 			let value = if let Some(value) = value {
 				value.to_vec()
-			} else if !matches!(kind, Kind::Storage(_)) {
-				let propagated_version = crate::fdb::propagate!(
-					Self::try_get_update_propagated_version(txn, subspace, &id, &kind).await
-				);
+			} else {
+				let key = match &kind {
+					Kind::Grant(_) | Kind::Node => Some(Key::PropagatedVersion {
+						id: id.clone(),
+						kind: kind.clone(),
+					}),
+					Kind::Storage(StorageKind::Add { account, .. }) => Some(Key::StorageAddition {
+						account: account.clone(),
+						id: id.clone(),
+					}),
+					Kind::Storage(StorageKind::Propagate { account, .. }) => {
+						Some(Key::StoragePropagation {
+							account: account.clone(),
+							id: id.clone(),
+						})
+					},
+					Kind::Storage(StorageKind::Clean(_) | StorageKind::CleanAll) => None,
+				};
+				let propagated_version = if let Some(key) = key {
+					crate::fdb::propagate!(
+						Self::try_get_propagation_version(txn, subspace, &key).await
+					)
+				} else {
+					None
+				};
 				if propagated_version.is_none_or(|propagated_version| version >= propagated_version)
 				{
-					Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
+					Self::clear_update_version(
+						txn,
+						subspace,
+						&id,
+						&kind,
+						partition,
+						&queued_version,
+					);
 					output.count += 1;
 					continue;
 				}
 				serialize_update(&kind, Source::Propagate)?
-			} else {
-				Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
-				output.count += 1;
-				continue;
 			};
 
 			let (cursor, source) = match &kind {
 				Kind::Grant(_) | Kind::Node => {
 					(None, Some(deserialize_source_update(&kind, &value)?))
 				},
-				Kind::Storage(_) => (StorageUpdate::deserialize(&value)?.cursor, None),
+				Kind::Storage(_) => {
+					let update = StorageUpdate::deserialize(&value)?;
+					let previous = update.version.map(fdbt::Versionstamp::from);
+					// Revisit earlier pages when an older obligation joins the traversal.
+					let cursor = if previous
+						.as_ref()
+						.is_some_and(|previous| version < *previous)
+					{
+						None
+					} else {
+						if let Some(previous) = previous {
+							version = version.min(previous);
+						}
+						update.cursor
+					};
+					(cursor, None)
+				},
 			};
 			let mut next_cursor = None;
 
@@ -616,6 +663,7 @@ impl Index {
 			let continued = if let Some(cursor) = next_cursor {
 				let update = StorageUpdate {
 					cursor: Some(cursor),
+					version: Some(*version.as_bytes()),
 				};
 				let key = Self::pack(
 					subspace,
@@ -641,7 +689,7 @@ impl Index {
 				false
 			};
 			if !continued {
-				Self::clear_update_version(txn, subspace, &id, &kind, partition, &version);
+				Self::clear_update_version(txn, subspace, &id, &kind, partition, &queued_version);
 			}
 
 			output.count += 1;
@@ -656,11 +704,19 @@ impl Index {
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		kind: &Kind,
 	) -> tg::Result<ControlFlow<Option<fdbt::Versionstamp>, fdb::FdbError>> {
-		let key = crate::fdb::Key::Update(Key::PropagatedVersion {
+		let key = Key::PropagatedVersion {
 			id: id.clone(),
 			kind: kind.clone(),
-		});
-		let key = Self::pack(subspace, &key);
+		};
+		Self::try_get_propagation_version(txn, subspace, &key).await
+	}
+
+	pub(super) async fn try_get_propagation_version(
+		txn: &crate::fdb::Transaction,
+		subspace: &Subspace,
+		key: &Key,
+	) -> tg::Result<ControlFlow<Option<fdbt::Versionstamp>, fdb::FdbError>> {
+		let key = Self::pack(subspace, &crate::fdb::Key::Update(key.clone()));
 		let result = txn.get(&key, false).await;
 		let value = crate::fdb::retry!(result);
 		let version = value
@@ -686,10 +742,55 @@ impl Index {
 		for kind in [
 			KeyKind::GrantUpdatePropagatedVersion,
 			KeyKind::NodeUpdatePropagatedVersion,
+			KeyKind::StorageAddition,
+			KeyKind::StoragePropagation,
 		] {
 			let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), id));
 			let (_, end) = Subspace::from_bytes(prefix.clone()).range();
 			txn.clear_range(&prefix, &end);
+		}
+	}
+
+	pub(super) async fn lower_storage_addition_version(
+		txn: &crate::fdb::Transaction,
+		subspace: &Subspace,
+		id: &tg::Either<tg::object::Id, tg::process::Id>,
+		account: &crate::usage::Account,
+		version: &fdbt::Versionstamp,
+	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
+		let key = Key::StorageAddition {
+			account: account.clone(),
+			id: id.clone(),
+		};
+		let previous =
+			crate::fdb::propagate!(Self::try_get_propagation_version(txn, subspace, &key).await);
+		if previous.is_some_and(|previous| *version >= previous) {
+			return Ok(ControlFlow::Break(false));
+		}
+		txn.set(
+			&Self::pack(subspace, &crate::fdb::Key::Update(key)),
+			version.as_bytes(),
+		);
+		Ok(ControlFlow::Break(true))
+	}
+
+	pub(super) fn clear_storage_propagations(
+		txn: &crate::fdb::Transaction,
+		subspace: &Subspace,
+		id: &tg::Either<tg::object::Id, tg::process::Id>,
+		account: &crate::usage::Account,
+	) {
+		for key in [
+			Key::StorageAddition {
+				account: account.clone(),
+				id: id.clone(),
+			},
+			Key::StoragePropagation {
+				account: account.clone(),
+				id: id.clone(),
+			},
+		] {
+			txn.clear(&Self::pack(subspace, &crate::fdb::Key::Update(key)));
 		}
 	}
 
@@ -704,6 +805,29 @@ impl Index {
 		touched_at: i64,
 		version: &fdbt::Versionstamp,
 	) -> tg::Result<ControlFlow<Option<StorageCursor>, fdb::FdbError>> {
+		let key = match id {
+			tg::Either::Left(object) => crate::fdb::usage::Key::AccountObject {
+				account: account.clone(),
+				object: object.clone(),
+			},
+			tg::Either::Right(process) => crate::fdb::usage::Key::AccountProcess {
+				account: account.clone(),
+				process: process.clone(),
+			},
+		};
+		let result = txn
+			.get(&Self::pack(subspace, &crate::fdb::Key::Usage(key)), false)
+			.await;
+		if crate::fdb::retry!(result).is_none() {
+			return Ok(ControlFlow::Break(None));
+		}
+
+		// Resolve the addition version once a versionstamped insertion starts propagating.
+		if cursor.is_none() {
+			crate::fdb::propagate!(
+				Self::lower_storage_addition_version(txn, subspace, id, account, version).await
+			);
+		}
 		let (relationships, cursor) = crate::fdb::propagate!(
 			Self::get_storage_relationships_page(txn, subspace, id, cursor).await
 		);
@@ -724,6 +848,17 @@ impl Index {
 				Source::Put,
 				partition_total,
 				Some(version),
+			);
+		}
+
+		if cursor.is_none() {
+			let key = Key::StoragePropagation {
+				account: account.clone(),
+				id: id.clone(),
+			};
+			txn.set(
+				&Self::pack(subspace, &crate::fdb::Key::Update(key)),
+				version.as_bytes(),
 			);
 		}
 

--- a/packages/index/src/fdb/update.rs
+++ b/packages/index/src/fdb/update.rs
@@ -425,17 +425,19 @@ impl Index {
 						id: id.clone(),
 						kind: kind.clone(),
 					}),
-					Kind::Storage(StorageKind::Add { account, .. }) => Some(Key::StorageAddition {
-						account: account.clone(),
-						id: id.clone(),
-					}),
+					Kind::Storage(StorageKind::Clean(_) | StorageKind::CleanAll) => None,
 					Kind::Storage(StorageKind::Propagate { account, .. }) => {
-						Some(Key::StoragePropagation {
+						Some(Key::StorageUpdatePropagatedVersion {
 							account: account.clone(),
 							id: id.clone(),
 						})
 					},
-					Kind::Storage(StorageKind::Clean(_) | StorageKind::CleanAll) => None,
+					Kind::Storage(StorageKind::Put { account, .. }) => {
+						Some(Key::StorageUpdatePutVersion {
+							account: account.clone(),
+							id: id.clone(),
+						})
+					},
 				};
 				let propagated_version = if let Some(key) = key {
 					crate::fdb::propagate!(
@@ -525,47 +527,6 @@ impl Index {
 						process_output.changed
 					},
 				},
-				Kind::Storage(StorageKind::Add {
-					account,
-					touched_at,
-				}) => match &id {
-					tg::Either::Left(object) => {
-						crate::fdb::propagate!(
-							Self::put_account_object(
-								txn,
-								subspace,
-								&crate::usage::storage::put::ObjectArg {
-									account: account.clone(),
-									object: object.clone(),
-									touched_at: *touched_at,
-								},
-								partition_total,
-								usage_partition_total,
-								false,
-								Some(&version),
-							)
-							.await
-						)
-					},
-					tg::Either::Right(process) => {
-						crate::fdb::propagate!(
-							Self::put_account_process(
-								txn,
-								subspace,
-								&crate::usage::storage::put::ProcessArg {
-									account: account.clone(),
-									process: process.clone(),
-									touched_at: *touched_at,
-								},
-								partition_total,
-								usage_partition_total,
-								false,
-								Some(&version),
-							)
-							.await
-						)
-					},
-				},
 				Kind::Storage(StorageKind::Clean(account)) => {
 					next_cursor = crate::fdb::propagate!(
 						Self::propagate_storage_clean(
@@ -611,6 +572,47 @@ impl Index {
 						.await
 					);
 					false
+				},
+				Kind::Storage(StorageKind::Put {
+					account,
+					touched_at,
+				}) => match &id {
+					tg::Either::Left(object) => {
+						crate::fdb::propagate!(
+							Self::put_account_object(
+								txn,
+								subspace,
+								&crate::usage::storage::put::ObjectArg {
+									account: account.clone(),
+									object: object.clone(),
+									touched_at: *touched_at,
+								},
+								partition_total,
+								usage_partition_total,
+								false,
+								Some(&version),
+							)
+							.await
+						)
+					},
+					tg::Either::Right(process) => {
+						crate::fdb::propagate!(
+							Self::put_account_process(
+								txn,
+								subspace,
+								&crate::usage::storage::put::ProcessArg {
+									account: account.clone(),
+									process: process.clone(),
+									touched_at: *touched_at,
+								},
+								partition_total,
+								usage_partition_total,
+								false,
+								Some(&version),
+							)
+							.await
+						)
+					},
 				},
 			};
 
@@ -742,8 +744,8 @@ impl Index {
 		for kind in [
 			KeyKind::GrantUpdatePropagatedVersion,
 			KeyKind::NodeUpdatePropagatedVersion,
-			KeyKind::StorageAddition,
-			KeyKind::StoragePropagation,
+			KeyKind::StorageUpdatePropagatedVersion,
+			KeyKind::StorageUpdatePutVersion,
 		] {
 			let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), id));
 			let (_, end) = Subspace::from_bytes(prefix.clone()).range();
@@ -751,14 +753,14 @@ impl Index {
 		}
 	}
 
-	pub(super) async fn lower_storage_addition_version(
+	pub(super) async fn lower_storage_update_put_version(
 		txn: &crate::fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		account: &crate::usage::Account,
 		version: &fdbt::Versionstamp,
 	) -> tg::Result<ControlFlow<bool, fdb::FdbError>> {
-		let key = Key::StorageAddition {
+		let key = Key::StorageUpdatePutVersion {
 			account: account.clone(),
 			id: id.clone(),
 		};
@@ -774,18 +776,18 @@ impl Index {
 		Ok(ControlFlow::Break(true))
 	}
 
-	pub(super) fn clear_storage_propagations(
+	pub(super) fn clear_storage_update_versions(
 		txn: &crate::fdb::Transaction,
 		subspace: &Subspace,
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		account: &crate::usage::Account,
 	) {
 		for key in [
-			Key::StorageAddition {
+			Key::StorageUpdatePropagatedVersion {
 				account: account.clone(),
 				id: id.clone(),
 			},
-			Key::StoragePropagation {
+			Key::StorageUpdatePutVersion {
 				account: account.clone(),
 				id: id.clone(),
 			},
@@ -822,16 +824,16 @@ impl Index {
 			return Ok(ControlFlow::Break(None));
 		}
 
-		// Resolve the addition version once a versionstamped insertion starts propagating.
+		// Resolve the put version once a versionstamped insertion starts propagating.
 		if cursor.is_none() {
 			crate::fdb::propagate!(
-				Self::lower_storage_addition_version(txn, subspace, id, account, version).await
+				Self::lower_storage_update_put_version(txn, subspace, id, account, version).await
 			);
 		}
 		let (relationships, cursor) = crate::fdb::propagate!(
 			Self::get_storage_relationships_page(txn, subspace, id, cursor).await
 		);
-		let kind = Kind::Storage(StorageKind::Add {
+		let kind = Kind::Storage(StorageKind::Put {
 			account: account.clone(),
 			touched_at,
 		});
@@ -852,7 +854,7 @@ impl Index {
 		}
 
 		if cursor.is_none() {
-			let key = Key::StoragePropagation {
+			let key = Key::StorageUpdatePropagatedVersion {
 				account: account.clone(),
 				id: id.clone(),
 			};

--- a/packages/index/src/fdb/update/key.rs
+++ b/packages/index/src/fdb/update/key.rs
@@ -16,6 +16,16 @@ pub enum Key {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,
 	},
+	// The oldest addition for an account association is independent of its touch timestamp.
+	StorageAddition {
+		account: crate::usage::Account,
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+	},
+	// A completed traversal can be replayed if an older queue marker arrives later.
+	StoragePropagation {
+		account: crate::usage::Account,
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+	},
 	Update {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,

--- a/packages/index/src/fdb/update/key.rs
+++ b/packages/index/src/fdb/update/key.rs
@@ -16,13 +16,13 @@ pub enum Key {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,
 	},
-	// The oldest addition for an account association is independent of its touch timestamp.
-	StorageAddition {
+	/// A completed traversal can be replayed if an older queue marker arrives later.
+	StorageUpdatePropagatedVersion {
 		account: crate::usage::Account,
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 	},
-	// A completed traversal can be replayed if an older queue marker arrives later.
-	StoragePropagation {
+	/// The oldest put version for an account association is independent of its touch timestamp.
+	StorageUpdatePutVersion {
 		account: crate::usage::Account,
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 	},
@@ -47,13 +47,13 @@ pub enum Kind {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageKind {
-	Add {
-		account: crate::usage::Account,
-		touched_at: i64,
-	},
 	Clean(crate::usage::Account),
 	CleanAll,
 	Propagate {
+		account: crate::usage::Account,
+		touched_at: i64,
+	},
+	Put {
 		account: crate::usage::Account,
 		touched_at: i64,
 	},

--- a/packages/index/src/fdb/update/tests.rs
+++ b/packages/index/src/fdb/update/tests.rs
@@ -7,6 +7,7 @@ use {
 };
 
 mod clean;
+mod storage;
 
 static NETWORK: OnceLock<fdb::api::NetworkAutoStop> = OnceLock::new();
 

--- a/packages/index/src/fdb/update/tests/storage.rs
+++ b/packages/index/src/fdb/update/tests/storage.rs
@@ -8,14 +8,14 @@ use {
 
 #[tokio::test]
 #[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
-async fn coalesced_storage_additions_preserve_the_oldest_version() {
-	super::run(async |index| additions(index, false).await).await;
+async fn coalesced_storage_puts_preserve_the_oldest_version() {
+	super::run(async |index| puts(index, false).await).await;
 }
 
 #[tokio::test]
 #[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
-async fn late_storage_additions_preserve_the_oldest_version() {
-	super::run(async |index| additions(index, true).await).await;
+async fn late_storage_puts_preserve_the_oldest_version() {
+	super::run(async |index| puts(index, true).await).await;
 }
 
 #[tokio::test]
@@ -57,7 +57,7 @@ async fn completed_storage_updates_preserve_the_oldest_version() {
 	.await;
 }
 
-async fn additions(index: &Index, late: bool) {
+async fn puts(index: &Index, late: bool) {
 	// Two directory roots reach the same account through a shared middle directory.
 	let leaf = super::directory(&[]);
 	let middle = super::directory(&[("leaf", leaf.id.clone())]);
@@ -93,7 +93,7 @@ async fn additions(index: &Index, late: bool) {
 		step(index, &old).await;
 	}
 	let entries = queue(index).await;
-	let old = entries.iter().find(|key| matches!(key, Key::UpdateVersion { kind: Kind::Storage(StorageKind::Add { .. }), version: value, .. } if *value == old_version)).unwrap();
+	let old = entries.iter().find(|key| matches!(key, Key::UpdateVersion { kind: Kind::Storage(StorageKind::Put { .. }), version: value, .. } if *value == old_version)).unwrap();
 	step(index, old).await;
 	assert!(!associated(index, &account, &leaf.id).await);
 	let oldest = index
@@ -107,11 +107,11 @@ async fn additions(index: &Index, late: bool) {
 	drain(index).await;
 	assert!(associated(index, &account, &leaf.id).await);
 
-	// A repeated old addition must stop without walking the descendants again.
+	// A repeated old put must stop without walking the descendants again.
 	enqueue(
 		index,
 		&middle.id,
-		&Kind::Storage(StorageKind::Add {
+		&Kind::Storage(StorageKind::Put {
 			account: account.clone(),
 			touched_at: 0,
 		}),
@@ -157,11 +157,11 @@ async fn additions(index: &Index, late: bool) {
 		let account = &account;
 		crate::fdb::run(&index.database, |txn| async move {
 			for key in [
-				Key::StorageAddition {
+				Key::StorageUpdatePutVersion {
 					account: account.clone(),
 					id: tg::Either::Left(id.clone()),
 				},
-				Key::StoragePropagation {
+				Key::StorageUpdatePropagatedVersion {
 					account: account.clone(),
 					id: tg::Either::Left(id.clone()),
 				},

--- a/packages/index/src/fdb/update/tests/storage.rs
+++ b/packages/index/src/fdb/update/tests/storage.rs
@@ -1,0 +1,407 @@
+use {
+	super::{Index, Key, Kind},
+	crate::fdb::update::StorageKind,
+	foundationdb as fdb, foundationdb_tuple as fdbt,
+	std::ops::ControlFlow,
+	tangram_client::prelude::*,
+};
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn coalesced_storage_additions_preserve_the_oldest_version() {
+	super::run(async |index| additions(index, false).await).await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn late_storage_additions_preserve_the_oldest_version() {
+	super::run(async |index| additions(index, true).await).await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn paginated_storage_updates_preserve_the_oldest_version() {
+	super::run(pages).await;
+}
+
+#[tokio::test]
+#[ignore = "requires FoundationDB and FDB_CLUSTER_FILE"]
+async fn completed_storage_updates_preserve_the_oldest_version() {
+	super::run(async |index| {
+		let leaf = super::directory(&[]);
+		let middle = super::directory(&[("leaf", leaf.id.clone())]);
+		super::put(index, vec![leaf.clone(), middle.clone()]).await;
+		super::drain(index).await;
+		let account = crate::usage::Account::User(tg::user::Id::new());
+		associate(index, &account, &middle.id, 0).await;
+		let old = queue(index).await.pop().unwrap();
+		let kind = Kind::Storage(StorageKind::Propagate {
+			account: account.clone(),
+			touched_at: 0,
+		});
+		enqueue(index, &middle.id, &kind, None).await;
+		let entries = queue(index).await;
+		let newer = entries.iter().max_by_key(|key| version(key)).unwrap();
+		step(index, newer).await;
+		step(index, &old).await;
+		let entries = queue(index).await;
+		assert!(
+			entries
+				.iter()
+				.any(|key| item(key) == &leaf.id && version(key) == version(&old))
+		);
+		assert!(!associated(index, &account, &leaf.id).await);
+		drain(index).await;
+		assert!(associated(index, &account, &leaf.id).await);
+	})
+	.await;
+}
+
+async fn additions(index: &Index, late: bool) {
+	// Two directory roots reach the same account through a shared middle directory.
+	let leaf = super::directory(&[]);
+	let middle = super::directory(&[("leaf", leaf.id.clone())]);
+	let first = super::directory(&[("first", middle.id.clone())]);
+	let second = super::directory(&[("second", middle.id.clone())]);
+	super::put(
+		index,
+		vec![leaf.clone(), middle.clone(), first.clone(), second.clone()],
+	)
+	.await;
+	super::drain(index).await;
+	let account = crate::usage::Account::User(tg::user::Id::new());
+	associate(index, &account, &first.id, 0).await;
+	let old = queue(index).await.pop().unwrap();
+	let old_version = version(&old).clone();
+	if !late {
+		step(index, &old).await;
+	}
+	let cutoff = index.get_transaction_id().await.unwrap();
+	associate(index, &account, &second.id, i64::from(late)).await;
+	let entries = queue(index).await;
+	let newer = entries.iter().find(|key| item(key) == &second.id).unwrap();
+	assert!(u64::from_be_bytes(version(newer).as_bytes()[..8].try_into().unwrap()) > cutoff);
+	step(index, newer).await;
+	let entries = queue(index).await;
+	let newer = entries
+		.iter()
+		.filter(|key| item(key) == &middle.id)
+		.max_by_key(|key| version(key))
+		.unwrap();
+	step(index, newer).await;
+	if late {
+		step(index, &old).await;
+	}
+	let entries = queue(index).await;
+	let old = entries.iter().find(|key| matches!(key, Key::UpdateVersion { kind: Kind::Storage(StorageKind::Add { .. }), version: value, .. } if *value == old_version)).unwrap();
+	step(index, old).await;
+	assert!(!associated(index, &account, &leaf.id).await);
+	let oldest = index
+		.try_get_oldest_update_transaction_id(crate::update::Kind::Storage)
+		.await
+		.unwrap();
+	assert!(
+		oldest.is_some_and(|version| version <= cutoff),
+		"the storage wait lost its pending descendants: {oldest:?} > {cutoff}"
+	);
+	drain(index).await;
+	assert!(associated(index, &account, &leaf.id).await);
+
+	// A repeated old addition must stop without walking the descendants again.
+	enqueue(
+		index,
+		&middle.id,
+		&Kind::Storage(StorageKind::Add {
+			account: account.clone(),
+			touched_at: 0,
+		}),
+		Some(&old_version),
+	)
+	.await;
+	let entry = queue(index).await.pop().unwrap();
+	step(index, &entry).await;
+	assert!(queue(index).await.is_empty());
+
+	// Collect the account associations while retaining the cached objects.
+	let ids = [leaf.id.clone(), middle.id, first.id.clone(), second.id];
+	index
+		.touch_objects_with_account(&ids, None, 100, std::time::Duration::ZERO)
+		.await
+		.unwrap();
+	let arg = crate::clean::Arg {
+		batch_size: 100,
+		max_object_touched_at: 1,
+		max_process_touched_at: 1,
+		max_sandbox_touched_at: 1,
+		now: 1,
+		partition_end: 2,
+		partition_start: 0,
+	};
+	for _ in 0..20 {
+		let done = index.clean(arg.clone()).await.unwrap().done;
+		drain(index).await;
+		if done && !associated(index, &account, &leaf.id).await {
+			break;
+		}
+	}
+	assert!(
+		index
+			.try_get_objects(&ids)
+			.await
+			.unwrap()
+			.iter()
+			.all(Option::is_some)
+	);
+	for id in &ids {
+		assert!(!associated(index, &account, id).await);
+		let account = &account;
+		crate::fdb::run(&index.database, |txn| async move {
+			for key in [
+				Key::StorageAddition {
+					account: account.clone(),
+					id: tg::Either::Left(id.clone()),
+				},
+				Key::StoragePropagation {
+					account: account.clone(),
+					id: tg::Either::Left(id.clone()),
+				},
+			] {
+				let value = crate::fdb::propagate!(
+					Index::try_get_propagation_version(&txn, &index.subspace, &key).await
+				);
+				assert!(value.is_none());
+			}
+			Ok(ControlFlow::Break(()))
+		})
+		.await
+		.unwrap();
+	}
+	associate(index, &account, &first.id, 2).await;
+	drain(index).await;
+	assert!(associated(index, &account, &leaf.id).await);
+}
+
+async fn pages(index: &Index) {
+	let leaf = super::directory(&[]);
+	let children = (0..12)
+		.map(|i| super::directory(&[(&format!("leaf_{i}"), leaf.id.clone())]))
+		.collect::<Vec<_>>();
+	let entries = children
+		.iter()
+		.enumerate()
+		.map(|(i, child)| (format!("child_{i}"), child.id.clone()))
+		.collect::<Vec<_>>();
+	let entries = entries
+		.iter()
+		.map(|(name, id)| (name.as_str(), id.clone()))
+		.collect::<Vec<_>>();
+	let middle = super::directory(&entries);
+	let objects = children
+		.iter()
+		.cloned()
+		.chain([leaf, middle.clone()])
+		.collect();
+	super::put(index, objects).await;
+	super::drain(index).await;
+	let account = crate::usage::Account::User(tg::user::Id::new());
+	associate(index, &account, &middle.id, 0).await;
+	let old = queue(index).await.pop().unwrap();
+	let cutoff = index.get_transaction_id().await.unwrap();
+	let kind = Kind::Storage(StorageKind::Propagate {
+		account: account.clone(),
+		touched_at: 0,
+	});
+	enqueue(index, &middle.id, &kind, None).await;
+	let entries = queue(index).await;
+	let newer = entries.iter().max_by_key(|key| version(key)).unwrap();
+	assert!(version(newer) > version(&old));
+	step(index, newer).await;
+	let entries = queue(index).await;
+	let first_child = entries.iter().find(|key| item(key) != &middle.id).unwrap();
+	let first_child = item(first_child).clone();
+	step(index, &old).await;
+	let entries = queue(index).await;
+	assert!(
+		entries
+			.iter()
+			.any(|key| item(key) == &first_child && version(key) == version(&old)),
+		"the older traversal skipped the page already visited by the newer traversal"
+	);
+	let oldest = index
+		.try_get_oldest_update_transaction_id(crate::update::Kind::Storage)
+		.await
+		.unwrap();
+	assert!(oldest.is_some_and(|version| version <= cutoff));
+	// A newer queue marker must finish the remaining page at the older cursor version.
+	step(index, newer).await;
+	let entries = queue(index).await;
+	for child in &children {
+		assert!(
+			entries
+				.iter()
+				.any(|key| item(key) == &child.id && version(key) == version(&old))
+		);
+	}
+	drain(index).await;
+	for child in children {
+		assert!(associated(index, &account, &child.id).await);
+	}
+}
+
+async fn associate(
+	index: &Index,
+	account: &crate::usage::Account,
+	object: &tg::object::Id,
+	touched_at: i64,
+) {
+	let arg = crate::usage::storage::put::ObjectArg {
+		account: account.clone(),
+		object: object.clone(),
+		touched_at,
+	};
+	let arg = crate::batch::Arg {
+		items: vec![crate::batch::Item::PutAccountObject(arg)],
+	};
+	index.batch(arg).await.unwrap();
+}
+
+async fn associated(
+	index: &Index,
+	account: &crate::usage::Account,
+	object: &tg::object::Id,
+) -> bool {
+	crate::fdb::run(&index.database, |txn| async move {
+		let key = crate::fdb::Key::Usage(crate::fdb::usage::Key::AccountObject {
+			account: account.clone(),
+			object: object.clone(),
+		});
+		let result = txn.get(&Index::pack(&index.subspace, &key), false).await;
+		let value = crate::fdb::retry!(result);
+		Ok(ControlFlow::Break(value.is_some()))
+	})
+	.await
+	.unwrap()
+}
+
+async fn enqueue(
+	index: &Index,
+	object: &tg::object::Id,
+	kind: &Kind,
+	version: Option<&fdbt::Versionstamp>,
+) {
+	crate::fdb::run(&index.database, |txn| async move {
+		Index::enqueue_update_with_kind_at_version(
+			&txn,
+			&index.subspace,
+			&tg::Either::Left(object.clone()),
+			kind,
+			crate::fdb::update::Source::Put,
+			2,
+			version,
+		);
+		Ok(ControlFlow::Break(()))
+	})
+	.await
+	.unwrap();
+}
+
+async fn step(index: &Index, selected: &Key) {
+	// Fix the partition assignment while keeping every real commit versionstamp intact.
+	let entries = queue(index).await;
+	crate::fdb::run(&index.database, |txn| {
+		let entries = &entries;
+		async move {
+			for entry in entries {
+				let Key::UpdateVersion {
+					id, kind, version, ..
+				} = entry
+				else {
+					unreachable!()
+				};
+				let selected = item(entry) == item(selected)
+					&& version == self::version(selected)
+					&& matches!(selected, Key::UpdateVersion { kind: selected_kind, .. } if kind == selected_kind);
+				txn.clear(&Index::pack(
+					&index.subspace,
+					&crate::fdb::Key::Update(entry.clone()),
+				));
+				let key = Key::UpdateVersion {
+					id: id.clone(),
+					kind: kind.clone(),
+					partition: u64::from(!selected),
+					version: version.clone(),
+				};
+				txn.set(
+					&Index::pack(&index.subspace, &crate::fdb::Key::Update(key)),
+					&[],
+				);
+			}
+			Ok(ControlFlow::Break(()))
+		}
+	})
+	.await
+	.unwrap();
+	assert_eq!(
+		index
+			.update_batch(crate::update::Kind::Storage, 1, 0, 1)
+			.await
+			.unwrap()
+			.count,
+		1
+	);
+}
+
+async fn drain(index: &Index) {
+	for _ in 0..100 {
+		if index
+			.update_batch(crate::update::Kind::Storage, 100, 0, 2)
+			.await
+			.unwrap()
+			.count == 0
+		{
+			return;
+		}
+	}
+	panic!("the storage updates did not drain");
+}
+
+async fn queue(index: &Index) -> Vec<Key> {
+	crate::fdb::run(&index.database, |txn| async move {
+		let begin = Index::pack(&index.subspace, &(63i32,));
+		let end = Index::pack(&index.subspace, &(64i32,));
+		let range = fdb::RangeOption::from((begin.as_slice(), end.as_slice()));
+		let result = txn.get_range(&range, 1, false).await;
+		let entries = crate::fdb::retry!(result);
+		let entries = entries
+			.iter()
+			.map(|entry| {
+				let crate::fdb::Key::Update(key) = Index::unpack(&index.subspace, entry.key())?
+				else {
+					unreachable!()
+				};
+				Ok(key)
+			})
+			.collect::<tg::Result<Vec<_>>>()?;
+		Ok(ControlFlow::Break(entries))
+	})
+	.await
+	.unwrap()
+}
+
+fn item(key: &Key) -> &tg::object::Id {
+	let Key::UpdateVersion {
+		id: tg::Either::Left(id),
+		..
+	} = key
+	else {
+		unreachable!()
+	};
+	id
+}
+
+fn version(key: &Key) -> &fdbt::Versionstamp {
+	let Key::UpdateVersion { version, .. } = key else {
+		unreachable!()
+	};
+	version
+}

--- a/packages/index/src/fdb/usage/storage/clean.rs
+++ b/packages/index/src/fdb/usage/storage/clean.rs
@@ -399,7 +399,12 @@ impl Index {
 			object: object.clone(),
 		});
 		txn.clear(&Self::pack(subspace, &key));
-		Self::clear_storage_propagations(txn, subspace, &tg::Either::Left(object.clone()), account);
+		Self::clear_storage_update_versions(
+			txn,
+			subspace,
+			&tg::Either::Left(object.clone()),
+			account,
+		);
 		let usage_partition = rand::random_range(0..usage_partition_total);
 		Self::add_usage_delta(
 			txn,
@@ -466,7 +471,7 @@ impl Index {
 			process: process.clone(),
 		});
 		txn.clear(&Self::pack(subspace, &key));
-		Self::clear_storage_propagations(
+		Self::clear_storage_update_versions(
 			txn,
 			subspace,
 			&tg::Either::Right(process.clone()),

--- a/packages/index/src/fdb/usage/storage/clean.rs
+++ b/packages/index/src/fdb/usage/storage/clean.rs
@@ -399,6 +399,7 @@ impl Index {
 			object: object.clone(),
 		});
 		txn.clear(&Self::pack(subspace, &key));
+		Self::clear_storage_propagations(txn, subspace, &tg::Either::Left(object.clone()), account);
 		let usage_partition = rand::random_range(0..usage_partition_total);
 		Self::add_usage_delta(
 			txn,
@@ -465,6 +466,12 @@ impl Index {
 			process: process.clone(),
 		});
 		txn.clear(&Self::pack(subspace, &key));
+		Self::clear_storage_propagations(
+			txn,
+			subspace,
+			&tg::Either::Right(process.clone()),
+			account,
+		);
 		let usage_partition = rand::random_range(0..usage_partition_total);
 		Self::add_usage_delta(
 			txn,

--- a/packages/index/src/fdb/usage/storage/put.rs
+++ b/packages/index/src/fdb/usage/storage/put.rs
@@ -110,7 +110,7 @@ impl Index {
 				txn,
 				subspace,
 				&tg::Either::Left(object.clone()),
-				&crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Add {
+				&crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Put {
 					account,
 					touched_at,
 				}),
@@ -161,7 +161,7 @@ impl Index {
 				txn,
 				subspace,
 				&tg::Either::Right(process.clone()),
-				&crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Add {
+				&crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Put {
 					account,
 					touched_at,
 				}),
@@ -489,7 +489,7 @@ impl Index {
 	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
 		if let Some(version) = version {
 			let lowered = crate::fdb::propagate!(
-				Self::lower_storage_addition_version(txn, subspace, id, account, version).await
+				Self::lower_storage_update_put_version(txn, subspace, id, account, version).await
 			);
 			if !lowered {
 				return Ok(ControlFlow::Break(()));

--- a/packages/index/src/fdb/usage/storage/put.rs
+++ b/packages/index/src/fdb/usage/storage/put.rs
@@ -314,6 +314,20 @@ impl Index {
 				txn.set(&entry_key, &value);
 				Self::put_account_object_clean_key(txn, subspace, arg, partition_total);
 			}
+			if let Some(version) = version {
+				crate::fdb::propagate!(
+					Self::propagate_account_storage(
+						txn,
+						subspace,
+						&tg::Either::Left(arg.object.clone()),
+						&arg.account,
+						arg.touched_at,
+						partition_total,
+						Some(version)
+					)
+					.await
+				);
+			}
 			return Ok(ControlFlow::Break(false));
 		}
 
@@ -360,17 +374,17 @@ impl Index {
 			usage_partition,
 		);
 
-		Self::enqueue_update_with_kind_at_version(
-			txn,
-			subspace,
-			&tg::Either::Left(arg.object.clone()),
-			&crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Propagate {
-				account: arg.account.clone(),
-				touched_at: arg.touched_at,
-			}),
-			crate::fdb::update::Source::Put,
-			partition_total,
-			version,
+		crate::fdb::propagate!(
+			Self::propagate_account_storage(
+				txn,
+				subspace,
+				&tg::Either::Left(arg.object.clone()),
+				&arg.account,
+				arg.touched_at,
+				partition_total,
+				version
+			)
+			.await
 		);
 
 		Ok(ControlFlow::Break(true))
@@ -398,6 +412,20 @@ impl Index {
 				let value = entry.serialize()?;
 				txn.set(&entry_key, &value);
 				Self::put_account_process_clean_key(txn, subspace, arg, partition_total);
+			}
+			if let Some(version) = version {
+				crate::fdb::propagate!(
+					Self::propagate_account_storage(
+						txn,
+						subspace,
+						&tg::Either::Right(arg.process.clone()),
+						&arg.account,
+						arg.touched_at,
+						partition_total,
+						Some(version)
+					)
+					.await
+				);
 			}
 			return Ok(ControlFlow::Break(false));
 		}
@@ -434,20 +462,53 @@ impl Index {
 			usage_partition,
 		);
 
+		crate::fdb::propagate!(
+			Self::propagate_account_storage(
+				txn,
+				subspace,
+				&tg::Either::Right(arg.process.clone()),
+				&arg.account,
+				arg.touched_at,
+				partition_total,
+				version
+			)
+			.await
+		);
+
+		Ok(ControlFlow::Break(true))
+	}
+
+	async fn propagate_account_storage(
+		txn: &crate::fdb::Transaction,
+		subspace: &fdbt::Subspace,
+		id: &tg::Either<tg::object::Id, tg::process::Id>,
+		account: &crate::usage::Account,
+		touched_at: i64,
+		partition_total: u64,
+		version: Option<&fdbt::Versionstamp>,
+	) -> tg::Result<ControlFlow<(), fdb::FdbError>> {
+		if let Some(version) = version {
+			let lowered = crate::fdb::propagate!(
+				Self::lower_storage_addition_version(txn, subspace, id, account, version).await
+			);
+			if !lowered {
+				return Ok(ControlFlow::Break(()));
+			}
+		}
+		let kind = crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Propagate {
+			account: account.clone(),
+			touched_at,
+		});
 		Self::enqueue_update_with_kind_at_version(
 			txn,
 			subspace,
-			&tg::Either::Right(arg.process.clone()),
-			&crate::fdb::update::Kind::Storage(crate::fdb::update::StorageKind::Propagate {
-				account: arg.account.clone(),
-				touched_at: arg.touched_at,
-			}),
+			id,
+			&kind,
 			crate::fdb::update::Source::Put,
 			partition_total,
 			version,
 		);
-
-		Ok(ControlFlow::Break(true))
+		Ok(ControlFlow::Break(()))
 	}
 
 	fn put_account_object_clean_key(

--- a/packages/index/src/lmdb/key.rs
+++ b/packages/index/src/lmdb/key.rs
@@ -83,7 +83,7 @@ pub enum Kind {
 	UsageUnavailable = 65,
 	GrantUpdatePropagatedVersion = 66,
 	NodeUpdatePropagatedVersion = 67,
-	StorageAddition = 68,
+	StorageUpdatePutVersion = 68,
 	GrantUpdateClean = 71,
 	NodeUpdateClean = 72,
 }
@@ -561,13 +561,13 @@ impl fdbt::TuplePack for Key {
 				Ok(offset)
 			},
 
-			Key::Update(crate::lmdb::update::Key::StorageAddition { account, id }) => {
+			Key::Update(crate::lmdb::update::Key::StorageUpdatePutVersion { account, id }) => {
 				let id = match id {
 					tg::Either::Left(id) => id.to_bytes(),
 					tg::Either::Right(id) => id.to_bytes(),
 				};
 				(
-					Kind::StorageAddition.to_i32().unwrap(),
+					Kind::StorageUpdatePutVersion.to_i32().unwrap(),
 					id.as_ref(),
 					account.id().to_bytes().as_ref(),
 				)
@@ -1471,7 +1471,7 @@ impl fdbt::TupleUnpack<'_> for Key {
 				Ok((input, key))
 			},
 
-			Kind::StorageAddition => {
+			Kind::StorageUpdatePutVersion => {
 				let (input, id): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
 				let id = tg::Id::from_slice(&id)
 					.map_err(|_| fdbt::PackError::Message("invalid id".into()))?;
@@ -1487,7 +1487,7 @@ impl fdbt::TupleUnpack<'_> for Key {
 					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
 				let account = crate::usage::Account::try_from(account)
 					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
-				let key = crate::lmdb::update::Key::StorageAddition { account, id };
+				let key = crate::lmdb::update::Key::StorageUpdatePutVersion { account, id };
 				Ok((input, Key::Update(key)))
 			},
 
@@ -1580,15 +1580,6 @@ fn pack_update_kind<W: std::io::Write>(
 		crate::lmdb::update::Kind::Grant(subject) => subject.to_string().pack(w, tuple_depth),
 		crate::lmdb::update::Kind::Node => ().pack(w, tuple_depth),
 		crate::lmdb::update::Kind::Storage(kind) => match kind {
-			crate::lmdb::update::StorageKind::Add {
-				account,
-				touched_at,
-			} => {
-				let mut offset = 0i32.pack(w, tuple_depth)?;
-				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
-				offset += touched_at.pack(w, tuple_depth)?;
-				Ok(offset)
-			},
 			crate::lmdb::update::StorageKind::Clean(account) => {
 				let mut offset = 1i32.pack(w, tuple_depth)?;
 				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
@@ -1600,6 +1591,15 @@ fn pack_update_kind<W: std::io::Write>(
 				touched_at,
 			} => {
 				let mut offset = 3i32.pack(w, tuple_depth)?;
+				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
+				offset += touched_at.pack(w, tuple_depth)?;
+				Ok(offset)
+			},
+			crate::lmdb::update::StorageKind::Put {
+				account,
+				touched_at,
+			} => {
+				let mut offset = 0i32.pack(w, tuple_depth)?;
 				offset += account.id().to_bytes().as_ref().pack(w, tuple_depth)?;
 				offset += touched_at.pack(w, tuple_depth)?;
 				Ok(offset)
@@ -1635,7 +1635,7 @@ fn unpack_update_kind(
 					let account = crate::usage::Account::try_from(account)
 						.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
 					let kind = match kind {
-						0 => crate::lmdb::update::StorageKind::Add {
+						0 => crate::lmdb::update::StorageKind::Put {
 							account,
 							touched_at,
 						},

--- a/packages/index/src/lmdb/key.rs
+++ b/packages/index/src/lmdb/key.rs
@@ -83,6 +83,7 @@ pub enum Kind {
 	UsageUnavailable = 65,
 	GrantUpdatePropagatedVersion = 66,
 	NodeUpdatePropagatedVersion = 67,
+	StorageAddition = 68,
 	GrantUpdateClean = 71,
 	NodeUpdateClean = 72,
 }
@@ -558,6 +559,19 @@ impl fdbt::TuplePack for Key {
 				let mut offset = id.as_ref().pack(w, tuple_depth)?;
 				offset += pack_update_kind(w, tuple_depth, kind)?;
 				Ok(offset)
+			},
+
+			Key::Update(crate::lmdb::update::Key::StorageAddition { account, id }) => {
+				let id = match id {
+					tg::Either::Left(id) => id.to_bytes(),
+					tg::Either::Right(id) => id.to_bytes(),
+				};
+				(
+					Kind::StorageAddition.to_i32().unwrap(),
+					id.as_ref(),
+					account.id().to_bytes().as_ref(),
+				)
+					.pack(w, tuple_depth)
 			},
 
 			Key::Update(crate::lmdb::update::Key::Update { id, kind }) => {
@@ -1455,6 +1469,26 @@ impl fdbt::TupleUnpack<'_> for Key {
 					.map_err(|_| fdbt::PackError::Message("invalid process id".into()))?;
 				let key = Key::LogCompaction(crate::lmdb::log::Key::Version { process, version });
 				Ok((input, key))
+			},
+
+			Kind::StorageAddition => {
+				let (input, id): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
+				let id = tg::Id::from_slice(&id)
+					.map_err(|_| fdbt::PackError::Message("invalid id".into()))?;
+				let id = if let Ok(id) = tg::process::Id::try_from(id.clone()) {
+					tg::Either::Right(id)
+				} else if let Ok(id) = tg::object::Id::try_from(id) {
+					tg::Either::Left(id)
+				} else {
+					return Err(fdbt::PackError::Message("invalid id".into()));
+				};
+				let (input, account): (_, Vec<u8>) = fdbt::TupleUnpack::unpack(input, tuple_depth)?;
+				let account = tg::Id::from_slice(&account)
+					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
+				let account = crate::usage::Account::try_from(account)
+					.map_err(|_| fdbt::PackError::Message("invalid usage account".into()))?;
+				let key = crate::lmdb::update::Key::StorageAddition { account, id };
+				Ok((input, Key::Update(key)))
 			},
 
 			Kind::GrantUpdatePropagatedVersion | Kind::NodeUpdatePropagatedVersion => {

--- a/packages/index/src/lmdb/tests/update.rs
+++ b/packages/index/src/lmdb/tests/update.rs
@@ -266,7 +266,7 @@ async fn separates_update_queues() {
 		&index.subspace,
 		&mut transaction,
 		id,
-		super::super::update::Kind::Storage(super::super::update::StorageKind::Add {
+		super::super::update::Kind::Storage(super::super::update::StorageKind::Put {
 			account: crate::usage::Account::User(user),
 			touched_at: 0,
 		}),

--- a/packages/index/src/lmdb/tests/versions.rs
+++ b/packages/index/src/lmdb/tests/versions.rs
@@ -61,6 +61,125 @@ async fn a_batch_preserves_an_older_propagation_when_combining_updates() {
 }
 
 #[tokio::test]
+async fn a_batch_preserves_an_older_storage_propagation_when_combining_updates() {
+	let (_dir, index) = super::new_index();
+	let bottom = object(0, []);
+	let leaf = object(1, [bottom.id.clone()]);
+	let middle = object(2, [leaf.id.clone()]);
+	let first = object(3, [middle.id.clone()]);
+	let second = object(4, [leaf.id.clone()]);
+	put(
+		&index,
+		vec![bottom.clone(), leaf, middle, first.clone(), second.clone()],
+	)
+	.await;
+	drain(&index, crate::update::Kind::Node).await;
+	let account = crate::usage::Account::User(tg::user::Id::new());
+	associate(&index, &account, &first.id).await;
+	let cutoff = index.get_transaction_id().await.unwrap();
+	associate(&index, &account, &second.id).await;
+	assert_eq!(
+		index
+			.update_batch(crate::update::Kind::Storage, 2)
+			.await
+			.unwrap()
+			.count,
+		2
+	);
+	let oldest = index
+		.try_get_oldest_update_transaction_id(crate::update::Kind::Storage)
+		.await
+		.unwrap();
+	assert!(
+		oldest.is_some_and(|version| version <= cutoff),
+		"the storage wait lost its pending descendants: {oldest:?} > {cutoff}"
+	);
+	assert!(!associated(&index, &account, &bottom.id));
+	drain(&index, crate::update::Kind::Storage).await;
+	assert!(associated(&index, &account, &bottom.id));
+}
+
+#[tokio::test]
+async fn late_storage_additions_preserve_the_oldest_version() {
+	let (_dir, index) = super::new_index();
+	let leaf = object(0, []);
+	let middle = object(1, [leaf.id.clone()]);
+	let top = object(2, [middle.id.clone()]);
+	put(&index, vec![leaf.clone(), middle.clone(), top.clone()]).await;
+	drain(&index, crate::update::Kind::Node).await;
+	let account = crate::usage::Account::User(tg::user::Id::new());
+	associate(&index, &account, &top.id).await;
+	let cutoff = index.get_transaction_id().await.unwrap();
+	associate(&index, &account, &middle.id).await;
+	assert_eq!(
+		index
+			.update_batch(crate::update::Kind::Storage, 1)
+			.await
+			.unwrap()
+			.count,
+		1
+	);
+	let oldest = index
+		.try_get_oldest_update_transaction_id(crate::update::Kind::Storage)
+		.await
+		.unwrap();
+	assert!(
+		oldest.is_some_and(|version| version <= cutoff),
+		"the late storage addition lost its pending descendants: {oldest:?} > {cutoff}"
+	);
+	assert!(!associated(&index, &account, &leaf.id));
+	drain(&index, crate::update::Kind::Storage).await;
+	assert!(associated(&index, &account, &leaf.id));
+
+	// Collection removes the retained versions without evicting the cached objects.
+	let ids = [leaf.id.clone(), middle.id, top.id.clone()];
+	index
+		.touch_objects_with_account(&ids, None, 100, std::time::Duration::ZERO)
+		.await
+		.unwrap();
+	let arg = crate::clean::Arg {
+		batch_size: 100,
+		max_object_touched_at: 0,
+		max_process_touched_at: 0,
+		max_sandbox_touched_at: 0,
+		now: 1,
+		partition_end: 1,
+		partition_start: 0,
+	};
+	for _ in 0..20 {
+		if index.clean(arg.clone()).await.unwrap().done {
+			break;
+		}
+	}
+	assert!(
+		index
+			.try_get_objects(&ids)
+			.await
+			.unwrap()
+			.iter()
+			.all(Option::is_some)
+	);
+	for id in &ids {
+		assert!(!associated(&index, &account, id));
+		let transaction = index.env.read_txn().unwrap();
+		let key = Key::Update(super::super::update::Key::StorageAddition {
+			account: account.clone(),
+			id: tg::Either::Left(id.clone()),
+		});
+		assert!(
+			index
+				.db
+				.get(&transaction, &Index::pack(&index.subspace, &key))
+				.unwrap()
+				.is_none()
+		);
+	}
+	associate(&index, &account, &top.id).await;
+	drain(&index, crate::update::Kind::Storage).await;
+	assert!(associated(&index, &account, &leaf.id));
+}
+
+#[tokio::test]
 async fn propagation_versions_reset_and_repeated_updates_stop() {
 	let (_dir, index) = super::new_index();
 	let child = object(0, []);
@@ -175,6 +294,31 @@ async fn put(index: &Index, objects: Vec<crate::object::put::Arg>) {
 		.collect();
 	let arg = crate::batch::Arg { items };
 	index.batch(arg).await.unwrap();
+}
+
+async fn associate(index: &Index, account: &crate::usage::Account, object: &tg::object::Id) {
+	let arg = crate::usage::storage::put::ObjectArg {
+		account: account.clone(),
+		object: object.clone(),
+		touched_at: 0,
+	};
+	let arg = crate::batch::Arg {
+		items: vec![crate::batch::Item::PutAccountObject(arg)],
+	};
+	index.batch(arg).await.unwrap();
+}
+
+fn associated(index: &Index, account: &crate::usage::Account, object: &tg::object::Id) -> bool {
+	let transaction = index.env.read_txn().unwrap();
+	let key = Key::Usage(super::super::usage::Key::AccountObject {
+		account: account.clone(),
+		object: object.clone(),
+	});
+	index
+		.db
+		.get(&transaction, &Index::pack(&index.subspace, &key))
+		.unwrap()
+		.is_some()
 }
 
 async fn drain(index: &Index, kind: crate::update::Kind) {

--- a/packages/index/src/lmdb/tests/versions.rs
+++ b/packages/index/src/lmdb/tests/versions.rs
@@ -100,7 +100,7 @@ async fn a_batch_preserves_an_older_storage_propagation_when_combining_updates()
 }
 
 #[tokio::test]
-async fn late_storage_additions_preserve_the_oldest_version() {
+async fn late_storage_puts_preserve_the_oldest_version() {
 	let (_dir, index) = super::new_index();
 	let leaf = object(0, []);
 	let middle = object(1, [leaf.id.clone()]);
@@ -125,7 +125,7 @@ async fn late_storage_additions_preserve_the_oldest_version() {
 		.unwrap();
 	assert!(
 		oldest.is_some_and(|version| version <= cutoff),
-		"the late storage addition lost its pending descendants: {oldest:?} > {cutoff}"
+		"the late storage put lost its pending descendants: {oldest:?} > {cutoff}"
 	);
 	assert!(!associated(&index, &account, &leaf.id));
 	drain(&index, crate::update::Kind::Storage).await;
@@ -162,7 +162,7 @@ async fn late_storage_additions_preserve_the_oldest_version() {
 	for id in &ids {
 		assert!(!associated(&index, &account, id));
 		let transaction = index.env.read_txn().unwrap();
-		let key = Key::Update(super::super::update::Key::StorageAddition {
+		let key = Key::Update(super::super::update::Key::StorageUpdatePutVersion {
 			account: account.clone(),
 			id: tg::Either::Left(id.clone()),
 		});

--- a/packages/index/src/lmdb/update.rs
+++ b/packages/index/src/lmdb/update.rs
@@ -33,7 +33,10 @@ pub(super) struct NodeUpdate {
 #[derive(
 	Clone, Debug, Eq, PartialEq, tangram_serialize::Deserialize, tangram_serialize::Serialize,
 )]
-pub(super) struct StorageUpdate {}
+pub(super) struct StorageUpdate {
+	#[tangram_serialize(id = 0)]
+	pub version: u64,
+}
 
 #[derive(
 	Clone, Copy, Debug, Eq, PartialEq, tangram_serialize::Deserialize, tangram_serialize::Serialize,
@@ -106,8 +109,8 @@ impl NodeUpdate {
 }
 
 impl StorageUpdate {
-	pub fn new() -> Self {
-		Self {}
+	pub fn new(version: u64) -> Self {
+		Self { version }
 	}
 
 	pub fn serialize(&self) -> tg::Result<Vec<u8>> {
@@ -196,19 +199,19 @@ impl Index {
 					.map_err(|error| tg::error!(!error, "failed to read update version entry"))?;
 				let key = Self::unpack(subspace, key)?;
 				let crate::lmdb::Key::Update(crate::lmdb::update::Key::UpdateVersion {
-					version,
 					id,
 					kind,
+					..
 				}) = key
 				else {
 					return Err(tg::error!("unexpected key type"));
 				};
-				Ok((version, id, kind))
+				Ok((id, kind))
 			})
 			.collect::<tg::Result<Vec<_>>>()?;
 
 		let mut output = crate::update::Output::default();
-		for (version, id, kind) in entries {
+		for (id, kind) in entries {
 			let key = crate::lmdb::Key::Update(crate::lmdb::update::Key::Update {
 				id: id.clone(),
 				kind: kind.clone(),
@@ -226,8 +229,8 @@ impl Index {
 					(Some(source), version)
 				},
 				Kind::Storage(_) => {
-					StorageUpdate::deserialize(value)?;
-					(None, version)
+					let update = StorageUpdate::deserialize(value)?;
+					(None, update.version)
 				},
 			};
 
@@ -1932,10 +1935,10 @@ impl Index {
 			.get(transaction, &key)
 			.map_err(|error| tg::error!(!error, "failed to get update key"))?
 		{
-			if matches!(kind, Kind::Storage(_)) {
-				return Ok(());
-			}
-			let (existing_source, existing_version) = deserialize_source_update(&kind, existing)?;
+			let (existing_source, existing_version) = match &kind {
+				Kind::Grant(_) | Kind::Node => deserialize_source_update(&kind, existing)?,
+				Kind::Storage(_) => (source, StorageUpdate::deserialize(existing)?.version),
+			};
 			if existing_source == Source::Put {
 				source = Source::Put;
 			}
@@ -1969,6 +1972,54 @@ impl Index {
 		Ok(())
 	}
 
+	pub(super) fn lower_storage_addition_version(
+		db: &Db,
+		subspace: &fdbt::Subspace,
+		transaction: &mut lmdb::RwTxn<'_>,
+		id: &tg::Either<tg::object::Id, tg::process::Id>,
+		account: &crate::usage::Account,
+		version: u64,
+	) -> tg::Result<bool> {
+		let key = Key::StorageAddition {
+			account: account.clone(),
+			id: id.clone(),
+		};
+		let key = Self::pack(subspace, &crate::lmdb::Key::Update(key));
+		let previous = db
+			.get(transaction, &key)
+			.map_err(|error| tg::error!(!error, "failed to get the storage addition version"))?
+			.map(|bytes| bytes.try_into().map(u64::from_be_bytes))
+			.transpose()
+			.map_err(|error| {
+				tg::error!(!error, "failed to deserialize the storage addition version")
+			})?;
+		if previous.is_some_and(|previous| version >= previous) {
+			return Ok(false);
+		}
+		db.put(transaction, &key, &version.to_be_bytes())
+			.map_err(|error| tg::error!(!error, "failed to put the storage addition version"))?;
+		Ok(true)
+	}
+
+	pub(super) fn clear_storage_propagations(
+		db: &Db,
+		subspace: &fdbt::Subspace,
+		transaction: &mut lmdb::RwTxn<'_>,
+		id: &tg::Either<tg::object::Id, tg::process::Id>,
+		account: &crate::usage::Account,
+	) -> tg::Result<()> {
+		let key = Key::StorageAddition {
+			account: account.clone(),
+			id: id.clone(),
+		};
+		db.delete(
+			transaction,
+			&Self::pack(subspace, &crate::lmdb::Key::Update(key)),
+		)
+		.map_err(|error| tg::error!(!error, "failed to delete the storage addition version"))?;
+		Ok(())
+	}
+
 	pub(super) fn clear_update_propagated_versions(
 		db: &Db,
 		subspace: &fdbt::Subspace,
@@ -1978,6 +2029,7 @@ impl Index {
 		for kind in [
 			KeyKind::GrantUpdatePropagatedVersion,
 			KeyKind::NodeUpdatePropagatedVersion,
+			KeyKind::StorageAddition,
 		] {
 			let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), id));
 			let (_, end) = fdbt::Subspace::from_bytes(prefix.clone()).range();
@@ -2021,7 +2073,7 @@ fn serialize_update(kind: &Kind, source: Source, version: u64) -> tg::Result<Vec
 	let value = match kind {
 		Kind::Grant(_) => GrantUpdate::new(source, version).serialize()?,
 		Kind::Node => NodeUpdate::new(source, version).serialize()?,
-		Kind::Storage(_) => StorageUpdate::new().serialize()?,
+		Kind::Storage(_) => StorageUpdate::new(version).serialize()?,
 	};
 
 	Ok(value)

--- a/packages/index/src/lmdb/update.rs
+++ b/packages/index/src/lmdb/update.rs
@@ -262,7 +262,10 @@ impl Index {
 						process_output.changed
 					},
 				},
-				Kind::Storage(StorageKind::Add {
+				Kind::Storage(
+					StorageKind::Clean(_) | StorageKind::CleanAll | StorageKind::Propagate { .. },
+				) => return Err(tg::error!("unsupported LMDB storage update kind")),
+				Kind::Storage(StorageKind::Put {
 					account,
 					touched_at,
 				}) => match &id {
@@ -299,9 +302,6 @@ impl Index {
 						)
 					}?,
 				},
-				Kind::Storage(
-					StorageKind::Clean(_) | StorageKind::CleanAll | StorageKind::Propagate { .. },
-				) => return Err(tg::error!("unsupported LMDB storage update kind")),
 			};
 
 			if let Some(source) = source {
@@ -1972,7 +1972,7 @@ impl Index {
 		Ok(())
 	}
 
-	pub(super) fn lower_storage_addition_version(
+	pub(super) fn lower_storage_update_put_version(
 		db: &Db,
 		subspace: &fdbt::Subspace,
 		transaction: &mut lmdb::RwTxn<'_>,
@@ -1980,35 +1980,38 @@ impl Index {
 		account: &crate::usage::Account,
 		version: u64,
 	) -> tg::Result<bool> {
-		let key = Key::StorageAddition {
+		let key = Key::StorageUpdatePutVersion {
 			account: account.clone(),
 			id: id.clone(),
 		};
 		let key = Self::pack(subspace, &crate::lmdb::Key::Update(key));
 		let previous = db
 			.get(transaction, &key)
-			.map_err(|error| tg::error!(!error, "failed to get the storage addition version"))?
+			.map_err(|error| tg::error!(!error, "failed to get the storage update put version"))?
 			.map(|bytes| bytes.try_into().map(u64::from_be_bytes))
 			.transpose()
 			.map_err(|error| {
-				tg::error!(!error, "failed to deserialize the storage addition version")
+				tg::error!(
+					!error,
+					"failed to deserialize the storage update put version"
+				)
 			})?;
 		if previous.is_some_and(|previous| version >= previous) {
 			return Ok(false);
 		}
 		db.put(transaction, &key, &version.to_be_bytes())
-			.map_err(|error| tg::error!(!error, "failed to put the storage addition version"))?;
+			.map_err(|error| tg::error!(!error, "failed to put the storage update put version"))?;
 		Ok(true)
 	}
 
-	pub(super) fn clear_storage_propagations(
+	pub(super) fn clear_storage_update_versions(
 		db: &Db,
 		subspace: &fdbt::Subspace,
 		transaction: &mut lmdb::RwTxn<'_>,
 		id: &tg::Either<tg::object::Id, tg::process::Id>,
 		account: &crate::usage::Account,
 	) -> tg::Result<()> {
-		let key = Key::StorageAddition {
+		let key = Key::StorageUpdatePutVersion {
 			account: account.clone(),
 			id: id.clone(),
 		};
@@ -2016,7 +2019,7 @@ impl Index {
 			transaction,
 			&Self::pack(subspace, &crate::lmdb::Key::Update(key)),
 		)
-		.map_err(|error| tg::error!(!error, "failed to delete the storage addition version"))?;
+		.map_err(|error| tg::error!(!error, "failed to delete the storage update put version"))?;
 		Ok(())
 	}
 
@@ -2029,7 +2032,7 @@ impl Index {
 		for kind in [
 			KeyKind::GrantUpdatePropagatedVersion,
 			KeyKind::NodeUpdatePropagatedVersion,
-			KeyKind::StorageAddition,
+			KeyKind::StorageUpdatePutVersion,
 		] {
 			let prefix = Self::pack(subspace, &(kind.to_i32().unwrap(), id));
 			let (_, end) = fdbt::Subspace::from_bytes(prefix.clone()).range();

--- a/packages/index/src/lmdb/update/key.rs
+++ b/packages/index/src/lmdb/update/key.rs
@@ -15,6 +15,11 @@ pub enum Key {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,
 	},
+	// The oldest addition for an account association is independent of its touch timestamp.
+	StorageAddition {
+		account: crate::usage::Account,
+		id: tg::Either<tg::object::Id, tg::process::Id>,
+	},
 	Update {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,

--- a/packages/index/src/lmdb/update/key.rs
+++ b/packages/index/src/lmdb/update/key.rs
@@ -15,8 +15,8 @@ pub enum Key {
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 		kind: Kind,
 	},
-	// The oldest addition for an account association is independent of its touch timestamp.
-	StorageAddition {
+	/// The oldest put version for an account association is independent of its touch timestamp.
+	StorageUpdatePutVersion {
 		account: crate::usage::Account,
 		id: tg::Either<tg::object::Id, tg::process::Id>,
 	},
@@ -40,13 +40,13 @@ pub enum Kind {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageKind {
-	Add {
-		account: crate::usage::Account,
-		touched_at: i64,
-	},
 	Clean(crate::usage::Account),
 	CleanAll,
 	Propagate {
+		account: crate::usage::Account,
+		touched_at: i64,
+	},
+	Put {
 		account: crate::usage::Account,
 		touched_at: i64,
 	},

--- a/packages/index/src/lmdb/usage/storage/clean.rs
+++ b/packages/index/src/lmdb/usage/storage/clean.rs
@@ -393,6 +393,13 @@ impl Index {
 		});
 		db.delete(transaction, &Self::pack(subspace, &key))
 			.map_err(|error| tg::error!(!error, "failed to delete the object account"))?;
+		Self::clear_storage_propagations(
+			db,
+			subspace,
+			transaction,
+			&tg::Either::Left(object.clone()),
+			account,
+		)?;
 		let usage_partition = rand::random_range(0..usage_partition_total);
 		let entry = crate::usage::DeltaArg {
 			account,
@@ -468,6 +475,13 @@ impl Index {
 		});
 		db.delete(transaction, &Self::pack(subspace, &key))
 			.map_err(|error| tg::error!(!error, "failed to delete the process account"))?;
+		Self::clear_storage_propagations(
+			db,
+			subspace,
+			transaction,
+			&tg::Either::Right(process.clone()),
+			account,
+		)?;
 		let usage_partition = rand::random_range(0..usage_partition_total);
 		let entry = crate::usage::DeltaArg {
 			account,

--- a/packages/index/src/lmdb/usage/storage/clean.rs
+++ b/packages/index/src/lmdb/usage/storage/clean.rs
@@ -393,7 +393,7 @@ impl Index {
 		});
 		db.delete(transaction, &Self::pack(subspace, &key))
 			.map_err(|error| tg::error!(!error, "failed to delete the object account"))?;
-		Self::clear_storage_propagations(
+		Self::clear_storage_update_versions(
 			db,
 			subspace,
 			transaction,
@@ -475,7 +475,7 @@ impl Index {
 		});
 		db.delete(transaction, &Self::pack(subspace, &key))
 			.map_err(|error| tg::error!(!error, "failed to delete the process account"))?;
-		Self::clear_storage_propagations(
+		Self::clear_storage_update_versions(
 			db,
 			subspace,
 			transaction,

--- a/packages/index/src/lmdb/usage/storage/put.rs
+++ b/packages/index/src/lmdb/usage/storage/put.rs
@@ -330,6 +330,9 @@ impl Index {
 					.map_err(|error| tg::error!(!error, "failed to touch the account object"))?;
 				Self::put_account_object_clean_key(db, subspace, transaction, arg)?;
 			}
+			if let Some(version) = version {
+				Self::propagate_account_object(db, subspace, transaction, arg, version)?;
+			}
 			return Ok(false);
 		}
 
@@ -374,22 +377,8 @@ impl Index {
 		};
 		Self::add_usage_delta(db, subspace, transaction, entry)?;
 
-		let children =
-			Self::get_object_children_with_transaction(db, subspace, transaction, &arg.object)?;
-		for child in children {
-			Self::enqueue_update_with_kind(
-				db,
-				subspace,
-				transaction,
-				tg::Either::Left(child),
-				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
-					account: arg.account.clone(),
-					touched_at: arg.touched_at,
-				}),
-				crate::lmdb::update::Source::Put,
-				version,
-			)?;
-		}
+		let version = version.unwrap_or_else(|| transaction.id() as u64);
+		Self::propagate_account_object(db, subspace, transaction, arg, version)?;
 
 		Ok(true)
 	}
@@ -419,6 +408,9 @@ impl Index {
 				db.put(transaction, &entry_key, &value)
 					.map_err(|error| tg::error!(!error, "failed to touch the account process"))?;
 				Self::put_account_process_clean_key(db, subspace, transaction, arg)?;
+			}
+			if let Some(version) = version {
+				Self::propagate_account_process(db, subspace, transaction, arg, version)?;
 			}
 			return Ok(false);
 		}
@@ -455,6 +447,68 @@ impl Index {
 		};
 		Self::add_usage_delta(db, subspace, transaction, entry)?;
 
+		let version = version.unwrap_or_else(|| transaction.id() as u64);
+		Self::propagate_account_process(db, subspace, transaction, arg, version)?;
+
+		Ok(true)
+	}
+
+	fn propagate_account_object(
+		db: &Db,
+		subspace: &fdbt::Subspace,
+		transaction: &mut lmdb::RwTxn<'_>,
+		arg: &crate::usage::storage::put::ObjectArg,
+		version: u64,
+	) -> tg::Result<()> {
+		let id = tg::Either::Left(arg.object.clone());
+		if !Self::lower_storage_addition_version(
+			db,
+			subspace,
+			transaction,
+			&id,
+			&arg.account,
+			version,
+		)? {
+			return Ok(());
+		}
+		let children =
+			Self::get_object_children_with_transaction(db, subspace, transaction, &arg.object)?;
+		for child in children {
+			Self::enqueue_update_with_kind(
+				db,
+				subspace,
+				transaction,
+				tg::Either::Left(child),
+				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+					account: arg.account.clone(),
+					touched_at: arg.touched_at,
+				}),
+				crate::lmdb::update::Source::Put,
+				Some(version),
+			)?;
+		}
+
+		Ok(())
+	}
+
+	fn propagate_account_process(
+		db: &Db,
+		subspace: &fdbt::Subspace,
+		transaction: &mut lmdb::RwTxn<'_>,
+		arg: &crate::usage::storage::put::ProcessArg,
+		version: u64,
+	) -> tg::Result<()> {
+		let id = tg::Either::Right(arg.process.clone());
+		if !Self::lower_storage_addition_version(
+			db,
+			subspace,
+			transaction,
+			&id,
+			&arg.account,
+			version,
+		)? {
+			return Ok(());
+		}
 		let children =
 			Self::get_process_children_with_transaction(db, subspace, transaction, &arg.process)?;
 		for child in children {
@@ -468,7 +522,7 @@ impl Index {
 					touched_at: arg.touched_at,
 				}),
 				crate::lmdb::update::Source::Put,
-				version,
+				Some(version),
 			)?;
 		}
 		let objects =
@@ -484,11 +538,11 @@ impl Index {
 					touched_at: arg.touched_at,
 				}),
 				crate::lmdb::update::Source::Put,
-				version,
+				Some(version),
 			)?;
 		}
 
-		Ok(true)
+		Ok(())
 	}
 
 	#[allow(clippy::too_many_arguments)]

--- a/packages/index/src/lmdb/usage/storage/put.rs
+++ b/packages/index/src/lmdb/usage/storage/put.rs
@@ -111,7 +111,7 @@ impl Index {
 				subspace,
 				transaction,
 				tg::Either::Left(object.clone()),
-				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Put {
 					account,
 					touched_at,
 				}),
@@ -158,7 +158,7 @@ impl Index {
 				subspace,
 				transaction,
 				tg::Either::Right(process.clone()),
-				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Put {
 					account,
 					touched_at,
 				}),
@@ -210,7 +210,7 @@ impl Index {
 		let objects =
 			Self::get_process_objects_with_transaction(db, subspace, transaction, process)?;
 		for account in accounts {
-			let kind = crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+			let kind = crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Put {
 				account,
 				touched_at,
 			});
@@ -461,7 +461,7 @@ impl Index {
 		version: u64,
 	) -> tg::Result<()> {
 		let id = tg::Either::Left(arg.object.clone());
-		if !Self::lower_storage_addition_version(
+		if !Self::lower_storage_update_put_version(
 			db,
 			subspace,
 			transaction,
@@ -479,7 +479,7 @@ impl Index {
 				subspace,
 				transaction,
 				tg::Either::Left(child),
-				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Put {
 					account: arg.account.clone(),
 					touched_at: arg.touched_at,
 				}),
@@ -499,7 +499,7 @@ impl Index {
 		version: u64,
 	) -> tg::Result<()> {
 		let id = tg::Either::Right(arg.process.clone());
-		if !Self::lower_storage_addition_version(
+		if !Self::lower_storage_update_put_version(
 			db,
 			subspace,
 			transaction,
@@ -517,7 +517,7 @@ impl Index {
 				subspace,
 				transaction,
 				tg::Either::Right(child),
-				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Put {
 					account: arg.account.clone(),
 					touched_at: arg.touched_at,
 				}),
@@ -533,7 +533,7 @@ impl Index {
 				subspace,
 				transaction,
 				tg::Either::Left(object),
-				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Add {
+				crate::lmdb::update::Kind::Storage(crate::lmdb::update::StorageKind::Put {
 					account: arg.account.clone(),
 					touched_at: arg.touched_at,
 				}),


### PR DESCRIPTION
Storage accounting can lose an older propagation obligation when a newer update creates an account association first. The older update then becomes a no-op, leaving descendant accounting queued above the wait cutoff and allowing `tg index` to finish early.

Preserve the oldest `StorageKind::Put` version per account association using `StorageUpdatePutVersion` in both backends, and preserve the minimum pending version when LMDB combines storage updates. In FoundationDB, retain completed traversal versions using `StorageUpdatePropagatedVersion` and bind each pagination cursor to its propagation version so an older obligation revisits pages already processed under a newer version. Repeated puts stop once covered, and collection removes the retained state.

Stacked on #1124. The base branch isolates this PR to the storage-accounting fix; merge #1124 first, then retarget this PR to `main`.

Validation:

- Added six storage regressions across FoundationDB and LMDB. Five were verified failing before the fix; all six pass. Coverage includes coalescing, late arrivals, completed and paginated traversals, interleaved queue markers, repeated puts, and collection followed by re-association.
- All 145 index tests passed, including the FoundationDB tests with `FDB_CLUSTER_FILE` and `--include-ignored`.
- All 40 CLI index/clean tests passed with `--no-cloud`.
- `bun run check` and `bun run format` passed.
