### PR TITLE
fix process field permissions on object subtrees

### DIFF
--- a/packages/cli/tests/grants/process_node_output_covers_object_subtree.nu
+++ b/packages/cli/tests/grants/process_node_output_covers_object_subtree.nu
@@ -1,0 +1,44 @@
+use ../../test.nu *
+
+# Node output permissions cover this process's object subtrees, not child processes' outputs.
+
+let server = server spawn --config { authentication: { users: { providers: { insecure: true } } } }
+let alice = tg login --verbose --name alice | from json
+let eve = tg login --verbose --name eve | from json
+
+# Alice builds a parent and child with distinct output object subtrees.
+let path = artifact {
+	tangram.ts: '
+		export default async function () {
+			await tg.build(child);
+			return tg.directory({ nested: tg.directory({ file: tg.file("parent output") }) });
+		}
+		export function child() {
+			return tg.directory({ nested: tg.directory({ file: tg.file("child output") }) });
+		}
+	',
+}
+let parent = tg --token $alice.token build --detach $path | str trim
+let output = (tg --token $alice.token wait $parent | from json).output.value | split row '?' | first
+tg --token $alice.token index
+let data = tg --token $alice.token get $parent | from json
+let child = $data.children.0.process | split row '?' | first
+let child_output = (tg --token $alice.token wait $child | from json).output.value | split row '?' | first
+
+# A node output grant allows checking out the parent's whole output subtree.
+tg --token $alice.token grant $eve.user.id process_node_output $parent
+let directory = mktemp --directory
+let parent_path = $directory | path join parent
+success (tg --token $eve.token checkout $output --path $parent_path | complete) "a node output grant should authorize the output subtree."
+assert equal (open --raw ($parent_path | path join nested file)) "parent output"
+
+# The process node, command, and child output remain unreadable.
+failure (tg --token $eve.token get $parent | complete) "a node output grant must not authorize the process node."
+failure (tg --token $eve.token get $data.command | complete) "a node output grant must not authorize the command."
+failure (tg --token $eve.token get $child_output | complete) "a node output grant must not authorize a child process's output."
+
+# A subtree output grant also allows checking out the child's whole output subtree.
+tg --token $alice.token grant $eve.user.id process_subtree_output $parent
+let child_path = $directory | path join child
+success (tg --token $eve.token checkout $child_output --path $child_path | complete) "a subtree output grant should authorize a child process's output subtree."
+assert equal (open --raw ($child_path | path join nested file)) "child output"

--- a/packages/index/src/authorize.rs
+++ b/packages/index/src/authorize.rs
@@ -305,9 +305,9 @@ pub(crate) fn write_permission_for_resource(
 
 pub(crate) fn process_object_permission(
 	kind: crate::process::object::Kind,
-	permission: tg::authorization::permission::object::Permission,
 ) -> tg::authorization::permission::process::Permission {
-	let process_permission = match kind {
+	// The node field permission covers the object's subtree; the subtree field permission additionally covers child processes.
+	match kind {
 		crate::process::object::Kind::Command => {
 			tg::authorization::permission::process::Permission::NodeCommand
 		},
@@ -319,12 +319,6 @@ pub(crate) fn process_object_permission(
 		},
 		crate::process::object::Kind::Output => {
 			tg::authorization::permission::process::Permission::NodeOutput
-		},
-	};
-	match permission {
-		tg::authorization::permission::object::Permission::Node => process_permission,
-		tg::authorization::permission::object::Permission::Subtree => {
-			process_permission.to_subtree()
 		},
 	}
 }

--- a/packages/index/src/authorize/search/ancestor.rs
+++ b/packages/index/src/authorize/search/ancestor.rs
@@ -553,7 +553,7 @@ impl Search {
 						crate::process::object::Kind::Output,
 					] {
 						let dependency_permission = tg::authorization::Permission::Process(
-							crate::authorize::process_object_permission(kind, permission),
+							crate::authorize::process_object_permission(kind),
 						);
 						let dependency = (tg::Id::from(process.clone()), dependency_permission);
 						if !self.source_authorizes(&dependency) {
@@ -894,11 +894,11 @@ impl Search {
 			implicit_processes.insert(process.clone());
 		}
 		match permission {
-			tg::authorization::Permission::Object(object_permission) => {
+			tg::authorization::Permission::Object(_) => {
 				for (process, kind) in &facts.object_processes {
 					if implicit_processes.contains(process) {
 						let permission = tg::authorization::Permission::Process(
-							crate::authorize::process_object_permission(*kind, *object_permission),
+							crate::authorize::process_object_permission(*kind),
 						);
 						dependencies.push((tg::Id::from(process.clone()), permission));
 					}

--- a/packages/index/src/authorize/search/descendant.rs
+++ b/packages/index/src/authorize/search/descendant.rs
@@ -384,12 +384,27 @@ impl Search {
 				..
 			} => {
 				let (after, objects) = output.into_process_objects()?;
-				let candidates = objects
-					.into_iter()
-					.filter_map(|(object, kind)| {
-						Self::process_object_candidate(&process, permission, object, kind, true)
-					})
-					.collect();
+				let kinds = process_object_kinds(permission);
+				// Keep each permission's candidates within the page size.
+				for permission in [
+					tg::authorization::permission::object::Permission::Subtree,
+					tg::authorization::permission::object::Permission::Node,
+				] {
+					let candidates = objects
+						.iter()
+						.filter(|(_, kind)| kinds.contains(kind))
+						.map(|(object, kind)| {
+							Self::process_object_candidate(
+								&process,
+								permission,
+								object.clone(),
+								*kind,
+								true,
+							)
+						})
+						.collect();
+					self.queue_candidates(depth, candidates, DescendantFallback::None);
+				}
 				let fallback = after.map_or(DescendantFallback::None, |after| {
 					DescendantFallback::ProcessObjects {
 						after: Some(after),
@@ -397,7 +412,7 @@ impl Search {
 						process,
 					}
 				});
-				self.queue_candidates(depth, candidates, fallback);
+				self.queue_fallback(depth, fallback);
 
 				return Ok(());
 			},
@@ -799,7 +814,7 @@ impl Search {
 						self.queue_fallback(depth, fallback);
 					}
 				}
-				if !process_object_permissions(permission).is_empty() {
+				if !process_object_kinds(permission).is_empty() {
 					let fallback = DescendantFallback::ProcessObjects {
 						after: None,
 						permission,
@@ -954,19 +969,24 @@ impl Search {
 			let Ok(object) = tg::object::Id::try_from(target.0.clone()) else {
 				continue;
 			};
-			for (kind, object_permission) in process_object_permissions(permission) {
-				if !object_permission.implies(target_permission) {
-					continue;
+			for kind in process_object_kinds(permission) {
+				// Preserve subtree proofs even when only the object node is requested.
+				for permission in [
+					tg::authorization::permission::object::Permission::Subtree,
+					tg::authorization::permission::object::Permission::Node,
+				] {
+					if !permission.implies(target_permission) {
+						continue;
+					}
+					let candidate = Self::process_object_candidate(
+						process,
+						permission,
+						object.clone(),
+						kind,
+						false,
+					);
+					candidates.push(candidate);
 				}
-				let candidate = Self::process_object_candidate(
-					process,
-					permission,
-					object.clone(),
-					kind,
-					false,
-				)
-				.unwrap();
-				candidates.push(candidate);
 			}
 		}
 		self.queue_candidates(depth, candidates, fallback);
@@ -974,15 +994,12 @@ impl Search {
 
 	fn process_object_candidate(
 		process: &tg::process::Id,
-		permission: tg::authorization::permission::process::Permission,
+		permission: tg::authorization::permission::object::Permission,
 		object: tg::object::Id,
 		kind: crate::process::object::Kind,
 		relationship_is_known: bool,
-	) -> Option<DescendantCandidate> {
-		let object_permission = process_object_permissions(permission)
-			.into_iter()
-			.find_map(|(candidate, permission)| (candidate == kind).then_some(permission))?;
-		let grant_permissions = match object_permission {
+	) -> DescendantCandidate {
+		let grant_permissions = match permission {
 			tg::authorization::permission::object::Permission::Node => vec![
 				tg::authorization::permission::object::Permission::Subtree,
 				tg::authorization::permission::object::Permission::Node,
@@ -1011,14 +1028,12 @@ impl Search {
 				proof
 			})
 			.collect();
-		let permission = tg::authorization::Permission::Object(object_permission);
-		let candidate = DescendantCandidate {
+		let permission = tg::authorization::Permission::Object(permission);
+		DescendantCandidate {
 			edges: 2,
 			neighbor: (tg::Id::from(object), permission),
 			proofs,
-		};
-
-		Some(candidate)
+		}
 	}
 
 	fn expand_subject(&mut self, depth: usize, subject: tg::authorization::Subject) {
@@ -1202,12 +1217,9 @@ fn process_child_permissions(
 	}
 }
 
-fn process_object_permissions(
+fn process_object_kinds(
 	permission: tg::authorization::permission::process::Permission,
-) -> Vec<(
-	crate::process::object::Kind,
-	tg::authorization::permission::object::Permission,
-)> {
+) -> Vec<crate::process::object::Kind> {
 	[
 		crate::process::object::Kind::Command,
 		crate::process::object::Kind::Error,
@@ -1215,17 +1227,7 @@ fn process_object_permissions(
 		crate::process::object::Kind::Output,
 	]
 	.into_iter()
-	.filter_map(|kind| {
-		let subtree = tg::authorization::permission::object::Permission::Subtree;
-		let needed = crate::authorize::process_object_permission(kind, subtree);
-		if permission.implies(needed) {
-			return Some((kind, subtree));
-		}
-		let node = tg::authorization::permission::object::Permission::Node;
-		let needed = crate::authorize::process_object_permission(kind, node);
-
-		permission.implies(needed).then_some((kind, node))
-	})
+	.filter(|kind| permission.implies(crate::authorize::process_object_permission(*kind)))
 	.collect()
 }
 

--- a/packages/index/src/lmdb/tests/authorize.rs
+++ b/packages/index/src/lmdb/tests/authorize.rs
@@ -1039,6 +1039,228 @@ async fn authorize_process_object_permissions_require_process_implicit_grants() 
 }
 
 #[tokio::test]
+async fn authorize_process_node_fields_cover_object_subtrees() {
+	let node = tg::authorization::permission::object::Permission::Node;
+	let subtree = tg::authorization::permission::object::Permission::Subtree;
+	for (kind, permission) in [
+		(
+			crate::process::object::Kind::Command,
+			tg::authorization::permission::process::Permission::NodeCommand,
+		),
+		(
+			crate::process::object::Kind::Error,
+			tg::authorization::permission::process::Permission::NodeError,
+		),
+		(
+			crate::process::object::Kind::Log,
+			tg::authorization::permission::process::Permission::NodeLog,
+		),
+		(
+			crate::process::object::Kind::Output,
+			tg::authorization::permission::process::Permission::NodeOutput,
+		),
+	] {
+		let (_directory, index) = new_index();
+		let process = tg::process::Id::new();
+		let child_process = tg::process::Id::new();
+		let sandbox = tg::sandbox::Id::new();
+		let node_reader = tg::user::Id::new();
+		let subtree_reader = tg::user::Id::new();
+		let object = object_id(0);
+		let object_child = object_id(1);
+		let child_object = object_id(2);
+		let child_object_child = object_id(3);
+		let foreign_object = object_id(4);
+		let node_object = object_id(5);
+		let node_object_child = object_id(6);
+		let other_object = object_id(7);
+
+		// Give each process an object subtree, plus references that are not fully authorized.
+		let mut transaction = index.env.write_txn().unwrap();
+		put_sandbox(&index, &mut transaction, &sandbox);
+		for process in [&process, &child_process] {
+			let set = crate::process::Set {
+				children: true,
+				error: true,
+				log: true,
+				output: true,
+			};
+			put_process_with_set(&index, &mut transaction, process, &sandbox, set);
+		}
+		put_process_child(&index, &mut transaction, &process, &child_process);
+		for object in [
+			&object,
+			&object_child,
+			&child_object,
+			&child_object_child,
+			&foreign_object,
+			&node_object,
+			&node_object_child,
+			&other_object,
+		] {
+			put_object(&index, &mut transaction, object);
+		}
+		for (parent, child) in [
+			(&object, &object_child),
+			(&child_object, &child_object_child),
+			(&node_object, &node_object_child),
+		] {
+			put_child(&index, &mut transaction, parent, child);
+		}
+		for (process, object, grant) in [
+			(&process, &object, Some(subtree)),
+			(&child_process, &child_object, Some(subtree)),
+			(&process, &foreign_object, None),
+			(&process, &node_object, Some(node)),
+		] {
+			put_process_object(&index, &mut transaction, process, object, kind);
+			if let Some(grant) = grant {
+				put_process_implicit_grant(
+					&index,
+					&mut transaction,
+					object.clone().into(),
+					process,
+					object_permission(grant),
+				);
+			}
+		}
+		let other_kind = if kind == crate::process::object::Kind::Output {
+			crate::process::object::Kind::Command
+		} else {
+			crate::process::object::Kind::Output
+		};
+		put_process_object(
+			&index,
+			&mut transaction,
+			&process,
+			&other_object,
+			other_kind,
+		);
+		put_process_implicit_grant(
+			&index,
+			&mut transaction,
+			other_object.clone().into(),
+			&process,
+			object_permission(subtree),
+		);
+		for (reader, permission) in [
+			(&node_reader, permission),
+			(&subtree_reader, permission.to_subtree()),
+		] {
+			put_resource_grant(
+				&index,
+				&mut transaction,
+				process.clone().into(),
+				tg::authorization::Subject::User(reader.clone()),
+				tg::authorization::Permission::Process(permission),
+			);
+		}
+		transaction.commit().unwrap();
+
+		// Exercise grants and tokens through both search directions independently and together.
+		let disabled = crate::authorize::SearchConfig {
+			max_depth: 0,
+			max_edges: 0,
+			max_nodes: 0,
+			..Default::default()
+		};
+		for (reader, permission, descendants) in [
+			(&node_reader, permission, false),
+			(&subtree_reader, permission.to_subtree(), true),
+		] {
+			let cases = [
+				(&object, node, true),
+				(&object, subtree, true),
+				(&object_child, node, true),
+				(&object_child, subtree, true),
+				(&child_object, node, descendants),
+				(&child_object, subtree, descendants),
+				(&child_object_child, node, descendants),
+				(&child_object_child, subtree, descendants),
+				(&foreign_object, node, false),
+				(&foreign_object, subtree, false),
+				(&node_object, node, true),
+				(&node_object, subtree, false),
+				(&node_object_child, node, false),
+				(&other_object, node, false),
+			];
+			for node_only in [false, true] {
+				let cases = cases
+					.into_iter()
+					.filter(|(_, permission, _)| !node_only || *permission == node)
+					.collect::<Vec<_>>();
+				for with_token in [false, true] {
+					let principal = if with_token {
+						tg::Principal::Anonymous
+					} else {
+						tg::Principal::User(reader.clone())
+					};
+					let token = with_token.then(|| tg::authorization::Body {
+						expires_at: i64::MAX,
+						permissions: vec![tg::authorization::Permission::Process(permission)],
+						resource: process.clone().into(),
+					});
+					let args = cases
+						.iter()
+						.map(|(object, permission, _)| {
+							let permissions = object_permission(*permission).into();
+							crate::authorize::Arg {
+								requested: permissions,
+								required: permissions,
+								resource: tg::Selector::Id((*object).clone().into()),
+								token: token.clone(),
+							}
+						})
+						.collect::<Vec<_>>();
+					for (search, config) in [
+						("both", crate::authorize::Config::default()),
+						(
+							"ancestor",
+							crate::authorize::Config {
+								descendant: disabled,
+								..Default::default()
+							},
+						),
+						(
+							"descendant",
+							crate::authorize::Config {
+								ancestor: disabled,
+								..Default::default()
+							},
+						),
+						(
+							"descendant paginated",
+							crate::authorize::Config {
+								ancestor: disabled,
+								descendant: crate::authorize::SearchConfig {
+									page_size: 1,
+									..Default::default()
+								},
+								..Default::default()
+							},
+						),
+					] {
+						let outcomes = index
+							.authorize_batch(&args, config, &principal)
+							.await
+							.unwrap();
+						for ((object, object_permission, expected), outcome) in
+							std::iter::zip(cases.iter().copied(), outcomes)
+						{
+							assert_eq!(
+								matches!(outcome, crate::authorize::Outcome::Authorized(_)),
+								expected,
+								"{kind:?} {permission}, {search}, token={with_token}, node_only={node_only}, {object} {object_permission}: {outcome:?}"
+							);
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+#[tokio::test]
 async fn authorize_parent_permission_flows_to_process_children() {
 	let (_dir, index) = new_index();
 	let child = tg::process::Id::new();


### PR DESCRIPTION
## Summary

- Fix `NodeOutput` to grant subtree access to this process's output objects. `SubtreeOutput` additionally covers descendant processes' outputs.
- Apply the same correction to command, error, and log permissions in both ancestor and descendant authorization searches.
- Preserve the process object grant checks: referencing an unreadable object does not grant access to it, and an object node grant does not become a subtree grant.
- Add index regression coverage for grants, tokens, pagination, and node-only batches, plus a CLI test checking out parent and child process outputs.

Token issuance is unchanged; the separate token work is not included.

## Validation

- `cargo test --package tangram_index --all-features` — 131 passed.
- `nu packages/cli/test.nu --no-cloud --no-progress-details 'grants/'` — 163 passed.
- `bun run check` — passed.
- `bun run format` — passed.
